### PR TITLE
docs: add Japanese summary block to 'For AI agents' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,44 @@ It is the file-based coordination layer for a small group of agents
 it, execute it, and review it afterwards — all with state that lives on
 disk and survives across sessions.
 
+> **日本語での概要（AIエージェント向け）**
+>
+> guild-cli は、AIエージェント（Claude / GPT / ローカルLLM など）と
+> 人間のオペレーターが混在する小規模チームのための、**ファイルベース
+> の協調基盤**です。デーモンもネットワークもDBも不要で、状態はすべて
+> YAMLファイルとしてディスク上に永続化され、セッションを跨いで保持
+> されます。
+>
+> 中核は **Two-Persona Devil Review ループ** — 「書いた人とレビュー
+> する人は別人格でなければならない」というルールを構造的に強制する
+> 仕組みです。単一エージェントの自己完結ループが見落としがちな盲点を、
+> 異なる視点（`devil | layer | cognitive | user` の4つのレンズ）から
+> 検出できます。
+>
+> あなたができること:
+>
+> - `guild new` で自分や仲間をメンバー登録する
+> - `gate request` で他のメンバー（または自分）に作業を依頼する
+> - `gate approve` → `execute` → `complete` でリクエストを状態遷移
+>   させ、各ステップが `status_log[]` に actor + timestamp 付きで残る
+> - `gate review` で**別メンバー**として批判的レビューを記録する
+> - `gate issues` で後で対処すべき欠陥を追跡する
+> - `gate message` / `broadcast` / `inbox` でメンバー間の非同期通知
+>   をやり取りする
+> - 小さな自己完結タスクなら `gate fast-track` で create→complete
+>   を一発で通し、記録だけ残して規律を緩める
+>
+> すべてファイル操作のみ。同一 content_root に複数プロセスが触る場合、
+> 作成系は O_EXCL で race-safe ですが、それ以外は協調的直列化を前提に
+> しています。自動化を上に組む場合は、domain/application 境界を安定
+> 層として扱い、infrastructure 層を差し替え可能な実装詳細とみなして
+> ください（新しい `Repository` 実装を書く方が、ユースケースを触る
+> より安全です）。
+>
+> 実動する典型例は [`examples/dogfood-session/`](./examples/dogfood-session/)
+> にあります — このツール自身がこのツールを使って自分を拡張した
+> セッションの完全な記録です。
+
 ### What you can do with it
 
 - **Register yourself or a teammate as a member.** `guild new --name noir


### PR DESCRIPTION
Non-English readers (or agents whose primary context language is Japanese) get a concise overview of what guild-cli is, the Two-Persona Devil Review loop, the top-level verbs, and the dogfood example pointer — without having to parse the surrounding English prose first. The English content is unchanged.

https://claude.ai/code/session_0124eGWouFj6f1SHxvZgTtoe