### PR TITLE
feat(cli): surface hosts in guild list/validate; GUILD_ACTOR env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,12 @@ node ./bin/gate.mjs pending
    assignee | trial | special | host`. Register with
    `guild new --name <n> --category <c>` or write the YAML by hand.
 
-3. **Verify with `guild validate`**. If it prints `N members valid`,
-   you're ready to file your first request.
+3. **Verify with `guild validate`**. If it prints
+   `N members valid, M host(s) configured`, you're ready to file your
+   first request. `guild list` will show all members plus any hosts
+   declared in `guild.config.yaml` with a `[host]` marker, so you can
+   see the full actor set (anyone who can appear in `--from` / `--by`
+   / `--executor` / `--auto-review`) without opening the config.
 
 4. **Try it on a real task.** `gate fast-track --from <you>
    --action "..." --reason "..."` is the lowest-friction entry
@@ -237,6 +241,20 @@ guild show <name>
 guild new --name <n> --category <core|professional|assignee|trial|special|host>
 guild validate
 ```
+
+`guild list` shows registered members first, then appends any
+`host_names` from `guild.config.yaml` with a `[host]` marker so the
+full actor set is visible in one place:
+
+```
+$ guild list
+kiri             [core]
+noir             [professional]
+alice            [host]  (non-member; no inbox)
+```
+
+`guild validate` reports both counts (`3 members valid, 2 host(s)
+configured`) so the output is not misleading about the total actor set.
 
 **`gate`** — request lifecycle, review, issues, messages (the what).
 
@@ -306,6 +324,52 @@ $ gate pending --for kiri
 $ gate list --state executing --executor noir
 $ gate list --state completed --auto-review rin
 ```
+
+### Interactive identity: `GUILD_ACTOR`
+
+If `GUILD_ACTOR` is set in the environment, it is used as the default
+for `--from` / `--by` / `--for` whenever those flags are omitted.
+Explicit flags always win. This is the low-friction way to drive the
+CLI by hand without retyping your name on every command:
+
+```
+$ export GUILD_ACTOR=kiri
+$ gate request --action "fix typo" --reason "trivial"    # --from kiri implied
+$ gate pending                                           # --for kiri implied
+# filtered by GUILD_ACTOR=kiri (use --for <m> or unset GUILD_ACTOR to override)
+$ gate complete 2026-04-14-007 --note "done"             # --by kiri implied
+```
+
+`--executor` and `--auto-review` are **not** covered: those flags
+point at *other* people (who will do the work, who will critique it),
+not at yourself, so env-filling them would silently mis-route
+delegation. Always pass them explicitly.
+
+For a one-off override without unexporting, pass an empty value —
+empty env vars are treated as unset:
+
+```
+$ GUILD_ACTOR= gate pending         # show everyone's queue this once
+$ GUILD_ACTOR=noir gate review 2026-04-14-007 --lense devil --verdict ok --comment "..."
+```
+
+`gate pending` and `gate list` emit a one-line stderr hint when the
+env var is implicitly filling in `--for`, so the behavior change is
+discoverable. Write-side commands currently apply the env var
+silently — if you switch shells frequently, double-check `echo
+$GUILD_ACTOR` before sending messages or broadcasting. (Extending
+the stderr hint to writes is tracked as follow-up in the dogfood
+session.)
+
+**Design note.** Identity is intentionally *not* part of
+`guild.config.yaml`: the config is shared across all operators of a
+content root, but "who am I in this shell" is per-session state.
+Using an environment variable (set in your shell profile, direnv, or
+a wrapper script) keeps the file-based ground truth unchanged — the
+env var only feeds the CLI boundary, and every write is still
+recorded in YAML with the explicit actor name. Automations should
+continue to pass `--from` / `--by` explicitly rather than relying on
+ambient state.
 
 ### Completion auto-review template
 

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -42,6 +42,14 @@ Messages:
 States: pending | approved | executing | completed | failed | denied
 Verdicts: ok | concern | reject
 Lenses: devil | layer | cognitive | user
+
+Environment:
+  GUILD_ACTOR=<name>   If set, used as the default for --from / --by /
+                       --for when those flags are omitted. Explicit flags
+                       always win. Intended for interactive shells
+                       (export it in your shell profile or direnv).
+                       Automations should continue to pass --from / --by
+                       explicitly.
 `;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -104,7 +112,12 @@ export async function main(argv: readonly string[]): Promise<number> {
 type C = ReturnType<typeof buildContainer>;
 
 async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
-  const from = requireOption(args, 'from', 'gate request --from <m> ...');
+  const from = requireOption(
+    args,
+    'from',
+    'gate request --from <m> ...',
+    'GUILD_ACTOR',
+  );
   const action = requireOption(args, 'action', '--action required');
   const reason = requireOption(args, 'reason', '--reason required');
   const input: Parameters<typeof c.requestUC.create>[0] = {
@@ -134,7 +147,18 @@ async function reqList(
   // --for is sugar: "anything I touch" — match if I'm the author, the
   // executor, or the assigned reviewer. Combines with other filters via
   // AND, not OR.
-  const forFilter = optionalOption(args, 'for');
+  //
+  // Env fallback: if --for is omitted and GUILD_ACTOR is set, use that
+  // as the implicit filter. This lets interactive users treat
+  // `gate pending` as "my queue" without retyping their name every time,
+  // without moving identity state into shared config. We also emit a
+  // one-line hint to stderr so the behavior is discoverable.
+  const explicitFor = optionalOption(args, 'for');
+  const envActor =
+    explicitFor === undefined && process.env['GUILD_ACTOR']
+      ? process.env['GUILD_ACTOR']
+      : undefined;
+  const forFilter = explicitFor ?? envActor;
 
   let items = await c.requestUC.listByState(state);
   if (fromFilter !== undefined) {
@@ -152,6 +176,12 @@ async function reqList(
         r.from.value === forFilter ||
         r.executor?.value === forFilter ||
         r.autoReview?.value === forFilter,
+    );
+  }
+
+  if (envActor !== undefined) {
+    process.stderr.write(
+      `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
     );
   }
 
@@ -251,7 +281,7 @@ function formatRequestText(r: Request): string {
 async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate approve <id> --by <m>');
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   await c.requestUC.approve(id, by, note);
   process.stdout.write(`✓ approved: ${id}\n`);
@@ -262,7 +292,7 @@ async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   const reason = args.positional.slice(1).join(' ');
   if (!id || !reason) throw new Error('Usage: gate deny <id> --by <m> <reason>');
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   await c.requestUC.deny(id, by, reason);
   process.stdout.write(`✓ denied: ${id}\n`);
   return 0;
@@ -271,7 +301,7 @@ async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
 async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate execute <id> --by <m>');
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   await c.requestUC.execute(id, by, note);
   process.stdout.write(`✓ executing: ${id}\n`);
@@ -281,7 +311,7 @@ async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
 async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate complete <id> --by <m>');
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   const r = await c.requestUC.complete(id, by, note);
   process.stdout.write(`✓ completed: ${id}\n`);
@@ -304,7 +334,7 @@ async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   const reason = args.positional.slice(1).join(' ');
   if (!id || !reason) throw new Error('Usage: gate fail <id> --by <m> <reason>');
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   await c.requestUC.fail(id, by, reason);
   process.stdout.write(`✓ failed: ${id}\n`);
   return 0;
@@ -318,7 +348,7 @@ async function reqReview(c: C, args: ParsedArgs): Promise<number> {
         '[--comment <s> | --comment - | <comment>]',
     );
   }
-  const by = requireOption(args, 'by', '--by required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const lense = requireOption(args, 'lense', '--lense required');
   const verdict = requireOption(args, 'verdict', '--verdict required');
 
@@ -356,7 +386,7 @@ async function readStdin(): Promise<string> {
 }
 
 async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
-  const from = requireOption(args, 'from', '--from required');
+  const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const action = requireOption(args, 'action', '--action required');
   const reason = requireOption(args, 'reason', '--reason required');
   const executor = optionalOption(args, 'executor') ?? from;
@@ -399,7 +429,7 @@ async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     return await issuesPromote(c, args);
   }
   if (sub === 'add') {
-    const from = requireOption(args, 'from', '--from required');
+    const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
     const severity = requireOption(args, 'severity', '--severity required');
     const area = requireOption(args, 'area', '--area required');
     const text = args.positional.slice(1).join(' ');
@@ -444,7 +474,7 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
         '[--auto-review <m>] [--action <a>] [--reason <r>]',
     );
   }
-  const from = requireOption(args, 'from', '--from required');
+  const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const executor = optionalOption(args, 'executor');
   const autoReview = optionalOption(args, 'auto-review');
   const actionOverride = optionalOption(args, 'action');
@@ -514,7 +544,7 @@ function truncateCodePoints(s: string, max: number): string {
 }
 
 async function msgSend(c: C, args: ParsedArgs): Promise<number> {
-  const from = requireOption(args, 'from', '--from required');
+  const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const to = requireOption(args, 'to', '--to required');
   const text = requireOption(args, 'text', '--text required');
   const type = optionalOption(args, 'type');
@@ -529,7 +559,7 @@ async function msgSend(c: C, args: ParsedArgs): Promise<number> {
 }
 
 async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
-  const from = requireOption(args, 'from', '--from required');
+  const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const text = requireOption(args, 'text', '--text required');
   const type = optionalOption(args, 'type');
   const { delivered, failed } = await c.messageUC.broadcast({
@@ -558,7 +588,7 @@ async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
 }
 
 async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
-  const forName = requireOption(args, 'for', '--for required');
+  const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
   const messages = await c.messageUC.inbox(forName);
   if (messages.length === 0) {
     process.stdout.write(`(inbox empty for ${forName})\n`);

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -25,9 +25,19 @@ export async function main(argv: readonly string[]): Promise<number> {
     switch (cmd) {
       case 'list': {
         const members = await c.memberUC.list();
+        const memberNames = new Set(members.map((m) => m.name.value));
         for (const m of members) {
           const dn = m.displayName ? ` (${m.displayName})` : '';
           process.stdout.write(`${m.name.value.padEnd(16)} [${m.category}]${dn}\n`);
+        }
+        // Hosts are non-member actors declared in guild.config.yaml.
+        // They may appear in --by / --from / --executor / --auto-review
+        // but have no members/*.yaml and cannot receive messages.
+        // Listing them here makes the full actor set visible without
+        // requiring the reader to open the config file.
+        for (const h of c.config.hostNames) {
+          if (memberNames.has(h)) continue; // don't double-print on collision
+          process.stdout.write(`${h.padEnd(16)} [host]  (non-member; no inbox)\n`);
         }
         return 0;
       }
@@ -54,7 +64,12 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
       case 'validate': {
         const members = await c.memberUC.list();
-        process.stdout.write(`✓ ${members.length} members valid\n`);
+        const hostCount = c.config.hostNames.length;
+        const hostSuffix =
+          hostCount === 0 ? '' : `, ${hostCount} host(s) configured`;
+        process.stdout.write(
+          `✓ ${members.length} members valid${hostSuffix}\n`,
+        );
         return 0;
       }
       default:

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -41,18 +41,27 @@ export function requireOption(
   args: ParsedArgs,
   key: string,
   usage: string,
+  envFallback?: string,
 ): string {
   const v = args.options[key];
-  if (typeof v !== 'string' || !v) {
-    throw new Error(`Missing --${key}. ${usage}`);
+  if (typeof v === 'string' && v) return v;
+  if (envFallback) {
+    const envVal = process.env[envFallback];
+    if (envVal && envVal.length > 0) return envVal;
   }
-  return v;
+  throw new Error(`Missing --${key}. ${usage}`);
 }
 
 export function optionalOption(
   args: ParsedArgs,
   key: string,
+  envFallback?: string,
 ): string | undefined {
   const v = args.options[key];
-  return typeof v === 'string' ? v : undefined;
+  if (typeof v === 'string') return v;
+  if (envFallback) {
+    const envVal = process.env[envFallback];
+    if (envVal && envVal.length > 0) return envVal;
+  }
+  return undefined;
 }

--- a/tests/interface/parseArgs.test.ts
+++ b/tests/interface/parseArgs.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseArgs,
+  requireOption,
+  optionalOption,
+} from '../../src/interface/shared/parseArgs.js';
+
+test('requireOption returns explicit value when present', () => {
+  const args = parseArgs(['--from', 'kiri']);
+  assert.equal(requireOption(args, 'from', 'usage'), 'kiri');
+});
+
+test('requireOption throws when key missing and no env fallback', () => {
+  const args = parseArgs([]);
+  assert.throws(() => requireOption(args, 'from', 'usage'), /Missing --from/);
+});
+
+test('requireOption falls back to env var when option missing', () => {
+  const args = parseArgs([]);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = 'noir';
+  try {
+    assert.equal(
+      requireOption(args, 'from', 'usage', 'GUILD_ACTOR'),
+      'noir',
+    );
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});
+
+test('requireOption: explicit value wins over env fallback', () => {
+  const args = parseArgs(['--from', 'kiri']);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = 'noir';
+  try {
+    assert.equal(
+      requireOption(args, 'from', 'usage', 'GUILD_ACTOR'),
+      'kiri',
+    );
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});
+
+test('requireOption: empty env var is treated as unset', () => {
+  const args = parseArgs([]);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = '';
+  try {
+    assert.throws(
+      () => requireOption(args, 'from', 'usage', 'GUILD_ACTOR'),
+      /Missing --from/,
+    );
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});
+
+test('optionalOption returns undefined when missing and no env fallback', () => {
+  const args = parseArgs([]);
+  assert.equal(optionalOption(args, 'for'), undefined);
+});
+
+test('optionalOption falls back to env var', () => {
+  const args = parseArgs([]);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = 'rin';
+  try {
+    assert.equal(optionalOption(args, 'for', 'GUILD_ACTOR'), 'rin');
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});
+
+test('optionalOption: explicit value wins over env', () => {
+  const args = parseArgs(['--for', 'noir']);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = 'rin';
+  try {
+    assert.equal(optionalOption(args, 'for', 'GUILD_ACTOR'), 'noir');
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});


### PR DESCRIPTION
## Summary

Three discoverability/ergonomics improvements surfaced by dogfooding the CLI on a fresh content root. Tracked end-to-end through the Two-Persona Devil Review loop in `/tmp/guild-test` — the session recorded 4 full-cycle requests, 4 reviews (3 devil-lens on the implementation, 1 user-lens on the docs), and 3 follow-up issues.

### 1. `guild list` shows hosts as part of the actor set

```
$ guild list
kiri             [core]
noir             [professional]
rin              [assignee]
alice            [host]  (non-member; no inbox)
bob              [host]  (non-member; no inbox)
```

Host names declared in `guild.config.yaml` now render with a `[host]` marker after the members (de-duped against member names on collision). The full set of actors allowed in `--from` / `--by` / `--executor` / `--auto-review` is visible in one place instead of requiring the reader to open the config file.

### 2. `guild validate` reports host count

```
$ guild validate
✓ 3 members valid, 2 host(s) configured
```

The previous `N members valid` was misleading about the total actor set. If no hosts are configured, the suffix is suppressed.

### 3. `GUILD_ACTOR` env var fallback for `--from` / `--by` / `--for`

```
$ export GUILD_ACTOR=kiri
$ gate request --action "..." --reason "..."   # --from kiri implied
$ gate pending                                 # --for kiri implied
# filtered by GUILD_ACTOR=kiri (use --for <m> or unset GUILD_ACTOR to override)
$ gate complete 2026-04-14-007 --note "done"   # --by kiri implied
```

Reduces handwork friction for interactive use without moving identity state into `guild.config.yaml` (which is shared across operators — per-shell identity doesn't belong there). Explicit flags always win. Empty env var (`GUILD_ACTOR= gate pending`) is treated as unset, enabling one-off overrides.

**Scope of env fallback:**
- Covered: `--from` (`request`/`fast-track`/`issues add`/`issues promote`/`message`/`broadcast`), `--by` (`approve`/`deny`/`execute`/`complete`/`fail`/`review`), `--for` (`pending`/`list`/`inbox`).
- **Excluded by design**: `--executor` and `--auto-review` point at *other* people (who will do the work, who will critique it) — env-filling them would silently mis-route delegation.

**Discoverability**: `gate pending` / `gate list` emit a one-line stderr hint when the env var implicitly filled in `--for`. Write-side commands currently apply the env var silently (tracked as follow-up `i-2026-04-14-002` in the dogfood session).

### Implementation

- `src/interface/shared/parseArgs.ts`: `requireOption` / `optionalOption` gain an optional `envFallback` parameter. Precedence: explicit flag > env var > throw/undefined.
- `src/interface/gate/index.ts`: 14 actor call sites updated. `reqList` reads `GUILD_ACTOR` directly so it can distinguish explicit `--for` from env fallback and emit the stderr hint only in the latter case.
- `src/interface/guild/index.ts`: list and validate handlers read `c.config.hostNames`.
- HELP text in `gate` updated with an `Environment:` section.
- README: new "Interactive identity: `GUILD_ACTOR`" subsection, updated First-time Setup and Two CLIs sections.
- New test file `tests/interface/parseArgs.test.ts` (8 cases) covering precedence, empty-env-var-is-unset, and the explicit-wins rule.

### Dogfood session audit trail

Requests driven through the full loop in `/tmp/guild-test`:
| ID | action | review |
|---|---|---|
| `2026-04-14-004` | guild list with [host] marker | `[devil/ok]` by noir |
| `2026-04-14-005` | validate host count | `[devil/ok]` by noir |
| `2026-04-14-006` | GUILD_ACTOR env fallback | `[devil/concern]` by noir → issue `i-2026-04-14-002` |
| `2026-04-14-008` | README updates | `[user/concern]` → fixed → `[user/ok]` by rin |

The devil review on 2026-04-14-006 caught a real concern: write-side commands apply the env var silently, so a stale `GUILD_ACTOR` from a previous shell could mis-attribute a write. That concern is captured as a follow-up issue rather than expanded into this PR to keep the scope focused. The user-lens review on 2026-04-14-008 raised two docs gaps (`--executor`/`--auto-review` exclusion and the empty-env-var unset idiom), both folded into the README before the final commit.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 52/52 passing (existing 44 + 8 new parseArgs tests)
- [x] Manual: `guild list` / `guild validate` print hosts / host count
- [x] Manual: `gate request` without `--from` fails; with `GUILD_ACTOR=kiri` succeeds
- [x] Manual: `gate pending` with `GUILD_ACTOR=kiri` emits stderr hint; explicit `--for` overrides
- [x] Manual: `GUILD_ACTOR= gate pending` (empty) shows everyone's queue
- [x] Manual: full `request → approve → execute → complete → review` lifecycle completed using env var for the actor at each step

## Follow-ups (not in this PR)

- `i-2026-04-14-002` [security] — extend the stderr hint pattern to write-side commands
- `i-2026-04-14-003` [docs] — residual note from the user-lens review

https://claude.ai/code/session_01G9UdoygPCyGa3oYchRYLXf