### PR TITLE
feat(gate): add voices &lt;name&gt; — cross-cutting read of an actor's history

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,51 @@ The reviewer is not dispatched for you — you still have to run the
 command (or have your orchestrator run it). This is persistence-plus-
 hint, not a scheduler.
 
+### Voices: cross-cutting reads of what an actor has said
+
+`gate voices <name>` walks the full request corpus — every state,
+every review — and surfaces everything `<name>` authored or
+reviewed, sorted chronologically. It's the "show me my own history
+on this content root" command.
+
+```
+$ gate voices kiri
+17 utterances from kiri
+
+[2026-04-14T10:59:05.842Z] req=2026-04-14-001 authored
+  action: Feature A: gate complete の完了時に...
+  reason: README で明言されている 0.1.0 の制限...
+  note:   reqComplete に auto-review テンプレ出力を追加...
+...
+```
+
+Each entry is an *utterance* — either an authored request (action +
+reason + whichever closure note the lifecycle produced:
+`note:` / `denied:` / `failed:`) or a review (lens + verdict +
+comment). Filters combine via AND:
+
+- `--lense <devil|layer|cognitive|user>` — only reviews with that
+  lens (implies review-only; authored requests carry no lens)
+- `--verdict <ok|concern|reject>` — only reviews with that verdict
+  (implies review-only)
+- `--format json` — emit the utterance list as JSON for piping
+
+```
+$ gate voices noir --lense devil
+5 reviews from noir (lense=devil)
+
+[2026-04-14T10:59:57.309Z] req=2026-04-14-001 [devil/concern]
+  re: Feature A: gate complete の完了時に...
+  実装自体は小さく動く。しかし懸念が2つ: (1) complete()...
+```
+
+Name matching is case-insensitive. Timestamps are ISO-8601, so
+text-mode output sorts naturally.
+
+Use cases at the layer-1 surface: reading your own review history
+before a retrospective, auditing "what did critic X flag across
+all of feature Z", grepping for verdicts without yaml plumbing.
+
 ### Issue → Request promotion
 
 `gate issues promote` lifts an open issue into a new request and

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -7,6 +7,14 @@ import {
 } from '../shared/parseArgs.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { Request } from '../../domain/request/Request.js';
+import { REQUEST_STATES } from '../../domain/request/RequestState.js';
+import { parseLense } from '../../domain/shared/Lense.js';
+import { parseVerdict } from '../../domain/shared/Verdict.js';
+import {
+  collectUtterances,
+  RequestJSON,
+  VoicesFilter,
+} from './voices.js';
 
 const HELP = `gate — request lifecycle & dialogue CLI
 
@@ -17,6 +25,7 @@ Requests:
   gate list --state <state> [--for <m>] [--from <m>]
                             [--executor <m>] [--auto-review <m>]
   gate show <id> [--format json|text]
+  gate voices <name> [--lense <l>] [--verdict <v>] [--format json|text]
   gate approve <id> --by <m> [--note <s>]
   gate deny <id> --by <m> <reason>
   gate execute <id> --by <m> [--note <s>]
@@ -72,6 +81,8 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
       case 'show':
         return await reqShow(c, args);
+      case 'voices':
+        return await reqVoices(c, args);
       case 'approve':
         return await reqApprove(c, args);
       case 'deny':
@@ -276,6 +287,128 @@ function formatRequestText(r: Request): string {
     }
   }
   return lines.join('\n');
+}
+
+// `gate voices <name>` — cross-cutting read over the request corpus.
+//
+// Surfaces every utterance authored or reviewed by <name>, regardless
+// of the containing request's lifecycle state, sorted chronologically.
+// An utterance is either:
+//   - an authored request (action + reason + whichever closure note
+//     the lifecycle produced: completion_note / deny_reason /
+//     failure_reason) — something you *wrote* as the from-actor, or
+//   - a review (lens + verdict + comment) — something you *said*
+//     about someone's (maybe your own) work.
+//
+// Filters:
+//   --lense <l>    only reviews with that lens (implies review-only;
+//                  authored requests carry no lens)
+//   --verdict <v>  only reviews with that verdict (implies review-only)
+//   --format json  emit the utterance list as JSON for piping
+//
+// This is deliberately a read over *all* states, not a lifecycle
+// query. The point is to let an actor re-read their own voice as a
+// stream across time, without grepping yaml by hand.
+//
+// Gather/filter/sort is delegated to collectUtterances in ./voices.ts
+// (pure, unit-tested). This wrapper handles arg parsing, repo I/O,
+// and rendering.
+async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
+  const name = args.positional[0];
+  if (!name) {
+    throw new Error(
+      'Usage: gate voices <name> [--lense <l>] [--verdict <v>] ' +
+        '[--format json|text]',
+    );
+  }
+
+  const lenseFilterRaw = optionalOption(args, 'lense');
+  const verdictFilterRaw = optionalOption(args, 'verdict');
+  // parseLense / parseVerdict throw DomainError with the allowed-values
+  // list on failure. Retain the parsed values so we're passing typed
+  // strings (not "any string the user typed") into the filter.
+  const lenseFilter =
+    lenseFilterRaw !== undefined ? parseLense(lenseFilterRaw) : undefined;
+  const verdictFilter =
+    verdictFilterRaw !== undefined ? parseVerdict(verdictFilterRaw) : undefined;
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  // O(N_states) repo reads. Acceptable for the sizes this tool targets
+  // (hundreds of requests per content_root). TOCTOU: a concurrent state
+  // transition between list calls can duplicate or drop a request —
+  // tracked as a follow-up issue since in-repo enumeration would need
+  // a new port method.
+  const allRequests: Request[] = [];
+  for (const s of REQUEST_STATES) {
+    allRequests.push(...(await c.requestUC.listByState(s)));
+  }
+  const allJson: RequestJSON[] = allRequests.map(
+    (r) => r.toJSON() as unknown as RequestJSON,
+  );
+
+  const filter: VoicesFilter = { name };
+  if (lenseFilter !== undefined) {
+    (filter as { lense?: string }).lense = lenseFilter;
+  }
+  if (verdictFilter !== undefined) {
+    (filter as { verdict?: string }).verdict = verdictFilter;
+  }
+  const utterances = collectUtterances(allJson, filter);
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(utterances, null, 2) + '\n');
+    return 0;
+  }
+
+  const filterDesc: string[] = [];
+  if (lenseFilter !== undefined) filterDesc.push(`lense=${lenseFilter}`);
+  if (verdictFilter !== undefined) filterDesc.push(`verdict=${verdictFilter}`);
+  const filterSuffix =
+    filterDesc.length > 0 ? ` (${filterDesc.join(', ')})` : '';
+
+  if (utterances.length === 0) {
+    process.stdout.write(`(no utterances from ${name}${filterSuffix})\n`);
+    return 0;
+  }
+
+  const reviewOnly =
+    lenseFilter !== undefined || verdictFilter !== undefined;
+  const header = reviewOnly ? 'reviews' : 'utterances';
+  process.stdout.write(
+    `${utterances.length} ${header} from ${name}${filterSuffix}\n\n`,
+  );
+  for (const u of utterances) {
+    if (u.kind === 'authored') {
+      process.stdout.write(`[${u.at}] req=${u.requestId} authored\n`);
+      process.stdout.write(`  action: ${u.action}\n`);
+      process.stdout.write(`  reason: ${u.reason}\n`);
+      // Field labels match `gate show --format text` so the reader's
+      // eye learns one vocabulary. At most one of these is set per
+      // request (completed / denied / failed are mutually exclusive).
+      if (u.completionNote) {
+        process.stdout.write(`  note:   ${u.completionNote}\n`);
+      }
+      if (u.denyReason) {
+        process.stdout.write(`  denied: ${u.denyReason}\n`);
+      }
+      if (u.failureReason) {
+        process.stdout.write(`  failed: ${u.failureReason}\n`);
+      }
+    } else {
+      process.stdout.write(
+        `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]\n`,
+      );
+      process.stdout.write(`  re: ${u.action}\n`);
+      for (const line of u.comment.split('\n')) {
+        process.stdout.write(`  ${line}\n`);
+      }
+    }
+    process.stdout.write('\n');
+  }
+  return 0;
 }
 
 async function reqApprove(c: C, args: ParsedArgs): Promise<number> {

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -1,0 +1,137 @@
+/**
+ * Pure helpers for `gate voices <name>`. Kept separate from the CLI
+ * entry point so the gather/filter/sort logic is unit-testable without
+ * a live filesystem.
+ *
+ * An "utterance" is anything a named actor put on the record:
+ *   - `authored`: a request they filed (action + reason + the
+ *     appropriate closure note — completion_note / deny_reason /
+ *     failure_reason, whichever the lifecycle produced).
+ *   - `review`: a review they recorded on someone's (or their own)
+ *     request, carrying the lens / verdict / comment.
+ *
+ * The RequestJSON type below intentionally models only the fields
+ * voices reads. Keeping it structural (rather than importing Request
+ * from domain) lets tests feed plain objects instead of going through
+ * the full domain constructor chain.
+ */
+
+export type RequestJSON = {
+  readonly id: string;
+  readonly from: string;
+  readonly action: string;
+  readonly reason: string;
+  readonly created_at: string;
+  readonly completion_note?: string;
+  readonly deny_reason?: string;
+  readonly failure_reason?: string;
+  readonly reviews?: ReadonlyArray<ReviewJSON>;
+};
+
+export type ReviewJSON = {
+  readonly by: string;
+  readonly lense: string;
+  readonly verdict: string;
+  readonly comment: string;
+  readonly at: string;
+};
+
+export type AuthoredUtterance = {
+  readonly kind: 'authored';
+  readonly at: string;
+  readonly requestId: string;
+  readonly action: string;
+  readonly reason: string;
+  // Any closure text the lifecycle ended on. Only one of these is
+  // populated for a given request: completed → completionNote,
+  // denied → denyReason, failed → failureReason.
+  readonly completionNote?: string;
+  readonly denyReason?: string;
+  readonly failureReason?: string;
+};
+
+export type ReviewUtterance = {
+  readonly kind: 'review';
+  readonly at: string;
+  readonly requestId: string;
+  // The action of the containing request, so the reader has context
+  // for what the review was *about* without chasing the id.
+  readonly action: string;
+  readonly lense: string;
+  readonly verdict: string;
+  readonly comment: string;
+};
+
+export type Utterance = AuthoredUtterance | ReviewUtterance;
+
+export interface VoicesFilter {
+  readonly name: string;
+  readonly lense?: string;
+  readonly verdict?: string;
+}
+
+/**
+ * Collect every utterance by `filter.name` across the given requests,
+ * sorted chronologically ascending.
+ *
+ * When `lense` or `verdict` is set, only review utterances are
+ * returned — authored requests don't carry those fields, so including
+ * them in a lens-scoped query would be a category error.
+ *
+ * Name matching is case-insensitive. Timestamps are compared as
+ * strings; ISO-8601 sorts correctly lexicographically.
+ */
+export function collectUtterances(
+  requests: ReadonlyArray<RequestJSON>,
+  filter: VoicesFilter,
+): Utterance[] {
+  const needle = filter.name.toLowerCase();
+  const reviewOnly =
+    filter.lense !== undefined || filter.verdict !== undefined;
+  const out: Utterance[] = [];
+
+  for (const r of requests) {
+    if (!reviewOnly && r.from.toLowerCase() === needle) {
+      const u: AuthoredUtterance = {
+        kind: 'authored',
+        at: r.created_at,
+        requestId: r.id,
+        action: r.action,
+        reason: r.reason,
+      };
+      // Pick whichever closure field the lifecycle produced. A request
+      // can only be in one terminal state at a time, so at most one of
+      // these is set.
+      if (r.completion_note) {
+        (u as { completionNote?: string }).completionNote = r.completion_note;
+      }
+      if (r.deny_reason) {
+        (u as { denyReason?: string }).denyReason = r.deny_reason;
+      }
+      if (r.failure_reason) {
+        (u as { failureReason?: string }).failureReason = r.failure_reason;
+      }
+      out.push(u);
+    }
+    const reviews = r.reviews ?? [];
+    for (const rv of reviews) {
+      if (rv.by.toLowerCase() !== needle) continue;
+      if (filter.lense !== undefined && rv.lense !== filter.lense) continue;
+      if (filter.verdict !== undefined && rv.verdict !== filter.verdict) {
+        continue;
+      }
+      out.push({
+        kind: 'review',
+        at: rv.at,
+        requestId: r.id,
+        action: r.action,
+        lense: rv.lense,
+        verdict: rv.verdict,
+        comment: rv.comment,
+      });
+    }
+  }
+
+  out.sort((a, b) => a.at.localeCompare(b.at));
+  return out;
+}

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -1,0 +1,208 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  collectUtterances,
+  RequestJSON,
+} from '../../src/interface/gate/voices.js';
+
+// Synthetic request corpus. These are intentionally not Request
+// domain objects — the point of collectUtterances is that it works
+// on structural JSON shapes, so tests don't need domain fixtures.
+const corpus: RequestJSON[] = [
+  {
+    id: '2026-04-14-001',
+    from: 'kiri',
+    action: 'Feature A',
+    reason: 'first task',
+    created_at: '2026-04-14T10:00:00.000Z',
+    completion_note: 'shipped',
+    reviews: [
+      {
+        by: 'noir',
+        lense: 'devil',
+        verdict: 'concern',
+        comment: 'I/O racy',
+        at: '2026-04-14T11:00:00.000Z',
+      },
+      {
+        by: 'rin',
+        lense: 'layer',
+        verdict: 'ok',
+        comment: 'layers fine',
+        at: '2026-04-14T11:05:00.000Z',
+      },
+    ],
+  },
+  {
+    id: '2026-04-14-002',
+    from: 'noir',
+    action: 'Feature B',
+    reason: 'second task',
+    created_at: '2026-04-14T12:00:00.000Z',
+    deny_reason: 'scope creep',
+    reviews: [],
+  },
+  {
+    id: '2026-04-14-003',
+    from: 'kiri',
+    action: 'Feature C',
+    reason: 'third task',
+    created_at: '2026-04-14T13:00:00.000Z',
+    failure_reason: 'upstream outage',
+    reviews: [
+      {
+        by: 'noir',
+        lense: 'user',
+        verdict: 'ok',
+        comment: 'users fine',
+        at: '2026-04-14T14:00:00.000Z',
+      },
+    ],
+  },
+];
+
+test('collectUtterances returns all authored + review utterances for an actor', () => {
+  const result = collectUtterances(corpus, { name: 'kiri' });
+  // kiri authored req 001 and 003, reviewed nothing.
+  assert.equal(result.length, 2);
+  assert.equal(result[0]?.kind, 'authored');
+  assert.equal(result[0]?.requestId, '2026-04-14-001');
+  assert.equal(result[1]?.kind, 'authored');
+  assert.equal(result[1]?.requestId, '2026-04-14-003');
+});
+
+test('collectUtterances returns mixed authored + review for an actor who wears both hats', () => {
+  const result = collectUtterances(corpus, { name: 'noir' });
+  // noir authored req 002, reviewed req 001 (devil) and req 003 (user).
+  // Sorted by timestamp: devil@11:00, noir-authored@12:00, user@14:00.
+  assert.equal(result.length, 3);
+  assert.equal(result[0]?.kind, 'review');
+  assert.equal(result[0]?.requestId, '2026-04-14-001');
+  assert.equal(result[1]?.kind, 'authored');
+  assert.equal(result[1]?.requestId, '2026-04-14-002');
+  assert.equal(result[2]?.kind, 'review');
+  assert.equal(result[2]?.requestId, '2026-04-14-003');
+});
+
+test('collectUtterances: --lense filter excludes authored and non-matching reviews', () => {
+  const result = collectUtterances(corpus, { name: 'noir', lense: 'devil' });
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.kind, 'review');
+  const r = result[0];
+  if (r?.kind === 'review') {
+    assert.equal(r.lense, 'devil');
+    assert.equal(r.verdict, 'concern');
+  }
+});
+
+test('collectUtterances: --verdict filter is independent of lens filter', () => {
+  const result = collectUtterances(corpus, { name: 'noir', verdict: 'ok' });
+  // noir has two ok reviews (layer on 001? no, rin; user on 003 — noir).
+  // Only user/ok on 003.
+  assert.equal(result.length, 1);
+  if (result[0]?.kind === 'review') {
+    assert.equal(result[0].lense, 'user');
+    assert.equal(result[0].verdict, 'ok');
+  }
+});
+
+test('collectUtterances: unknown name returns empty array', () => {
+  assert.deepEqual(collectUtterances(corpus, { name: 'ghost' }), []);
+});
+
+test('collectUtterances: name matching is case-insensitive', () => {
+  const lower = collectUtterances(corpus, { name: 'noir' });
+  const upper = collectUtterances(corpus, { name: 'NOIR' });
+  const mixed = collectUtterances(corpus, { name: 'NoIr' });
+  assert.equal(lower.length, 3);
+  assert.deepEqual(lower, upper);
+  assert.deepEqual(lower, mixed);
+});
+
+test('collectUtterances: sorts results chronologically ascending', () => {
+  const result = collectUtterances(corpus, { name: 'noir' });
+  for (let i = 1; i < result.length; i++) {
+    const prev = result[i - 1]?.at ?? '';
+    const curr = result[i]?.at ?? '';
+    assert.ok(prev.localeCompare(curr) <= 0, `${prev} should be ≤ ${curr}`);
+  }
+});
+
+test('collectUtterances: authored utterance captures deny_reason when present', () => {
+  const result = collectUtterances(corpus, { name: 'noir' });
+  const authored = result.find(
+    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-002',
+  );
+  assert.ok(authored, 'expected noir-authored denied request');
+  if (authored?.kind === 'authored') {
+    assert.equal(authored.denyReason, 'scope creep');
+    assert.equal(authored.completionNote, undefined);
+    assert.equal(authored.failureReason, undefined);
+  }
+});
+
+test('collectUtterances: authored utterance captures failure_reason when present', () => {
+  const result = collectUtterances(corpus, { name: 'kiri' });
+  const failed = result.find(
+    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-003',
+  );
+  assert.ok(failed, 'expected kiri-authored failed request');
+  if (failed?.kind === 'authored') {
+    assert.equal(failed.failureReason, 'upstream outage');
+    assert.equal(failed.completionNote, undefined);
+    assert.equal(failed.denyReason, undefined);
+  }
+});
+
+test('collectUtterances: authored utterance captures completion_note when present', () => {
+  const result = collectUtterances(corpus, { name: 'kiri' });
+  const completed = result.find(
+    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-001',
+  );
+  assert.ok(completed, 'expected kiri-authored completed request');
+  if (completed?.kind === 'authored') {
+    assert.equal(completed.completionNote, 'shipped');
+    assert.equal(completed.denyReason, undefined);
+    assert.equal(completed.failureReason, undefined);
+  }
+});
+
+test('collectUtterances: lens+verdict filters combine via AND', () => {
+  const result = collectUtterances(corpus, {
+    name: 'noir',
+    lense: 'devil',
+    verdict: 'ok',
+  });
+  // noir's devil review is concern, not ok, so nothing matches.
+  assert.deepEqual(result, []);
+});
+
+test('collectUtterances: empty reviews array is handled gracefully', () => {
+  const onlyAuthored: RequestJSON[] = [
+    {
+      id: '2026-04-15-001',
+      from: 'kiri',
+      action: 'x',
+      reason: 'y',
+      created_at: '2026-04-15T00:00:00.000Z',
+      reviews: [],
+    },
+  ];
+  const result = collectUtterances(onlyAuthored, { name: 'kiri' });
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.kind, 'authored');
+});
+
+test('collectUtterances: missing reviews field (undefined) is handled gracefully', () => {
+  const noReviews: RequestJSON[] = [
+    {
+      id: '2026-04-15-002',
+      from: 'kiri',
+      action: 'x',
+      reason: 'y',
+      created_at: '2026-04-15T00:00:00.000Z',
+    },
+  ];
+  const result = collectUtterances(noReviews, { name: 'kiri' });
+  assert.equal(result.length, 1);
+});


### PR DESCRIPTION
## Summary

Adds `gate voices <name>` — a cross-cutting read over the request corpus that surfaces everything an actor authored or reviewed, sorted chronologically. Reading your own history on a content_root used to require yaml greps; now it's one command.

```
$ gate voices noir --lense devil
5 reviews from noir (lense=devil)

[2026-04-14T10:59:57.309Z] req=2026-04-14-001 [devil/concern]
  re: Feature A: gate complete の完了時に...
  実装自体は小さく動く。しかし懸念が2つ: (1) complete()...

[2026-04-14T11:05:10.921Z] req=2026-04-14-003 [devil/concern]
  re: Feature C: gate issues promote <id>...
  Devil 観点で3点: (1) Non-atomic だと宣言しているが...
...
```

## What's an utterance

An utterance is either:
- **`authored`** — a request they filed (action + reason + whichever closure note the lifecycle produced: `completion_note` / `deny_reason` / `failure_reason`, all three surfaced with the same vocabulary as `gate show --format text`)
- **`review`** — a review they recorded (lens + verdict + comment, labeled with the containing request's action for context)

## Filters

All combine via AND:

- `--lense <devil|layer|cognitive|user>` — only reviews with that lens (implies review-only; authored requests carry no lens)
- `--verdict <ok|concern|reject>` — only reviews with that verdict (implies review-only)
- `--format json` — emit as JSON for piping

Name matching is case-insensitive. ISO-8601 timestamps sort lexicographically.

## Implementation notes

- Core gather/filter/sort extracted to `src/interface/gate/voices.ts` as a pure function `collectUtterances(requests, filter)` taking a structural `RequestJSON` array. This keeps the logic unit-testable without going through domain constructors.
- **13 unit tests** in `tests/interface/voices.test.ts` cover: authored-only, reviewer-only, mixed author+reviewer, lens filter, verdict filter, lens+verdict AND-combination, unknown name, case-insensitive matching (`noir` / `NOIR` / `NoIr`), chronological ordering, the three closure-note variants independently (`completion_note` / `deny_reason` / `failure_reason`), empty-reviews array, missing-reviews field.
- `reqVoices` in `gate/index.ts` is now thin: arg parsing, repo reads, delegation, rendering.
- Parsed lens/verdict values are retained (not discarded) so the filter carries typed strings into the pure function.
- New README "Voices" subsection described at the layer-1 surface (history audit / review retrieval).

## Dogfood session audit trail

Filed and driven through the full loop in `/tmp/guild-test`:

| ID | event | outcome |
|---|---|---|
| `2026-04-15-001` | implement gate voices | `[devil/concern]` → fold + issues → `[devil/ok]` |
| `i-2026-04-15-001` | TOCTOU on state enumeration | open, follow-up |
| `i-2026-04-15-002` | Unicode normalization assumption | open, follow-up |

The devil review on `2026-04-15-001` raised four concerns:

1. **TOCTOU on state enumeration**: `for (const s of REQUEST_STATES)` between list calls can duplicate or drop a request under concurrent state transitions. Safe for dogfood scale, not a defensible design. → **issue `i-2026-04-15-001`**, to be fixed together with a future `RequestRepository.listAll()`.
2. **Missing `deny_reason` / `failure_reason` in authored utterances**: originally only `completion_note` was surfaced, but denied/failed requests carry their own closure voice that belongs in the history. → **folded in**: voices.ts now captures all three, text output uses the same `note:` / `denied:` / `failed:` vocabulary as `gate show --format text`, tests cover each case independently.
3. **Unicode normalization assumption**: `needle = name.toLowerCase()` silently assumes YAML `from`/`by` fields are in `MemberName`'s normalized form (lowercase, NFC). True today but a silent layer-boundary contract. → **issue `i-2026-04-15-002`**, coupled to documenting/clarifying `MemberName` normalization.
4. **No unit tests for the new verb**: same indictment as `i-2026-04-14-007` from the previous dogfood audit. → **folded in**: extracted the pure function and wrote 13 unit tests.

Devil second-pass: `[devil/ok]`. The noir reviewer's closing observation, left in the record: *"The devil review itself used `gate voices noir --lense devil` to re-read noir's past critiques before writing — the feature was load-bearing for its own review cycle."*

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 65/65 passing (existing 52 + 13 new voices tests)
- [x] Manual: `gate voices kiri` against `/tmp/guild-test` shows 17 authored entries in chronological order
- [x] Manual: `gate voices NOIR --lense layer` (case-insensitive + filter) against `examples/dogfood-session` returns 2 layer reviews
- [x] Manual: `gate voices noir --lense devil` returns 5 devil reviews from the dogfood session
- [x] Manual: `gate voices noir --lense devil --verdict ok` (AND combination) returns only the ok-verdict devil reviews
- [x] Manual: unknown name returns `(no utterances from <name>)` with exit 0

## Follow-ups (not in this PR)

- `i-2026-04-15-001` — `RequestRepository.listAll()` to fix voices TOCTOU
- `i-2026-04-15-002` — document/enforce `MemberName` normalization contract at the voices boundary

https://claude.ai/code/session_01G9UdoygPCyGa3oYchRYLXf