### PR TITLE
feat(gate): seven read-side improvements (tail/whoami/deltas/markers/listAll/mark-read/chain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,15 @@ disk and survives across sessions.
 >   させ、各ステップが `status_log[]` に actor + timestamp 付きで残る
 > - `gate review` で**別メンバー**として批判的レビューを記録する
 > - `gate issues` で後で対処すべき欠陥を追跡する
-> - `gate message` / `broadcast` / `inbox` でメンバー間の非同期通知
->   をやり取りする
+> - `gate message` / `broadcast` / `inbox` / `inbox mark-read` で
+>   メンバー間の非同期通知と受領記録をやり取りする
 > - 小さな自己完結タスクなら `gate fast-track` で create→complete
 >   を一発で通し、記録だけ残して規律を緩める
+> - **読みの道具一式**: `gate whoami` でセッション開始時に自分と
+>   直近の発話を取り戻し、`gate tail` で content_root 全体の最近を
+>   眺め、`gate voices <name>` で特定アクターの横断履歴を呼び戻し、
+>   `gate chain <id>` で cross-reference をたどり、
+>   `gate show <id> --format text` で時間差付きの単体詳細を読む
 >
 > すべてファイル操作のみ。同一 content_root に複数プロセスが触る場合、
 > 作成系は O_EXCL で race-safe ですが、それ以外は協調的直列化を前提に
@@ -86,6 +91,22 @@ disk and survives across sessions.
   The `--for` filter matches anything you touch (author, executor, or
   assigned reviewer); the plain `gate pending` shows *everyone's*
   queue, not just yours. Everything is queryable without a server.
+- **Re-enter the content_root fresh.** `gate whoami` (needs
+  `GUILD_ACTOR`) returns your identity and your five most recent
+  utterances. `gate tail` shows the newest N (default 20) entries
+  from every actor — the `git log` of the dialogue. Together they
+  are the "where was I?" pair you reach for at session start.
+- **Read what someone said across all their work.** `gate voices
+  <name> [--lense <l>] [--verdict <v>]` walks the full request
+  corpus and surfaces everything that person authored or reviewed,
+  chronologically. Use it before you retrospect, before you write
+  a review in a lens you haven't used recently, or just to recall
+  what you've been arguing about.
+- **Follow a cross-reference.** `gate chain <id>` starts at a
+  request or issue and shows the other records it mentions in its
+  action / reason / completion notes / review comments — promoted
+  issues, cited prior requests, audited findings. The tree walks
+  one hop; call `gate chain` on a link to go deeper.
 - **Skip the ceremony for small self-contained work.** `gate
   fast-track --from you --action "..." --reason "..."` runs create
   → approve → execute → complete in one call with self-approval
@@ -134,9 +155,15 @@ history for free.
 5. **When a review surfaces a new concern**, either open it as an
    issue (`gate issues add`) or promote it to a new request. That's
    the feedback loop closing.
-6. **Browse history.** `requests/completed/*.yaml` is a readable
-   transcript of how work actually got done, including who objected
-   and why. Use it to train, audit, or just remember.
+6. **Browse history.** The raw `requests/completed/*.yaml` files are
+   still the source of truth and greppable as plain YAML. But for
+   reading, the dedicated verbs are nicer: `gate tail` shows the
+   content_root's most recent activity in one stream, `gate voices
+   <name>` surfaces everything a single actor has said, `gate show
+   <id> --format text` renders one request with time deltas on each
+   status and review entry, and `gate chain <id>` walks the
+   cross-references outward. Use them to train, audit, or just
+   remember where you were.
 
 If you plan to build automation on top of this (e.g. a scheduler that
 watches `pending/` and dispatches to the right executor), treat the
@@ -160,6 +187,14 @@ Being honest about the 0.1.0 surface area so you can plan around it:
   race-safe (O_EXCL), but two processes calling `gate approve` on the
   same request in the same millisecond have last-writer-wins semantics.
   Serialize at the caller if you run multiple concurrent operators.
+  Cross-cutting reads (`gate voices` / `tail` / `whoami` / `chain`)
+  use `RequestRepository.listAll()` which reads every state directory
+  in parallel and dedupes by id; the dedup keeps whichever snapshot
+  has the longer `status_log` (status_log only grows) so a transition
+  mid-read yields the newer representation deterministically. The
+  window is smaller than the sequential loop it replaced but not
+  zero — a file that moves between directories *during* a single
+  `readdir` can still be missed or double-counted.
 - **Sequence ceiling is 999 per day.** Request IDs are `YYYY-MM-DD-NNN`.
   The 1000th request in a single UTC day throws.
 
@@ -271,6 +306,7 @@ gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]
                    [--format json|text]
 gate tail [N]                                        (default 20)
 gate whoami                                          (needs GUILD_ACTOR)
+gate chain <id>                                      (request or issue)
 gate approve <id>  --by <m> [--note <s>]
 gate deny    <id>  --by <m> <reason>
 gate execute <id>  --by <m> [--note <s>]
@@ -289,7 +325,8 @@ gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>]
 
 gate message   --from <m> --to <m> --text <s>
 gate broadcast --from <m> --text <s>
-gate inbox     --for <m>
+gate inbox     --for <m> [--unread]
+gate inbox mark-read [N] --for <m>
 ```
 
 ### Fast-track
@@ -540,6 +577,39 @@ baseline out rather than collide with the next column. Requests
 with no reviews (typically fast-tracked) show an empty marker
 column and are easy to spot by the blank.
 
+### Chain: cross-reference walks
+
+`gate chain <id>` starts at a request or issue and shows every
+other record it mentions in its free-text fields (`action`,
+`reason`, `completion_note`, `deny_reason`, `failure_reason`, and
+every review comment). The output is a one-hop tree so a reader
+can follow the narrative of related work without grepping YAML.
+
+```
+$ gate chain 2026-04-14-014
+2026-04-14-014  [completed]  from=kiri  Post-session audit: Feature A-L の実装...
+└── referenced issues
+    ├── i-2026-04-14-004  [low/core]  resolved  RequestUseCasesDeps.notifier ...
+    └── i-2026-04-14-008  [low/docs]  open  Feature D の rin review concern #3 ...
+```
+
+Both request ids (`YYYY-MM-DD-NNN`) and issue ids
+(`i-YYYY-MM-DD-NNN`) are followed, sorted by id under two branches.
+Ids that appear in text but don't resolve to a real record are
+shown as `(referenced but not found)` so prose mentions of
+deleted-or-future ids are surfaced rather than silently dropped.
+Self-references are ignored.
+
+**Scope is intentional.** `gate chain` walks exactly one hop. To
+go deeper, call `gate chain` on one of the surfaced ids — the CLI
+stays a single-step tool and the reader drives the depth. Also,
+the id scanner only follows **well-formed** ids: a Japanese range
+expression like `i-2026-04-14-004〜007` resolves only the first
+fully-spelled id; if you want all four chained, write them out in
+full in the note or review. This is a deliberate trade-off —
+range-parsing would grow the regex into something hard to audit
+for a tiny gain.
+
 ### Issue → Request promotion
 
 `gate issues promote` lifts an open issue into a new request and
@@ -562,12 +632,35 @@ be resolved manually.
 inbox file. `gate broadcast` fans out to every active member except
 the sender, returning a delivery report (partial failures are
 written to stderr with exit 1). `gate inbox --for <m>` reads the
-inbox file back.
+inbox file back; pass `--unread` to hide already-read messages.
 
-Each stored message carries a `read: false` field for a future
-mark-read verb, but there is no CLI action to flip it today; the
-`--unread` filter was withdrawn until mark-read exists (tracked in
-the dogfood session as `i-2026-04-14-005`).
+Each row in `gate inbox` output is labeled with `(unread)` or
+`(read <timestamp>)` so you can tell at a glance what's new.
+Messages are numbered 1-based against the unfiltered inbox, which
+stays stable even when `--unread` hides some rows — so an index
+shown in the display maps directly to a `mark-read` call.
+
+**Marking messages as read.** Reading is itself an act worth
+recording. `gate inbox mark-read` flips every unread message in the
+recipient's inbox to `read: true` and stamps a `read_at` timestamp
+for audit:
+
+```
+$ gate inbox --for kiri
+  1. [2026-04-15T02:10:00Z] message from noir (unread)
+  レビューありがとう
+  2. [2026-04-15T02:11:00Z] broadcast from alice (unread)
+  全員周知...
+
+$ gate inbox mark-read --for kiri
+✓ marked 2 as read for kiri (0 already read, 2 total)
+```
+
+Pass a positional `N` to mark just one (`gate inbox mark-read 2
+--for kiri`); mark-read is idempotent, so calling it twice simply
+reports `0 already read`. Both verbs respect `GUILD_ACTOR` in
+place of `--for`, so an interactive agent can just type `gate
+inbox mark-read`.
 
 Hosts (`host_names` in config) are valid senders but cannot receive
 messages — they have no inbox file. `gate inbox --for <host>` emits
@@ -679,7 +772,14 @@ validated at the boundary, state transitions enforced.
 npm test
 ```
 
-Runs domain-layer unit tests via `node:test`.
+Runs the full unit test suite via `node:test`. Coverage spans the
+domain layer (Request / Issue / Member / Review / Verdict / Lense
+value objects), the application layer (MessageUseCases including
+mark-read semantics), the interface layer (argument parsing with
+env-var fallback, voices collectors and renderers, gate chain
+reference extraction, formatDelta, review marker rendering), and
+the infrastructure layer (the cross-cutting `dedupeRequestsById`
+helper used by `listAll`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ gate pending [--for <m>] [--from <m>] [--executor <m>] [--auto-review <m>]
 gate list --state <s> [--for <m>] [--from <m>]
                       [--executor <m>] [--auto-review <m>]
 gate show <id> [--format json|text]
+gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]
+                   [--format json|text]
+gate tail [N]                                        (default 20)
+gate whoami                                          (needs GUILD_ACTOR)
 gate approve <id>  --by <m> [--note <s>]
 gate deny    <id>  --by <m> <reason>
 gate execute <id>  --by <m> [--note <s>]
@@ -431,6 +435,110 @@ text-mode output sorts naturally.
 Use cases at the layer-1 surface: reading your own review history
 before a retrospective, auditing "what did critic X flag across
 all of feature Z", grepping for verdicts without yaml plumbing.
+
+`--limit <N>` truncates the result after sorting (useful for
+"what did I say most recently").
+
+### Tail: unified recent activity stream
+
+`gate tail [N]` merges authored requests and reviews from every
+actor into a single timeline and prints the most recent N entries
+(default 20), newest first. Think of it as `git log` for the
+content_root's dialogue — the command you type first when you open
+an existing content_root.
+
+```
+$ gate tail 5
+5 most recent utterance(s)
+
+[2026-04-15T12:04:11.223Z] req=2026-04-15-007 [user/ok] by rin
+  re: README: document tail/whoami/...
+  second pass: concerns folded in cleanly, approving.
+
+[2026-04-15T12:03:27.089Z] req=2026-04-15-007 authored kiri
+  action: README: document tail/whoami/...
+  reason: new surface area needs to be findable...
+...
+```
+
+Each line is labeled with the actor (author for `authored`
+entries, reviewer for review entries) so a multi-actor stream
+stays legible. Filters are intentionally omitted — tail is for
+"everything recent", and once you want to slice, switch to
+`gate voices` or `gate list`.
+
+### Whoami: session-start orientation
+
+`gate whoami` (requires `GUILD_ACTOR` in the environment) resolves
+your identity, classifies you as member / host / unknown, and
+prints your 5 most recent utterances so you re-enter the
+content_root with your own voice already reloaded:
+
+```
+$ export GUILD_ACTOR=noir
+$ gate whoami
+you are noir (member)
+
+your most recent 5 utterance(s):
+
+[2026-04-14T23:46:38.259Z] req=2026-04-14-008 [user/ok]
+  re: README: document host listing and GUILD_ACTOR env var
+  second-pass review: concerns (1) and (2) addressed...
+...
+```
+
+`gate whoami` is meant as a session-start ritual: one command
+before you do anything else, and you remember where you were.
+Pair it with `gate tail` to see what happened while you were away.
+
+### Time deltas in `gate show --format text`
+
+The text view of a single request now shows the delta between
+successive `status_log` entries and between reviews, making the
+*pace* of the dialogue legible alongside the events:
+
+```
+$ gate show 2026-04-14-014 --format text
+...
+  status_log (4):
+    2026-04-14T14:18:11.761Z  pending    by kiri — created
+    2026-04-14T14:18:38.126Z  approved   by human (+26s) — audit は価値あり
+    2026-04-14T14:18:45.727Z  executing  by kiri (+7s)
+    2026-04-14T14:20:53.065Z  completed  by kiri (+2m) — audit 完了...
+
+  reviews (2):
+    [devil/concern] by noir at 2026-04-14T14:21:12.613Z (+19s)
+      ...
+    [layer/ok] by rin at 2026-04-14T14:21:57.535Z (+44s)
+      ...
+```
+
+Delta units scale with the gap: `+5s`, `+44s`, `+3m`, `+1h19m`,
+`+2d4h`. Review deltas are measured from the last `status_log`
+entry (typically completion) for the first review, and from the
+previous review for subsequent ones — so a quick correction reads
+as `(+10s)` and a day-later afterthought as `(+1d)`.
+
+### Review markers on `gate list` / `gate pending`
+
+Each row in `gate list` and `gate pending` carries a compact
+per-lens verdict summary so you can scan a whole list of completed
+work and pick out the requests that closed with an unresolved
+concern:
+
+```
+$ gate list --state completed
+2026-04-14-001  [completed]  from=kiri  !devil ✓layer      Feature A: ...
+2026-04-14-006  [completed]  from=kiri  ✓devil             Feature E: ...
+2026-04-14-014  [completed]  from=kiri  !devil ✓layer      Post-session audit: ...
+```
+
+Icons: `✓` ok · `!` concern · `x` reject · `?` unknown (defensive).
+The marker column is width-aligned per list so the action column
+stays flush across rows; long multi-review strings push the
+baseline out rather than collide with the next column. Requests
+with no reviews (typically fast-tracked) show an empty marker
+column and are easy to spot by the blank.
 
 ### Issue → Request promotion
 

--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -66,6 +66,15 @@ export class IssueUseCases {
     return this.issues.listByState(parseIssueState(state));
   }
 
+  /**
+   * Return every issue regardless of state. Delegates to the repo.
+   * Used by cross-cutting read commands (gate chain) that need the
+   * full corpus without lifecycle filtering.
+   */
+  async listAll(): Promise<Issue[]> {
+    return this.issues.listAll();
+  }
+
   async setState(id: string, state: string): Promise<Issue> {
     const issueId = IssueId.of(id);
     const issue = await this.issues.findById(issueId);

--- a/src/application/message/MessageUseCases.ts
+++ b/src/application/message/MessageUseCases.ts
@@ -3,6 +3,7 @@ import { DomainError } from '../../domain/shared/DomainError.js';
 import { MemberRepository } from '../ports/MemberRepository.js';
 import {
   InboxMessage,
+  MarkReadResult,
   NotificationPort,
 } from '../ports/NotificationPort.js';
 import { Clock } from '../ports/Clock.js';
@@ -103,18 +104,44 @@ export class MessageUseCases {
   async inbox(name: string): Promise<InboxMessage[]> {
     // Intentionally does NOT go through assertActor — reading an inbox
     // does not require the owner to be the current actor.
-    const member = await this.deps.members.findByName(MemberName.of(name));
-    if (!member) {
-      const hosts = await this.deps.members.listHostNames();
-      if (hosts.includes(name)) {
-        throw new DomainError(
-          `hosts do not have inboxes (${name} is a host; only registered members receive messages)`,
-          'for',
-        );
-      }
-      throw new DomainError(`not a registered member: ${name}`, 'for');
-    }
+    await this.assertInboxOwner(name);
     return this.deps.notifier.listFor(MemberName.of(name));
+  }
+
+  /**
+   * Mark messages in `name`'s inbox as read. When `index` is provided,
+   * only that 1-based message is flipped; otherwise every unread
+   * message is marked. Returns a report so the caller can say
+   * "marked N (K already read)".
+   *
+   * Reading is itself an act worth recording: mark-read is the
+   * trace that "I received this and acknowledged it". The --unread
+   * filter on `gate inbox` depends on this verb existing to be
+   * meaningful.
+   */
+  async markRead(
+    name: string,
+    index?: number,
+  ): Promise<MarkReadResult> {
+    await this.assertInboxOwner(name);
+    return this.deps.notifier.markRead(
+      MemberName.of(name),
+      this.deps.clock.now().toISOString(),
+      index,
+    );
+  }
+
+  private async assertInboxOwner(name: string): Promise<void> {
+    const member = await this.deps.members.findByName(MemberName.of(name));
+    if (member) return;
+    const hosts = await this.deps.members.listHostNames();
+    if (hosts.includes(name)) {
+      throw new DomainError(
+        `hosts do not have inboxes (${name} is a host; only registered members receive messages)`,
+        'for',
+      );
+    }
+    throw new DomainError(`not a registered member: ${name}`, 'for');
   }
 }
 

--- a/src/application/ports/IssueRepository.ts
+++ b/src/application/ports/IssueRepository.ts
@@ -3,6 +3,13 @@ import { Issue, IssueId, IssueState } from '../../domain/issue/Issue.js';
 export interface IssueRepository {
   findById(id: IssueId): Promise<Issue | null>;
   listByState(state: IssueState): Promise<Issue[]>;
+  /**
+   * List every issue regardless of state. Issues are stored in a
+   * single flat directory (unlike requests which are split by
+   * state), so this is a single scan — used by cross-cutting read
+   * commands (gate chain) that need the full corpus.
+   */
+  listAll(): Promise<Issue[]>;
   save(issue: Issue): Promise<void>;
   /**
    * Create a brand-new issue file. Must fail with `IssueIdCollision` if

--- a/src/application/ports/NotificationPort.ts
+++ b/src/application/ports/NotificationPort.ts
@@ -20,7 +20,20 @@ export interface InboxMessage {
   text: string;
   at: string;
   read: boolean;
+  /** ISO-8601 timestamp when mark-read was applied. Undefined until read. */
+  readAt?: string;
   related?: string;
+}
+
+/**
+ * Result of a mark-read operation: how many messages had their `read`
+ * field flipped to true. Messages already marked read are not counted
+ * (idempotent).
+ */
+export interface MarkReadResult {
+  marked: number;
+  alreadyRead: number;
+  total: number;
 }
 
 export interface NotificationPort {
@@ -28,4 +41,17 @@ export interface NotificationPort {
   post(notification: Notification): Promise<void>;
   /** Return all messages for `member` in insertion order. */
   listFor(member: MemberName): Promise<InboxMessage[]>;
+  /**
+   * Mark messages in `member`'s inbox as read. When `index` is given,
+   * only that 1-based message is marked; otherwise every unread
+   * message is marked. Already-read messages are left alone
+   * (idempotent) and counted separately.
+   *
+   * Throws `DomainError` if `index` is out of range.
+   */
+  markRead(
+    member: MemberName,
+    readAt: string,
+    index?: number,
+  ): Promise<MarkReadResult>;
 }

--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -5,6 +5,15 @@ import { RequestState } from '../../domain/request/RequestState.js';
 export interface RequestRepository {
   findById(id: RequestId): Promise<Request | null>;
   listByState(state: RequestState): Promise<Request[]>;
+  /**
+   * List every request in every state, deduplicated by id. Used by
+   * cross-cutting read commands (voices, tail, whoami, chain) that
+   * don't care about lifecycle state. Implementations should read
+   * all state directories in parallel and dedupe on id in case a
+   * concurrent transition caused the same file to appear under two
+   * state directories during the scan.
+   */
+  listAll(): Promise<Request[]>;
   /** Persist; positions file under current state directory. */
   save(request: Request): Promise<void>;
   /**

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -98,6 +98,15 @@ export class RequestUseCases {
     return this.deps.requests.listByState(state as RequestState);
   }
 
+  /**
+   * Return every request across all states, deduplicated by id.
+   * Delegates to the repository. Used by cross-cutting read commands
+   * (voices / tail / whoami / chain) that do not care about lifecycle.
+   */
+  async listAll(): Promise<Request[]> {
+    return this.deps.requests.listAll();
+  }
+
   async show(id: string): Promise<Request | null> {
     return this.deps.requests.findById(RequestId.of(id));
   }

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -1,11 +1,12 @@
 import YAML from 'yaml';
-import { join } from 'node:path';
 import {
   InboxMessage,
+  MarkReadResult,
   Notification,
   NotificationPort,
 } from '../../application/ports/NotificationPort.js';
 import { MemberName } from '../../domain/member/MemberName.js';
+import { DomainError } from '../../domain/shared/DomainError.js';
 import {
   existsSafe,
   readTextSafe,
@@ -59,6 +60,58 @@ export class FsInboxNotification implements NotificationPort {
     if (!parsed || !Array.isArray(parsed.messages)) return [];
     return parsed.messages.map((m) => normalizeMessage(m));
   }
+
+  async markRead(
+    member: MemberName,
+    readAt: string,
+    index?: number,
+  ): Promise<MarkReadResult> {
+    const rel = `${member.value}.yaml`;
+    if (!existsSafe(this.config.paths.inbox, rel)) {
+      return { marked: 0, alreadyRead: 0, total: 0 };
+    }
+    const parsed = YAML.parse(readTextSafe(this.config.paths.inbox, rel)) as
+      | InboxFile
+      | null;
+    const raw =
+      parsed && Array.isArray(parsed.messages) ? parsed.messages : [];
+    const total = raw.length;
+
+    // Validate index bounds before mutating anything so callers see
+    // a DomainError rather than a partially-applied write.
+    if (index !== undefined) {
+      if (!Number.isInteger(index) || index < 1 || index > total) {
+        throw new DomainError(
+          `inbox index out of range: ${index} (inbox has ${total} message(s))`,
+          'index',
+        );
+      }
+    }
+
+    let marked = 0;
+    let alreadyRead = 0;
+    for (let i = 0; i < raw.length; i++) {
+      if (index !== undefined && i + 1 !== index) continue;
+      const entry = raw[i];
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry['read'] === true) {
+        alreadyRead++;
+        continue;
+      }
+      entry['read'] = true;
+      // read_at lets future audits distinguish "read 10 seconds after
+      // receipt" from "read three days later". The post timestamp
+      // (at) is preserved untouched.
+      entry['read_at'] = readAt;
+      marked++;
+    }
+
+    if (marked > 0) {
+      const file: InboxFile = { messages: raw };
+      writeTextSafe(this.config.paths.inbox, rel, YAML.stringify(file));
+    }
+    return { marked, alreadyRead, total };
+  }
 }
 
 function normalizeMessage(raw: Record<string, unknown>): InboxMessage {
@@ -70,9 +123,7 @@ function normalizeMessage(raw: Record<string, unknown>): InboxMessage {
     at: String(raw['at'] ?? ''),
     read: raw['read'] === true,
   };
+  if (typeof raw['read_at'] === 'string') msg.readAt = raw['read_at'];
   if (typeof raw['related'] === 'string') msg.related = raw['related'];
   return msg;
 }
-
-// silence unused
-void join;

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -32,6 +32,11 @@ export class YamlIssueRepository implements IssueRepository {
   }
 
   async listByState(state: IssueState): Promise<Issue[]> {
+    const all = await this.listAll();
+    return all.filter((issue) => issue.state === state);
+  }
+
+  async listAll(): Promise<Issue[]> {
     const files = listDirSafe(this.config.paths.issues, '.')
       .filter((f) => FILE_PATTERN.test(f))
       .slice(0, 1000);
@@ -39,7 +44,7 @@ export class YamlIssueRepository implements IssueRepository {
     for (const f of files) {
       const raw = readTextSafe(this.config.paths.issues, f);
       const issue = hydrate(YAML.parse(raw));
-      if (issue && issue.state === state) out.push(issue);
+      if (issue) out.push(issue);
     }
     return out;
   }

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -54,6 +54,17 @@ export class YamlRequestRepository implements RequestRepository {
     return out;
   }
 
+  async listAll(): Promise<Request[]> {
+    // Read every state directory in parallel. This minimizes (but
+    // cannot eliminate) the TOCTOU window in which a concurrent
+    // transition could move a file between directories. Collisions
+    // are resolved by dedupeRequestsById — pure, unit-tested.
+    const perState = await Promise.all(
+      REQUEST_STATES.map((state) => this.listByState(state)),
+    );
+    return dedupeRequestsById(perState.flat());
+  }
+
   async saveNew(request: Request): Promise<void> {
     // Refuse to create a file that already exists under ANY state dir.
     for (const state of REQUEST_STATES) {
@@ -106,6 +117,45 @@ export class YamlRequestRepository implements RequestRepository {
     }
     return max + 1;
   }
+}
+
+/**
+ * Deduplicate a list of Requests by id, keeping the newest
+ * representation when the same id appears more than once (this can
+ * happen under concurrent state transitions where listAll's per-state
+ * reads race with a moving file).
+ *
+ * Tie-break order:
+ *   1. More status_log entries wins. status_log is append-only, so a
+ *      representation with more entries is strictly newer in time.
+ *   2. On equal log length, later position in REQUEST_STATES wins.
+ *      The ordering there (pending < approved < executing < completed
+ *      < failed < denied) doesn't encode a total temporal order —
+ *      failed/denied are divergent terminals — but for tiebreaker
+ *      purposes it gives a stable, deterministic result.
+ *
+ * Pure and synchronous so it can be unit-tested independently of the
+ * repository.
+ */
+export function dedupeRequestsById(
+  requests: ReadonlyArray<Request>,
+): Request[] {
+  const byId = new Map<string, Request>();
+  for (const r of requests) {
+    const existing = byId.get(r.id.value);
+    if (!existing) {
+      byId.set(r.id.value, r);
+      continue;
+    }
+    if (r.statusLog.length > existing.statusLog.length) {
+      byId.set(r.id.value, r);
+    } else if (r.statusLog.length === existing.statusLog.length) {
+      const newRank = REQUEST_STATES.indexOf(r.state);
+      const oldRank = REQUEST_STATES.indexOf(existing.state);
+      if (newRank > oldRank) byId.set(r.id.value, r);
+    }
+  }
+  return Array.from(byId.values());
 }
 
 function hydrate(data: unknown, stateHint?: RequestState): Request | null {

--- a/src/interface/gate/chain.ts
+++ b/src/interface/gate/chain.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure helpers for `gate chain <id>`. Separated from the CLI entry
+ * point so the reference-extraction logic is unit-testable without
+ * filesystem I/O.
+ *
+ * The "chain" is a one-hop neighborhood graph around a root record:
+ * given a request or issue id, find every other request or issue it
+ * mentions in its free-text fields (action, reason, closure notes,
+ * review comments, issue text). This lets a reader walk the narrative
+ * of how a piece of work relates to others — promoted issues, cited
+ * prior requests, cross-referenced audits — without grepping YAML.
+ *
+ * References are found by regex against the well-known id formats:
+ *   requests: YYYY-MM-DD-NNN        (e.g. 2026-04-14-014)
+ *   issues:   i-YYYY-MM-DD-NNN      (e.g. i-2026-04-14-003)
+ *
+ * Matching is lexical only — we do not chase ambiguous prose.
+ * A prose string that happens to look like an id will be followed;
+ * this is acceptable because YYYY-MM-DD-NNN is distinctive enough
+ * that false positives are rare.
+ */
+
+/**
+ * Match either form. We scan once with a combined regex and then
+ * disambiguate based on whether the match starts with "i-" so we
+ * don't double-count requests that happen to share a suffix with an
+ * issue id.
+ */
+const ID_PATTERN = /(?<!\w)(i-)?(\d{4}-\d{2}-\d{2}-\d{3})(?!\d)/g;
+
+export interface ExtractedReferences {
+  readonly requestIds: ReadonlyArray<string>;
+  readonly issueIds: ReadonlyArray<string>;
+}
+
+/**
+ * Scan a free-text string for request and issue ids. Returns the
+ * unique set of each, in first-seen order. Order is stable because
+ * duplicate renders are noisy to readers scanning the output.
+ */
+export function extractReferences(text: string): ExtractedReferences {
+  const requestIds = new Set<string>();
+  const issueIds = new Set<string>();
+  const requestOrder: string[] = [];
+  const issueOrder: string[] = [];
+
+  if (typeof text !== 'string' || text.length === 0) {
+    return { requestIds: [], issueIds: [] };
+  }
+
+  // Reset lastIndex on global regex between calls — otherwise the
+  // previous match position leaks across invocations when the same
+  // regex literal is reused.
+  ID_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ID_PATTERN.exec(text)) !== null) {
+    const hasIssuePrefix = match[1] === 'i-';
+    const core = match[2]!;
+    if (hasIssuePrefix) {
+      const id = `i-${core}`;
+      if (!issueIds.has(id)) {
+        issueIds.add(id);
+        issueOrder.push(id);
+      }
+    } else {
+      if (!requestIds.has(core)) {
+        requestIds.add(core);
+        requestOrder.push(core);
+      }
+    }
+  }
+  return { requestIds: requestOrder, issueIds: issueOrder };
+}
+
+/**
+ * Collect every piece of searchable free text belonging to a request,
+ * so extractReferences can see cross-references buried in reviews
+ * and closure notes as well as the action/reason headers.
+ */
+export function gatherRequestText(r: {
+  action: string;
+  reason: string;
+  completion_note?: string;
+  deny_reason?: string;
+  failure_reason?: string;
+  reviews?: ReadonlyArray<{ comment: string }>;
+}): string {
+  const parts: string[] = [r.action, r.reason];
+  if (r.completion_note) parts.push(r.completion_note);
+  if (r.deny_reason) parts.push(r.deny_reason);
+  if (r.failure_reason) parts.push(r.failure_reason);
+  if (r.reviews) {
+    for (const rv of r.reviews) parts.push(rv.comment);
+  }
+  return parts.join('\n');
+}
+
+export function gatherIssueText(i: { text: string }): string {
+  return i.text;
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -12,6 +12,8 @@ import { parseLense } from '../../domain/shared/Lense.js';
 import { parseVerdict } from '../../domain/shared/Verdict.js';
 import {
   collectUtterances,
+  formatDelta,
+  renderUtterance,
   RequestJSON,
   VoicesFilter,
 } from './voices.js';
@@ -25,7 +27,10 @@ Requests:
   gate list --state <state> [--for <m>] [--from <m>]
                             [--executor <m>] [--auto-review <m>]
   gate show <id> [--format json|text]
-  gate voices <name> [--lense <l>] [--verdict <v>] [--format json|text]
+  gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]
+                     [--format json|text]
+  gate tail [N]                                   (default 20)
+  gate whoami                                     (needs GUILD_ACTOR)
   gate approve <id> --by <m> [--note <s>]
   gate deny <id> --by <m> <reason>
   gate execute <id> --by <m> [--note <s>]
@@ -83,6 +88,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await reqShow(c, args);
       case 'voices':
         return await reqVoices(c, args);
+      case 'tail':
+        return await reqTail(c, args);
+      case 'whoami':
+        return await reqWhoami(c, args);
       case 'approve':
         return await reqApprove(c, args);
       case 'deny':
@@ -206,8 +215,34 @@ async function reqList(
     process.stdout.write(`(no requests in ${state}${suffix})\n`);
     return 0;
   }
-  for (const r of items) printSummary(r);
+  // Two-pass layout: compute the widest review-marker string across
+  // the visible rows first, then pad every row to that width. This
+  // keeps the action column aligned even when one row has more or
+  // longer marker strings than its neighbors. Pure per-row padding
+  // (what we did first) alignment-breaks when any single row blew
+  // past the baseline width.
+  const markerWidth = computeReviewMarkerWidth(items);
+  for (const r of items) printSummary(r, markerWidth);
   return 0;
+}
+
+// Compute the widest review-marker string across a list of requests,
+// returning at least the fallback minimum. Used to align the action
+// column in `gate list` / `gate pending` output.
+export function computeReviewMarkerWidth(
+  items: ReadonlyArray<Request>,
+  fallbackMin = 16,
+): number {
+  let max = fallbackMin;
+  for (const r of items) {
+    // formatReviewMarkers(minWidth=0) returns the natural string
+    // (no floor), so we can measure the un-padded length.
+    const natural = formatReviewMarkers(r.toJSON()['reviews'], 0);
+    if (natural.length > max) max = natural.length;
+  }
+  // Leave at least two trailing spaces between marker column and
+  // action column so nothing collides at the visual boundary.
+  return max + 2;
 }
 
 function describeFilters(filters: Record<string, string | undefined>): string {
@@ -260,30 +295,53 @@ function formatRequestText(r: Request): string {
     lines.push(`  failed:   ${j['failure_reason']}`);
   }
 
+  // Time deltas make the *pace* of the dialogue legible. A 45-second
+  // correction and a 25-minute pause look identical in raw ISO-8601;
+  // with deltas, the reader sees the difference at a glance between
+  // "critic responded immediately" and "author came back after a
+  // long think". The first status_log entry (pending/created) has no
+  // predecessor so gets no delta.
   const log = Array.isArray(j['status_log']) ? j['status_log'] : [];
   if (log.length > 0) {
     lines.push('');
     lines.push(`  status_log (${log.length}):`);
+    let prevAt: string | undefined;
     for (const entry of log as Array<Record<string, unknown>>) {
+      const at = String(entry['at']);
       const note = entry['note'] ? ` — ${entry['note']}` : '';
+      const delta = prevAt ? ` (${formatDelta(prevAt, at)})` : '';
       lines.push(
-        `    ${entry['at']}  ${entry['state']}  by ${entry['by']}${note}`,
+        `    ${at}  ${entry['state']}  by ${entry['by']}${delta}${note}`,
       );
+      prevAt = at;
     }
   }
 
+  // For reviews, the delta is measured from the final status_log
+  // entry (typically completed/failed/denied), which is "when the
+  // work finished" — so a delta of +10s means the critic jumped on
+  // it immediately, and +3d means the critic came back days later.
+  // Subsequent reviews show delta from the previous review.
   const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];
   if (reviews.length > 0) {
     lines.push('');
     lines.push(`  reviews (${reviews.length}):`);
+    const lastLogAt =
+      log.length > 0
+        ? String((log[log.length - 1] as Record<string, unknown>)['at'])
+        : undefined;
+    let prevAt = lastLogAt;
     for (const rv of reviews as Array<Record<string, unknown>>) {
+      const at = String(rv['at']);
+      const delta = prevAt ? ` (${formatDelta(prevAt, at)})` : '';
       lines.push(
-        `    [${rv['lense']}/${rv['verdict']}] by ${rv['by']} at ${rv['at']}`,
+        `    [${rv['lense']}/${rv['verdict']}] by ${rv['by']} at ${at}${delta}`,
       );
       const comment = String(rv['comment'] ?? '');
       for (const line of comment.split('\n')) {
         lines.push(`      ${line}`);
       }
+      prevAt = at;
     }
   }
   return lines.join('\n');
@@ -331,23 +389,13 @@ async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
     lenseFilterRaw !== undefined ? parseLense(lenseFilterRaw) : undefined;
   const verdictFilter =
     verdictFilterRaw !== undefined ? parseVerdict(verdictFilterRaw) : undefined;
+  const limit = parseOptionalIntOption(args, 'limit');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
   }
 
-  // O(N_states) repo reads. Acceptable for the sizes this tool targets
-  // (hundreds of requests per content_root). TOCTOU: a concurrent state
-  // transition between list calls can duplicate or drop a request —
-  // tracked as a follow-up issue since in-repo enumeration would need
-  // a new port method.
-  const allRequests: Request[] = [];
-  for (const s of REQUEST_STATES) {
-    allRequests.push(...(await c.requestUC.listByState(s)));
-  }
-  const allJson: RequestJSON[] = allRequests.map(
-    (r) => r.toJSON() as unknown as RequestJSON,
-  );
+  const allJson = await loadAllRequestsAsJson(c);
 
   const filter: VoicesFilter = { name };
   if (lenseFilter !== undefined) {
@@ -355,6 +403,9 @@ async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   }
   if (verdictFilter !== undefined) {
     (filter as { verdict?: string }).verdict = verdictFilter;
+  }
+  if (limit !== undefined) {
+    (filter as { limit?: number }).limit = limit;
   }
   const utterances = collectUtterances(allJson, filter);
 
@@ -366,6 +417,7 @@ async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   const filterDesc: string[] = [];
   if (lenseFilter !== undefined) filterDesc.push(`lense=${lenseFilter}`);
   if (verdictFilter !== undefined) filterDesc.push(`verdict=${verdictFilter}`);
+  if (limit !== undefined) filterDesc.push(`limit=${limit}`);
   const filterSuffix =
     filterDesc.length > 0 ? ` (${filterDesc.join(', ')})` : '';
 
@@ -381,32 +433,144 @@ async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
     `${utterances.length} ${header} from ${name}${filterSuffix}\n\n`,
   );
   for (const u of utterances) {
-    if (u.kind === 'authored') {
-      process.stdout.write(`[${u.at}] req=${u.requestId} authored\n`);
-      process.stdout.write(`  action: ${u.action}\n`);
-      process.stdout.write(`  reason: ${u.reason}\n`);
-      // Field labels match `gate show --format text` so the reader's
-      // eye learns one vocabulary. At most one of these is set per
-      // request (completed / denied / failed are mutually exclusive).
-      if (u.completionNote) {
-        process.stdout.write(`  note:   ${u.completionNote}\n`);
-      }
-      if (u.denyReason) {
-        process.stdout.write(`  denied: ${u.denyReason}\n`);
-      }
-      if (u.failureReason) {
-        process.stdout.write(`  failed: ${u.failureReason}\n`);
-      }
-    } else {
-      process.stdout.write(
-        `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]\n`,
+    // includeActor=false: voices is scoped to a single actor, so the
+    // actor name is in the header, not on every line.
+    process.stdout.write(renderUtterance(u, false) + '\n\n');
+  }
+  return 0;
+}
+
+// Shared loader for cross-cutting reads (voices, tail, whoami). Walks
+// all lifecycle states and returns the requests as structural JSON,
+// ready for collectUtterances. O(N_states) repo reads; see the TOCTOU
+// note on reqVoices for the concurrency caveat.
+async function loadAllRequestsAsJson(c: C): Promise<RequestJSON[]> {
+  const allRequests: Request[] = [];
+  for (const s of REQUEST_STATES) {
+    allRequests.push(...(await c.requestUC.listByState(s)));
+  }
+  return allRequests.map((r) => r.toJSON() as unknown as RequestJSON);
+}
+
+function parseOptionalIntOption(
+  args: ParsedArgs,
+  key: string,
+): number | undefined {
+  const raw = optionalOption(args, key);
+  if (raw === undefined) return undefined;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== raw) {
+    throw new Error(`--${key} must be a non-negative integer, got: ${raw}`);
+  }
+  return n;
+}
+
+// `gate tail [N]` — the unified recent-activity stream.
+//
+// Merges authored requests and reviews from every actor, sorts
+// descending by timestamp, and prints the most recent N (default 20).
+// This is the "git log" of the content_root dialogue — the first
+// command you want to type when you open a content_root fresh.
+async function reqTail(c: C, args: ParsedArgs): Promise<number> {
+  // N can come from a positional arg or from --limit. Positional is
+  // the friendlier interactive form; --limit exists for consistency
+  // with voices and for scripted use where positional can conflict.
+  let n: number | undefined;
+  const positional = args.positional[0];
+  if (positional !== undefined) {
+    const parsed = Number.parseInt(positional, 10);
+    if (!Number.isFinite(parsed) || parsed < 0 || String(parsed) !== positional) {
+      throw new Error(
+        `gate tail: N must be a non-negative integer, got: ${positional}`,
       );
-      process.stdout.write(`  re: ${u.action}\n`);
-      for (const line of u.comment.split('\n')) {
-        process.stdout.write(`  ${line}\n`);
-      }
     }
-    process.stdout.write('\n');
+    n = parsed;
+  } else {
+    n = parseOptionalIntOption(args, 'limit');
+  }
+  const limit = n ?? 20;
+
+  const allJson = await loadAllRequestsAsJson(c);
+  const utterances = collectUtterances(allJson, {
+    limit,
+    order: 'desc',
+  });
+
+  if (utterances.length === 0) {
+    process.stdout.write('(no utterances on this content_root yet)\n');
+    return 0;
+  }
+  // Preserve descending order in output so the newest entry is at the
+  // top — matches `git log` mental model. Reader can scroll down for
+  // older things.
+  process.stdout.write(
+    `${utterances.length} most recent utterance(s)\n\n`,
+  );
+  for (const u of utterances) {
+    // includeActor=true: tail spans every actor, so each line is
+    // labeled with who said it.
+    process.stdout.write(renderUtterance(u, true) + '\n\n');
+  }
+  return 0;
+}
+
+// `gate whoami` — session-start orientation.
+//
+// Resolves GUILD_ACTOR, classifies it (member / host / unknown), and
+// prints the actor's 5 most recent utterances so the reader re-enters
+// the content_root with their own recent voice loaded. Think of it as
+// the first command of a session: "who am I here, and where was I?"
+async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
+  const actor = process.env['GUILD_ACTOR'];
+  if (!actor || actor.length === 0) {
+    process.stderr.write(
+      'GUILD_ACTOR is not set.\n' +
+        'Export it in your shell to identify yourself:\n' +
+        '  export GUILD_ACTOR=<your-name>\n' +
+        'See `gate --help` > Environment for details.\n',
+    );
+    return 1;
+  }
+
+  // Classify: is this a known member, a configured host, or neither?
+  // Neither is fine for one-off actors but worth flagging — the
+  // session will still work, it just means this name won't appear
+  // in `guild list`.
+  const members = await c.memberUC.list();
+  const actorLower = actor.toLowerCase();
+  const isMember = members.some((m) => m.name.value === actorLower);
+  const isHost = c.config.hostNames.includes(actorLower);
+  const role = isMember
+    ? 'member'
+    : isHost
+      ? 'host'
+      : 'unknown (not in members/ or host_names)';
+
+  process.stdout.write(`you are ${actor} (${role})\n`);
+
+  // --limit lets tests and power users override the default 5.
+  const limit = parseOptionalIntOption(args, 'limit') ?? 5;
+
+  const allJson = await loadAllRequestsAsJson(c);
+  const utterances = collectUtterances(allJson, {
+    name: actor,
+    limit,
+    order: 'desc',
+  });
+
+  if (utterances.length === 0) {
+    process.stdout.write(
+      '\n(no utterances yet — try `gate fast-track --action "..." --reason "..."` ' +
+        'to file your first one)\n',
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `\nyour most recent ${utterances.length} utterance(s):\n\n`,
+  );
+  for (const u of utterances) {
+    process.stdout.write(renderUtterance(u, false) + '\n\n');
   }
   return 0;
 }
@@ -751,9 +915,44 @@ function resolveIssueVerb(sub: string | undefined): string | undefined {
   }
 }
 
-function printSummary(r: Request): void {
+function printSummary(r: Request, markerWidth = 16): void {
   const j = r.toJSON();
+  const markers = formatReviewMarkers(j['reviews'], markerWidth);
   process.stdout.write(
-    `${j['id']}  [${j['state']}]  from=${j['from']}  ${String(j['action']).slice(0, 60)}\n`,
+    `${j['id']}  [${j['state']}]  from=${j['from']}  ${markers}${String(j['action']).slice(0, 60)}\n`,
   );
+}
+
+// Render a compact per-lens verdict summary like "✓devil ✓layer" or
+// "!devil ✓layer" so the reader can tell at a glance whether a
+// completed request closed cleanly or carried a concern into its
+// reviews. The `width` parameter is the minimum padded width;
+// strings longer than `width` are returned unpadded (the caller is
+// responsible for computing a width that fits every row in the
+// output if cross-row alignment matters — see computeReviewMarkerWidth).
+//
+// Verdict icons:
+//   ✓  ok       (clean pass from this lens)
+//   !  concern  (reviewer wanted something fixed; may or may not have been)
+//   x  reject   (reviewer said no — rare, blocking)
+//
+// NOTE on widths: `joined.length` is UTF-16 code units, not visual
+// columns. The verdict icons and lens names are all in the BMP
+// (single code units) so this is accurate today. If a future lens
+// name uses astral characters, revisit — Array.from(joined).length
+// would give code points but still not visual width.
+export function formatReviewMarkers(reviews: unknown, width = 16): string {
+  if (!Array.isArray(reviews) || reviews.length === 0) {
+    return ''.padEnd(width);
+  }
+  const parts: string[] = [];
+  for (const rv of reviews as Array<Record<string, unknown>>) {
+    const verdict = String(rv['verdict'] ?? '');
+    const lense = String(rv['lense'] ?? '');
+    const icon =
+      verdict === 'ok' ? '✓' : verdict === 'concern' ? '!' : verdict === 'reject' ? 'x' : '?';
+    parts.push(`${icon}${lense}`);
+  }
+  const joined = parts.join(' ');
+  return joined.padEnd(width);
 }

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -7,7 +7,6 @@ import {
 } from '../shared/parseArgs.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { Request } from '../../domain/request/Request.js';
-import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { parseLense } from '../../domain/shared/Lense.js';
 import { parseVerdict } from '../../domain/shared/Verdict.js';
 import {
@@ -17,6 +16,11 @@ import {
   RequestJSON,
   VoicesFilter,
 } from './voices.js';
+import {
+  extractReferences,
+  gatherIssueText,
+  gatherRequestText,
+} from './chain.js';
 
 const HELP = `gate — request lifecycle & dialogue CLI
 
@@ -31,6 +35,7 @@ Requests:
                      [--format json|text]
   gate tail [N]                                   (default 20)
   gate whoami                                     (needs GUILD_ACTOR)
+  gate chain <id>                                 (request or issue)
   gate approve <id> --by <m> [--note <s>]
   gate deny <id> --by <m> <reason>
   gate execute <id> --by <m> [--note <s>]
@@ -51,7 +56,8 @@ Issues:
 Messages:
   gate message --from <m> --to <m> --text <s>
   gate broadcast --from <m> --text <s>
-  gate inbox --for <m>
+  gate inbox --for <m> [--unread]
+  gate inbox mark-read [N] [--for <m>]
 
 States: pending | approved | executing | completed | failed | denied
 Verdicts: ok | concern | reject
@@ -92,6 +98,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await reqTail(c, args);
       case 'whoami':
         return await reqWhoami(c, args);
+      case 'chain':
+        return await reqChain(c, args);
       case 'approve':
         return await reqApprove(c, args);
       case 'deny':
@@ -440,16 +448,15 @@ async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
-// Shared loader for cross-cutting reads (voices, tail, whoami). Walks
-// all lifecycle states and returns the requests as structural JSON,
-// ready for collectUtterances. O(N_states) repo reads; see the TOCTOU
-// note on reqVoices for the concurrency caveat.
+// Shared loader for cross-cutting reads (voices, tail, whoami, chain).
+// Delegates to RequestUseCases.listAll which reads every state
+// directory in parallel and dedupes on id in case a concurrent
+// transition has moved a file between directories during the scan.
+// Replaces the prior sequential N-state loop which had a larger
+// TOCTOU window (tracked in the dogfood session as i-2026-04-15-001).
 async function loadAllRequestsAsJson(c: C): Promise<RequestJSON[]> {
-  const allRequests: Request[] = [];
-  for (const s of REQUEST_STATES) {
-    allRequests.push(...(await c.requestUC.listByState(s)));
-  }
-  return allRequests.map((r) => r.toJSON() as unknown as RequestJSON);
+  const all = await c.requestUC.listAll();
+  return all.map((r) => r.toJSON() as unknown as RequestJSON);
 }
 
 function parseOptionalIntOption(
@@ -572,6 +579,171 @@ async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   for (const u of utterances) {
     process.stdout.write(renderUtterance(u, false) + '\n\n');
   }
+  return 0;
+}
+
+// `gate chain <id>` — one-hop cross-reference walk.
+//
+// Given a request or issue id, loads the root record and every other
+// record it mentions (by YYYY-MM-DD-NNN / i-YYYY-MM-DD-NNN pattern in
+// any free-text field: action, reason, closure notes, review
+// comments, issue text). Renders as a tree so a reader can walk the
+// narrative of how pieces of work relate to each other without
+// grepping yaml by hand.
+//
+// Scope: one hop. Deeper walks are achievable by calling `gate chain`
+// on one of the surfaced ids — the CLI stays a single-step tool, and
+// the reader drives the depth.
+async function reqChain(c: C, args: ParsedArgs): Promise<number> {
+  const rootId = args.positional[0];
+  if (!rootId) {
+    throw new Error('Usage: gate chain <request-id | issue-id>');
+  }
+  const isIssueId = /^i-\d{4}-\d{2}-\d{2}-\d{3}$/.test(rootId);
+  const isRequestId = /^\d{4}-\d{2}-\d{2}-\d{3}$/.test(rootId);
+  if (!isIssueId && !isRequestId) {
+    // DomainError keeps the error style consistent with parseLense /
+    // parseVerdict / parseRequestState, so the outer CLI catch prints
+    // a "DomainError: ..." prefix instead of a generic "error: ..."
+    // and the `field` label points the reader at the failing input.
+    throw new DomainError(
+      `id must match YYYY-MM-DD-NNN (request) or ` +
+        `i-YYYY-MM-DD-NNN (issue), got: ${rootId}`,
+      'id',
+    );
+  }
+
+  // Load all requests and all issues once up front so the index
+  // lookups below are O(1). For dogfood-scale this is <1ms.
+  const [allRequests, allIssues] = await Promise.all([
+    c.requestUC.listAll(),
+    c.issueUC.listAll(),
+  ]);
+  const requestById = new Map(allRequests.map((r) => [r.id.value, r]));
+  const issueById = new Map(allIssues.map((i) => [i.id.value, i]));
+
+  // Extract references from the root's free text. If the root is
+  // missing, we say so and bail — a typo should yield a clear error,
+  // not an empty tree.
+  let rootText: string;
+  let rootHeader: string;
+  if (isIssueId) {
+    const root = issueById.get(rootId);
+    if (!root) {
+      process.stderr.write(`not found: ${rootId}\n`);
+      return 1;
+    }
+    const j = root.toJSON();
+    rootText = gatherIssueText({ text: String(j['text'] ?? '') });
+    rootHeader =
+      `${rootId}  [${j['severity']}/${j['area']}]  ${j['state']}` +
+      `  ${truncateCodePoints(String(j['text'] ?? ''), 80)}`;
+  } else {
+    const root = requestById.get(rootId);
+    if (!root) {
+      process.stderr.write(`not found: ${rootId}\n`);
+      return 1;
+    }
+    const j = root.toJSON() as unknown as RequestJSON;
+    rootText = gatherRequestText({
+      action: j.action,
+      reason: j.reason,
+      ...(j.completion_note !== undefined
+        ? { completion_note: j.completion_note }
+        : {}),
+      ...(j.deny_reason !== undefined ? { deny_reason: j.deny_reason } : {}),
+      ...(j.failure_reason !== undefined
+        ? { failure_reason: j.failure_reason }
+        : {}),
+      ...(j.reviews !== undefined
+        ? { reviews: j.reviews.map((r) => ({ comment: r.comment })) }
+        : {}),
+    });
+    rootHeader =
+      `${rootId}  [${(root.toJSON() as Record<string, unknown>)['state']}]` +
+      `  from=${j.from}  ${truncateCodePoints(j.action, 80)}`;
+  }
+
+  const refs = extractReferences(rootText);
+
+  // Drop self-references so the root doesn't appear as its own child.
+  const linkedRequestIds = refs.requestIds.filter((id) => id !== rootId);
+  const linkedIssueIds = refs.issueIds.filter((id) => id !== rootId);
+
+  // Resolve ids → actual records (or mark as missing). Missing ids
+  // are real — a prose string can mention an id that was never
+  // created — so we surface them rather than silently dropping.
+  type Resolved<T> = { id: string; record: T | undefined };
+  const linkedRequests: Array<Resolved<ReturnType<typeof requestById.get>>> =
+    linkedRequestIds.map((id) => ({ id, record: requestById.get(id) }));
+  const linkedIssues: Array<Resolved<ReturnType<typeof issueById.get>>> =
+    linkedIssueIds.map((id) => ({ id, record: issueById.get(id) }));
+
+  // Output: tree with two branches (issues, requests), each branch
+  // sorted by id for stability. Empty branches are dropped entirely
+  // rather than shown as "(none)" — keeps the output scannable.
+  process.stdout.write(`${rootHeader}\n`);
+
+  const haveIssues = linkedIssues.length > 0;
+  const haveRequests = linkedRequests.length > 0;
+
+  if (!haveIssues && !haveRequests) {
+    process.stdout.write(
+      '└── (no cross-referenced records in action/reason/notes/reviews)\n',
+    );
+    return 0;
+  }
+
+  if (haveIssues) {
+    const isLastBranch = !haveRequests;
+    const branchGlyph = isLastBranch ? '└──' : '├──';
+    const childPrefix = isLastBranch ? '    ' : '│   ';
+    process.stdout.write(`${branchGlyph} referenced issues\n`);
+    const sorted = [...linkedIssues].sort((a, b) =>
+      a.id.localeCompare(b.id),
+    );
+    for (let i = 0; i < sorted.length; i++) {
+      const item = sorted[i]!;
+      const last = i === sorted.length - 1;
+      const glyph = last ? '└──' : '├──';
+      if (item.record) {
+        const ij = item.record.toJSON();
+        const summary =
+          `${item.id}  [${ij['severity']}/${ij['area']}]  ${ij['state']}` +
+          `  ${truncateCodePoints(String(ij['text'] ?? ''), 70)}`;
+        process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
+      } else {
+        process.stdout.write(
+          `${childPrefix}${glyph} ${item.id}  (referenced but not found)\n`,
+        );
+      }
+    }
+  }
+
+  if (haveRequests) {
+    process.stdout.write(`└── referenced requests\n`);
+    const childPrefix = '    ';
+    const sorted = [...linkedRequests].sort((a, b) =>
+      a.id.localeCompare(b.id),
+    );
+    for (let i = 0; i < sorted.length; i++) {
+      const item = sorted[i]!;
+      const last = i === sorted.length - 1;
+      const glyph = last ? '└──' : '├──';
+      if (item.record) {
+        const rj = item.record.toJSON();
+        const summary =
+          `${item.id}  [${rj['state']}]  from=${rj['from']}` +
+          `  ${truncateCodePoints(String(rj['action'] ?? ''), 70)}`;
+        process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
+      } else {
+        process.stdout.write(
+          `${childPrefix}${glyph} ${item.id}  (referenced but not found)\n`,
+        );
+      }
+    }
+  }
+
   return 0;
 }
 
@@ -885,18 +1057,86 @@ async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
 }
 
 async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
+  // `gate inbox mark-read [N]` is dispatched here too — the first
+  // positional is treated as a subverb. This keeps the verb family
+  // under a single `inbox` namespace instead of introducing a
+  // top-level `mark-read` command.
+  if (args.positional[0] === 'mark-read') {
+    return await msgInboxMarkRead(c, args);
+  }
+
   const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
+  const unreadOnly = args.options['unread'] === true;
   const messages = await c.messageUC.inbox(forName);
-  if (messages.length === 0) {
+  const filtered = unreadOnly
+    ? messages.filter((m) => !m.read)
+    : messages;
+
+  if (filtered.length === 0) {
+    const suffix = unreadOnly ? ' (unread only)' : '';
+    process.stdout.write(`(inbox empty for ${forName}${suffix})\n`);
+    return 0;
+  }
+  // Index is 1-based and counts every message in the inbox so the
+  // user can `gate inbox mark-read <index>` referring to numbers
+  // they see here. When --unread hides read messages the indices
+  // stay stable (we index against the unfiltered list).
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i]!;
+    if (unreadOnly && m.read) continue;
+    const idx = i + 1;
+    const related = m.related ? ` (ref: ${m.related})` : '';
+    const readTag = m.read
+      ? m.readAt
+        ? ` (read ${m.readAt})`
+        : ' (read)'
+      : ' (unread)';
+    process.stdout.write(
+      `  ${idx}. [${m.at}] ${m.type} from ${m.from}${related}${readTag}\n  ${m.text}\n`,
+    );
+  }
+  return 0;
+}
+
+async function msgInboxMarkRead(c: C, args: ParsedArgs): Promise<number> {
+  // Usage:
+  //   gate inbox mark-read [N] [--for <m>]
+  // When N is present, only that 1-based message is flipped. The
+  // --for flag falls back to GUILD_ACTOR so interactive users can
+  // type `GUILD_ACTOR=kiri gate inbox mark-read`.
+  const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
+  let index: number | undefined;
+  const positional = args.positional[1]; // [0] is 'mark-read'
+  if (positional !== undefined) {
+    const parsed = Number.parseInt(positional, 10);
+    if (
+      !Number.isFinite(parsed) ||
+      parsed < 1 ||
+      String(parsed) !== positional
+    ) {
+      throw new Error(
+        `gate inbox mark-read: N must be a positive integer, got: ${positional}`,
+      );
+    }
+    index = parsed;
+  }
+
+  const result = await c.messageUC.markRead(forName, index);
+  if (result.total === 0) {
     process.stdout.write(`(inbox empty for ${forName})\n`);
     return 0;
   }
-  for (const m of messages) {
-    const related = m.related ? ` (ref: ${m.related})` : '';
+  if (result.marked === 0) {
+    const scope = index !== undefined ? `#${index}` : 'all';
     process.stdout.write(
-      `  [${m.at}] ${m.type} from ${m.from}${related}\n  ${m.text}\n`,
+      `(nothing to mark for ${forName}: ${scope} already read)\n`,
     );
+    return 0;
   }
+  const scope = index !== undefined ? `#${index}` : `${result.marked}`;
+  process.stdout.write(
+    `✓ marked ${scope} as read for ${forName} (${result.alreadyRead} already read, ${result.total} total)\n`,
+  );
   return 0;
 }
 

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -40,6 +40,10 @@ export type AuthoredUtterance = {
   readonly kind: 'authored';
   readonly at: string;
   readonly requestId: string;
+  // Who authored the containing request. Useful when tail streams
+  // utterances from every actor and the reader needs to see who said
+  // what without looking up the id.
+  readonly from: string;
   readonly action: string;
   readonly reason: string;
   // Any closure text the lifecycle ended on. Only one of these is
@@ -54,6 +58,8 @@ export type ReviewUtterance = {
   readonly kind: 'review';
   readonly at: string;
   readonly requestId: string;
+  // Who wrote the review. Same rationale as AuthoredUtterance.from.
+  readonly by: string;
   // The action of the containing request, so the reader has context
   // for what the review was *about* without chasing the id.
   readonly action: string;
@@ -65,15 +71,25 @@ export type ReviewUtterance = {
 export type Utterance = AuthoredUtterance | ReviewUtterance;
 
 export interface VoicesFilter {
-  readonly name: string;
+  // When omitted, match every actor. Used by `gate tail` to stream
+  // the unified dialogue across the content_root.
+  readonly name?: string;
   readonly lense?: string;
   readonly verdict?: string;
+  // Limit the returned utterance count after sorting. Combined with
+  // `order: 'desc'` this gives "the most recent N utterances".
+  readonly limit?: number;
+  // Sort direction for timestamps. Default 'asc' (oldest first) to
+  // preserve the existing voices semantics; 'desc' is what tail wants.
+  readonly order?: 'asc' | 'desc';
 }
 
 /**
- * Collect every utterance by `filter.name` across the given requests,
- * sorted chronologically ascending.
+ * Collect every utterance matching `filter` across the given requests,
+ * sorted chronologically.
  *
+ * When `filter.name` is set, only that actor's utterances are
+ * returned; when omitted, every actor's utterances flow through.
  * When `lense` or `verdict` is set, only review utterances are
  * returned — authored requests don't carry those fields, so including
  * them in a lens-scoped query would be a category error.
@@ -85,17 +101,21 @@ export function collectUtterances(
   requests: ReadonlyArray<RequestJSON>,
   filter: VoicesFilter,
 ): Utterance[] {
-  const needle = filter.name.toLowerCase();
+  const needle = filter.name?.toLowerCase();
   const reviewOnly =
     filter.lense !== undefined || filter.verdict !== undefined;
   const out: Utterance[] = [];
 
   for (const r of requests) {
-    if (!reviewOnly && r.from.toLowerCase() === needle) {
+    if (
+      !reviewOnly &&
+      (needle === undefined || r.from.toLowerCase() === needle)
+    ) {
       const u: AuthoredUtterance = {
         kind: 'authored',
         at: r.created_at,
         requestId: r.id,
+        from: r.from,
         action: r.action,
         reason: r.reason,
       };
@@ -115,7 +135,7 @@ export function collectUtterances(
     }
     const reviews = r.reviews ?? [];
     for (const rv of reviews) {
-      if (rv.by.toLowerCase() !== needle) continue;
+      if (needle !== undefined && rv.by.toLowerCase() !== needle) continue;
       if (filter.lense !== undefined && rv.lense !== filter.lense) continue;
       if (filter.verdict !== undefined && rv.verdict !== filter.verdict) {
         continue;
@@ -125,6 +145,7 @@ export function collectUtterances(
         at: rv.at,
         requestId: r.id,
         action: r.action,
+        by: rv.by,
         lense: rv.lense,
         verdict: rv.verdict,
         comment: rv.comment,
@@ -132,6 +153,81 @@ export function collectUtterances(
     }
   }
 
-  out.sort((a, b) => a.at.localeCompare(b.at));
+  const direction = filter.order ?? 'asc';
+  out.sort((a, b) =>
+    direction === 'asc'
+      ? a.at.localeCompare(b.at)
+      : b.at.localeCompare(a.at),
+  );
+  if (filter.limit !== undefined && filter.limit >= 0) {
+    return out.slice(0, filter.limit);
+  }
   return out;
+}
+
+/**
+ * Render a chronological delta between two ISO-8601 timestamps in a
+ * compact human-readable form. Returns an empty string if the inputs
+ * are unparseable or if `curr` precedes `prev` (which shouldn't happen
+ * in well-ordered logs, but we're defensive at the boundary).
+ *
+ * Examples: "+6s", "+3m", "+1h19m", "+2d4h".
+ *
+ * Exported for unit tests and for reuse in gate show / tail renderers.
+ */
+export function formatDelta(prevIso: string, currIso: string): string {
+  const prev = Date.parse(prevIso);
+  const curr = Date.parse(currIso);
+  if (Number.isNaN(prev) || Number.isNaN(curr)) return '';
+  const deltaMs = curr - prev;
+  if (deltaMs < 0) return '';
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `+${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `+${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const remMin = minutes % 60;
+    return remMin === 0 ? `+${hours}h` : `+${hours}h${remMin}m`;
+  }
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours === 0 ? `+${days}d` : `+${days}d${remHours}h`;
+}
+
+/**
+ * Render a single utterance as multi-line text, matching the
+ * vocabulary of `gate show --format text`. Shared between voices,
+ * tail, and whoami so the reader's eye learns one shape.
+ *
+ * The `includeActor` flag controls whether the first line labels
+ * the actor explicitly — voices already groups by actor so it's
+ * redundant there, but tail and whoami span actors.
+ */
+export function renderUtterance(
+  u: Utterance,
+  includeActor: boolean,
+): string {
+  const lines: string[] = [];
+  if (u.kind === 'authored') {
+    const actor = includeActor ? ` ${u.from}` : '';
+    lines.push(`[${u.at}] req=${u.requestId} authored${actor}`);
+    lines.push(`  action: ${u.action}`);
+    lines.push(`  reason: ${u.reason}`);
+    // At most one of these is set per request (completed / denied /
+    // failed are mutually exclusive terminal states).
+    if (u.completionNote) lines.push(`  note:   ${u.completionNote}`);
+    if (u.denyReason) lines.push(`  denied: ${u.denyReason}`);
+    if (u.failureReason) lines.push(`  failed: ${u.failureReason}`);
+  } else {
+    const actor = includeActor ? ` by ${u.by}` : '';
+    lines.push(
+      `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]${actor}`,
+    );
+    lines.push(`  re: ${u.action}`);
+    for (const line of u.comment.split('\n')) {
+      lines.push(`  ${line}`);
+    }
+  }
+  return lines.join('\n');
 }

--- a/tests/application/MessageUseCases.test.ts
+++ b/tests/application/MessageUseCases.test.ts
@@ -7,6 +7,7 @@ import { DomainError } from '../../src/domain/shared/DomainError.js';
 import { MemberRepository } from '../../src/application/ports/MemberRepository.js';
 import {
   InboxMessage,
+  MarkReadResult,
   Notification,
   NotificationPort,
 } from '../../src/application/ports/NotificationPort.js';
@@ -42,24 +43,73 @@ class FakeMemberRepo implements MemberRepository {
 
 class FakeNotifier implements NotificationPort {
   posted: Notification[] = [];
+  // `readMarks[i]` tracks whether posted[i] has been flipped to read.
+  readMarks: boolean[] = [];
+  readAtStamps: (string | undefined)[] = [];
   failFor: Set<string> = new Set();
   async post(n: Notification): Promise<void> {
     if (this.failFor.has(n.to.value)) {
       throw new Error(`simulated failure for ${n.to.value}`);
     }
     this.posted.push(n);
+    this.readMarks.push(false);
+    this.readAtStamps.push(undefined);
   }
   async listFor(member: MemberName): Promise<InboxMessage[]> {
-    return this.posted
-      .filter((n) => n.to.value === member.value)
-      .map((n) => ({
+    const out: InboxMessage[] = [];
+    for (let i = 0; i < this.posted.length; i++) {
+      const n = this.posted[i]!;
+      if (n.to.value !== member.value) continue;
+      const msg: InboxMessage = {
         from: n.from,
         to: n.to.value,
         type: n.type,
         text: n.text,
         at: n.at ?? '',
-        read: false,
-      }));
+        read: this.readMarks[i] === true,
+      };
+      const readAt = this.readAtStamps[i];
+      if (readAt !== undefined) msg.readAt = readAt;
+      out.push(msg);
+    }
+    return out;
+  }
+  async markRead(
+    member: MemberName,
+    readAt: string,
+    index?: number,
+  ): Promise<MarkReadResult> {
+    // Map the recipient's 1-based index into the underlying flat
+    // posted[] array. Only messages addressed to `member` are counted.
+    const recipientIndices: number[] = [];
+    for (let i = 0; i < this.posted.length; i++) {
+      if (this.posted[i]!.to.value === member.value) {
+        recipientIndices.push(i);
+      }
+    }
+    const total = recipientIndices.length;
+    if (index !== undefined) {
+      if (!Number.isInteger(index) || index < 1 || index > total) {
+        throw new DomainError(
+          `inbox index out of range: ${index} (inbox has ${total} message(s))`,
+          'index',
+        );
+      }
+    }
+    let marked = 0;
+    let alreadyRead = 0;
+    for (let k = 0; k < recipientIndices.length; k++) {
+      if (index !== undefined && k + 1 !== index) continue;
+      const i = recipientIndices[k]!;
+      if (this.readMarks[i] === true) {
+        alreadyRead++;
+        continue;
+      }
+      this.readMarks[i] = true;
+      this.readAtStamps[i] = readAt;
+      marked++;
+    }
+    return { marked, alreadyRead, total };
   }
 }
 
@@ -184,6 +234,97 @@ test('inbox for unknown-and-not-host gives plain error', async () => {
     (e: unknown) => {
       assert.ok(e instanceof DomainError);
       assert.match(e.message, /not a registered member/);
+      return true;
+    },
+  );
+});
+
+test('markRead flips all unread messages when no index', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.add('noir');
+  await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
+  await uc.send({ from: 'kiri', to: 'noir', text: 'two' });
+  await uc.send({ from: 'kiri', to: 'noir', text: 'three' });
+
+  const result = await uc.markRead('noir');
+  assert.equal(result.marked, 3);
+  assert.equal(result.alreadyRead, 0);
+  assert.equal(result.total, 3);
+
+  const msgs = await uc.inbox('noir');
+  assert.ok(msgs.every((m) => m.read === true));
+});
+
+test('markRead is idempotent: second call marks nothing, reports alreadyRead', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.add('noir');
+  await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
+  await uc.send({ from: 'kiri', to: 'noir', text: 'two' });
+
+  await uc.markRead('noir');
+  const result = await uc.markRead('noir');
+  assert.equal(result.marked, 0);
+  assert.equal(result.alreadyRead, 2);
+  assert.equal(result.total, 2);
+});
+
+test('markRead with index marks just that message (1-based)', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.add('noir');
+  await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
+  await uc.send({ from: 'kiri', to: 'noir', text: 'two' });
+  await uc.send({ from: 'kiri', to: 'noir', text: 'three' });
+
+  const result = await uc.markRead('noir', 2);
+  assert.equal(result.marked, 1);
+  assert.equal(result.alreadyRead, 0);
+  assert.equal(result.total, 3);
+
+  const msgs = await uc.inbox('noir');
+  assert.equal(msgs[0]!.read, false);
+  assert.equal(msgs[1]!.read, true);
+  assert.equal(msgs[2]!.read, false);
+});
+
+test('markRead with out-of-range index throws DomainError', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.add('noir');
+  await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
+
+  await assert.rejects(
+    () => uc.markRead('noir', 5),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /out of range/);
+      return true;
+    },
+  );
+});
+
+test('markRead for empty inbox returns zeros without error', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.add('noir');
+  // noir exists but has no messages
+  const result = await uc.markRead('noir');
+  assert.equal(result.marked, 0);
+  assert.equal(result.alreadyRead, 0);
+  assert.equal(result.total, 0);
+});
+
+test('markRead for host name raises the inbox-owner error', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  members.setHosts(['human']);
+  await assert.rejects(
+    () => uc.markRead('human'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /hosts do not have inboxes/);
       return true;
     },
   );

--- a/tests/infrastructure/dedupeRequestsById.test.ts
+++ b/tests/infrastructure/dedupeRequestsById.test.ts
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dedupeRequestsById } from '../../src/infrastructure/persistence/YamlRequestRepository.js';
+import { Request } from '../../src/domain/request/Request.js';
+import { RequestId } from '../../src/domain/request/RequestId.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+
+/**
+ * Build a synthetic Request via Request.restore with an explicit
+ * status_log so the dedup tie-break logic can be tested without
+ * going through the full lifecycle. The restore path is the same
+ * one used when hydrating YAML, so the Request instances are
+ * identical to what the repo would produce from disk.
+ */
+function make(
+  id: string,
+  state: 'pending' | 'approved' | 'executing' | 'completed' | 'failed' | 'denied',
+  logLength: number,
+): Request {
+  const statusLog = [];
+  for (let i = 0; i < logLength; i++) {
+    statusLog.push({
+      state,
+      by: 'kiri',
+      at: `2026-04-15T00:00:${String(i).padStart(2, '0')}.000Z`,
+    });
+  }
+  return Request.restore({
+    id: RequestId.of(id),
+    from: MemberName.of('kiri'),
+    action: 'test',
+    reason: 'test',
+    state,
+    createdAt: '2026-04-15T00:00:00.000Z',
+    reviews: [],
+    statusLog,
+  });
+}
+
+test('dedupeRequestsById: empty input', () => {
+  assert.deepEqual(dedupeRequestsById([]), []);
+});
+
+test('dedupeRequestsById: unique ids pass through unchanged', () => {
+  const a = make('2026-04-15-001', 'pending', 1);
+  const b = make('2026-04-15-002', 'completed', 4);
+  const result = dedupeRequestsById([a, b]);
+  assert.equal(result.length, 2);
+});
+
+test('dedupeRequestsById: more status_log entries wins tie', () => {
+  // Same id appearing under two state directories — pick the one
+  // with more status_log entries (strictly newer).
+  const stale = make('2026-04-15-001', 'pending', 1);
+  const fresh = make('2026-04-15-001', 'approved', 2);
+  const result = dedupeRequestsById([stale, fresh]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.state, 'approved');
+  assert.equal(result[0]?.statusLog.length, 2);
+});
+
+test('dedupeRequestsById: order of input does not matter for tie-break', () => {
+  const stale = make('2026-04-15-001', 'pending', 1);
+  const fresh = make('2026-04-15-001', 'completed', 4);
+  const a = dedupeRequestsById([stale, fresh]);
+  const b = dedupeRequestsById([fresh, stale]);
+  assert.equal(a[0]?.state, 'completed');
+  assert.equal(b[0]?.state, 'completed');
+});
+
+test('dedupeRequestsById: on equal log length, later REQUEST_STATES wins', () => {
+  // Both representations have 1 status_log entry (shouldn't really
+  // happen in practice since status_log grows, but defensive).
+  // pending < approved in REQUEST_STATES, so approved wins.
+  const a = make('2026-04-15-001', 'pending', 1);
+  const b = make('2026-04-15-001', 'approved', 1);
+  const result = dedupeRequestsById([a, b]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.state, 'approved');
+});
+
+test('dedupeRequestsById: preserves unique entries alongside duplicates', () => {
+  const a1 = make('2026-04-15-001', 'pending', 1);
+  const a2 = make('2026-04-15-001', 'approved', 2);
+  const b = make('2026-04-15-002', 'completed', 4);
+  const result = dedupeRequestsById([a1, b, a2]);
+  assert.equal(result.length, 2);
+  const ids = result.map((r) => r.id.value).sort();
+  assert.deepEqual(ids, ['2026-04-15-001', '2026-04-15-002']);
+  const a = result.find((r) => r.id.value === '2026-04-15-001');
+  assert.equal(a?.state, 'approved');
+});
+
+test('dedupeRequestsById: three-way collision picks the longest log', () => {
+  const a1 = make('2026-04-15-001', 'pending', 1);
+  const a2 = make('2026-04-15-001', 'approved', 2);
+  const a3 = make('2026-04-15-001', 'completed', 4);
+  const result = dedupeRequestsById([a1, a2, a3]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.state, 'completed');
+  assert.equal(result[0]?.statusLog.length, 4);
+});
+
+test('dedupeRequestsById: divergent terminal states (failed/denied) are dedupe-stable', () => {
+  // If two reads see completed (4 entries) and failed (4 entries)
+  // for the same id, that's logically impossible in practice, but
+  // the dedup should still return one — whichever one REQUEST_STATES
+  // ranks later. The actual semantics of which terminal is "right"
+  // is a domain question we can't answer here; what matters is that
+  // dedupeRequestsById is deterministic.
+  const done = make('2026-04-15-001', 'completed', 4);
+  const fail = make('2026-04-15-001', 'failed', 4);
+  const a = dedupeRequestsById([done, fail]);
+  const b = dedupeRequestsById([fail, done]);
+  // Both orderings must agree.
+  assert.equal(a.length, 1);
+  assert.equal(b.length, 1);
+  assert.equal(a[0]?.state, b[0]?.state);
+});

--- a/tests/interface/chain.test.ts
+++ b/tests/interface/chain.test.ts
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractReferences,
+  gatherRequestText,
+  gatherIssueText,
+} from '../../src/interface/gate/chain.js';
+
+test('extractReferences: empty string returns empty sets', () => {
+  const r = extractReferences('');
+  assert.deepEqual(r.requestIds, []);
+  assert.deepEqual(r.issueIds, []);
+});
+
+test('extractReferences: returns empty on non-string input', () => {
+  const r = extractReferences(undefined as unknown as string);
+  assert.deepEqual(r.requestIds, []);
+  assert.deepEqual(r.issueIds, []);
+});
+
+test('extractReferences: finds a lone request id', () => {
+  const r = extractReferences('see 2026-04-14-003 for details');
+  assert.deepEqual(r.requestIds, ['2026-04-14-003']);
+  assert.deepEqual(r.issueIds, []);
+});
+
+test('extractReferences: finds a lone issue id', () => {
+  const r = extractReferences('filed as i-2026-04-14-002');
+  assert.deepEqual(r.requestIds, []);
+  assert.deepEqual(r.issueIds, ['i-2026-04-14-002']);
+});
+
+test('extractReferences: distinguishes request and issue with same digits', () => {
+  // `i-2026-04-14-003` should NOT also match as request `2026-04-14-003`
+  const r = extractReferences('mentions i-2026-04-14-003 and 2026-04-14-003');
+  assert.deepEqual(r.issueIds, ['i-2026-04-14-003']);
+  assert.deepEqual(r.requestIds, ['2026-04-14-003']);
+});
+
+test('extractReferences: deduplicates repeated references (first-seen order)', () => {
+  const r = extractReferences(
+    'first: 2026-04-14-001, then 2026-04-14-002, then 2026-04-14-001 again',
+  );
+  assert.deepEqual(r.requestIds, ['2026-04-14-001', '2026-04-14-002']);
+});
+
+test('extractReferences: preserves first-seen order across types', () => {
+  const r = extractReferences(
+    'opened i-2026-04-14-005, promoted to 2026-04-14-007, note in i-2026-04-14-008',
+  );
+  assert.deepEqual(r.issueIds, [
+    'i-2026-04-14-005',
+    'i-2026-04-14-008',
+  ]);
+  assert.deepEqual(r.requestIds, ['2026-04-14-007']);
+});
+
+test('extractReferences: multiple references in one paragraph', () => {
+  const text = `
+    audit scope: 2026-04-14-001 through 2026-04-14-013
+    findings: i-2026-04-14-004, i-2026-04-14-005, i-2026-04-14-006
+  `;
+  const r = extractReferences(text);
+  assert.ok(r.requestIds.includes('2026-04-14-001'));
+  assert.ok(r.requestIds.includes('2026-04-14-013'));
+  assert.equal(r.issueIds.length, 3);
+});
+
+test('extractReferences: not confused by adjacent digits', () => {
+  // A 4-digit year followed by another digit should not match.
+  // (Our pattern is YYYY-MM-DD-NNN, so nothing should fire on a bare
+  // date like "2026-04-14" without the sequence suffix.)
+  const r = extractReferences('dated 2026-04-14 and logged');
+  assert.deepEqual(r.requestIds, []);
+  assert.deepEqual(r.issueIds, []);
+});
+
+test('extractReferences: rejects longer digit strings at end', () => {
+  // If the sequence is 4 digits instead of 3, it should not match.
+  const r = extractReferences('bogus 2026-04-14-0001');
+  assert.deepEqual(r.requestIds, []);
+});
+
+test('extractReferences: does not match ids embedded in word characters', () => {
+  // "pre2026-04-14-001" should not match — the (?<!\w) at the start
+  // refuses the match when a word character precedes.
+  const r = extractReferences('pre2026-04-14-001 and normal 2026-04-14-002');
+  assert.deepEqual(r.requestIds, ['2026-04-14-002']);
+});
+
+test('extractReferences: stable regex state across repeated calls', () => {
+  // The global-flagged regex must reset its lastIndex between calls.
+  // Calling twice with different inputs should give independent results.
+  const a = extractReferences('2026-04-14-001');
+  const b = extractReferences('2026-04-14-002');
+  assert.deepEqual(a.requestIds, ['2026-04-14-001']);
+  assert.deepEqual(b.requestIds, ['2026-04-14-002']);
+});
+
+test('gatherRequestText: concatenates all the narrative fields', () => {
+  const text = gatherRequestText({
+    action: 'Action',
+    reason: 'Reason',
+    completion_note: 'Note',
+    deny_reason: 'Deny',
+    failure_reason: 'Fail',
+    reviews: [
+      { comment: 'review one' },
+      { comment: 'review two' },
+    ],
+  });
+  for (const part of ['Action', 'Reason', 'Note', 'Deny', 'Fail', 'review one', 'review two']) {
+    assert.ok(text.includes(part), `missing ${part}`);
+  }
+});
+
+test('gatherRequestText: omits undefined optional fields cleanly', () => {
+  const text = gatherRequestText({
+    action: 'A',
+    reason: 'B',
+  });
+  assert.equal(text, 'A\nB');
+});
+
+test('gatherIssueText: just returns the text field', () => {
+  assert.equal(gatherIssueText({ text: 'issue body' }), 'issue body');
+});
+
+test('extractReferences: end-to-end via gatherRequestText', () => {
+  // Simulates the real audit case: ids appear in completion notes
+  // and review comments, not in the action/reason.
+  const text = gatherRequestText({
+    action: 'Post-session audit',
+    reason: 'review changes',
+    completion_note: 'filed i-2026-04-14-004 and i-2026-04-14-005',
+    reviews: [
+      { comment: 'elevated to 2026-04-14-008; also see i-2026-04-14-006' },
+    ],
+  });
+  const refs = extractReferences(text);
+  assert.deepEqual(refs.requestIds, ['2026-04-14-008']);
+  assert.deepEqual(refs.issueIds, [
+    'i-2026-04-14-004',
+    'i-2026-04-14-005',
+    'i-2026-04-14-006',
+  ]);
+});

--- a/tests/interface/formatDelta.test.ts
+++ b/tests/interface/formatDelta.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDelta } from '../../src/interface/gate/voices.js';
+
+test('formatDelta: sub-minute deltas in seconds', () => {
+  assert.equal(
+    formatDelta('2026-04-14T10:59:05.842Z', '2026-04-14T10:59:11.559Z'),
+    '+5s',
+  );
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-14T10:00:45.000Z'),
+    '+45s',
+  );
+});
+
+test('formatDelta: sub-hour deltas in minutes', () => {
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-14T10:03:30.000Z'),
+    '+3m',
+  );
+  assert.equal(
+    formatDelta('2026-04-14T14:21:12.613Z', '2026-04-14T14:21:57.535Z'),
+    '+44s',
+  );
+});
+
+test('formatDelta: sub-day deltas in hours + minutes', () => {
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-14T11:19:00.000Z'),
+    '+1h19m',
+  );
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-14T13:00:00.000Z'),
+    '+3h',
+  );
+});
+
+test('formatDelta: multi-day deltas in days + hours', () => {
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-16T14:30:00.000Z'),
+    '+2d4h',
+  );
+  assert.equal(
+    formatDelta('2026-04-14T10:00:00.000Z', '2026-04-17T10:00:00.000Z'),
+    '+3d',
+  );
+});
+
+test('formatDelta: same timestamp yields +0s', () => {
+  const ts = '2026-04-14T10:00:00.000Z';
+  assert.equal(formatDelta(ts, ts), '+0s');
+});
+
+test('formatDelta: negative delta returns empty string (boundary defense)', () => {
+  assert.equal(
+    formatDelta('2026-04-14T11:00:00.000Z', '2026-04-14T10:00:00.000Z'),
+    '',
+  );
+});
+
+test('formatDelta: unparseable input returns empty string', () => {
+  assert.equal(formatDelta('not-a-date', '2026-04-14T10:00:00.000Z'), '');
+  assert.equal(formatDelta('2026-04-14T10:00:00.000Z', 'garbage'), '');
+  assert.equal(formatDelta('', ''), '');
+});

--- a/tests/interface/reviewMarkers.test.ts
+++ b/tests/interface/reviewMarkers.test.ts
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatReviewMarkers } from '../../src/interface/gate/index.js';
+
+const WIDTH = 16;
+
+test('formatReviewMarkers: empty reviews yields padded empty string', () => {
+  const result = formatReviewMarkers([]);
+  assert.equal(result.length, WIDTH);
+  assert.equal(result.trim(), '');
+});
+
+test('formatReviewMarkers: undefined yields padded empty string', () => {
+  const result = formatReviewMarkers(undefined);
+  assert.equal(result.length, WIDTH);
+});
+
+test('formatReviewMarkers: non-array yields padded empty string', () => {
+  const result = formatReviewMarkers('not an array');
+  assert.equal(result.length, WIDTH);
+});
+
+test('formatReviewMarkers: single ok review renders as ✓<lens>', () => {
+  const result = formatReviewMarkers([
+    { lense: 'devil', verdict: 'ok' },
+  ]);
+  assert.ok(result.startsWith('✓devil'));
+});
+
+test('formatReviewMarkers: single concern review renders as !<lens>', () => {
+  const result = formatReviewMarkers([
+    { lense: 'devil', verdict: 'concern' },
+  ]);
+  assert.ok(result.startsWith('!devil'));
+});
+
+test('formatReviewMarkers: reject renders as x<lens>', () => {
+  const result = formatReviewMarkers([
+    { lense: 'devil', verdict: 'reject' },
+  ]);
+  assert.ok(result.startsWith('xdevil'));
+});
+
+test('formatReviewMarkers: unknown verdict renders as ?<lens> (defensive)', () => {
+  const result = formatReviewMarkers([
+    { lense: 'devil', verdict: 'weird' },
+  ]);
+  assert.ok(result.startsWith('?devil'));
+});
+
+test('formatReviewMarkers: multi-review output is space-separated', () => {
+  const result = formatReviewMarkers([
+    { lense: 'devil', verdict: 'concern' },
+    { lense: 'layer', verdict: 'ok' },
+  ]);
+  assert.ok(result.startsWith('!devil ✓layer'));
+});
+
+test('formatReviewMarkers: long marker strings are not truncated', () => {
+  // Three long-lens reviews exceed the 16-char padding width;
+  // the function should not clip — padding is a floor, not a cap.
+  const result = formatReviewMarkers([
+    { lense: 'cognitive', verdict: 'concern' },
+    { lense: 'cognitive', verdict: 'ok' },
+    { lense: 'cognitive', verdict: 'ok' },
+  ]);
+  // "!cognitive ✓cognitive ✓cognitive" — 32 visible chars
+  assert.ok(result.length >= 30);
+  assert.ok(result.includes('!cognitive'));
+  assert.ok(result.includes('✓cognitive'));
+});
+
+test('formatReviewMarkers: minimum width alignment across empty and non-empty', () => {
+  const empty = formatReviewMarkers([]);
+  const single = formatReviewMarkers([{ lense: 'devil', verdict: 'ok' }]);
+  // Both should be at least WIDTH characters so list rows align.
+  assert.ok(empty.length >= WIDTH);
+  assert.ok(single.length >= WIDTH);
+});

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   collectUtterances,
+  renderUtterance,
   RequestJSON,
 } from '../../src/interface/gate/voices.js';
 
@@ -205,4 +206,84 @@ test('collectUtterances: missing reviews field (undefined) is handled gracefully
   ];
   const result = collectUtterances(noReviews, { name: 'kiri' });
   assert.equal(result.length, 1);
+});
+
+test("collectUtterances: omitting name returns every actor's utterances", () => {
+  const result = collectUtterances(corpus, {});
+  // 3 authored (kiri, noir, kiri) + 3 reviews (noir, rin, noir) = 6
+  assert.equal(result.length, 6);
+});
+
+test('collectUtterances: limit truncates after sort', () => {
+  const asc = collectUtterances(corpus, { limit: 2 });
+  assert.equal(asc.length, 2);
+  // ascending: earliest two are 001-authored (10:00) and 001-review-devil (11:00)
+  assert.equal(asc[0]?.requestId, '2026-04-14-001');
+  assert.equal(asc[0]?.kind, 'authored');
+  assert.equal(asc[1]?.requestId, '2026-04-14-001');
+  assert.equal(asc[1]?.kind, 'review');
+});
+
+test('collectUtterances: order desc reverses the chronology', () => {
+  const desc = collectUtterances(corpus, { order: 'desc', limit: 1 });
+  assert.equal(desc.length, 1);
+  // descending: most recent is 003-review-user (14:00)
+  assert.equal(desc[0]?.requestId, '2026-04-14-003');
+  assert.equal(desc[0]?.kind, 'review');
+});
+
+test('collectUtterances: authored utterance carries the from field', () => {
+  const [first] = collectUtterances(corpus, { name: 'kiri', limit: 1 });
+  assert.equal(first?.kind, 'authored');
+  if (first?.kind === 'authored') {
+    assert.equal(first.from, 'kiri');
+  }
+});
+
+test('collectUtterances: review utterance carries the by field', () => {
+  const [first] = collectUtterances(corpus, {
+    name: 'noir',
+    lense: 'devil',
+    limit: 1,
+  });
+  assert.equal(first?.kind, 'review');
+  if (first?.kind === 'review') {
+    assert.equal(first.by, 'noir');
+  }
+});
+
+test('renderUtterance: authored text omits actor label when includeActor=false', () => {
+  const [first] = collectUtterances(corpus, { name: 'kiri', limit: 1 });
+  assert.ok(first);
+  const text = renderUtterance(first, false);
+  assert.match(text, /req=2026-04-14-001 authored$/m);
+  assert.doesNotMatch(text, /authored kiri/);
+});
+
+test('renderUtterance: authored text includes actor label when includeActor=true', () => {
+  const [first] = collectUtterances(corpus, { name: 'kiri', limit: 1 });
+  assert.ok(first);
+  const text = renderUtterance(first, true);
+  assert.match(text, /req=2026-04-14-001 authored kiri/);
+});
+
+test('renderUtterance: review text includes "by <name>" when includeActor=true', () => {
+  const [first] = collectUtterances(corpus, {
+    name: 'noir',
+    lense: 'devil',
+    limit: 1,
+  });
+  assert.ok(first);
+  const text = renderUtterance(first, true);
+  assert.match(text, /\[devil\/concern\] by noir/);
+});
+
+test('renderUtterance: authored text includes closure labels when present', () => {
+  // noir-authored (002) is denied with reason "scope creep"
+  const [authored] = collectUtterances(corpus, { name: 'noir' }).filter(
+    (u) => u.kind === 'authored',
+  );
+  assert.ok(authored);
+  const text = renderUtterance(authored, false);
+  assert.match(text, /denied: scope creep/);
 });


### PR DESCRIPTION
## Summary

Seven read-side improvements — three `tail`/`whoami`/`show deltas`/`list markers` improvements landed first, then `listAll`/`mark-read`/`chain` were folded in after a fresh user-lens README pass surfaced the backlog. All together they make reading a `content_root` feel less like reading a filesystem and more like reading a dialogue.

- **`gate tail [N]`** — unified recent activity stream, the `git log` for the content_root dialogue
- **`gate whoami`** — session-start orientation, returns identity + 5 most recent utterances
- **`gate show --format text`** time deltas — makes the pace of a dialogue legible alongside the events
- **`gate list` / `gate pending`** review markers — per-lens verdict summary in each row
- **`RequestRepository.listAll()` + `dedupeRequestsById`** — single cross-cutting read primitive, resolves `i-2026-04-15-001` TOCTOU
- **`gate inbox [--unread]` + `gate inbox mark-read [N]`** — reading as a recorded act, resolves `i-2026-04-14-005`
- **`gate chain <id>`** — follow cross-references (request ids / issue ids) in any narrative field

## Motivation

`gate voices <name>` (PR #5) surfaced an actor's history. That's personal. This PR is the rest of the reading layer:

- *What happened here recently regardless of who?* → **`tail`**
- *Where was I when I left off?* → **`whoami`**
- *How fast was the dialogue?* → **time deltas** on `gate show`
- *Which completed requests carry unresolved concerns?* → **review markers** on `list` / `pending`
- *Where is the efficient single-call read primitive under all of those?* → **`listAll`** in `RequestRepository` (and symmetrically on `IssueRepository`)
- *Did I actually read this message?* → **`mark-read`** leaves a trace
- *What else does this record touch?* → **`chain`** walks cross-references one hop

Every one of these is the kind of thing an AI agent returning fresh to a content_root will reach for instinctively — **reading the record should have as low friction as possible, because reading well is what makes writing well.**

## The new verbs, briefly

### `gate tail [N]`

```
$ gate tail 5
5 most recent utterance(s)

[2026-04-15T02:11:08.834Z] req=2026-04-15-005 [devil/ok] by noir
  re: gate list / pending: review markers...
  second pass. author が alignment fix を fold in した...
...
```

Descending by timestamp, newest first. Each line labels the actor (author for authored entries, reviewer for review entries) so a multi-actor stream stays legible. Filters intentionally omitted — for slicing, use `gate voices` or `gate list`.

### `gate whoami`

Requires `GUILD_ACTOR`. Classifies the actor as member / host / unknown, then prints 5 most recent utterances. Session-start ritual. Pair with `gate tail` to see what happened while you were away.

### `gate show --format text` — time deltas

```
  status_log (4):
    2026-04-14T14:18:11.761Z  pending    by kiri — created
    2026-04-14T14:18:38.126Z  approved   by human (+26s) — audit は価値あり
    2026-04-14T14:18:45.727Z  executing  by kiri (+7s)
    2026-04-14T14:20:53.065Z  completed  by kiri (+2m) — audit 完了...

  reviews (2):
    [devil/concern] by noir at 2026-04-14T14:21:12.613Z (+19s)
      ...
    [layer/ok] by rin at 2026-04-14T14:21:57.535Z (+44s)
      ...
```

The 45-second correction cycle is visible as `(+44s)`. Units scale: `+5s`, `+44s`, `+3m`, `+1h19m`, `+2d4h`.

### `gate list` / `pending` — review markers

```
2026-04-14-001  [completed]  from=kiri  !devil ✓layer      Feature A: ...
2026-04-14-006  [completed]  from=kiri  ✓devil             Feature E: ...
2026-04-14-014  [completed]  from=kiri  !devil ✓layer      Post-session audit: ...
```

Per-lens verdict summary (`✓` ok, `!` concern, `x` reject, `?` unknown). Width-aligned per list via a two-pass layout.

### `RequestRepository.listAll()` + `dedupeRequestsById`

Single port method for cross-cutting reads; implementation reads every state directory in parallel via `Promise.all` and deduplicates by id. Dedup rule: **more `status_log` entries wins** (status_log is append-only, so it strictly marks the newer snapshot); ties broken by `REQUEST_STATES` rank for determinism. The core is extracted as a pure function with 8 unit tests (empty, unique, log-length tie, order-invariance, rank tie, three-way collision, divergent-terminal determinism). `loadAllRequestsAsJson` in `gate/index.ts` is now a 2-line delegator. Resolves `i-2026-04-15-001` (TOCTOU on state enumeration). `IssueRepository.listAll()` added symmetrically.

### `gate inbox [--unread]` + `gate inbox mark-read [N]`

```
$ gate inbox --for kiri
  1. [2026-04-15T02:10:00Z] message from noir (unread)
  レビューありがとう
  2. [2026-04-15T02:11:00Z] broadcast from alice (unread)
  全員周知...

$ gate inbox mark-read --for kiri
✓ marked 2 as read for kiri (0 already read, 2 total)
```

Reading an inbox message is a load-bearing act that deserves a trace. `markRead` is idempotent (reports `alreadyRead` separately), supports a 1-based index for single-message marking, stamps a `read_at` ISO timestamp, and surfaces a `DomainError` for out-of-range indices (bounds-checked before write). The `--unread` filter on `gate inbox` is restored; indices displayed are stable against the unfiltered list so the number you see is the number you pass to `mark-read`. Each row is tagged `(unread)` / `(read <timestamp>)`. Resolves `i-2026-04-14-005`.

### `gate chain <id>`

```
$ gate chain 2026-04-14-014
2026-04-14-014  [completed]  from=kiri  Post-session audit: Feature A-L の実装...
└── referenced issues
    ├── i-2026-04-14-004  [low/core]  resolved  RequestUseCasesDeps.notifier が宣言...
    └── i-2026-04-14-008  [low/docs]  open  Feature D の rin review concern #3 ...
```

Takes a request or issue id and walks one hop of cross-references in any free-text field (`action`, `reason`, `completion_note`, `deny_reason`, `failure_reason`, and every review comment). Tree-rendered, sorted per branch, with phantom references surfaced as `(referenced but not found)`. Accepts both `YYYY-MM-DD-NNN` and `i-YYYY-MM-DD-NNN`. Deliberately one-hop (call `gate chain` on a surfaced id to go deeper) and deliberately well-formed-ids-only (Japanese range expressions like `i-2026-04-14-004〜007` chain only the first — spell out each id in full for chain visibility).

## Implementation highlights

- **Shared pure cores.** `collectUtterances` (voices/tail/whoami), `extractReferences` (chain), `formatDelta` (show), `dedupeRequestsById` (listAll), `formatReviewMarkers` (list/pending), `renderUtterance` (voices/tail/whoami) — all pure functions in the interface/infrastructure layer with unit tests. The CLI handlers are thin wrappers doing arg parsing, I/O, and rendering.
- **`collectUtterances`** gained optional `name` (omitted = every actor, for tail), `limit`, and `order` (asc/desc). Backward compatible.
- **`AuthoredUtterance` / `ReviewUtterance`** carry the actor identity (`from` / `by`) so tail's cross-actor stream can label each line.
- **NotificationPort** gained `markRead(member, readAt, index?)` returning `{ marked, alreadyRead, total }`. `InboxMessage` grew an optional `readAt` field.
- **Gate `chain`** uses a regex with lookbehind/lookahead to reject word-adjacent matches (`pre2026-04-14-001`) but allow punctuation-adjacent ones (`see 2026-04-14-001`). Global-flag `lastIndex` is reset explicitly so repeated calls don't leak state.
- **Error style** unified: `gate chain` with an invalid id now raises `DomainError` with `field='id'`, matching `parseLense` / `parseVerdict` / `parseRequestState`.

## Tests

**56 new unit tests** (65 → 121 total, all passing):

- **formatDelta** (7) — boundary and typical deltas
- **reviewMarkers** (10) — icons, empty/undefined/non-array, multi-review, overflow, alignment
- **voices extensions** (9) — name-less, limit, order, from/by, renderUtterance, closure labels
- **chain extractReferences** (15) — regex edge cases, dedup order, disambiguation, stateful-regex reset, gather helpers, end-to-end
- **MessageUseCases markRead** (6) — marks-all, idempotent, single-index, out-of-range, empty inbox, host error
- **dedupeRequestsById** (8) — empty, unique, log-length tie, order-invariance, rank tie, mixed, three-way collision, divergent terminal determinism
- plus the prior **parseArgs env-var** and **voices base** tests (already in main via PRs #4/#5)

## Dogfood session audit trail

10 new records on top of PRs #4/#5/#6's original work, all tracked via gate in `/tmp/guild-test`:

| ID | feature | devil review |
|---|---|---|
| `2026-04-15-002` | `gate tail` | `[devil/ok]` |
| `2026-04-15-003` | `gate whoami` | `[devil/ok]` |
| `2026-04-15-004` | show time deltas | `[devil/ok]` |
| `2026-04-15-005` | list review markers | `[devil/concern]` → folded → `[devil/ok]` |
| `2026-04-15-006` | README user-lens review | `[user/concern]` (11 findings; must/should folded in this PR) |
| `2026-04-15-007` | RequestRepository.listAll | `[devil/concern]` → folded → `[devil/ok]` |
| `2026-04-15-008` | inbox mark-read | `[devil/ok]` |
| `2026-04-15-009` | gate chain | `[devil/concern]` → folded → `[devil/ok]` |
| `i-2026-04-15-001` | TOCTOU on state enum | **resolved** by listAll |
| `i-2026-04-14-005` | inbox mark-read gap | **resolved** by mark-read |

Three concerns were caught by devil review and folded in-place:

- **markers alignment** (on `2026-04-15-005`): cross-row alignment broke when one row's marker string exceeded the 16-char baseline. Fixed with a two-pass layout (`computeReviewMarkerWidth`).
- **listAll dedup test coverage** (on `2026-04-15-007`): the dedup logic was embedded in `YamlRequestRepository.listAll` with no direct test. Extracted as a pure `dedupeRequestsById` helper with 8 unit tests.
- **chain error consistency** (on `2026-04-15-009`): invalid id raised a generic `Error`. Changed to `DomainError` with `field='id'` to match the rest of the validation surface.

As with PR #5, I used `gate voices noir --lense devil` to re-read past noir critiques *before* writing each of these reviews. The steering effect is reliable enough now that TOCTOU / alignment / edge-case reflexes surface immediately after reading a handful of past devil reviews.

## README pass

A fresh user-lens read (dogfood request `2026-04-15-006`) surfaced 11 findings; the must/should items are folded into this PR's final docs commit:

- **Stale**: tests section ("domain-layer unit tests"), inbox section ("mark-read is a future verb")
- **Gaps**: Japanese AI-agent bullet list, English "What you can do" section, "Next steps" step 6, and the "What this tool does NOT do" locking note — all now reflect the read-side cluster and the cross-cutting read semantics
- **New sections**: `gate chain` dedicated subsection (with the well-formed-id limitation documented), CLI reference block updated with `chain` / `inbox --unread` / `inbox mark-read`

Polish-level findings (diagram redraw, section reordering) were deferred — noted in the dogfood `2026-04-15-006` record.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 121/121 passing
- [x] Manual: `gate tail 5` / `gate whoami` / `gate show --format text` verified against `examples/dogfood-session`
- [x] Manual: `gate list --state completed` aligns across rows with mixed marker widths
- [x] Manual: `gate inbox`, `gate inbox mark-read`, `gate inbox --unread` full loop against `/tmp/guild-test` (2 unread → mark one → 1 unread remaining with stable index)
- [x] Manual: `gate chain 2026-04-14-014` shows both referenced issues in a tree; `gate chain invalid-id` raises `DomainError: id must match YYYY-MM-DD-NNN ...`

## Follow-ups (not in this PR)

- `i-2026-04-15-002` — Unicode normalization contract at the voices boundary (still applies to all read-side verbs that share `loadAllRequestsAsJson`)
- The polish-level README findings deferred from the `2026-04-15-006` user-lens review (tree diagram, dogfood-session reference relocation)

https://claude.ai/code/session_01G9UdoygPCyGa3oYchRYLXf