### PR TITLE
ci: add GitHub Actions workflow (typecheck + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node --test \"dist/tests/**/*.test.js\"",
+    "test": "tsc && find dist/tests -name '*.test.js' -print0 | xargs -0 node --test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` — runs `tsc --noEmit` + `npm test` on Node 20 / 22
- `permissions: contents: read` only (minimum privilege)
- `persist-credentials: false` for checkout (defense in depth)

## Why now
Repo is entering serious-dev phase after distribution to all group companies. Need a regression gate before enabling `required_status_checks` on `main`.

## Test plan
- [x] Local: `npm run typecheck && npm test` — 121 pass
- [ ] CI: Actions run this PR
- [ ] After merge: register `test (node 20)` + `test (node 22)` as required status checks