### PR TITLE
fix(infrastructure): surface hydrate skips via onMalformed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ### Changed (internal)
 - **Refactor**: `src/interface/gate/index.ts` split into `handlers/{request,review,read,issues,messages}.ts` plus `handlers/internal.ts` for shared helpers. `index.ts` is now 158 lines (was 1206) and contains only routing + HELP. Behavior unchanged; `formatReviewMarkers` and `computeReviewMarkerWidth` are re-exported from `index.ts` for backward-compat with existing test imports.
+- **Data-loss visibility**: malformed YAML records (requests, issues, members, and individual `status_log` entries) no longer disappear silently. `GuildConfig` now carries an `onMalformed: (msg: string) => void` callback, defaulting to `process.stderr.write("warn: ...")`, and every hydrate code path routes skipped records through it with source path + id hint + cause. Tests inject a collecting spy; production users see warnings on stderr.
 
 ### Infrastructure
 - `.github/workflows/ci.yml` — typecheck + test on Node 20 / 22.

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -3,6 +3,18 @@ import { resolve, isAbsolute, join } from 'node:path';
 import YAML from 'yaml';
 import { DomainError } from '../../domain/shared/DomainError.js';
 
+/**
+ * Called by repository hydrate paths when a YAML record cannot be
+ * parsed into a domain object. The CLI wires this to stderr so that
+ * data-loss events surface instead of being silently swallowed.
+ * Tests inject a collecting spy to assert the exact messages.
+ */
+export type OnMalformed = (msg: string) => void;
+
+export const defaultOnMalformed: OnMalformed = (msg) => {
+  process.stderr.write(`warn: ${msg}\n`);
+};
+
 export interface GuildConfigProps {
   root: string;
   contentRoot: string;
@@ -13,6 +25,7 @@ export interface GuildConfigProps {
     inbox: string;
   };
   hostNames: readonly string[];
+  onMalformed: OnMalformed;
 }
 
 const DEFAULT_HOSTS = ['eris', 'nao'] as const;
@@ -29,13 +42,17 @@ export class GuildConfig implements GuildConfigProps {
     readonly contentRoot: string,
     readonly paths: GuildConfigProps['paths'],
     readonly hostNames: readonly string[],
+    readonly onMalformed: OnMalformed,
   ) {}
 
-  static load(cwd: string = process.cwd()): GuildConfig {
+  static load(
+    cwd: string = process.cwd(),
+    onMalformed: OnMalformed = defaultOnMalformed,
+  ): GuildConfig {
     const configPath = findConfig(cwd);
     if (!configPath) {
       // Default: treat cwd as guild root
-      return GuildConfig.default(cwd);
+      return GuildConfig.default(cwd, onMalformed);
     }
     const raw = YAML.parse(readFileSync(configPath, 'utf8')) ?? {};
     const root = resolve(configPath, '..');
@@ -55,10 +72,13 @@ export class GuildConfig implements GuildConfigProps {
           .filter((x: unknown): x is string => typeof x === 'string')
           .map((x: string) => x.toLowerCase())
       : [...DEFAULT_HOSTS];
-    return new GuildConfig(root, contentRoot, paths, hostNames);
+    return new GuildConfig(root, contentRoot, paths, hostNames, onMalformed);
   }
 
-  static default(root: string): GuildConfig {
+  static default(
+    root: string,
+    onMalformed: OnMalformed = defaultOnMalformed,
+  ): GuildConfig {
     const abs = resolve(root);
     return new GuildConfig(
       abs,
@@ -70,6 +90,7 @@ export class GuildConfig implements GuildConfigProps {
         inbox: join(abs, 'inbox'),
       },
       [...DEFAULT_HOSTS],
+      onMalformed,
     );
   }
 }

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -28,7 +28,7 @@ export class YamlIssueRepository implements IssueRepository {
     const rel = `${id.value}.yaml`;
     if (!existsSafe(this.config.paths.issues, rel)) return null;
     const raw = readTextSafe(this.config.paths.issues, rel);
-    return hydrate(YAML.parse(raw));
+    return hydrate(YAML.parse(raw), rel, this.config.onMalformed);
   }
 
   async listByState(state: IssueState): Promise<Issue[]> {
@@ -43,7 +43,7 @@ export class YamlIssueRepository implements IssueRepository {
     const out: Issue[] = [];
     for (const f of files) {
       const raw = readTextSafe(this.config.paths.issues, f);
-      const issue = hydrate(YAML.parse(raw));
+      const issue = hydrate(YAML.parse(raw), f, this.config.onMalformed);
       if (issue) out.push(issue);
     }
     return out;
@@ -86,8 +86,13 @@ export class YamlIssueRepository implements IssueRepository {
   }
 }
 
-function hydrate(data: unknown): Issue | null {
+function hydrate(
+  data: unknown,
+  source: string,
+  onMalformed: (msg: string) => void,
+): Issue | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    onMalformed(`issue ${source}: top-level YAML is not a mapping; skipping`);
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -103,7 +108,12 @@ function hydrate(data: unknown): Issue | null {
       createdAt: String(obj['created_at'] ?? new Date().toISOString()),
     });
     return issue;
-  } catch {
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const idHint = typeof obj['id'] === 'string' ? ` (id=${obj['id']})` : '';
+    onMalformed(
+      `issue ${source}${idHint}: hydrate failed, skipping record: ${msg}`,
+    );
     return null;
   }
 }

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -26,7 +26,7 @@ export class YamlMemberRepository implements MemberRepository {
     if (!existsSafe(this.config.paths.members, file)) return null;
     const raw = readTextSafe(this.config.paths.members, file);
     const data = YAML.parse(raw);
-    return hydrate(data, name.value);
+    return hydrate(data, name.value, file, this.config.onMalformed);
   }
 
   async exists(name: MemberName): Promise<boolean> {
@@ -42,7 +42,7 @@ export class YamlMemberRepository implements MemberRepository {
       const raw = readTextSafe(this.config.paths.members, f);
       const data = YAML.parse(raw);
       const name = f.replace(/\.yaml$/, '');
-      const m = hydrate(data, name);
+      const m = hydrate(data, name, f, this.config.onMalformed);
       if (m) out.push(m);
     }
     return out;
@@ -60,8 +60,16 @@ export class YamlMemberRepository implements MemberRepository {
   }
 }
 
-function hydrate(data: unknown, fallbackName: string): Member | null {
+function hydrate(
+  data: unknown,
+  fallbackName: string,
+  source: string,
+  onMalformed: (msg: string) => void,
+): Member | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    onMalformed(
+      `member ${source}: top-level YAML is not a mapping; skipping`,
+    );
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -84,7 +92,11 @@ function hydrate(data: unknown, fallbackName: string): Member | null {
     };
     if (displayName !== undefined) args.displayName = displayName;
     return Member.create(args);
-  } catch {
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    onMalformed(
+      `member ${source} (name=${name}): hydrate failed, skipping record: ${msg}`,
+    );
     return null;
   }
 }

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -35,7 +35,7 @@ export class YamlRequestRepository implements RequestRepository {
       const rel = join(state, `${id.value}.yaml`);
       if (existsSafe(this.config.paths.requests, rel)) {
         const raw = readTextSafe(this.config.paths.requests, rel);
-        return hydrate(YAML.parse(raw), state);
+        return hydrate(YAML.parse(raw), state, rel, this.config.onMalformed);
       }
     }
     return null;
@@ -47,8 +47,9 @@ export class YamlRequestRepository implements RequestRepository {
       .slice(0, 1000);
     const out: Request[] = [];
     for (const f of files) {
-      const raw = readTextSafe(this.config.paths.requests, join(state, f));
-      const r = hydrate(YAML.parse(raw), state);
+      const rel = join(state, f);
+      const raw = readTextSafe(this.config.paths.requests, rel);
+      const r = hydrate(YAML.parse(raw), state, rel, this.config.onMalformed);
       if (r) out.push(r);
     }
     return out;
@@ -158,8 +159,16 @@ export function dedupeRequestsById(
   return Array.from(byId.values());
 }
 
-function hydrate(data: unknown, stateHint?: RequestState): Request | null {
+function hydrate(
+  data: unknown,
+  stateHint: RequestState | undefined,
+  source: string,
+  onMalformed: (msg: string) => void,
+): Request | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    onMalformed(
+      `request ${source}: top-level YAML is not a mapping; skipping`,
+    );
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -192,11 +201,12 @@ function hydrate(data: unknown, stateHint?: RequestState): Request | null {
       ? (obj['status_log'] as unknown[])
       : [];
     const statusLog: StatusLogEntry[] = [];
-    for (const s of statusLogRaw) {
+    for (let i = 0; i < statusLogRaw.length; i++) {
+      const s = statusLogRaw[i];
       if (!s || typeof s !== 'object') continue;
       const so = s as Record<string, unknown>;
       // Legacy entries may omit `state` (e.g., review notes). Skip them
-      // rather than failing the whole request.
+      // rather than failing the whole request — they are known-benign.
       if (typeof so['state'] !== 'string') continue;
       try {
         const entry: StatusLogEntry = {
@@ -206,8 +216,11 @@ function hydrate(data: unknown, stateHint?: RequestState): Request | null {
         };
         if (typeof so['note'] === 'string') entry.note = so['note'] as string;
         statusLog.push(entry);
-      } catch {
-        // drop malformed entries silently
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        onMalformed(
+          `request ${source}: dropping status_log[${i}] (state="${String(so['state'])}"): ${msg}`,
+        );
       }
     }
     const createdAt =
@@ -248,7 +261,13 @@ function hydrate(data: unknown, stateHint?: RequestState): Request | null {
     if (typeof obj['failure_reason'] === 'string')
       props.failureReason = obj['failure_reason'] as string;
     return Request.restore(props);
-  } catch {
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const idHint =
+      typeof obj['id'] === 'string' ? ` (id=${obj['id']})` : '';
+    onMalformed(
+      `request ${source}${idHint}: hydrate failed, skipping record: ${msg}`,
+    );
     return null;
   }
 }

--- a/tests/infrastructure/hydrateErrorSurface.test.ts
+++ b/tests/infrastructure/hydrateErrorSurface.test.ts
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GuildConfig } from '../../src/infrastructure/config/GuildConfig.js';
+import { YamlRequestRepository } from '../../src/infrastructure/persistence/YamlRequestRepository.js';
+import { YamlIssueRepository } from '../../src/infrastructure/persistence/YamlIssueRepository.js';
+import { YamlMemberRepository } from '../../src/infrastructure/persistence/YamlMemberRepository.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+
+function makeRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-hydrate-'));
+  mkdirSync(join(root, 'members'));
+  mkdirSync(join(root, 'requests', 'pending'), { recursive: true });
+  mkdirSync(join(root, 'issues'));
+  mkdirSync(join(root, 'inbox'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [alice]\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('YamlRequestRepository: malformed request YAML surfaces via onMalformed', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // write a request YAML missing required fields so hydrate will throw
+    const badPath = join(root, 'requests', 'pending', '2026-04-15-001.yaml');
+    writeFileSync(badPath, 'id: 2026-04-15-001\n# missing from/action/reason\n');
+
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const repo = new YamlRequestRepository(config);
+
+    const items = await repo.listByState('pending');
+    assert.equal(items.length, 0, 'malformed record should be dropped');
+    assert.equal(warnings.length, 1, 'exactly one warning should surface');
+    assert.match(warnings[0]!, /request /);
+    assert.match(warnings[0]!, /id=2026-04-15-001/);
+    assert.match(warnings[0]!, /hydrate failed/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlRequestRepository: malformed status_log entry surfaces per-entry', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // valid top-level but status_log[1] has an invalid state value
+    const path = join(root, 'requests', 'pending', '2026-04-15-002.yaml');
+    writeFileSync(
+      path,
+      [
+        'id: 2026-04-15-002',
+        'from: alice',
+        'action: test',
+        'reason: test',
+        'state: pending',
+        'created_at: 2026-04-15T00:00:00Z',
+        'status_log:',
+        '  - state: pending',
+        '    by: alice',
+        '    at: 2026-04-15T00:00:00Z',
+        '  - state: not-a-real-state',
+        '    by: alice',
+        '    at: 2026-04-15T00:01:00Z',
+        'reviews: []',
+        '',
+      ].join('\n'),
+    );
+
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const repo = new YamlRequestRepository(config);
+
+    const items = await repo.listByState('pending');
+    assert.equal(items.length, 1, 'request itself should still load');
+    assert.equal(items[0]!.statusLog.length, 1, 'bad entry should be dropped');
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /status_log\[1\]/);
+    assert.match(warnings[0]!, /not-a-real-state/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlIssueRepository: malformed issue surfaces via onMalformed', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const badPath = join(root, 'issues', 'i-2026-04-15-001.yaml');
+    writeFileSync(badPath, 'id: i-2026-04-15-001\n# missing required fields\n');
+
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const repo = new YamlIssueRepository(config);
+
+    const items = await repo.listAll();
+    assert.equal(items.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /issue /);
+    assert.match(warnings[0]!, /i-2026-04-15-001/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlMemberRepository: malformed member surfaces via onMalformed', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const badPath = join(root, 'members', 'broken.yaml');
+    // category is not a valid MemberCategory
+    writeFileSync(badPath, 'name: broken\ncategory: not-a-category\n');
+
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const repo = new YamlMemberRepository(config);
+
+    const items = await repo.listAll();
+    assert.equal(items.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /member /);
+    assert.match(warnings[0]!, /name=broken/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('findByName also routes through onMalformed on malformed YAML', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    writeFileSync(
+      join(root, 'members', 'broken.yaml'),
+      'name: broken\ncategory: invalid\n',
+    );
+
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const repo = new YamlMemberRepository(config);
+
+    const result = await repo.findByName(MemberName.of('broken'));
+    assert.equal(result, null);
+    assert.equal(warnings.length, 1);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Malformed YAML records were being silently dropped by empty \`catch\` blocks in the three repository hydrate functions and the per-\`status_log\`-entry loop. Operators at distributed Anotete sites had no way to distinguish \"record doesn't exist\" from \"record exists but silently failed to load\".

This PR routes every skipped record through a configurable \`onMalformed: (msg: string) => void\` callback stashed on \`GuildConfig\`, defaulting to \`process.stderr.write(\"warn: ...\")\`. Tests inject a collecting spy.

## Changes

- \`src/infrastructure/config/GuildConfig.ts\`
  - New \`OnMalformed\` type + \`defaultOnMalformed\` (stderr writer)
  - \`GuildConfig.load()\` and \`GuildConfig.default()\` accept an optional 2nd parameter
  - Callback stored as \`readonly onMalformed\` on the instance

- \`src/infrastructure/persistence/YamlRequestRepository.ts\`
  - \`hydrate()\` now takes \`source\` (file path) and \`onMalformed\`
  - Whole-record catch emits \`request <path> (id=...): hydrate failed, skipping record: <cause>\`
  - Per-\`status_log\`-entry catch emits \`request <path>: dropping status_log[<i>] (state=\"...\"): <cause>\`
  - Both \`findById\` and \`listByState\` thread the relative path

- \`src/infrastructure/persistence/YamlIssueRepository.ts\` — same pattern
- \`src/infrastructure/persistence/YamlMemberRepository.ts\` — same pattern

## Why this shape, not a port?

A dedicated \`MalformedDataPort\` would be architecturally cleaner but adds a port, a default implementation, container wiring, and a stub for tests — noise disproportionate to a one-line callback. Callbacks stashed on config are already the pattern for low-ceremony cross-layer hooks in this codebase, and the signature is narrow enough that there's no ambiguity about what flows through it.

## Test plan
- [x] 5 new tests in \`tests/infrastructure/hydrateErrorSurface.test.ts\`
  - Malformed request → 1 warning, record dropped
  - Malformed \`status_log[1]\` → 1 warning, record loads with bad entry dropped
  - Malformed issue → 1 warning, record dropped
  - Malformed member → 1 warning, record dropped
  - \`findByName\` also routes through callback
- [x] All existing tests still pass (132 total)
- [x] Typecheck clean
- [ ] CI green