### PR TITLE
feat(domain): widen sequence ceiling 999 -> 9999 (3 -> 4 digit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 - `CHANGELOG.md` and `POLICY.md` — versioning promise and change history.
 - `guild --version` / `gate --version` (alias `-v`) — print `guild-cli <version>` and exit 0.
 
+### Changed
+- **Sequence ceiling**: Request and Issue ids now use 4-digit
+  sequences (`YYYY-MM-DD-NNNN` / `i-YYYY-MM-DD-NNNN`), raising the
+  per-UTC-day ceiling from 999 to 9999. The loader accepts **both**
+  3- and 4-digit forms; existing content roots continue to work
+  without migration. Generation always produces 4 digits. Regex
+  patterns in `chain` cross-references, file filters, and
+  `nextSequence` parsers all widened accordingly.
+
 ### Changed (internal)
 - **Refactor**: `src/interface/gate/index.ts` split into `handlers/{request,review,read,issues,messages}.ts` plus `handlers/internal.ts` for shared helpers. `index.ts` is now 158 lines (was 1206) and contains only routing + HELP. Behavior unchanged; `formatReviewMarkers` and `computeReviewMarkerWidth` are re-exported from `index.ts` for backward-compat with existing test imports.
 - **Data-loss visibility**: malformed YAML records (requests, issues, members, and individual `status_log` entries) no longer disappear silently. `GuildConfig` now carries an `onMalformed: (msg: string) => void` callback, defaulting to `process.stderr.write("warn: ...")`, and every hydrate code path routes skipped records through it with source path + id hint + cause. Tests inject a collecting spy; production users see warnings on stderr.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ Being honest about the 0.1.0 surface area so you can plan around it:
   window is smaller than the sequential loop it replaced but not
   zero — a file that moves between directories *during* a single
   `readdir` can still be missed or double-counted.
-- **Sequence ceiling is 999 per day.** Request IDs are `YYYY-MM-DD-NNN`.
-  The 1000th request in a single UTC day throws.
+- **Sequence ceiling is 9999 per UTC day.** Request IDs are
+  `YYYY-MM-DD-NNNN`. The 10,000th request in a single UTC day throws.
+  Legacy 3-digit ids (`YYYY-MM-DD-NNN`) produced by 0.1.x are still
+  accepted on read for backward compatibility.
 
 These are scope choices for 0.1.0, not accidents. If any of them
 blocks your use case, open an issue describing the workflow — the
@@ -758,7 +760,9 @@ subdirectory names.
   inbox/<name>.yaml
 ```
 
-Request IDs are `YYYY-MM-DD-NNN`; issue IDs are `i-YYYY-MM-DD-NNN`.
+Request IDs are `YYYY-MM-DD-NNNN`; issue IDs are `i-YYYY-MM-DD-NNNN`.
+Legacy 3-digit ids from 0.1.x are still accepted on read for backward
+compatibility; all newly-generated ids use the 4-digit form.
 
 ## Security
 

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -48,7 +48,9 @@ export function assertIssueTransition(
   }
 }
 
-const ISSUE_ID_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3}$/;
+// Accepts both 3- and 4-digit sequences for backward compatibility
+// (see RequestId.ts for rationale). Generation produces 4 digits.
+const ISSUE_ID_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3,4}$/;
 const AREA_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/;
 const MAX_TEXT = 2048;
 
@@ -58,7 +60,7 @@ export class IssueId {
   static of(raw: unknown): IssueId {
     if (typeof raw !== 'string' || !ISSUE_ID_PATTERN.test(raw)) {
       throw new DomainError(
-        `Invalid issue id: "${String(raw)}". Expected i-YYYY-MM-DD-NNN`,
+        `Invalid issue id: "${String(raw)}". Expected i-YYYY-MM-DD-NNNN (or legacy NNN)`,
         'id',
       );
     }
@@ -66,13 +68,13 @@ export class IssueId {
   }
 
   static generate(today: Date, sequence: number): IssueId {
-    if (!Number.isInteger(sequence) || sequence < 0 || sequence > 999) {
+    if (!Number.isInteger(sequence) || sequence < 0 || sequence > 9999) {
       throw new DomainError(`Invalid sequence: ${sequence}`, 'sequence');
     }
     const yyyy = today.getUTCFullYear().toString().padStart(4, '0');
     const mm = (today.getUTCMonth() + 1).toString().padStart(2, '0');
     const dd = today.getUTCDate().toString().padStart(2, '0');
-    const seq = sequence.toString().padStart(3, '0');
+    const seq = sequence.toString().padStart(4, '0');
     return new IssueId(`i-${yyyy}-${mm}-${dd}-${seq}`);
   }
 

--- a/src/domain/request/RequestId.ts
+++ b/src/domain/request/RequestId.ts
@@ -1,6 +1,10 @@
 import { DomainError } from '../shared/DomainError.js';
 
-const PATTERN = /^\d{4}-\d{2}-\d{2}-\d{3}$/;
+// Accepts both 3- and 4-digit sequences for backward compatibility with
+// pre-0.2.0 content roots. New ids are generated as 4 digits (see generate
+// below) — ceiling is 9999/UTC day. Files written under the old 3-digit
+// scheme keep loading without migration.
+const PATTERN = /^\d{4}-\d{2}-\d{2}-\d{3,4}$/;
 
 export class RequestId {
   private constructor(public readonly value: string) {}
@@ -8,7 +12,7 @@ export class RequestId {
   static of(raw: unknown): RequestId {
     if (typeof raw !== 'string' || !PATTERN.test(raw)) {
       throw new DomainError(
-        `Invalid request id: "${String(raw)}". Expected YYYY-MM-DD-NNN`,
+        `Invalid request id: "${String(raw)}". Expected YYYY-MM-DD-NNNN (or legacy NNN)`,
         'id',
       );
     }
@@ -16,13 +20,13 @@ export class RequestId {
   }
 
   static generate(today: Date, sequence: number): RequestId {
-    if (!Number.isInteger(sequence) || sequence < 0 || sequence > 999) {
+    if (!Number.isInteger(sequence) || sequence < 0 || sequence > 9999) {
       throw new DomainError(`Invalid sequence: ${sequence}`, 'sequence');
     }
     const yyyy = today.getUTCFullYear().toString().padStart(4, '0');
     const mm = (today.getUTCMonth() + 1).toString().padStart(2, '0');
     const dd = today.getUTCDate().toString().padStart(2, '0');
-    const seq = sequence.toString().padStart(3, '0');
+    const seq = sequence.toString().padStart(4, '0');
     return new RequestId(`${yyyy}-${mm}-${dd}-${seq}`);
   }
 

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -19,7 +19,7 @@ import {
 } from './safeFs.js';
 import { GuildConfig } from '../config/GuildConfig.js';
 
-const FILE_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3}\.yaml$/;
+const FILE_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
 
 export class YamlIssueRepository implements IssueRepository {
   constructor(private readonly config: GuildConfig) {}
@@ -76,7 +76,7 @@ export class YamlIssueRepository implements IssueRepository {
   async nextSequence(dateKey: string): Promise<number> {
     let max = 0;
     for (const f of listDirSafe(this.config.paths.issues, '.')) {
-      const m = f.match(/^i-(\d{4}-\d{2}-\d{2})-(\d{3})\.yaml$/);
+      const m = f.match(/^i-(\d{4}-\d{2}-\d{2})-(\d{3,4})\.yaml$/);
       if (m && m[1] === dateKey) {
         const n = parseInt(m[2] as string, 10);
         if (n > max) max = n;

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -43,7 +43,7 @@ export class YamlRequestRepository implements RequestRepository {
 
   async listByState(state: RequestState): Promise<Request[]> {
     const files = listDirSafe(this.config.paths.requests, state)
-      .filter((f) => /^\d{4}-\d{2}-\d{2}-\d{3}\.yaml$/.test(f))
+      .filter((f) => /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/.test(f))
       .slice(0, 1000);
     const out: Request[] = [];
     for (const f of files) {
@@ -109,7 +109,7 @@ export class YamlRequestRepository implements RequestRepository {
     for (const state of REQUEST_STATES) {
       const files = listDirSafe(this.config.paths.requests, state);
       for (const f of files) {
-        const m = f.match(/^(\d{4}-\d{2}-\d{2})-(\d{3})\.yaml$/);
+        const m = f.match(/^(\d{4}-\d{2}-\d{2})-(\d{3,4})\.yaml$/);
         if (m && m[1] === dateKey) {
           const n = parseInt(m[2] as string, 10);
           if (n > max) max = n;

--- a/src/interface/gate/chain.ts
+++ b/src/interface/gate/chain.ts
@@ -26,7 +26,10 @@
  * don't double-count requests that happen to share a suffix with an
  * issue id.
  */
-const ID_PATTERN = /(?<!\w)(i-)?(\d{4}-\d{2}-\d{2}-\d{3})(?!\d)/g;
+// \d{3,4} accepts both legacy (0.1.x) 3-digit and current 4-digit
+// sequence suffixes. The trailing (?!\d) forbids longer digit runs
+// so "2026-04-15-00123" (5+ digits) is not partially matched.
+const ID_PATTERN = /(?<!\w)(i-)?(\d{4}-\d{2}-\d{2}-\d{3,4})(?!\d)/g;
 
 export interface ExtractedReferences {
   readonly requestIds: ReadonlyArray<string>;

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -183,12 +183,13 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   if (!rootId) {
     throw new Error('Usage: gate chain <request-id | issue-id>');
   }
-  const isIssueId = /^i-\d{4}-\d{2}-\d{2}-\d{3}$/.test(rootId);
-  const isRequestId = /^\d{4}-\d{2}-\d{2}-\d{3}$/.test(rootId);
+  // Accept 3- or 4-digit sequences for backward compat with pre-0.2.0 ids.
+  const isIssueId = /^i-\d{4}-\d{2}-\d{2}-\d{3,4}$/.test(rootId);
+  const isRequestId = /^\d{4}-\d{2}-\d{2}-\d{3,4}$/.test(rootId);
   if (!isIssueId && !isRequestId) {
     throw new DomainError(
-      `id must match YYYY-MM-DD-NNN (request) or ` +
-        `i-YYYY-MM-DD-NNN (issue), got: ${rootId}`,
+      `id must match YYYY-MM-DD-NNNN (request) or ` +
+        `i-YYYY-MM-DD-NNNN (issue), got: ${rootId}`,
       'id',
     );
   }

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -21,15 +21,33 @@ function mkReq(): Request {
   });
 }
 
-test('RequestId generate produces correct format', () => {
+test('RequestId generate produces 4-digit format', () => {
   const id = RequestId.generate(d, 42);
-  assert.equal(id.value, '2026-04-14-042');
+  assert.equal(id.value, '2026-04-14-0042');
+});
+
+test('RequestId generate zero-pads small sequences', () => {
+  const id = RequestId.generate(d, 1);
+  assert.equal(id.value, '2026-04-14-0001');
+});
+
+test('RequestId generate accepts up to 9999', () => {
+  const id = RequestId.generate(d, 9999);
+  assert.equal(id.value, '2026-04-14-9999');
+  assert.throws(() => RequestId.generate(d, 10000), DomainError);
 });
 
 test('RequestId of validates pattern', () => {
   assert.throws(() => RequestId.of('2026-4-14-001'), DomainError);
   assert.throws(() => RequestId.of('bad'), DomainError);
+  // Legacy 3-digit still accepted for backward compatibility.
   assert.doesNotThrow(() => RequestId.of('2026-04-14-001'));
+  // New 4-digit form.
+  assert.doesNotThrow(() => RequestId.of('2026-04-14-0001'));
+  // 2 digits rejected.
+  assert.throws(() => RequestId.of('2026-04-14-01'), DomainError);
+  // 5 digits rejected.
+  assert.throws(() => RequestId.of('2026-04-14-00001'), DomainError);
 });
 
 test('Request starts in pending', () => {

--- a/tests/interface/chain.test.ts
+++ b/tests/interface/chain.test.ts
@@ -75,10 +75,23 @@ test('extractReferences: not confused by adjacent digits', () => {
   assert.deepEqual(r.issueIds, []);
 });
 
-test('extractReferences: rejects longer digit strings at end', () => {
-  // If the sequence is 4 digits instead of 3, it should not match.
-  const r = extractReferences('bogus 2026-04-14-0001');
+test('extractReferences: accepts 4-digit sequences', () => {
+  // As of 0.2.0, sequence ceiling is 9999/day and ids are 4 digits.
+  const r = extractReferences('see 2026-04-14-0001');
+  assert.deepEqual(r.requestIds, ['2026-04-14-0001']);
+});
+
+test('extractReferences: rejects 5+ digit sequences', () => {
+  // 5 digits exceeds the domain pattern and should not be extracted.
+  const r = extractReferences('bogus 2026-04-14-00001');
   assert.deepEqual(r.requestIds, []);
+});
+
+test('extractReferences: accepts legacy 3-digit sequences', () => {
+  // Backward-compat: content roots from 0.1.x still produce 3-digit ids
+  // and cross-references to them must keep working.
+  const r = extractReferences('legacy 2026-04-14-001');
+  assert.deepEqual(r.requestIds, ['2026-04-14-001']);
 });
 
 test('extractReferences: does not match ids embedded in word characters', () => {


### PR DESCRIPTION
## Summary

Raise the per-UTC-day request and issue id ceiling from **999** to **9999** with **full backward compatibility** for existing content roots.

- New ids generated as \`YYYY-MM-DD-NNNN\` / \`i-YYYY-MM-DD-NNNN\` (4 digits)
- Loader accepts **both** 3- and 4-digit forms — legacy 0.1.x content roots load without migration
- \`extractReferences\` in \`chain\` also accepts both

## Why now

\`guild-cli\` is distributed to all Anotete group companies. A single burst-heavy consumer today can exceed 999 ids/day and hit the ceiling. Per PR#8 noir devil (tracker i-2026-04-15-00X) and the original README \"known limitations\" entry, this was a known scope choice for 0.1.0 that deserves to be lifted before it bites in production.

## Changes

- \`src/domain/request/RequestId.ts\` — \`PATTERN\` widened to \`\\d{3,4}\`, \`generate\` pads to 4 digits and caps at 9999
- \`src/domain/issue/Issue.ts\` — same treatment for \`IssueId\`
- \`src/infrastructure/persistence/YamlRequestRepository.ts\` — file filter \`\\d{3,4}\`, \`nextSequence\` parser \`\\d{3,4}\`
- \`src/infrastructure/persistence/YamlIssueRepository.ts\` — same
- \`src/interface/gate/chain.ts\` — \`ID_PATTERN\` widened; trailing \`(?!\\d)\` still forbids 5+ digit runs
- \`src/interface/gate/handlers/read.ts\` — \`reqChain\` root-id validators widened
- \`README.md\` — \"Sequence ceiling is 9999 per UTC day\" + backward-compat note
- \`CHANGELOG.md\` — new Changed entry explaining the widening and migration-free loader

## Compatibility promise

- **Read**: any existing 0.1.x content root works unchanged. 3-digit ids are still valid when loaded, cross-referenced in \`chain\`, filtered in \`list\`, and rendered in \`show\` / \`voices\` / \`tail\`.
- **Write**: new ids are always 4 digits. A content root may contain a mix of 3- and 4-digit ids without any collision risk (the sequence parser reads both).
- **Parse consumers**: any downstream tool that string-parses ids as exactly \`\\d{3}\` needs to widen its regex. This is the only breaking change and is per \`POLICY.md\` minor-bump allowed.

## Test plan
- [x] Updated \`RequestId generate\` tests: 4-digit output, zero-pad, 9999 ceiling
- [x] Updated \`RequestId.of\` tests: accepts 3-digit (legacy), accepts 4-digit, rejects 2 or 5+
- [x] Updated \`extractReferences\` tests: accepts 4-digit, accepts 3-digit (legacy), rejects 5+
- [x] 136 tests pass (was 132, +4 new assertions replace 2 old)
- [x] Typecheck clean
- [ ] CI green