### PR TITLE
fix(sort): numeric-aware id ordering (#i-0017)

### DIFF
--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -5,6 +5,7 @@ import {
   parseIssueState,
 } from '../../domain/issue/Issue.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
+import { compareSequenceIds } from '../../domain/shared/compareSequenceIds.js';
 import {
   IssueRepository,
   IssueIdCollision,
@@ -60,10 +61,11 @@ export class IssueUseCases {
   }
 
   async list(state?: string): Promise<Issue[]> {
-    if (state === undefined) {
-      return this.issues.listByState('open');
-    }
-    return this.issues.listByState(parseIssueState(state));
+    const items =
+      state === undefined
+        ? await this.issues.listByState('open')
+        : await this.issues.listByState(parseIssueState(state));
+    return sortIssues(items);
   }
 
   /**
@@ -72,7 +74,7 @@ export class IssueUseCases {
    * full corpus without lifecycle filtering.
    */
   async listAll(): Promise<Issue[]> {
-    return this.issues.listAll();
+    return sortIssues(await this.issues.listAll());
   }
 
   async setState(id: string, state: string): Promise<Issue> {
@@ -83,4 +85,8 @@ export class IssueUseCases {
     await this.issues.save(issue);
     return issue;
   }
+}
+
+function sortIssues(items: Issue[]): Issue[] {
+  return [...items].sort((a, b) => compareSequenceIds(a.id.value, b.id.value));
 }

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -6,6 +6,7 @@ import {
 } from '../../domain/request/RequestState.js';
 import { Review } from '../../domain/request/Review.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
+import { compareSequenceIds } from '../../domain/shared/compareSequenceIds.js';
 import {
   RequestRepository,
   RequestIdCollision,
@@ -95,7 +96,8 @@ export class RequestUseCases {
     if (!(REQUEST_STATES as readonly string[]).includes(state)) {
       throw new DomainError(`Invalid state: ${state}`, 'state');
     }
-    return this.deps.requests.listByState(state as RequestState);
+    const items = await this.deps.requests.listByState(state as RequestState);
+    return sortRequests(items);
   }
 
   /**
@@ -104,7 +106,7 @@ export class RequestUseCases {
    * (voices / tail / whoami / chain) that do not care about lifecycle.
    */
   async listAll(): Promise<Request[]> {
-    return this.deps.requests.listAll();
+    return sortRequests(await this.deps.requests.listAll());
   }
 
   async show(id: string): Promise<Request | null> {
@@ -177,4 +179,10 @@ export class RequestUseCases {
     if (!req) throw new DomainError(`Request not found: ${id}`, 'id');
     return req;
   }
+}
+
+function sortRequests(items: Request[]): Request[] {
+  return [...items].sort((a, b) =>
+    compareSequenceIds(a.id.value, b.id.value),
+  );
 }

--- a/src/domain/shared/compareSequenceIds.ts
+++ b/src/domain/shared/compareSequenceIds.ts
@@ -1,0 +1,24 @@
+// Numeric-aware comparison for guild ids of the form
+// `YYYY-MM-DD-NNN[N]` (request) or `i-YYYY-MM-DD-NNN[N]` (issue).
+//
+// Naive lexicographic comparison breaks once the sequence width changes
+// (e.g. 999 -> 9999, see PR#12 / i-2026-04-15-0017): "001" sorts after
+// "0011" because '0' < '1' character by character. We compare the
+// date prefix lexicographically (ISO-8601 sorts correctly as text) and
+// the trailing sequence numerically.
+//
+// Inputs that don't match the expected shape fall back to a stable
+// localeCompare so unknown shapes still produce a deterministic order
+// rather than throwing. This keeps the comparator safe for use in
+// listings that may include legacy or hand-edited records.
+
+const ID_PATTERN = /^(?:i-)?(\d{4}-\d{2}-\d{2})-(\d{3,4})$/;
+
+export function compareSequenceIds(a: string, b: string): number {
+  const ma = ID_PATTERN.exec(a);
+  const mb = ID_PATTERN.exec(b);
+  if (!ma || !mb) return a.localeCompare(b);
+  const dateCmp = (ma[1] as string).localeCompare(mb[1] as string);
+  if (dateCmp !== 0) return dateCmp;
+  return parseInt(ma[2] as string, 10) - parseInt(mb[2] as string, 10);
+}

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -5,6 +5,7 @@ import {
 import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
+import { compareSequenceIds } from '../../../domain/shared/compareSequenceIds.js';
 import {
   collectUtterances,
   renderUtterance,
@@ -269,7 +270,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
     const childPrefix = isLastBranch ? '    ' : '│   ';
     process.stdout.write(`${branchGlyph} referenced issues\n`);
     const sorted = [...linkedIssues].sort((a, b) =>
-      a.id.localeCompare(b.id),
+      compareSequenceIds(a.id, b.id),
     );
     for (let i = 0; i < sorted.length; i++) {
       const item = sorted[i]!;
@@ -293,7 +294,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(`└── referenced requests\n`);
     const childPrefix = '    ';
     const sorted = [...linkedRequests].sort((a, b) =>
-      a.id.localeCompare(b.id),
+      compareSequenceIds(a.id, b.id),
     );
     for (let i = 0; i < sorted.length; i++) {
       const item = sorted[i]!;

--- a/tests/application/IssueUseCases.sortContract.test.ts
+++ b/tests/application/IssueUseCases.sortContract.test.ts
@@ -1,0 +1,107 @@
+// D1 contract test (noir devil review on req 2026-04-15-0008):
+// IssueUseCases.list / listAll must guarantee numeric-aware sort
+// regardless of repository return order. Without this test, the
+// "application sorts" boundary is convention only — a future refactor
+// could quietly bypass it (i-2026-04-15-0014 risk).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { IssueUseCases } from '../../src/application/issue/IssueUseCases.js';
+import { Issue, IssueId, IssueState } from '../../src/domain/issue/Issue.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+import { Member } from '../../src/domain/member/Member.js';
+import {
+  IssueRepository,
+} from '../../src/application/ports/IssueRepository.js';
+import { MemberRepository } from '../../src/application/ports/MemberRepository.js';
+import { Clock } from '../../src/application/ports/Clock.js';
+
+class ShuffledIssueRepo implements IssueRepository {
+  constructor(private items: Issue[]) {}
+  async findById(id: IssueId): Promise<Issue | null> {
+    return this.items.find((i) => i.id.value === id.value) ?? null;
+  }
+  async listByState(state: IssueState): Promise<Issue[]> {
+    // Return in deliberately wrong order to prove the UseCase sorts.
+    return [...this.items].filter((i) => i.toJSON()['state'] === state);
+  }
+  async listAll(): Promise<Issue[]> {
+    return [...this.items];
+  }
+  async save(_i: Issue): Promise<void> {}
+  async saveNew(_i: Issue): Promise<void> {}
+  async nextSequence(_d: string): Promise<number> {
+    return 1;
+  }
+}
+
+class StubMemberRepo implements MemberRepository {
+  async findByName(name: MemberName): Promise<Member | null> {
+    return Member.create({ name: name.value, category: 'professional' });
+  }
+  async exists(_n: MemberName): Promise<boolean> {
+    return true;
+  }
+  async listAll(): Promise<Member[]> {
+    return [];
+  }
+  async save(_m: Member): Promise<void> {}
+  async listHostNames(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FixedClock implements Clock {
+  now(): Date {
+    return new Date('2026-04-15T00:00:00Z');
+  }
+}
+
+function mkIssue(idStr: string): Issue {
+  return Issue.create({
+    id: IssueId.of(idStr),
+    from: 'eris',
+    severity: 'low',
+    area: 'test',
+    text: idStr,
+  });
+}
+
+test('IssueUseCases.list returns numeric-aware sorted order (mixed widths)', async () => {
+  // Deliberately shuffled, mixed 3-digit / 4-digit, multiple dates.
+  const repo = new ShuffledIssueRepo([
+    mkIssue('i-2026-04-15-0011'),
+    mkIssue('i-2026-04-15-002'),
+    mkIssue('i-2026-04-14-0099'),
+    mkIssue('i-2026-04-15-001'),
+    mkIssue('i-2026-04-15-0020'),
+    mkIssue('i-2026-04-15-009'),
+  ]);
+  const uc = new IssueUseCases(repo, new StubMemberRepo(), new FixedClock());
+  const out = await uc.list();
+  assert.deepEqual(
+    out.map((i) => i.id.value),
+    [
+      'i-2026-04-14-0099',
+      'i-2026-04-15-001',
+      'i-2026-04-15-002',
+      'i-2026-04-15-009',
+      'i-2026-04-15-0011',
+      'i-2026-04-15-0020',
+    ],
+  );
+});
+
+test('IssueUseCases.listAll also enforces numeric-aware sort', async () => {
+  const repo = new ShuffledIssueRepo([
+    mkIssue('i-2026-04-15-0011'),
+    mkIssue('i-2026-04-15-001'),
+    mkIssue('i-2026-04-15-002'),
+  ]);
+  const uc = new IssueUseCases(repo, new StubMemberRepo(), new FixedClock());
+  const out = await uc.listAll();
+  assert.deepEqual(
+    out.map((i) => i.id.value),
+    ['i-2026-04-15-001', 'i-2026-04-15-002', 'i-2026-04-15-0011'],
+  );
+});

--- a/tests/domain/compareSequenceIds.test.ts
+++ b/tests/domain/compareSequenceIds.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { compareSequenceIds } from '../../src/domain/shared/compareSequenceIds.js';
+
+test('compareSequenceIds: 4-digit only sorts numerically', () => {
+  const ids = ['2026-04-15-0011', '2026-04-15-0002', '2026-04-15-0020'];
+  ids.sort(compareSequenceIds);
+  assert.deepEqual(ids, [
+    '2026-04-15-0002',
+    '2026-04-15-0011',
+    '2026-04-15-0020',
+  ]);
+});
+
+test('compareSequenceIds: mixed 3-digit / 4-digit no longer collapses', () => {
+  // The bug: lex sort puts "001" before "0011" before "002".
+  // The fix: parse the trailing number and compare numerically.
+  const ids = [
+    '2026-04-15-001',
+    '2026-04-15-0011',
+    '2026-04-15-002',
+    '2026-04-15-0020',
+  ];
+  ids.sort(compareSequenceIds);
+  assert.deepEqual(ids, [
+    '2026-04-15-001',
+    '2026-04-15-002',
+    '2026-04-15-0011',
+    '2026-04-15-0020',
+  ]);
+});
+
+test('compareSequenceIds: issue ids (i- prefix) sort the same way', () => {
+  const ids = [
+    'i-2026-04-15-001',
+    'i-2026-04-15-0011',
+    'i-2026-04-15-002',
+    'i-2026-04-15-0020',
+    'i-2026-04-15-009',
+  ];
+  ids.sort(compareSequenceIds);
+  assert.deepEqual(ids, [
+    'i-2026-04-15-001',
+    'i-2026-04-15-002',
+    'i-2026-04-15-009',
+    'i-2026-04-15-0011',
+    'i-2026-04-15-0020',
+  ]);
+});
+
+test('compareSequenceIds: date prefix wins over sequence', () => {
+  const ids = ['2026-04-15-0001', '2026-04-14-9999', '2026-04-16-0001'];
+  ids.sort(compareSequenceIds);
+  assert.deepEqual(ids, [
+    '2026-04-14-9999',
+    '2026-04-15-0001',
+    '2026-04-16-0001',
+  ]);
+});
+
+test('compareSequenceIds: unknown shapes fall back to localeCompare', () => {
+  // Should not throw for malformed input. Order is deterministic
+  // (lexicographic) so stable sorts stay stable.
+  const ids = ['xyz', 'abc'];
+  ids.sort(compareSequenceIds);
+  assert.deepEqual(ids, ['abc', 'xyz']);
+});
+
+test('compareSequenceIds: comparator contract (anti-symmetric, reflexive)', () => {
+  const a = '2026-04-15-002';
+  const b = '2026-04-15-0011';
+  assert.ok(compareSequenceIds(a, b) < 0);
+  assert.ok(compareSequenceIds(b, a) > 0);
+  assert.equal(compareSequenceIds(a, a), 0);
+});


### PR DESCRIPTION
## Summary

- Lex sort broke once PR#12 widened sequences to 4 digits: `001 → 0011 → 002` on the live tracker
- New `compareSequenceIds` (domain/shared): ISO date prefix lex-compare, sequence numeric-compare, safe fallback
- `IssueUseCases` / `RequestUseCases` `list` and `listAll` now sort before returning — application owns the ordering contract, infrastructure stays a pure scan
- `handlers/read.ts` chain rendering also switched to the new comparator
- 144 tests pass (was 136): 6 unit + 2 application contract

## Two-Persona Devil Review

Tracked in dogfood tracker as request `2026-04-15-0008`. Three lenses:

| lens      | actor | verdict | resolution |
|-----------|-------|---------|------------|
| user      | eris  | ok      | author self-check before handing off |
| devil     | noir  | concern | D1 enforced in this PR via application contract test; D2/D3/D4 deferred to follow-up issues |
| cognitive | eris  | ok      | correction trace acknowledging D1 (was: convention only → now: pinned) and D4 (user lens scope honesty) |

D1 specifically: the "application sorts" boundary was convention only. A future handler refactor (cf. i-2026-04-15-0014) could quietly bypass it. The new `IssueUseCases.sortContract.test.ts` uses a `ShuffledIssueRepo` to pin the contract.

## Scope discipline

Display format (zero-pad widths) is intentionally unchanged. Only lex-sort breakage is fixed. A separate issue may revisit listing UX.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 144/144 pass
- [x] Live tracker visual check: `gate issues list` renders 001 → 002 → ... → 010 → 0012 → ... → 0020
- [x] CI matrix (Node 20/22) — pending GitHub Actions

Refs: i-2026-04-15-0017