### PR TITLE
feat(doctor): add `gate doctor` read-only diagnostic verb (#i-0015)

### DIFF
--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -1,0 +1,78 @@
+// DiagnosticUseCases — observation layer for `gate doctor`.
+//
+// The application layer assembles a fresh set of repositories with a
+// *collecting* onMalformed callback, drives every listAll, and
+// returns a DiagnosticReport. We deliberately do NOT use the shared
+// container's repos: those are wired with stderr-emitting callbacks
+// for normal CLI flows, and we want diagnostic to capture findings
+// without spamming stderr a second time.
+//
+// The injector is a closure that builds three repos for a given
+// onMalformed. Tests inject fakes; the production wiring uses
+// GuildConfig.load(cwd, collector). This keeps the application layer
+// pure (no infra import) and the production wiring a one-liner.
+
+import { MemberRepository } from '../ports/MemberRepository.js';
+import { RequestRepository } from '../ports/RequestRepository.js';
+import { IssueRepository } from '../ports/IssueRepository.js';
+import { OnMalformed } from '../ports/OnMalformed.js';
+import {
+  DiagnosticArea,
+  DiagnosticFinding,
+  DiagnosticReport,
+  classifyMessage,
+} from '../../domain/diagnostic/DiagnosticReport.js';
+
+export interface DiagnosticRepoBundle {
+  readonly members: MemberRepository;
+  readonly requests: RequestRepository;
+  readonly issues: IssueRepository;
+}
+
+export type DiagnosticRepoFactory = (
+  onMalformed: OnMalformed,
+) => DiagnosticRepoBundle;
+
+export class DiagnosticUseCases {
+  constructor(private readonly buildRepos: DiagnosticRepoFactory) {}
+
+  async run(): Promise<DiagnosticReport> {
+    // Findings accumulate across all three areas. Two invariants
+    // (D1/D2 from noir devil review on req 2026-04-15-0009):
+    //   - area tagging is owned by the area-bound collector closure,
+    //     not by post-hoc filtering. The repo never sees an area —
+    //     the collector bakes it in at construction time.
+    //   - per-area count is a local delta over `findings.length`,
+    //     not a filter pass. This keeps the count correct even if
+    //     classifyMessage or area tagging ever drift.
+    const findings: DiagnosticFinding[] = [];
+
+    const areaCollector = (area: DiagnosticArea): OnMalformed =>
+      (msg: string) =>
+        findings.push({ area, kind: classifyMessage(msg), message: msg });
+
+    const beforeMembers = findings.length;
+    const memberBundle = this.buildRepos(areaCollector('members'));
+    const members = await memberBundle.members.listAll();
+    const memberMalformed = findings.length - beforeMembers;
+
+    const beforeRequests = findings.length;
+    const requestBundle = this.buildRepos(areaCollector('requests'));
+    const requests = await requestBundle.requests.listAll();
+    const requestMalformed = findings.length - beforeRequests;
+
+    const beforeIssues = findings.length;
+    const issueBundle = this.buildRepos(areaCollector('issues'));
+    const issues = await issueBundle.issues.listAll();
+    const issueMalformed = findings.length - beforeIssues;
+
+    return new DiagnosticReport(
+      {
+        members: { total: members.length, malformed: memberMalformed },
+        requests: { total: requests.length, malformed: requestMalformed },
+        issues: { total: issues.length, malformed: issueMalformed },
+      },
+      findings,
+    );
+  }
+}

--- a/src/application/ports/OnMalformed.ts
+++ b/src/application/ports/OnMalformed.ts
@@ -1,0 +1,6 @@
+// OnMalformed — port for surfacing data-loss events from hydrate
+// paths. The infrastructure layer's GuildConfig.OnMalformed type is
+// structurally identical; this port lives in application so use cases
+// (e.g. DiagnosticUseCases) don't reach back into infrastructure.
+
+export type OnMalformed = (msg: string) => void;

--- a/src/domain/diagnostic/DiagnosticReport.ts
+++ b/src/domain/diagnostic/DiagnosticReport.ts
@@ -1,0 +1,78 @@
+// DiagnosticReport — value object describing the health of a guild
+// content root. Produced by DiagnosticUseCases.run, consumed by
+// `gate doctor` (and, eventually, `gate repair` in a future PR).
+//
+// Design split (silent_fail_taxonomy 0414):
+//   observation layer  = this report (read-only, side-effect-free)
+//   intervention layer = `gate repair` (writes; not yet implemented)
+//
+// Keeping diagnostic and repair on separate verbs means an operator
+// can always run `gate doctor` without fearing accidental data
+// modification. The report shape is JSON-stable so a future repair
+// verb can consume it from --json output.
+
+export type DiagnosticArea = 'members' | 'requests' | 'issues';
+
+export type DiagnosticKind =
+  | 'top_level_not_mapping'
+  | 'hydration_error'
+  | 'duplicate_id'
+  | 'unknown';
+
+export interface DiagnosticFinding {
+  readonly area: DiagnosticArea;
+  readonly kind: DiagnosticKind;
+  readonly message: string;
+}
+
+export interface DiagnosticAreaSummary {
+  readonly total: number;
+  readonly malformed: number;
+}
+
+export interface DiagnosticSummary {
+  readonly members: DiagnosticAreaSummary;
+  readonly requests: DiagnosticAreaSummary;
+  readonly issues: DiagnosticAreaSummary;
+}
+
+export class DiagnosticReport {
+  constructor(
+    readonly summary: DiagnosticSummary,
+    readonly findings: readonly DiagnosticFinding[],
+  ) {}
+
+  get isClean(): boolean {
+    return this.findings.length === 0;
+  }
+
+  toJSON(): unknown {
+    return {
+      summary: this.summary,
+      findings: this.findings.map((f) => ({ ...f })),
+    };
+  }
+}
+
+// Heuristic message-to-kind classifier. The hydrate paths emit
+// stable english prefixes, so we recognise them as a best effort
+// to give operators a category. Unknown messages fall through to
+// 'unknown' rather than throwing — diagnostic must never crash.
+export function classifyMessage(message: string): DiagnosticKind {
+  const m = message.toLowerCase();
+  if (m.includes('top-level yaml is not a mapping')) {
+    return 'top_level_not_mapping';
+  }
+  if (m.includes('duplicate') || m.includes('collision')) {
+    return 'duplicate_id';
+  }
+  if (
+    m.includes('skipping') ||
+    m.includes('failed to hydrate') ||
+    m.includes('domainerror') ||
+    m.includes('invalid')
+  ) {
+    return 'hydration_error';
+  }
+  return 'unknown';
+}

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -1,0 +1,88 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import {
+  DiagnosticReport,
+  DiagnosticAreaSummary,
+  DiagnosticFinding,
+} from '../../../domain/diagnostic/DiagnosticReport.js';
+
+// gate doctor — read-only diagnostic over the guild content root.
+//
+// Returns 0 if the report is clean, 1 if any finding is present.
+// Three formats:
+//   text     (default) — human-readable per-area summary + findings list
+//   summary  (--summary) — one-line per area, no per-finding detail
+//   json     (--format json) — DiagnosticReport.toJSON for machine
+//                              consumption (future `gate repair` input)
+//
+// Repair is intentionally a separate verb (not yet implemented).
+// See i-2026-04-15-0015 narrative and the silent_fail_taxonomy
+// principle of separating observation from intervention.
+
+export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
+  const report = await c.diagnosticUC.run();
+  const format = optionalOption(args, 'format') ?? 'text';
+  const summaryOnly =
+    args.options['summary'] === true || args.positional[0] === 'summary';
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(report.toJSON(), null, 2) + '\n');
+    return report.isClean ? 0 : 1;
+  }
+
+  if (summaryOnly) {
+    writeSummaryLine('members', report.summary.members);
+    writeSummaryLine('requests', report.summary.requests);
+    writeSummaryLine('issues', report.summary.issues);
+    writeOverall(report);
+    return report.isClean ? 0 : 1;
+  }
+
+  // text (default)
+  process.stdout.write('gate doctor — content root health\n\n');
+  writeAreaSection('members', report.summary.members, report.findings);
+  writeAreaSection('requests', report.summary.requests, report.findings);
+  writeAreaSection('issues', report.summary.issues, report.findings);
+  writeOverall(report);
+  if (!report.isClean) {
+    process.stdout.write(
+      '\nnote: `gate doctor` is read-only. A future `gate repair`\n' +
+        'verb will consume `gate doctor --format json` to drive fixes.\n' +
+        'For now, inspect the offending YAML files manually.\n',
+    );
+  }
+  return report.isClean ? 0 : 1;
+}
+
+function writeSummaryLine(
+  area: string,
+  s: DiagnosticAreaSummary,
+): void {
+  const glyph = s.malformed === 0 ? '✓' : '✗';
+  process.stdout.write(
+    `${glyph} ${area.padEnd(9)} ${s.total} total, ${s.malformed} malformed\n`,
+  );
+}
+
+function writeAreaSection(
+  area: 'members' | 'requests' | 'issues',
+  s: DiagnosticAreaSummary,
+  findings: readonly DiagnosticFinding[],
+): void {
+  writeSummaryLine(area, s);
+  const local = findings.filter((f) => f.area === area);
+  for (const f of local) {
+    process.stdout.write(`    [${f.kind}] ${f.message}\n`);
+  }
+}
+
+function writeOverall(report: DiagnosticReport): void {
+  process.stdout.write('\n');
+  if (report.isClean) {
+    process.stdout.write('✓ clean — no malformed records detected\n');
+  } else {
+    process.stdout.write(
+      `✗ ${report.findings.length} finding(s) — exit 1\n`,
+    );
+  }
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -21,6 +21,7 @@ import {
   reqChain,
 } from './handlers/read.js';
 import { issuesCmd } from './handlers/issues.js';
+import { doctorCmd } from './handlers/doctor.js';
 import {
   msgSend,
   msgBroadcast,
@@ -84,6 +85,12 @@ Environment:
                        Automations should continue to pass --from / --by
                        explicitly.
 
+Diagnostic:
+  gate doctor [--summary | --format json]
+                       Read-only health check over the content root.
+                       Exits 1 if any malformed records are detected.
+                       (Repair will be a separate verb in a future PR.)
+
 Meta:
   gate --version       Print version and exit
 `;
@@ -142,6 +149,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await msgBroadcast(c, args);
       case 'inbox':
         return await msgInbox(c, args);
+      case 'doctor':
+        return await doctorCmd(c, args);
       default:
         process.stderr.write(`unknown command: ${cmd}\n${HELP}`);
         return 1;

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -8,6 +8,11 @@ import { MemberUseCases } from '../../application/member/MemberUseCases.js';
 import { RequestUseCases } from '../../application/request/RequestUseCases.js';
 import { IssueUseCases } from '../../application/issue/IssueUseCases.js';
 import { MessageUseCases } from '../../application/message/MessageUseCases.js';
+import {
+  DiagnosticUseCases,
+  DiagnosticRepoBundle,
+} from '../../application/diagnostic/DiagnosticUseCases.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
 export interface Container {
   config: GuildConfig;
@@ -15,6 +20,7 @@ export interface Container {
   requestUC: RequestUseCases;
   issueUC: IssueUseCases;
   messageUC: MessageUseCases;
+  diagnosticUC: DiagnosticUseCases;
 }
 
 export function buildContainer(): Container {
@@ -24,11 +30,23 @@ export function buildContainer(): Container {
   const issues = new YamlIssueRepository(config);
   const notifier = new FsInboxNotification(config);
   const clock = systemClock;
+  // Diagnostic uses a fresh config per area so its collecting
+  // onMalformed callback isn't shared with the stderr-emitting
+  // default that the rest of the CLI uses.
+  const buildDiagRepos = (om: OnMalformed): DiagnosticRepoBundle => {
+    const cfg = GuildConfig.load(process.cwd(), om);
+    return {
+      members: new YamlMemberRepository(cfg),
+      requests: new YamlRequestRepository(cfg),
+      issues: new YamlIssueRepository(cfg),
+    };
+  };
   return {
     config,
     memberUC: new MemberUseCases(members),
     requestUC: new RequestUseCases({ requests, members, notifier, clock }),
     issueUC: new IssueUseCases(issues, members, clock),
     messageUC: new MessageUseCases({ members, notifier, clock }),
+    diagnosticUC: new DiagnosticUseCases(buildDiagRepos),
   };
 }

--- a/tests/application/DiagnosticUseCases.test.ts
+++ b/tests/application/DiagnosticUseCases.test.ts
@@ -1,0 +1,208 @@
+// DiagnosticUseCases — application tests.
+// Verify that:
+//   1. clean repos produce an empty findings list and isClean=true
+//   2. malformed records surface as findings tagged with the right area
+//   3. classification heuristics map known onMalformed messages to kinds
+//   4. totals reflect successfully hydrated records (not malformed ones)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DiagnosticUseCases,
+  DiagnosticRepoBundle,
+} from '../../src/application/diagnostic/DiagnosticUseCases.js';
+import { OnMalformed } from '../../src/application/ports/OnMalformed.js';
+import { MemberRepository } from '../../src/application/ports/MemberRepository.js';
+import { RequestRepository } from '../../src/application/ports/RequestRepository.js';
+import { IssueRepository } from '../../src/application/ports/IssueRepository.js';
+import { Member } from '../../src/domain/member/Member.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+import { Issue, IssueId, IssueState } from '../../src/domain/issue/Issue.js';
+import { Request } from '../../src/domain/request/Request.js';
+import { RequestId } from '../../src/domain/request/RequestId.js';
+import { RequestState } from '../../src/domain/request/RequestState.js';
+
+class FakeMemberRepo implements MemberRepository {
+  constructor(
+    private items: Member[],
+    private malformedMessages: string[] = [],
+  ) {}
+  async findByName(_n: MemberName): Promise<Member | null> {
+    return null;
+  }
+  async exists(_n: MemberName): Promise<boolean> {
+    return false;
+  }
+  async listAll(): Promise<Member[]> {
+    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    return this.items;
+  }
+  async save(_m: Member): Promise<void> {}
+  async listHostNames(): Promise<string[]> {
+    return [];
+  }
+  onMalformed?: OnMalformed;
+}
+
+class FakeRequestRepo implements RequestRepository {
+  constructor(
+    private items: Request[],
+    private malformedMessages: string[] = [],
+  ) {}
+  async listByState(_s: RequestState): Promise<Request[]> {
+    return [];
+  }
+  async listAll(): Promise<Request[]> {
+    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    return this.items;
+  }
+  async findById(_id: RequestId): Promise<Request | null> {
+    return null;
+  }
+  async save(_r: Request): Promise<void> {}
+  async saveNew(_r: Request): Promise<void> {}
+  async nextSequence(_d: string): Promise<number> {
+    return 1;
+  }
+  onMalformed?: OnMalformed;
+}
+
+class FakeIssueRepo implements IssueRepository {
+  constructor(
+    private items: Issue[],
+    private malformedMessages: string[] = [],
+  ) {}
+  async findById(_id: IssueId): Promise<Issue | null> {
+    return null;
+  }
+  async listByState(_s: IssueState): Promise<Issue[]> {
+    return [];
+  }
+  async listAll(): Promise<Issue[]> {
+    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    return this.items;
+  }
+  async save(_i: Issue): Promise<void> {}
+  async saveNew(_i: Issue): Promise<void> {}
+  async nextSequence(_d: string): Promise<number> {
+    return 1;
+  }
+  onMalformed?: OnMalformed;
+}
+
+function makeFactory(
+  members: FakeMemberRepo,
+  requests: FakeRequestRepo,
+  issues: FakeIssueRepo,
+): (om: OnMalformed) => DiagnosticRepoBundle {
+  // Each call rebuilds the closure binding so DiagnosticUseCases'
+  // per-area collector wiring works correctly.
+  return (om: OnMalformed) => {
+    members.onMalformed = om;
+    requests.onMalformed = om;
+    issues.onMalformed = om;
+    return { members, requests, issues };
+  };
+}
+
+function mkMember(name: string): Member {
+  return Member.create({ name, category: 'professional' });
+}
+function mkIssue(id: string): Issue {
+  return Issue.create({
+    id: IssueId.of(id),
+    from: 'eris',
+    severity: 'low',
+    area: 'test',
+    text: id,
+  });
+}
+
+test('DiagnosticUseCases.run: clean repos return isClean=true', async () => {
+  const members = new FakeMemberRepo([mkMember('eris'), mkMember('noir')]);
+  const requests = new FakeRequestRepo([]);
+  const issues = new FakeIssueRepo([mkIssue('i-2026-04-15-0001')]);
+  const uc = new DiagnosticUseCases(makeFactory(members, requests, issues));
+  const report = await uc.run();
+  assert.equal(report.isClean, true);
+  assert.equal(report.findings.length, 0);
+  assert.equal(report.summary.members.total, 2);
+  assert.equal(report.summary.members.malformed, 0);
+  assert.equal(report.summary.issues.total, 1);
+});
+
+test('DiagnosticUseCases.run: malformed messages surface tagged by area', async () => {
+  const members = new FakeMemberRepo([], [
+    'member eris.yaml: top-level YAML is not a mapping; skipping',
+  ]);
+  const requests = new FakeRequestRepo([], [
+    'request 2026-04-15-0001.yaml: failed to hydrate (DomainError: Invalid id)',
+  ]);
+  const issues = new FakeIssueRepo([], [
+    'issue i-bogus.yaml: top-level YAML is not a mapping; skipping',
+    'issue dup: duplicate id detected during hydrate',
+  ]);
+  const uc = new DiagnosticUseCases(makeFactory(members, requests, issues));
+  const report = await uc.run();
+  assert.equal(report.isClean, false);
+  assert.equal(report.findings.length, 4);
+
+  const byArea = (a: string) =>
+    report.findings.filter((f) => f.area === a);
+  assert.equal(byArea('members').length, 1);
+  assert.equal(byArea('requests').length, 1);
+  assert.equal(byArea('issues').length, 2);
+});
+
+test('DiagnosticUseCases.run: classifyMessage maps known prefixes', async () => {
+  const issues = new FakeIssueRepo([], [
+    'issue a.yaml: top-level YAML is not a mapping; skipping',
+    'issue b.yaml: failed to hydrate (DomainError: Invalid sequence)',
+    'issue c.yaml: duplicate id collision',
+    'issue d.yaml: something completely unexpected here',
+  ]);
+  const uc = new DiagnosticUseCases(
+    makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), issues),
+  );
+  const report = await uc.run();
+  const kinds = report.findings.map((f) => f.kind);
+  assert.deepEqual(kinds, [
+    'top_level_not_mapping',
+    'hydration_error',
+    'duplicate_id',
+    'unknown',
+  ]);
+});
+
+test('DiagnosticUseCases.run: totals count successful hydrations only', async () => {
+  // Hydrated items are returned as Member/Issue/Request instances;
+  // malformed messages are reported separately and do NOT inflate totals.
+  const members = new FakeMemberRepo(
+    [mkMember('eris')],
+    ['member broken.yaml: top-level YAML is not a mapping; skipping'],
+  );
+  const uc = new DiagnosticUseCases(
+    makeFactory(members, new FakeRequestRepo([]), new FakeIssueRepo([])),
+  );
+  const report = await uc.run();
+  assert.equal(report.summary.members.total, 1);
+  assert.equal(report.summary.members.malformed, 1);
+});
+
+test('DiagnosticReport.toJSON: stable shape for future repair consumer', async () => {
+  const issues = new FakeIssueRepo([mkIssue('i-2026-04-15-0001')], [
+    'issue x.yaml: top-level YAML is not a mapping; skipping',
+  ]);
+  const uc = new DiagnosticUseCases(
+    makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), issues),
+  );
+  const report = await uc.run();
+  const json = report.toJSON() as {
+    summary: unknown;
+    findings: { area: string; kind: string; message: string }[];
+  };
+  assert.ok(json.summary);
+  assert.equal(json.findings.length, 1);
+  assert.equal(json.findings[0]?.area, 'issues');
+  assert.equal(json.findings[0]?.kind, 'top_level_not_mapping');
+});


### PR DESCRIPTION
## Summary

- Closes the user-lens gap from PR#11: hydrate warnings now have a single verb that surfaces them as findings, classifies them, and exits 1
- `gate doctor` is **read-only**. Repair will be a separate verb in a future PR — observation and intervention live on different lifecycles (silent_fail_taxonomy 0414)
- Three output formats: text (default) / `--summary` / `--format json` (the JSON shape is stable so the future `gate repair` can consume it)

## What's new

- `domain/diagnostic/DiagnosticReport.ts` — value object + `classifyMessage` heuristic
- `application/ports/OnMalformed.ts` — port so use cases never reach into infrastructure
- `application/diagnostic/DiagnosticUseCases.ts` — area-bound collector closure + per-area count via local delta (both invariants enforced after noir devil review)
- `interface/gate/handlers/doctor.ts` — text / summary / json formatters
- `interface/shared/container.ts` — `buildDiagRepos(om)` factory closure

## Tests

149 total (was 144). 5 new application tests:
- clean repos → `isClean=true`, totals correct
- malformed messages → tagged with the right area
- `classifyMessage` → maps known infra prefixes (top_level_not_mapping, hydration_error, duplicate_id, unknown)
- totals exclude malformed records
- `toJSON` shape stability for the future repair consumer

## Verification

- Live tracker dogfood: `4 members, 9 requests, 22 issues, 0 findings, exit 0` ✓
- Tmp-dir smoke test with intentionally broken issue YAML: `exit 1, 2 hydration_error findings` ✓

## Two-Persona Devil Review

Tracked in dogfood tracker as request `2026-04-15-0009`. Three lenses:

| lens      | actor | verdict | resolution |
|-----------|-------|---------|------------|
| user      | eris  | ok      | MVP completion check |
| devil     | noir  | concern | D1+D2 enforced in this PR; D3/D4/D5 deferred |
| cognitive | eris  | ok      | correction trace for D1/D2 + narrative for D5 |

**D1** (noir): area tagging was happening via post-hoc `findings.filter(area)`, which makes the area→finding mapping a *convention* rather than an *invariant*. Fixed: area is baked into the collector closure at construction, so the repo never sees an area at all.

**D2** (noir): per-area counts were using filter passes, which compound the D1 risk. Fixed: each area takes a local delta over `findings.length` before/after `listAll`, so counts stay correct even if classification ever drifts.

D3 (infra↔app classifier integration test), D4 (deterministic finding sort), and D5 (file-path contract on infra-side onMalformed messages) are deferred to follow-up issues.

## Scope discipline

The output explicitly tells operators: `gate doctor` is read-only; a future `gate repair` will consume `--format json`. No silent partial repair.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 149/149 pass
- [x] Live tracker clean run + tmp-dir smoke
- [x] CI matrix (Node 20/22) — pending

Refs: i-2026-04-15-0015