### PR TITLE
feat(repair): gate repair verb (quarantine MVP) + OnMalformed source contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,33 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate repair` verb** — intervention layer paired with `gate doctor`.
+  Consumes `gate doctor --format json` from stdin (or `--from-doctor <path>`)
+  and either prints the proposed plan (default `--dry-run`) or executes it
+  (`--apply`). Quarantine is the only action: malformed records
+  (`top_level_not_mapping`, `hydration_error`) are moved to
+  `<content_root>/quarantine/<ISO-timestamp>/<area>/<basename>`.
+  `duplicate_id` and `unknown` findings are no-op (data safety: automatic
+  resolution risks data loss). `text` and `json` output formats. The
+  `--apply` path is idempotent (already-moved sources are skipped, not
+  errored). Path safety is enforced via `realpathSync` canonicalization
+  on both content_root and source — symlink-escape is closed structurally.
+  Closes `i-2026-04-15-0026` (partial: quarantine path; field-level patch
+  repair tracked separately).
 - `CHANGELOG.md` and `POLICY.md` — versioning promise and change history.
 - `guild --version` / `gate --version` (alias `-v`) — print `guild-cli <version>` and exit 0.
+
+### Changed (breaking — application port)
+- **`OnMalformed` port signature** widened from `(msg: string) => void`
+  to `(source: string, msg: string) => void`. The `source` is the
+  absolute filesystem path of the offending file. This makes the
+  intervention contract type-enforced rather than convention-pinned
+  (previously the path was carried as a prefix of the message string).
+  All three YAML repositories (`YamlMemberRepository`,
+  `YamlRequestRepository`, `YamlIssueRepository`) now pass the absolute
+  source path explicitly. `DiagnosticFinding` gains a new
+  `readonly source: string` field, surfaced in `gate doctor` text/json
+  output. Closes `i-2026-04-15-0025`.
 
 ### Changed
 - **Sequence ceiling**: Request and Issue ids now use 4-digit

--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -48,8 +48,13 @@ export class DiagnosticUseCases {
     const findings: DiagnosticFinding[] = [];
 
     const areaCollector = (area: DiagnosticArea): OnMalformed =>
-      (msg: string) =>
-        findings.push({ area, kind: classifyMessage(msg), message: msg });
+      (source: string, msg: string) =>
+        findings.push({
+          area,
+          source,
+          kind: classifyMessage(msg),
+          message: msg,
+        });
 
     const beforeMembers = findings.length;
     const memberBundle = this.buildRepos(areaCollector('members'));

--- a/src/application/ports/OnMalformed.ts
+++ b/src/application/ports/OnMalformed.ts
@@ -2,5 +2,11 @@
 // paths. The infrastructure layer's GuildConfig.OnMalformed type is
 // structurally identical; this port lives in application so use cases
 // (e.g. DiagnosticUseCases) don't reach back into infrastructure.
+//
+// `source` is the absolute filesystem path of the offending file.
+// Structured-by-construction so that intervention verbs (gate repair)
+// can act on it without parsing free-form messages — this closes
+// i-2026-04-15-0025 by making the contract type-enforced rather than
+// convention-pinned.
 
-export type OnMalformed = (msg: string) => void;
+export type OnMalformed = (source: string, msg: string) => void;

--- a/src/application/ports/QuarantineStore.ts
+++ b/src/application/ports/QuarantineStore.ts
@@ -1,0 +1,32 @@
+// QuarantineStore — port for moving offending files out of the hot
+// path. Implementations enforce that both source and destination
+// resolve under the configured content_root; path traversal must be
+// rejected. The port is intentionally narrow: a single move() verb,
+// no copy / no delete / no overwrite. Idempotency is the caller's
+// responsibility (applyRepair skips actions whose source no longer
+// exists).
+//
+// The destination directory layout is decided by the implementation,
+// not by the use case, so the application layer stays unaware of the
+// concrete filesystem shape.
+
+export interface QuarantineResult {
+  readonly source: string;
+  readonly destination: string;
+}
+
+export interface QuarantineStore {
+  /**
+   * Move `absSource` into the quarantine area. Returns the absolute
+   * destination path. Throws if `absSource` does not exist, escapes
+   * the content root, or the move fails.
+   */
+  move(absSource: string): Promise<QuarantineResult>;
+
+  /**
+   * Returns true if the absolute path currently exists. Used by
+   * applyRepair to make repair idempotent (already-quarantined files
+   * are skipped without throwing).
+   */
+  sourceExists(absSource: string): boolean;
+}

--- a/src/application/repair/RepairUseCases.ts
+++ b/src/application/repair/RepairUseCases.ts
@@ -1,0 +1,133 @@
+// RepairUseCases — application layer for `gate repair`.
+//
+// Two responsibilities, kept as separate methods so the dry-run /
+// apply split is structural rather than a flag check:
+//
+//   plan(report)           — pure, returns a RepairPlan
+//   apply(plan)            — executes quarantine actions via the
+//                            QuarantineStore port
+//
+// The port keeps the use case ignorant of filesystem details so unit
+// tests can inject a fake. Idempotency: actions whose source file no
+// longer exists are skipped silently with status='skipped' rather
+// than throwing — repair is safe to re-run.
+//
+// Errors during a single action do NOT abort the whole apply: each
+// action records its own outcome so the operator gets a complete
+// picture of what worked and what didn't. This is the inverse of
+// the cleanup-of-cleanup anti-pattern: failures surface as data,
+// not as silently swallowed exceptions.
+
+import { DiagnosticFinding } from '../../domain/diagnostic/DiagnosticReport.js';
+import {
+  RepairPlan,
+  RepairAction,
+  planRepair,
+} from '../../domain/repair/RepairPlan.js';
+import { QuarantineStore } from '../ports/QuarantineStore.js';
+
+export type RepairOutcomeStatus = 'quarantined' | 'skipped' | 'no_op' | 'error';
+
+export interface RepairOutcome {
+  readonly action: RepairAction;
+  readonly status: RepairOutcomeStatus;
+  readonly destination?: string;
+  readonly error?: string;
+}
+
+export interface RepairOutcomeSummary {
+  readonly total: number;
+  readonly quarantined: number;
+  readonly skipped: number;
+  readonly noOp: number;
+  readonly error: number;
+}
+
+export class RepairResult {
+  constructor(readonly outcomes: readonly RepairOutcome[]) {}
+
+  get summary(): RepairOutcomeSummary {
+    let quarantined = 0;
+    let skipped = 0;
+    let noOp = 0;
+    let error = 0;
+    for (const o of this.outcomes) {
+      if (o.status === 'quarantined') quarantined++;
+      else if (o.status === 'skipped') skipped++;
+      else if (o.status === 'no_op') noOp++;
+      else if (o.status === 'error') error++;
+    }
+    return {
+      total: this.outcomes.length,
+      quarantined,
+      skipped,
+      noOp,
+      error,
+    };
+  }
+
+  get hasErrors(): boolean {
+    return this.outcomes.some((o) => o.status === 'error');
+  }
+
+  toJSON(): unknown {
+    return {
+      summary: this.summary,
+      outcomes: this.outcomes.map((o) => ({
+        status: o.status,
+        destination: o.destination,
+        error: o.error,
+        action: {
+          kind: o.action.kind,
+          rationale: o.action.rationale,
+          finding: { ...o.action.finding },
+        },
+      })),
+    };
+  }
+}
+
+export class RepairUseCases {
+  constructor(private readonly quarantine: QuarantineStore) {}
+
+  // Pure: planning is a function of findings and never touches
+  // the filesystem. Used by --dry-run. Accepting findings directly
+  // (rather than a full DiagnosticReport) keeps the handler boundary
+  // simple — repair only ever needs the array.
+  plan(findings: readonly DiagnosticFinding[]): RepairPlan {
+    return planRepair(findings);
+  }
+
+  // Drives quarantine actions through the port. Each outcome is
+  // captured independently — one failure does not abort siblings.
+  async apply(plan: RepairPlan): Promise<RepairResult> {
+    const outcomes: RepairOutcome[] = [];
+    for (const action of plan.actions) {
+      if (action.kind === 'no_op') {
+        outcomes.push({ action, status: 'no_op' });
+        continue;
+      }
+      // quarantine
+      const source = action.finding.source;
+      if (!this.quarantine.sourceExists(source)) {
+        outcomes.push({ action, status: 'skipped' });
+        continue;
+      }
+      try {
+        const result = await this.quarantine.move(source);
+        outcomes.push({
+          action,
+          status: 'quarantined',
+          destination: result.destination,
+        });
+      } catch (e) {
+        outcomes.push({
+          action,
+          status: 'error',
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    return new RepairResult(outcomes);
+  }
+}

--- a/src/domain/diagnostic/DiagnosticReport.ts
+++ b/src/domain/diagnostic/DiagnosticReport.ts
@@ -21,6 +21,7 @@ export type DiagnosticKind =
 
 export interface DiagnosticFinding {
   readonly area: DiagnosticArea;
+  readonly source: string; // absolute path of the offending file
   readonly kind: DiagnosticKind;
   readonly message: string;
 }

--- a/src/domain/repair/RepairPlan.ts
+++ b/src/domain/repair/RepairPlan.ts
@@ -1,0 +1,114 @@
+// RepairPlan — value object describing the intended response to a
+// DiagnosticReport. Pure: planning is a total function of findings.
+//
+// Design split (silent_fail_taxonomy 0414):
+//   observation layer  = DiagnosticReport (read-only)
+//   intervention layer = RepairPlan + applyRepair (writes)
+//
+// MVP scope (i-2026-04-15-0026 partial):
+//   - quarantine: move the offending file to a timestamped quarantine
+//     directory under the content root. Reversible via git or manual mv.
+//   - no_op:      record the finding but do nothing. Used for kinds
+//     where automatic repair would risk data loss (duplicate_id) or
+//     where the kind is unrecognized (unknown).
+//
+// Field-level patch repairs are explicitly out of scope and tracked
+// as a follow-up issue. Quarantine is the smallest action that lets
+// the rest of the system proceed without the offending file blocking
+// reads or polluting summaries.
+
+import {
+  DiagnosticFinding,
+  DiagnosticKind,
+} from '../diagnostic/DiagnosticReport.js';
+
+export type RepairActionKind = 'quarantine' | 'no_op';
+
+export interface RepairAction {
+  readonly finding: DiagnosticFinding;
+  readonly kind: RepairActionKind;
+  readonly rationale: string;
+}
+
+export interface RepairPlanSummary {
+  readonly total: number;
+  readonly quarantine: number;
+  readonly noOp: number;
+}
+
+export class RepairPlan {
+  constructor(readonly actions: readonly RepairAction[]) {}
+
+  get summary(): RepairPlanSummary {
+    let quarantine = 0;
+    let noOp = 0;
+    for (const a of this.actions) {
+      if (a.kind === 'quarantine') quarantine++;
+      else noOp++;
+    }
+    return { total: this.actions.length, quarantine, noOp };
+  }
+
+  get isEmpty(): boolean {
+    return this.actions.length === 0;
+  }
+
+  toJSON(): unknown {
+    return {
+      summary: this.summary,
+      actions: this.actions.map((a) => ({
+        kind: a.kind,
+        rationale: a.rationale,
+        finding: { ...a.finding },
+      })),
+    };
+  }
+}
+
+// Pure mapping from finding kind to action. The mapping is total —
+// every DiagnosticKind has an explicit branch — so adding a new kind
+// to the diagnostic side will fail typecheck here, surfacing the
+// scope decision instead of silently defaulting.
+export function planRepair(
+  findings: readonly DiagnosticFinding[],
+): RepairPlan {
+  const actions: RepairAction[] = [];
+  for (const f of findings) {
+    actions.push(actionForKind(f));
+  }
+  return new RepairPlan(actions);
+}
+
+function actionForKind(f: DiagnosticFinding): RepairAction {
+  const kind: DiagnosticKind = f.kind;
+  switch (kind) {
+    case 'top_level_not_mapping':
+      return {
+        finding: f,
+        kind: 'quarantine',
+        rationale:
+          'YAML root is not a mapping; structurally unrepairable, move out of hot path',
+      };
+    case 'hydration_error':
+      return {
+        finding: f,
+        kind: 'quarantine',
+        rationale:
+          'domain hydrate failed; field-level patch out of MVP scope, move out of hot path',
+      };
+    case 'duplicate_id':
+      return {
+        finding: f,
+        kind: 'no_op',
+        rationale:
+          'duplicate id — automatic resolution risks data loss; operator must compare and reconcile manually',
+      };
+    case 'unknown':
+      return {
+        finding: f,
+        kind: 'no_op',
+        rationale:
+          'unrecognized failure kind; refusing to act without classification',
+      };
+  }
+}

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -8,11 +8,15 @@ import { DomainError } from '../../domain/shared/DomainError.js';
  * parsed into a domain object. The CLI wires this to stderr so that
  * data-loss events surface instead of being silently swallowed.
  * Tests inject a collecting spy to assert the exact messages.
+ *
+ * `source` is the absolute filesystem path of the offending file.
+ * The path is mandatory and structured: gate repair consumes it
+ * directly without parsing the message string.
  */
-export type OnMalformed = (msg: string) => void;
+export type OnMalformed = (source: string, msg: string) => void;
 
-export const defaultOnMalformed: OnMalformed = (msg) => {
-  process.stderr.write(`warn: ${msg}\n`);
+export const defaultOnMalformed: OnMalformed = (source, msg) => {
+  process.stderr.write(`warn: ${source}: ${msg}\n`);
 };
 
 export interface GuildConfigProps {

--- a/src/infrastructure/persistence/SafeFsQuarantineStore.ts
+++ b/src/infrastructure/persistence/SafeFsQuarantineStore.ts
@@ -1,0 +1,134 @@
+// SafeFsQuarantineStore — adapter for QuarantineStore that moves
+// files into <content_root>/quarantine/<ISO-timestamp>/<area>/<basename>.
+//
+// Constraints:
+//   - source must already resolve under content_root (validated by
+//     resolve+startsWith against the configured root)
+//   - destination is computed under content_root, no escape possible
+//   - the timestamped subdirectory is created on first move per
+//     instance, so a single repair run groups its actions together
+//     and a re-run produces a new timestamp directory
+//   - move uses fs.renameSync where possible (atomic within a
+//     filesystem); cross-device renames fall back to copy+unlink
+//
+// This keeps the silent_fail_taxonomy "cleanup-of-cleanup is an
+// anti-pattern" rule honored: a failed move throws and surfaces,
+// rather than partially completing and leaving a half-quarantined
+// state.
+
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  copyFileSync,
+  unlinkSync,
+  realpathSync,
+} from 'node:fs';
+import { resolve, basename, join, sep } from 'node:path';
+import {
+  QuarantineStore,
+  QuarantineResult,
+} from '../../application/ports/QuarantineStore.js';
+
+export class SafeFsQuarantineStore implements QuarantineStore {
+  private readonly contentRoot: string;
+  private readonly quarantineDir: string;
+
+  constructor(contentRoot: string, nowIso: string = new Date().toISOString()) {
+    // Canonicalize via realpath so the symlink-resolved comparison in
+    // move() doesn't false-positive on platforms where common parents
+    // (e.g. macOS /var → /private/var) are themselves symlinks.
+    const absRoot = resolve(contentRoot);
+    try {
+      this.contentRoot = realpathSync(absRoot);
+    } catch {
+      this.contentRoot = absRoot;
+    }
+    // ':' is legal on POSIX but awkward in shells; replace with '-'
+    const safeStamp = nowIso.replace(/[:.]/g, '-');
+    this.quarantineDir = join(this.contentRoot, 'quarantine', safeStamp);
+  }
+
+  sourceExists(absSource: string): boolean {
+    const resolved = resolve(absSource);
+    if (!existsSync(resolved)) return false;
+    try {
+      const real = realpathSync(resolved);
+      return this.isUnderContentRoot(real);
+    } catch {
+      return false;
+    }
+  }
+
+  async move(absSource: string): Promise<QuarantineResult> {
+    const resolvedSource = resolve(absSource);
+    if (!existsSync(resolvedSource)) {
+      throw new Error(`quarantine refused: source does not exist: ${absSource}`);
+    }
+    // Defense in depth (D1 from noir devil review on req 2026-04-15-0012):
+    // resolve() does not follow symlinks, so a symlink inside content_root
+    // pointing outside would pass a naive startsWith check. Canonicalize
+    // both sides via realpath (constructor canonicalizes contentRoot) and
+    // do the boundary check on the canonical form — that closes the
+    // symlink-escape hole and keeps the test for normal files working.
+    const realSource = realpathSync(resolvedSource);
+    if (!this.isUnderContentRoot(realSource)) {
+      // U1 (eris user review on req 2026-04-15-0012): never claim
+      // "via symlink" — on macOS /var → /private/var canonicalization
+      // makes parent-level differences common even with no symlink in
+      // the path the operator gave us. Show both forms when they
+      // differ and let the operator compare; that's honest without
+      // inventing a cause.
+      const detail =
+        realSource === resolvedSource
+          ? absSource
+          : `${absSource} (canonical: ${realSource})`;
+      throw new Error(
+        `quarantine refused: source is outside content_root: ${detail}`,
+      );
+    }
+
+    const area = this.areaOf(realSource);
+    const destDir = join(this.quarantineDir, area);
+    mkdirSync(destDir, { recursive: true });
+    const dest = join(destDir, basename(resolvedSource));
+
+    if (!this.isUnderContentRoot(dest)) {
+      throw new Error(
+        `quarantine refused: computed destination escapes content_root: ${dest}`,
+      );
+    }
+
+    try {
+      renameSync(realSource, dest);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EXDEV') {
+        // cross-device — fall back to copy+unlink
+        copyFileSync(realSource, dest);
+        unlinkSync(realSource);
+      } else {
+        throw e;
+      }
+    }
+
+    return { source: realSource, destination: dest };
+  }
+
+  private isUnderContentRoot(absPath: string): boolean {
+    const r = resolve(absPath);
+    return r === this.contentRoot || r.startsWith(this.contentRoot + sep);
+  }
+
+  // Best-effort area inference from path segment. Falls back to
+  // 'other' rather than throwing — the file still gets quarantined.
+  private areaOf(absSource: string): string {
+    const rel = absSource.startsWith(this.contentRoot + sep)
+      ? absSource.slice(this.contentRoot.length + 1)
+      : absSource;
+    const first = rel.split(sep)[0] ?? '';
+    if (first === 'members' || first === 'requests' || first === 'issues') {
+      return first;
+    }
+    return 'other';
+  }
+}

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -17,7 +17,9 @@ import {
   readTextSafe,
   writeTextSafe,
 } from './safeFs.js';
+import { join } from 'node:path';
 import { GuildConfig } from '../config/GuildConfig.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
 const FILE_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
 
@@ -28,7 +30,8 @@ export class YamlIssueRepository implements IssueRepository {
     const rel = `${id.value}.yaml`;
     if (!existsSafe(this.config.paths.issues, rel)) return null;
     const raw = readTextSafe(this.config.paths.issues, rel);
-    return hydrate(YAML.parse(raw), rel, this.config.onMalformed);
+    const absSource = join(this.config.paths.issues, rel);
+    return hydrate(YAML.parse(raw), absSource, this.config.onMalformed);
   }
 
   async listByState(state: IssueState): Promise<Issue[]> {
@@ -43,7 +46,8 @@ export class YamlIssueRepository implements IssueRepository {
     const out: Issue[] = [];
     for (const f of files) {
       const raw = readTextSafe(this.config.paths.issues, f);
-      const issue = hydrate(YAML.parse(raw), f, this.config.onMalformed);
+      const absSource = join(this.config.paths.issues, f);
+      const issue = hydrate(YAML.parse(raw), absSource, this.config.onMalformed);
       if (issue) out.push(issue);
     }
     return out;
@@ -89,10 +93,10 @@ export class YamlIssueRepository implements IssueRepository {
 function hydrate(
   data: unknown,
   source: string,
-  onMalformed: (msg: string) => void,
+  onMalformed: OnMalformed,
 ): Issue | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
-    onMalformed(`issue ${source}: top-level YAML is not a mapping; skipping`);
+    onMalformed(source, 'top-level YAML is not a mapping; skipping');
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -112,7 +116,8 @@ function hydrate(
     const msg = e instanceof Error ? e.message : String(e);
     const idHint = typeof obj['id'] === 'string' ? ` (id=${obj['id']})` : '';
     onMalformed(
-      `issue ${source}${idHint}: hydrate failed, skipping record: ${msg}`,
+      source,
+      `hydrate failed${idHint}, skipping record: ${msg}`,
     );
     return null;
   }

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -9,7 +9,9 @@ import {
   readTextSafe,
   writeTextSafe,
 } from './safeFs.js';
+import { join } from 'node:path';
 import { GuildConfig } from '../config/GuildConfig.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
 /**
  * File layout: <config.paths.members>/<name>.yaml
@@ -26,7 +28,8 @@ export class YamlMemberRepository implements MemberRepository {
     if (!existsSafe(this.config.paths.members, file)) return null;
     const raw = readTextSafe(this.config.paths.members, file);
     const data = YAML.parse(raw);
-    return hydrate(data, name.value, file, this.config.onMalformed);
+    const absSource = join(this.config.paths.members, file);
+    return hydrate(data, name.value, absSource, this.config.onMalformed);
   }
 
   async exists(name: MemberName): Promise<boolean> {
@@ -42,7 +45,8 @@ export class YamlMemberRepository implements MemberRepository {
       const raw = readTextSafe(this.config.paths.members, f);
       const data = YAML.parse(raw);
       const name = f.replace(/\.yaml$/, '');
-      const m = hydrate(data, name, f, this.config.onMalformed);
+      const absSource = join(this.config.paths.members, f);
+      const m = hydrate(data, name, absSource, this.config.onMalformed);
       if (m) out.push(m);
     }
     return out;
@@ -64,12 +68,10 @@ function hydrate(
   data: unknown,
   fallbackName: string,
   source: string,
-  onMalformed: (msg: string) => void,
+  onMalformed: OnMalformed,
 ): Member | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
-    onMalformed(
-      `member ${source}: top-level YAML is not a mapping; skipping`,
-    );
+    onMalformed(source, 'top-level YAML is not a mapping; skipping');
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -95,7 +97,8 @@ function hydrate(
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     onMalformed(
-      `member ${source} (name=${name}): hydrate failed, skipping record: ${msg}`,
+      source,
+      `hydrate failed (name=${name}), skipping record: ${msg}`,
     );
     return null;
   }

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -21,6 +21,7 @@ import {
   moveSafe,
 } from './safeFs.js';
 import { GuildConfig } from '../config/GuildConfig.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
 /**
  * Layout: <paths.requests>/<state>/<id>.yaml
@@ -35,7 +36,8 @@ export class YamlRequestRepository implements RequestRepository {
       const rel = join(state, `${id.value}.yaml`);
       if (existsSafe(this.config.paths.requests, rel)) {
         const raw = readTextSafe(this.config.paths.requests, rel);
-        return hydrate(YAML.parse(raw), state, rel, this.config.onMalformed);
+        const absSource = join(this.config.paths.requests, rel);
+        return hydrate(YAML.parse(raw), state, absSource, this.config.onMalformed);
       }
     }
     return null;
@@ -49,7 +51,8 @@ export class YamlRequestRepository implements RequestRepository {
     for (const f of files) {
       const rel = join(state, f);
       const raw = readTextSafe(this.config.paths.requests, rel);
-      const r = hydrate(YAML.parse(raw), state, rel, this.config.onMalformed);
+      const absSource = join(this.config.paths.requests, rel);
+      const r = hydrate(YAML.parse(raw), state, absSource, this.config.onMalformed);
       if (r) out.push(r);
     }
     return out;
@@ -163,12 +166,10 @@ function hydrate(
   data: unknown,
   stateHint: RequestState | undefined,
   source: string,
-  onMalformed: (msg: string) => void,
+  onMalformed: OnMalformed,
 ): Request | null {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
-    onMalformed(
-      `request ${source}: top-level YAML is not a mapping; skipping`,
-    );
+    onMalformed(source, 'top-level YAML is not a mapping; skipping');
     return null;
   }
   const obj = data as Record<string, unknown>;
@@ -219,7 +220,8 @@ function hydrate(
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         onMalformed(
-          `request ${source}: dropping status_log[${i}] (state="${String(so['state'])}"): ${msg}`,
+          source,
+          `dropping status_log[${i}] (state="${String(so['state'])}"): ${msg}`,
         );
       }
     }
@@ -266,7 +268,8 @@ function hydrate(
     const idHint =
       typeof obj['id'] === 'string' ? ` (id=${obj['id']})` : '';
     onMalformed(
-      `request ${source}${idHint}: hydrate failed, skipping record: ${msg}`,
+      source,
+      `hydrate failed${idHint}, skipping record: ${msg}`,
     );
     return null;
   }

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -46,9 +46,10 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
   writeOverall(report);
   if (!report.isClean) {
     process.stdout.write(
-      '\nnote: `gate doctor` is read-only. A future `gate repair`\n' +
-        'verb will consume `gate doctor --format json` to drive fixes.\n' +
-        'For now, inspect the offending YAML files manually.\n',
+      '\nnote: `gate doctor` is read-only (observation layer).\n' +
+        'To act on findings, pipe to `gate repair` (intervention layer):\n' +
+        '  gate doctor --format json | gate repair          # dry-run plan\n' +
+        '  gate doctor --format json | gate repair --apply  # quarantine\n',
     );
   }
   return report.isClean ? 0 : 1;
@@ -72,7 +73,8 @@ function writeAreaSection(
   writeSummaryLine(area, s);
   const local = findings.filter((f) => f.area === area);
   for (const f of local) {
-    process.stdout.write(`    [${f.kind}] ${f.message}\n`);
+    process.stdout.write(`    [${f.kind}] ${f.source}\n`);
+    process.stdout.write(`      ${f.message}\n`);
   }
 }
 

--- a/src/interface/gate/handlers/repair.ts
+++ b/src/interface/gate/handlers/repair.ts
@@ -1,0 +1,204 @@
+// gate repair — intervention layer paired with `gate doctor`.
+//
+// Consumes a `gate doctor --format json` payload (from stdin or
+// --from-doctor <file>) and either prints the proposed repair plan
+// (default --dry-run) or executes it (--apply).
+//
+// The split between dry-run and apply is structural at the use-case
+// level, not just a flag check inside the handler: planning is pure
+// and never touches the filesystem, applying is the only path that
+// invokes QuarantineStore.
+
+import { readFileSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C, readStdin } from './internal.js';
+import {
+  DiagnosticFinding,
+  DiagnosticArea,
+  DiagnosticKind,
+} from '../../../domain/diagnostic/DiagnosticReport.js';
+import {
+  RepairPlan,
+  RepairAction,
+} from '../../../domain/repair/RepairPlan.js';
+import { RepairResult } from '../../../application/repair/RepairUseCases.js';
+
+const VALID_AREAS: ReadonlySet<DiagnosticArea> = new Set([
+  'members',
+  'requests',
+  'issues',
+]);
+const VALID_KINDS: ReadonlySet<DiagnosticKind> = new Set([
+  'top_level_not_mapping',
+  'hydration_error',
+  'duplicate_id',
+  'unknown',
+]);
+
+export async function repairCmd(c: C, args: ParsedArgs): Promise<number> {
+  const apply = args.options['apply'] === true;
+  const format = optionalOption(args, 'format') ?? 'text';
+  const fromPath = optionalOption(args, 'from-doctor');
+
+  // 1. Acquire raw doctor JSON (file > stdin)
+  let rawJson: string;
+  if (fromPath !== undefined) {
+    try {
+      rawJson = readFileSync(fromPath, 'utf8');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`error: failed to read --from-doctor file: ${msg}\n`);
+      return 1;
+    }
+  } else if (process.stdin.isTTY) {
+    process.stderr.write(
+      'error: gate repair needs `gate doctor --format json` on stdin\n' +
+        'usage: gate doctor --format json | gate repair [--apply]\n' +
+        '       gate repair --from-doctor <path-to-doctor-json> [--apply]\n',
+    );
+    return 1;
+  } else {
+    rawJson = await readStdin();
+  }
+
+  // 2. Parse + validate findings (boundary)
+  let findings: DiagnosticFinding[];
+  try {
+    findings = parseDoctorJson(rawJson);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`error: invalid doctor json: ${msg}\n`);
+    return 1;
+  }
+
+  // 3. Plan (pure)
+  const plan = c.repairUC.plan(findings);
+
+  // 4. Either render plan (dry-run) or apply
+  if (!apply) {
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(plan.toJSON(), null, 2) + '\n');
+    } else {
+      writePlanText(plan);
+    }
+    return plan.isEmpty ? 0 : 0; // dry-run never fails on findings
+  }
+
+  const result = await c.repairUC.apply(plan);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(result.toJSON(), null, 2) + '\n');
+  } else {
+    writeResultText(result);
+  }
+  return result.hasErrors ? 1 : 0;
+}
+
+// Parses doctor's --format json output. Validates that each finding
+// has the four required fields with valid enum values; rejects on
+// anything unexpected so an operator can't accidentally feed in a
+// hand-edited plan that smuggles in a path outside content_root.
+// Exported for boundary tests (interface/parseDoctorJson.test.ts).
+export function parseDoctorJson(raw: string): DiagnosticFinding[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error('top-level not an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const findingsRaw = obj['findings'];
+  if (!Array.isArray(findingsRaw)) {
+    throw new Error('missing or non-array `findings` field');
+  }
+  const out: DiagnosticFinding[] = [];
+  for (let i = 0; i < findingsRaw.length; i++) {
+    const f = findingsRaw[i];
+    if (f === null || typeof f !== 'object') {
+      throw new Error(`findings[${i}] is not an object`);
+    }
+    const fo = f as Record<string, unknown>;
+    const area = fo['area'];
+    const source = fo['source'];
+    const kind = fo['kind'];
+    const message = fo['message'];
+    if (typeof area !== 'string' || !VALID_AREAS.has(area as DiagnosticArea)) {
+      throw new Error(`findings[${i}].area invalid: ${String(area)}`);
+    }
+    if (typeof source !== 'string' || source.length === 0) {
+      throw new Error(`findings[${i}].source missing`);
+    }
+    // D3 (noir devil review on req 2026-04-15-0012): the boundary must
+    // refuse relative paths. doctor always emits absolutes; a
+    // hand-crafted plan that smuggles in a relative path would let
+    // SafeFsQuarantineStore resolve it against cwd, which could land
+    // anywhere depending on where gate repair was invoked from.
+    if (!isAbsolute(source)) {
+      throw new Error(
+        `findings[${i}].source must be an absolute path, got: ${source}`,
+      );
+    }
+    if (typeof kind !== 'string' || !VALID_KINDS.has(kind as DiagnosticKind)) {
+      throw new Error(`findings[${i}].kind invalid: ${String(kind)}`);
+    }
+    if (typeof message !== 'string') {
+      throw new Error(`findings[${i}].message missing`);
+    }
+    out.push({
+      area: area as DiagnosticArea,
+      source,
+      kind: kind as DiagnosticKind,
+      message,
+    });
+  }
+  return out;
+}
+
+function writePlanText(plan: RepairPlan): void {
+  process.stdout.write('gate repair — proposed plan (dry-run)\n\n');
+  if (plan.isEmpty) {
+    process.stdout.write('✓ no findings, nothing to repair\n');
+    return;
+  }
+  for (const a of plan.actions) {
+    writeActionLine(a);
+  }
+  const s = plan.summary;
+  process.stdout.write(
+    `\n${s.total} action(s) — ${s.quarantine} quarantine, ${s.noOp} no-op\n` +
+      'note: this is a dry-run. Re-run with --apply to execute.\n' +
+      'destination scheme: <content_root>/quarantine/<ISO-timestamp>/<area>/<basename>\n' +
+      '         each --apply invocation creates a fresh timestamp directory,\n' +
+      '         so to undo:  mv <content_root>/quarantine/<stamp>/<area>/* <area>/\n',
+  );
+}
+
+function writeActionLine(a: RepairAction): void {
+  const glyph = a.kind === 'quarantine' ? '→' : '·';
+  process.stdout.write(
+    `  ${glyph} [${a.kind}] ${a.finding.area}/${a.finding.kind}\n` +
+      `    source: ${a.finding.source}\n` +
+      `    why:    ${a.rationale}\n`,
+  );
+}
+
+function writeResultText(result: RepairResult): void {
+  process.stdout.write('gate repair — outcomes\n\n');
+  for (const o of result.outcomes) {
+    let glyph = '·';
+    if (o.status === 'quarantined') glyph = '✓';
+    else if (o.status === 'error') glyph = '✗';
+    else if (o.status === 'skipped') glyph = '○';
+    process.stdout.write(
+      `  ${glyph} [${o.status}] ${o.action.finding.source}\n`,
+    );
+    if (o.destination !== undefined) {
+      process.stdout.write(`    → ${o.destination}\n`);
+    }
+    if (o.error !== undefined) {
+      process.stdout.write(`    error: ${o.error}\n`);
+    }
+  }
+  const s = result.summary;
+  process.stdout.write(
+    `\n${s.total} outcome(s) — ${s.quarantined} quarantined, ${s.skipped} skipped (already gone), ${s.noOp} no-op, ${s.error} error\n`,
+  );
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -22,6 +22,7 @@ import {
 } from './handlers/read.js';
 import { issuesCmd } from './handlers/issues.js';
 import { doctorCmd } from './handlers/doctor.js';
+import { repairCmd } from './handlers/repair.js';
 import {
   msgSend,
   msgBroadcast,
@@ -85,11 +86,20 @@ Environment:
                        Automations should continue to pass --from / --by
                        explicitly.
 
-Diagnostic:
+Diagnostic / Repair:
   gate doctor [--summary | --format json]
                        Read-only health check over the content root.
                        Exits 1 if any malformed records are detected.
-                       (Repair will be a separate verb in a future PR.)
+  gate repair [--apply] [--from-doctor <path>] [--format json]
+                       Intervention layer paired with doctor. Reads
+                       'gate doctor --format json' from stdin (or
+                       --from-doctor <file>) and either prints the
+                       proposed plan (default --dry-run) or executes
+                       it (--apply). Quarantine is the only action;
+                       duplicate_id and unknown findings are no-op.
+                       Usage:
+                         gate doctor --format json | gate repair
+                         gate doctor --format json | gate repair --apply
 
 Meta:
   gate --version       Print version and exit
@@ -151,6 +161,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await msgInbox(c, args);
       case 'doctor':
         return await doctorCmd(c, args);
+      case 'repair':
+        return await repairCmd(c, args);
       default:
         process.stderr.write(`unknown command: ${cmd}\n${HELP}`);
         return 1;

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -12,6 +12,8 @@ import {
   DiagnosticUseCases,
   DiagnosticRepoBundle,
 } from '../../application/diagnostic/DiagnosticUseCases.js';
+import { RepairUseCases } from '../../application/repair/RepairUseCases.js';
+import { SafeFsQuarantineStore } from '../../infrastructure/persistence/SafeFsQuarantineStore.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
 export interface Container {
@@ -21,6 +23,7 @@ export interface Container {
   issueUC: IssueUseCases;
   messageUC: MessageUseCases;
   diagnosticUC: DiagnosticUseCases;
+  repairUC: RepairUseCases;
 }
 
 export function buildContainer(): Container {
@@ -41,6 +44,9 @@ export function buildContainer(): Container {
       issues: new YamlIssueRepository(cfg),
     };
   };
+  // Repair quarantine store is constructed per-CLI-run so its
+  // timestamp directory groups all actions from a single invocation.
+  const quarantine = new SafeFsQuarantineStore(config.contentRoot);
   return {
     config,
     memberUC: new MemberUseCases(members),
@@ -48,5 +54,6 @@ export function buildContainer(): Container {
     issueUC: new IssueUseCases(issues, members, clock),
     messageUC: new MessageUseCases({ members, notifier, clock }),
     diagnosticUC: new DiagnosticUseCases(buildDiagRepos),
+    repairUC: new RepairUseCases(quarantine),
   };
 }

--- a/tests/application/DiagnosticUseCases.test.ts
+++ b/tests/application/DiagnosticUseCases.test.ts
@@ -23,6 +23,7 @@ import { RequestId } from '../../src/domain/request/RequestId.js';
 import { RequestState } from '../../src/domain/request/RequestState.js';
 
 class FakeMemberRepo implements MemberRepository {
+  private fakeArea = '/members';
   constructor(
     private items: Member[],
     private malformedMessages: string[] = [],
@@ -34,7 +35,9 @@ class FakeMemberRepo implements MemberRepository {
     return false;
   }
   async listAll(): Promise<Member[]> {
-    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    for (let i = 0; i < this.malformedMessages.length; i++) {
+      this.onMalformed?.(`/fake${this.fakeArea}/${i}.yaml`, this.malformedMessages[i]!);
+    }
     return this.items;
   }
   async save(_m: Member): Promise<void> {}
@@ -45,6 +48,7 @@ class FakeMemberRepo implements MemberRepository {
 }
 
 class FakeRequestRepo implements RequestRepository {
+  private fakeArea = '/requests';
   constructor(
     private items: Request[],
     private malformedMessages: string[] = [],
@@ -53,7 +57,9 @@ class FakeRequestRepo implements RequestRepository {
     return [];
   }
   async listAll(): Promise<Request[]> {
-    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    for (let i = 0; i < this.malformedMessages.length; i++) {
+      this.onMalformed?.(`/fake${this.fakeArea}/${i}.yaml`, this.malformedMessages[i]!);
+    }
     return this.items;
   }
   async findById(_id: RequestId): Promise<Request | null> {
@@ -68,6 +74,7 @@ class FakeRequestRepo implements RequestRepository {
 }
 
 class FakeIssueRepo implements IssueRepository {
+  private fakeArea = '/issues';
   constructor(
     private items: Issue[],
     private malformedMessages: string[] = [],
@@ -79,7 +86,9 @@ class FakeIssueRepo implements IssueRepository {
     return [];
   }
   async listAll(): Promise<Issue[]> {
-    for (const m of this.malformedMessages) this.onMalformed?.(m);
+    for (let i = 0; i < this.malformedMessages.length; i++) {
+      this.onMalformed?.(`/fake${this.fakeArea}/${i}.yaml`, this.malformedMessages[i]!);
+    }
     return this.items;
   }
   async save(_i: Issue): Promise<void> {}
@@ -199,10 +208,12 @@ test('DiagnosticReport.toJSON: stable shape for future repair consumer', async (
   const report = await uc.run();
   const json = report.toJSON() as {
     summary: unknown;
-    findings: { area: string; kind: string; message: string }[];
+    findings: { area: string; source: string; kind: string; message: string }[];
   };
   assert.ok(json.summary);
   assert.equal(json.findings.length, 1);
   assert.equal(json.findings[0]?.area, 'issues');
   assert.equal(json.findings[0]?.kind, 'top_level_not_mapping');
+  assert.equal(typeof json.findings[0]?.source, 'string');
+  assert.match(json.findings[0]!.source, /\.yaml$/);
 });

--- a/tests/application/RepairUseCases.test.ts
+++ b/tests/application/RepairUseCases.test.ts
@@ -1,0 +1,154 @@
+// RepairUseCases — application tests for plan + apply.
+//
+// Verifies:
+//   1. planRepair maps every DiagnosticKind to the right RepairAction
+//   2. apply quarantines hydration_error and top_level_not_mapping
+//   3. apply leaves duplicate_id and unknown as no_op (data safety)
+//   4. apply is idempotent: a missing source becomes 'skipped', not error
+//   5. apply records errors per-action without aborting the rest
+//   6. RepairResult.summary reflects mixed outcomes correctly
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  RepairUseCases,
+  RepairResult,
+} from '../../src/application/repair/RepairUseCases.js';
+import { planRepair } from '../../src/domain/repair/RepairPlan.js';
+import {
+  DiagnosticFinding,
+} from '../../src/domain/diagnostic/DiagnosticReport.js';
+import {
+  QuarantineStore,
+  QuarantineResult,
+} from '../../src/application/ports/QuarantineStore.js';
+
+class FakeQuarantineStore implements QuarantineStore {
+  movedSources: string[] = [];
+  errorOnSource: string | null = null;
+  constructor(private existingSources: Set<string>) {}
+  sourceExists(absSource: string): boolean {
+    return this.existingSources.has(absSource);
+  }
+  async move(absSource: string): Promise<QuarantineResult> {
+    if (this.errorOnSource === absSource) {
+      throw new Error(`mock failure for ${absSource}`);
+    }
+    this.movedSources.push(absSource);
+    this.existingSources.delete(absSource); // make idempotent
+    return {
+      source: absSource,
+      destination: `/quarantine/${absSource.split('/').pop()}`,
+    };
+  }
+}
+
+function f(
+  area: 'members' | 'requests' | 'issues',
+  source: string,
+  kind: DiagnosticFinding['kind'],
+  message = '...',
+): DiagnosticFinding {
+  return { area, source, kind, message };
+}
+
+test('planRepair: top_level_not_mapping → quarantine', () => {
+  const plan = planRepair([f('issues', '/r/i/x.yaml', 'top_level_not_mapping')]);
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0]?.kind, 'quarantine');
+});
+
+test('planRepair: hydration_error → quarantine', () => {
+  const plan = planRepair([f('members', '/r/m/x.yaml', 'hydration_error')]);
+  assert.equal(plan.actions[0]?.kind, 'quarantine');
+});
+
+test('planRepair: duplicate_id → no_op (data safety)', () => {
+  const plan = planRepair([f('issues', '/r/i/x.yaml', 'duplicate_id')]);
+  assert.equal(plan.actions[0]?.kind, 'no_op');
+  assert.match(plan.actions[0]!.rationale, /data loss|reconcile|manually/);
+});
+
+test('planRepair: unknown → no_op (refusal to act)', () => {
+  const plan = planRepair([f('requests', '/r/r/x.yaml', 'unknown')]);
+  assert.equal(plan.actions[0]?.kind, 'no_op');
+});
+
+test('planRepair: empty findings → empty plan', () => {
+  const plan = planRepair([]);
+  assert.equal(plan.isEmpty, true);
+  assert.deepEqual(plan.summary, { total: 0, quarantine: 0, noOp: 0 });
+});
+
+test('planRepair: summary counts each kind correctly', () => {
+  const plan = planRepair([
+    f('members', '/a.yaml', 'top_level_not_mapping'),
+    f('members', '/b.yaml', 'hydration_error'),
+    f('issues', '/c.yaml', 'duplicate_id'),
+    f('requests', '/d.yaml', 'unknown'),
+  ]);
+  assert.deepEqual(plan.summary, { total: 4, quarantine: 2, noOp: 2 });
+});
+
+test('apply: quarantines existing sources', async () => {
+  const store = new FakeQuarantineStore(new Set(['/a.yaml', '/b.yaml']));
+  const uc = new RepairUseCases(store);
+  const plan = uc.plan([
+    f('members', '/a.yaml', 'top_level_not_mapping'),
+    f('issues', '/b.yaml', 'hydration_error'),
+  ]);
+  const result = await uc.apply(plan);
+  assert.equal(result.summary.quarantined, 2);
+  assert.equal(result.summary.error, 0);
+  assert.equal(store.movedSources.length, 2);
+});
+
+test('apply: missing source becomes skipped (idempotency)', async () => {
+  const store = new FakeQuarantineStore(new Set()); // nothing exists
+  const uc = new RepairUseCases(store);
+  const plan = uc.plan([f('members', '/gone.yaml', 'hydration_error')]);
+  const result = await uc.apply(plan);
+  assert.equal(result.summary.skipped, 1);
+  assert.equal(result.summary.quarantined, 0);
+  assert.equal(result.summary.error, 0);
+  assert.equal(store.movedSources.length, 0);
+});
+
+test('apply: duplicate_id is no_op even when source exists', async () => {
+  const store = new FakeQuarantineStore(new Set(['/dup.yaml']));
+  const uc = new RepairUseCases(store);
+  const plan = uc.plan([f('issues', '/dup.yaml', 'duplicate_id')]);
+  const result = await uc.apply(plan);
+  assert.equal(result.summary.noOp, 1);
+  assert.equal(store.movedSources.length, 0); // file untouched
+});
+
+test('apply: per-action errors do not abort siblings', async () => {
+  const store = new FakeQuarantineStore(new Set(['/a.yaml', '/b.yaml']));
+  store.errorOnSource = '/a.yaml';
+  const uc = new RepairUseCases(store);
+  const plan = uc.plan([
+    f('members', '/a.yaml', 'top_level_not_mapping'),
+    f('issues', '/b.yaml', 'hydration_error'),
+  ]);
+  const result = await uc.apply(plan);
+  assert.equal(result.summary.error, 1);
+  assert.equal(result.summary.quarantined, 1);
+  assert.equal(result.hasErrors, true);
+  // The other action still ran
+  assert.equal(store.movedSources.includes('/b.yaml'), true);
+});
+
+test('RepairResult.toJSON: stable shape', async () => {
+  const store = new FakeQuarantineStore(new Set(['/a.yaml']));
+  const uc = new RepairUseCases(store);
+  const plan = uc.plan([f('members', '/a.yaml', 'hydration_error')]);
+  const result = await uc.apply(plan);
+  const json = result.toJSON() as {
+    summary: { quarantined: number };
+    outcomes: { status: string; destination: string }[];
+  };
+  assert.equal(json.summary.quarantined, 1);
+  assert.equal(json.outcomes[0]?.status, 'quarantined');
+  assert.match(json.outcomes[0]!.destination!, /^\/quarantine\//);
+});

--- a/tests/infrastructure/SafeFsQuarantineStore.test.ts
+++ b/tests/infrastructure/SafeFsQuarantineStore.test.ts
@@ -1,0 +1,137 @@
+// SafeFsQuarantineStore — infrastructure tests.
+//
+// Verifies:
+//   1. move() relocates a real file under <root>/quarantine/<stamp>/<area>/
+//   2. sources outside content_root are rejected (path traversal guard)
+//   3. nonexistent sources throw with a descriptive error
+//   4. area is correctly inferred from the path (members/requests/issues/other)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SafeFsQuarantineStore } from '../../src/infrastructure/persistence/SafeFsQuarantineStore.js';
+
+function makeRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-quarantine-'));
+  mkdirSync(join(root, 'issues'));
+  mkdirSync(join(root, 'requests', 'pending'), { recursive: true });
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('SafeFsQuarantineStore.move: relocates issue file under quarantine', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const src = join(root, 'issues', 'i-broken.yaml');
+    writeFileSync(src, 'garbage');
+    const store = new SafeFsQuarantineStore(root, '2026-04-15T10:00:00.000Z');
+    const result = await store.move(src);
+    assert.equal(existsSync(src), false, 'source should be gone');
+    assert.equal(existsSync(result.destination), true, 'dest should exist');
+    assert.match(
+      result.destination,
+      /quarantine\/2026-04-15T10-00-00-000Z\/issues\/i-broken\.yaml$/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('SafeFsQuarantineStore.move: rejects source outside content root', async () => {
+  const { root, cleanup } = makeRoot();
+  const outside = mkdtempSync(join(tmpdir(), 'guild-cli-outside-'));
+  try {
+    const src = join(outside, 'evil.yaml');
+    writeFileSync(src, 'evil');
+    const store = new SafeFsQuarantineStore(root);
+    // U1: a plain outside-of-root path must NOT mention symlinks
+    await assert.rejects(
+      () => store.move(src),
+      (e: Error) =>
+        /outside content_root/.test(e.message) &&
+        !/via symlink/.test(e.message),
+    );
+    // Source untouched
+    assert.equal(existsSync(src), true);
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+    cleanup();
+  }
+});
+
+test('SafeFsQuarantineStore.move: missing source throws descriptive error', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const store = new SafeFsQuarantineStore(root);
+    await assert.rejects(
+      () => store.move(join(root, 'issues', 'never-existed.yaml')),
+      /does not exist/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('SafeFsQuarantineStore.sourceExists: reflects filesystem state', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const src = join(root, 'issues', 'i-x.yaml');
+    writeFileSync(src, '');
+    const store = new SafeFsQuarantineStore(root);
+    assert.equal(store.sourceExists(src), true);
+    rmSync(src);
+    assert.equal(store.sourceExists(src), false);
+    // Sources outside the content root never report as existing
+    assert.equal(store.sourceExists('/etc/passwd'), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('SafeFsQuarantineStore.move: refuses symlink that escapes content_root (D1)', async () => {
+  const { root, cleanup } = makeRoot();
+  const outside = mkdtempSync(join(tmpdir(), 'guild-cli-symlink-target-'));
+  try {
+    const real = join(outside, 'evil.yaml');
+    writeFileSync(real, 'evil');
+    const link = join(root, 'issues', 'i-link.yaml');
+    symlinkSync(real, link);
+    const store = new SafeFsQuarantineStore(root);
+    await assert.rejects(
+      () => store.move(link),
+      // Generic "outside content_root" with canonical hint — no
+      // false claim about symlink involvement (U1).
+      /outside content_root.*canonical:/,
+    );
+    // The real target is untouched; the link is also untouched
+    assert.equal(existsSync(real), true);
+    assert.equal(existsSync(link), true);
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+    cleanup();
+  }
+});
+
+test('SafeFsQuarantineStore.move: requests file goes under requests/ area', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const src = join(root, 'requests', 'pending', '2026-04-15-099.yaml');
+    writeFileSync(src, 'broken');
+    const store = new SafeFsQuarantineStore(root, '2026-04-15T10:00:00.000Z');
+    const result = await store.move(src);
+    assert.match(
+      result.destination,
+      /quarantine\/2026-04-15T10-00-00-000Z\/requests\/2026-04-15-099\.yaml$/,
+    );
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/infrastructure/hydrateErrorSurface.test.ts
+++ b/tests/infrastructure/hydrateErrorSurface.test.ts
@@ -30,13 +30,13 @@ test('YamlRequestRepository: malformed request YAML surfaces via onMalformed', a
     writeFileSync(badPath, 'id: 2026-04-15-001\n# missing from/action/reason\n');
 
     const warnings: string[] = [];
-    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const config = GuildConfig.load(root, (source, msg) => warnings.push(`${source}: ${msg}`));
     const repo = new YamlRequestRepository(config);
 
     const items = await repo.listByState('pending');
     assert.equal(items.length, 0, 'malformed record should be dropped');
     assert.equal(warnings.length, 1, 'exactly one warning should surface');
-    assert.match(warnings[0]!, /request /);
+    assert.match(warnings[0]!, /requests\/pending\/2026-04-15-001\.yaml/);
     assert.match(warnings[0]!, /id=2026-04-15-001/);
     assert.match(warnings[0]!, /hydrate failed/);
   } finally {
@@ -71,7 +71,7 @@ test('YamlRequestRepository: malformed status_log entry surfaces per-entry', asy
     );
 
     const warnings: string[] = [];
-    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const config = GuildConfig.load(root, (source, msg) => warnings.push(`${source}: ${msg}`));
     const repo = new YamlRequestRepository(config);
 
     const items = await repo.listByState('pending');
@@ -92,13 +92,13 @@ test('YamlIssueRepository: malformed issue surfaces via onMalformed', async () =
     writeFileSync(badPath, 'id: i-2026-04-15-001\n# missing required fields\n');
 
     const warnings: string[] = [];
-    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const config = GuildConfig.load(root, (source, msg) => warnings.push(`${source}: ${msg}`));
     const repo = new YamlIssueRepository(config);
 
     const items = await repo.listAll();
     assert.equal(items.length, 0);
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0]!, /issue /);
+    assert.match(warnings[0]!, /issues\/i-2026-04-15-001\.yaml/);
     assert.match(warnings[0]!, /i-2026-04-15-001/);
   } finally {
     cleanup();
@@ -113,13 +113,13 @@ test('YamlMemberRepository: malformed member surfaces via onMalformed', async ()
     writeFileSync(badPath, 'name: broken\ncategory: not-a-category\n');
 
     const warnings: string[] = [];
-    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const config = GuildConfig.load(root, (source, msg) => warnings.push(`${source}: ${msg}`));
     const repo = new YamlMemberRepository(config);
 
     const items = await repo.listAll();
     assert.equal(items.length, 0);
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0]!, /member /);
+    assert.match(warnings[0]!, /members\/broken\.yaml/);
     assert.match(warnings[0]!, /name=broken/);
   } finally {
     cleanup();
@@ -135,7 +135,7 @@ test('findByName also routes through onMalformed on malformed YAML', async () =>
     );
 
     const warnings: string[] = [];
-    const config = GuildConfig.load(root, (msg) => warnings.push(msg));
+    const config = GuildConfig.load(root, (source, msg) => warnings.push(`${source}: ${msg}`));
     const repo = new YamlMemberRepository(config);
 
     const result = await repo.findByName(MemberName.of('broken'));

--- a/tests/interface/parseDoctorJson.test.ts
+++ b/tests/interface/parseDoctorJson.test.ts
@@ -1,0 +1,91 @@
+// parseDoctorJson — boundary validator for `gate repair`.
+// Verifies the contract that protects intervention from malformed
+// or hostile doctor JSON inputs (D3 from noir devil review on req
+// 2026-04-15-0012).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDoctorJson } from '../../src/interface/gate/handlers/repair.js';
+
+const VALID = JSON.stringify({
+  summary: {},
+  findings: [
+    {
+      area: 'issues',
+      source: '/abs/path/issues/i-x.yaml',
+      kind: 'hydration_error',
+      message: '...',
+    },
+  ],
+});
+
+test('parseDoctorJson: accepts well-formed payload', () => {
+  const findings = parseDoctorJson(VALID);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.area, 'issues');
+});
+
+test('parseDoctorJson: rejects relative source (D3)', () => {
+  const json = JSON.stringify({
+    findings: [
+      {
+        area: 'issues',
+        source: 'issues/i-relative.yaml',
+        kind: 'hydration_error',
+        message: '...',
+      },
+    ],
+  });
+  assert.throws(
+    () => parseDoctorJson(json),
+    /must be an absolute path/,
+  );
+});
+
+test('parseDoctorJson: rejects unknown kind', () => {
+  const json = JSON.stringify({
+    findings: [
+      {
+        area: 'issues',
+        source: '/abs/x.yaml',
+        kind: 'made_up_kind',
+        message: '...',
+      },
+    ],
+  });
+  assert.throws(() => parseDoctorJson(json), /kind invalid/);
+});
+
+test('parseDoctorJson: rejects unknown area', () => {
+  const json = JSON.stringify({
+    findings: [
+      {
+        area: 'inbox',
+        source: '/abs/x.yaml',
+        kind: 'hydration_error',
+        message: '...',
+      },
+    ],
+  });
+  assert.throws(() => parseDoctorJson(json), /area invalid/);
+});
+
+test('parseDoctorJson: rejects missing source', () => {
+  const json = JSON.stringify({
+    findings: [
+      { area: 'issues', kind: 'hydration_error', message: '...' },
+    ],
+  });
+  assert.throws(() => parseDoctorJson(json), /source missing/);
+});
+
+test('parseDoctorJson: rejects non-array findings', () => {
+  assert.throws(
+    () => parseDoctorJson(JSON.stringify({ findings: 'oops' })),
+    /non-array/,
+  );
+});
+
+test('parseDoctorJson: rejects non-object top-level', () => {
+  assert.throws(() => parseDoctorJson('null'), /top-level/);
+});


### PR DESCRIPTION
## Summary

- New `gate repair` verb pairs an intervention layer with `gate doctor`. Reads `gate doctor --format json` from stdin (or `--from-doctor <path>`) and either prints the proposed plan (default `--dry-run`) or executes it (`--apply`). MVP scope: **quarantine only** — malformed records move to `<content_root>/quarantine/<ISO>/<area>/<basename>`. `duplicate_id` and `unknown` are no-op (data safety).
- **Breaking (application port)**: `OnMalformed` widened from `(msg: string) => void` to `(source: string, msg: string) => void` where `source` is the absolute file path. `DiagnosticFinding` gains `readonly source: string`. Closes the contract that `gate doctor` was relying on by convention. Closes #i-2026-04-15-0025.
- **Path safety** is structural: `SafeFsQuarantineStore` canonicalizes both content_root and source via `realpathSync` before the boundary check. Symlink-escape closed.
- **149 → 173 tests** (+24): RepairUseCases (11), SafeFsQuarantineStore (6), parseDoctorJson (7).
- Closes #i-2026-04-15-0026 partially (quarantine path; field-level patch tracked as #i-2026-04-15-0027).

## Design

The split between `gate doctor` (observation) and `gate repair` (intervention) follows the silent_fail_taxonomy 0414 principle: an operator must be able to inspect the content_root without fearing accidental data modification, and the intervention surface must consume — not re-derive — the observation findings. doctor stays read-only; repair takes its JSON output as authority.

Within repair itself the dry-run/apply split is **structural at the use-case level**, not just a flag check inside the handler:

- `RepairUseCases.plan(findings)` is pure. Returns a `RepairPlan` of `RepairAction[]` via a total switch over `DiagnosticKind` (adding a new kind will fail typecheck rather than silently default).
- `RepairUseCases.apply(plan)` is the only path that touches the filesystem, via the `QuarantineStore` port. Per-action errors are recorded as `RepairOutcome` rather than aborting siblings — failures surface as data, not silently swallowed exceptions.

## Two-Persona Devil Review

Recorded in tracker request `2026-04-15-0012`. Same model, different binding. Three lenses, four reviews:

| review | actor | lens | verdict | concerns |
|---|---|---|---|---|
| 1 | noir | devil | concern | D1 symlink escape, D2 dry-run exit code, D3 relative path injection, D4 areaOf fallback |
| 2 | eris | cognitive | ok | D1+D3 fixed in same edit; D2/D4 → follow-up issues |
| 3 | eris | user | concern | U1 lying error message, U2 destination invisible, U3 timestamp visual, U4 recovery hint |
| 4 | eris | cognitive | ok | U1 simplified to honest "outside content_root + canonical hint"; U2 fixed via dry-run closing-note documentation |

The U1 fix-of-fix is informative: when I first patched the symlink-escape D1, I introduced a message that claimed "via symlink" unconditionally. The user lens pass on the same code surfaced that this was a lie on macOS (where `/var → /private/var` canonicalization triggers parent-level differences without any actual symlink in the operator-given path). The devil pass had verified the *structural* defense was correct but didn't descend to message wording. Different lenses, different blind spots — exactly the chain principle.

## Test plan

- [x] `npm test` — 173 / 173 pass on Node 22 (CI matrix will cover 20)
- [x] `npx tsc --noEmit` — clean
- [x] Real tracker dogfood — 4 members, 12 requests, 26 issues, `gate doctor` clean
- [x] Smoke test (4-step in tmp dir):
      1. seed broken YAML — `gate doctor` surfaces 2 findings with absolute paths (exit 1)
      2. `gate doctor --format json | gate repair` — dry-run plan shows 2 quarantine actions + scheme docs
      3. `... | gate repair --apply` — both quarantined to `quarantine/<ISO>/issues/`, exit 0
      4. `gate doctor` — clean

## Follow-up issues filed

| id | sev | scope |
|---|---|---|
| `i-2026-04-15-0027` | high | field-level patch repair (i-0026 残り半分) |
| `i-2026-04-15-0028` | low | repair --dry-run exit code semantics (D2) |
| `i-2026-04-15-0029` | low | areaOf 撤去 + finding.area 直渡し (D4) |
| `i-2026-04-15-0030` | low | quarantine timestamp visual prefix (U3) |
| `i-2026-04-15-0031` | med | full destination preview verb (U2 follow-up) |
| `i-2026-04-15-0032` | low | parseDoctorJson を application 層に降ろすか検討 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)