### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-15
+
+Second alpha release. Focus: **observation layer** (`gate doctor`),
+**intervention layer** (`gate repair`), **cross-cutting read verbs**
+(`voices` / `tail` / `whoami` / `chain` / `show --format text` time
+deltas / `list` review markers), and the **interactive-identity**
+affordance (`GUILD_ACTOR` env var fallback). Breaking changes are
+concentrated in the `OnMalformed` application port — if you've
+embedded `guild-cli` as a library, see the migration note below.
+
 ### Fixed
 - **`gate doctor` no longer crashes on unparseable YAML.** Previously,
   a file containing YAML syntax the library couldn't parse (e.g. a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guild-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Guild CLI — DDD/TS member & request management with Two-Persona Devil Review",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

**First minor bump of the project.** Cuts the `[Unreleased]` section that has been accumulating since `0.1.0` (2026-04-14) into a tagged `0.2.0` release.

Per [`POLICY.md`](./POLICY.md)'s strict 0.x variant — patch releases (`0.x.Y`) MUST be backward-compatible — the presence of even one breaking change in `[Unreleased]` forces a minor bump rather than a patch. This PR is that minor bump.

## Why minor (and not 0.1.1)

`[Unreleased]` already contains a `### Changed (breaking — application port)` entry: the `OnMalformed` port signature was widened from `(msg: string) => void` to `(source: string, msg: string) => void` to give `gate repair` the absolute source path without having to parse it out of the message string. That's a contract change on POLICY.md's explicitly-stable `application/ports/` surface, so:

- `0.1.1` (patch) is **not an option** — patch MUST be backward-compatible per POLICY
- `0.2.0` (minor) is **required** — minor is where breaking changes land in 0.x

The sequence-ceiling widening (999 → 9999, 3-digit → 4-digit IDs) is *arguably* also breaking for any external consumer parsing IDs with a 3-digit regex, though the loader accepts both forms for backward-compat on read. Either way, `OnMalformed` alone is enough to force the minor bump.

## What shipped in 0.2.0

### Observation + intervention layer
- **`gate doctor`** — read-only content-root health check with per-area summaries, per-finding detail, `text` / `--summary` / `--format json` outputs
- **`gate repair`** — intervention layer paired with doctor, consumes doctor's JSON, plan (`--dry-run`) vs apply (`--apply`) split, quarantine is the only action, idempotent, `realpathSync` path-safety
- **`DiagnosticKind` taxonomy**: `top_level_not_mapping`, `hydration_error`, `yaml_parse_error`, `duplicate_id`, `unknown`
- **`OnMalformed` port widening** — every hydrate + YAML.parse codepath routes through it, closing the silent-fail taxonomy

### Read-side verb cluster (reading the content_root as dialogue)
- **`gate voices <name>`** — cross-cutting read of an actor's utterances with `--lense` / `--verdict` / `--limit` filters
- **`gate tail [N]`** — unified recent activity stream, the `git log` for a content_root
- **`gate whoami`** — session-start orientation (requires `GUILD_ACTOR`)
- **`gate chain <id>`** — one-hop cross-reference walker for request/issue ids in free-text fields
- **`gate show --format text`** — time deltas between `status_log` entries and between reviews, making dialogue pace legible
- **`gate list` / `gate pending`** — per-lens review markers with per-list max-width alignment

### Interactive identity
- **`GUILD_ACTOR`** env var fallback for `--from` / `--by` / `--for` (`--executor` and `--auto-review` intentionally excluded because they point at *other* people)

### Domain widenings
- **Sequence ceiling**: `YYYY-MM-DD-NNN` → `YYYY-MM-DD-NNNN` (999 → 9999 per UTC day). Legacy 3-digit IDs still accepted on read.
- **`compareSequenceIds`** pure helper for numeric-aware ID sort across mixed 3/4-digit sequences

### Infrastructure / quality
- **`.github/workflows/ci.yml`** — typecheck + test on Node 20 and Node 22
- **`POLICY.md`** — strict 0.x variant (patch is a stability promise even pre-1.0)
- **`CHANGELOG.md`** — versioning history
- **`gate --version` / `guild --version`** / `-v` alias
- **`gate/index.ts` refactor**: 1206 → 179 lines via split into `handlers/{request,review,read,issues,messages,doctor,repair,internal}.ts`
- **`RequestRepository.listAll()` + `IssueRepository.listAll()` + `dedupeRequestsById`** for cross-cutting reads
- **README reframing** around "event log of judgments" and "before asking what this tool does, ask what you would like to freeze"
- **`docs/verbs.md`** — verb cookbook extracted from README

### Final fix (merged just before tagging, #17)
- `gate doctor` no longer crashes on unparseable YAML; `parseYamlSafe` helper routes all 6 `YAML.parse` sites through `onMalformed`; `yaml_parse_error` is now a full `DiagnosticKind` with classifier + `RepairPlan` routing + 18 new tests.

## Migration note

If you've embedded `guild-cli` as a library and implemented your own `NotificationPort` / `MemberRepository` / other repos that delegate to an `OnMalformed` callback, **the callback signature has changed**:

```diff
- type OnMalformed = (msg: string) => void;
+ type OnMalformed = (source: string, msg: string) => void;
```

The `source` parameter is the absolute filesystem path of the offending file and is mandatory — it's how `gate repair` knows which file to quarantine without parsing the message string. All three bundled YAML repositories have been updated; the change only affects consumers who implemented their own repositories.

## Stats

- **191 tests** (up from 44 at 0.1.0, a 4.3× increase)
- **CI on Node 20 + Node 22**, matrix green
- **13 `gate` verbs + 4 `guild` verbs**
- **Zero runtime dependencies** beyond `yaml`
- **src/interface/gate/index.ts**: 1206 lines → 179 lines (the rest lives in focused handler modules)

## The diff in this PR

Minimal on purpose — just the version bump and CHANGELOG rename:

```diff
# package.json
- "version": "0.1.0",
+ "version": "0.2.0",

# CHANGELOG.md
 ## [Unreleased]

+## [0.2.0] — 2026-04-15
+
+Second alpha release. Focus: observation/intervention layer,
+read-side verbs, interactive identity. ...
+
 ### Fixed
 - gate doctor no longer crashes on unparseable YAML. ...
```

A fresh empty `[Unreleased]` sits at the top so the next change starts clean.

## Test plan

- [x] `npm run build` clean (tsc exits zero)
- [x] `npm test` — 191/191 passing
- [x] `gate --version` / `guild --version` print `guild-cli 0.2.0`
- [x] `gate doctor` against `examples/dogfood-session/` reports clean (regression check on the shipped example)
- [x] CHANGELOG entries preserved under the new `[0.2.0]` header (no content lost in the rename)

## After merge

Once this ships, a fresh `[Unreleased]` section is ready for the next cycle:

- **Patch bumps (0.2.1, 0.2.2)**: backward-compatible bug fixes and internal improvements
- **Minor bumps (0.3.0)**: breaking changes, new stable-surface verbs, deprecation starts per POLICY.md's deprecation policy
- **v1.0.0**: when the API surface has been stable for a full minor cycle with no changes

Follow-ups carried over from the dogfood session that are candidates for 0.2.1 / 0.3.0 (not in this PR):

- `i-2026-04-15-002` — Unicode normalization contract at the voices boundary
- POLICY.md: explicit stability statement for the `diagnostic/` layer (currently unlisted = implicit unstable)
- Field-level patch repair beyond quarantine (`i-2026-04-15-0026` remainder)

https://claude.ai/code/session_01G9UdoygPCyGa3oYchRYLXf