### PR TITLE
docs(policy): MemberName ASCII-only + diagnostic/repair partial stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **POLICY.md: value-object invariants under `domain/`.** `MemberName`'s
+  ASCII-only shape (`^[a-z][a-z0-9_-]{0,31}$`) is now declared a
+  *stable contract*, not just a current-implementation detail. The
+  read-side verbs (`gate voices` / `tail` / `whoami` / `chain`)
+  rely on this invariant to do case-insensitive matching via
+  `.toLowerCase()` at the interface layer without routing through
+  `MemberName.of()`; freezing the invariant explicitly means a
+  future relaxation to non-ASCII identifiers is a breaking change
+  that forces a Unicode-normalization audit of every caller.
+  Similarly, `RequestId` / `IssueId` lexical shape (accepts both
+  3-digit legacy and 4-digit current sequence suffixes, ceiling
+  9999/UTC-day) is now pinned as a documented consumer contract.
+- **POLICY.md: `domain/diagnostic/` and `domain/repair/` partial
+  stability.** These layers are declared *partially stable*: the
+  top-level JSON shapes of `DiagnosticReport` and `RepairResult`
+  are frozen for a given 0.x line, but the enum variants inside
+  (`DiagnosticKind`, `RepairActionKind`, outcome statuses) are
+  **additive only**. External tools that pipe `gate doctor --format
+  json` into dashboards or migration scripts should code against
+  the shape rather than enum exhaustiveness and treat unknown
+  kinds as opaque pass-through — this gives clean forward-compat
+  as the taxonomy grows. Closes the implicit-curation ambiguity
+  surfaced by the 0.2.0 PR #17 retrospective (where `yaml_parse_error`
+  was added as an additive variant but POLICY did not explicitly
+  say that was the contract).
+
 ## [0.2.0] — 2026-04-15
 
 Second alpha release. Focus: **observation layer** (`gate doctor`),

--- a/POLICY.md
+++ b/POLICY.md
@@ -34,6 +34,28 @@ and a migration note:
 If you are extending `guild-cli` by embedding it as a library, build
 against this layer.
 
+**Value-object invariants (stable).** Per-type invariants that are
+load-bearing for interface-layer code and therefore part of the
+stability contract, not just current-implementation details:
+
+- **`MemberName` is ASCII-only.** The regex `^[a-z][a-z0-9_-]{0,31}$`
+  is a *promised shape*, not a temporary restriction. Downstream read
+  verbs (`gate voices`, `gate tail`, `gate whoami`, `gate chain`)
+  rely on the ASCII invariant to do case-insensitive matching via
+  `.toLowerCase()` at the interface layer without routing through
+  `MemberName.of()`. If this rule is ever relaxed (e.g. to allow
+  non-ASCII identifiers), every caller that lowercases names as a
+  convenience must be updated to apply a full Unicode normalization
+  pass — treat the relaxation as a breaking change in its own right
+  and bump minor even if the domain test suite passes.
+
+- **`RequestId` / `IssueId` lexical shape.** `YYYY-MM-DD-NNN` (3-digit
+  legacy) and `YYYY-MM-DD-NNNN` (4-digit current) are both valid on
+  read; generation always produces the wider form. The per-day
+  sequence ceiling is 9999. Consumers that parse ids from yaml or
+  prose (e.g. via the `gate chain` cross-reference scanner) must
+  accept both widths.
+
 ### `application/` (use-case boundary)
 - The `*UseCases` classes and their method signatures
 - The `ports/` interfaces (`MemberRepository`, `RequestRepository`, `IssueRepository`, `NotificationPort`, `Clock`)
@@ -48,6 +70,44 @@ against this layer.
 
 Output **text** formatting is **not** part of the stable surface — if you
 need a machine-readable output, use `--format json` where available.
+
+### `domain/diagnostic/` and `domain/repair/` (partially stable)
+
+These layers are newer than the rest of the domain and their shape is
+still settling. They are **partially stable**: the top-level JSON
+contracts are frozen so external tools can pipe `gate doctor` and
+`gate repair` output, but the enum variants inside are **additive**
+so future failure modes can be named without a breaking bump.
+
+- **`DiagnosticReport.toJSON()` shape**: stable. The `summary` and
+  `findings` top-level keys and the `{area, source, kind, message}`
+  shape of each finding will not rename or drop fields within a 0.x
+  line. Adding new fields is a backward-compat change per the YAML
+  forward-compat rule below.
+
+- **`DiagnosticKind` enum**: **additive only**. New kinds
+  (e.g. `yaml_parse_error`, added in 0.2.0) MAY appear in any
+  release, including patch releases, as the taxonomy grows to cover
+  previously-invisible failure modes. Consumers that consume
+  `gate doctor --format json` MUST treat unknown kinds as opaque
+  pass-through values and surface them to a human operator rather
+  than crashing or silently dropping them. Renaming or removing a
+  kind is breaking.
+
+- **`RepairActionKind`** (`quarantine` | `no_op`, today):
+  **additive only**. A future release may add `patch_field` or
+  similar once the interactive-confirmation design lands. Consumers
+  of `gate repair --format json` outcomes apply the same "unknown
+  kind is opaque" rule.
+
+- **`RepairResult.outcomes[*].status`** (`quarantined` | `skipped` |
+  `no_op` | `error`, today): **additive only**.
+
+If you pipe `gate doctor --format json` into an external dashboard
+or migration script, the rule is simple: **code against the shape,
+not the enum exhaustiveness**. Let unknown values fall through to a
+human-readable "unrecognized, inspect manually" path and you'll get
+clean forward-compat as the taxonomy grows.
 
 ## Internal surface (unstable)
 

--- a/tests/domain/MemberName.test.ts
+++ b/tests/domain/MemberName.test.ts
@@ -50,3 +50,35 @@ test('MemberName rejects over 32 chars', () => {
   assert.throws(() => MemberName.of('a'.repeat(33)), DomainError);
   assert.doesNotThrow(() => MemberName.of('a'.repeat(32)));
 });
+
+test('MemberName rejects non-ASCII (ASCII-only invariant per POLICY.md)', () => {
+  // This test pins the ASCII-only contract declared in POLICY.md under
+  // "Value-object invariants (stable)". The regex ^[a-z][a-z0-9_-]{0,31}$
+  // refuses every non-ASCII identifier form. Widening the regex to
+  // accept Unicode letter classes is a BREAKING change — it forces a
+  // Unicode-normalization audit of every read-side verb that currently
+  // does case-insensitive matching via .toLowerCase() at the interface
+  // layer (voices, tail, whoami, chain). If you're updating the regex
+  // and this test fails, re-read POLICY.md § domain/ value-object
+  // invariants before proceeding.
+  //
+  // Test inputs cover the failure modes a future i18n-minded maintainer
+  // would try first:
+  const cases = [
+    'café',       // Latin-1 supplement (NFC pre-composed)
+    'caf\u00e9', // same, written as escape — pins NFC rejection
+    'café',      // NFD decomposed (e + combining acute U+0301)
+    '日本語',     // CJK ideographs
+    'עברית',    // RTL Hebrew
+    'α',          // single Greek letter (shortest possible non-ASCII)
+    'Ⅸ',          // Roman numeral 9 (Unicode letter-like)
+    'a\u200b',   // Latin + zero-width space (invisible sneak)
+  ];
+  for (const input of cases) {
+    assert.throws(
+      () => MemberName.of(input),
+      DomainError,
+      `expected MemberName.of(${JSON.stringify(input)}) to reject non-ASCII`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Two POLICY.md clarifications carried over from the 0.2.0 retrospective follow-ups. Both make existing **implicit** stability assumptions **explicit** so future maintainers don't accidentally widen a "current behavior" into a "promised shape" or vice versa. Docs-only + 1 new test.

This is the smallest substantive patch against `0.2.0` — no code changes, no behavior changes, pure contract tightening.

## POLICY.md additions

### 1. `domain/` value-object invariants (stable)

Two value-object shapes are now declared as part of the stable contract rather than current-implementation detail:

**`MemberName` is ASCII-only.** The regex `^[a-z][a-z0-9_-]{0,31}$` is a *promised shape*. The read-side verbs (`gate voices` / `tail` / `whoami` / `chain`) rely on the ASCII invariant to do case-insensitive matching via `.toLowerCase()` at the interface layer without routing through `MemberName.of()`. If this rule is ever relaxed to accept non-ASCII identifiers, the relaxation is **breaking**: every caller that lowercases names must be audited and moved to full Unicode normalization. Minor bump required even if domain tests pass.

This closes the follow-up I filed at the end of PR #5 as `i-2026-04-15-002` — at the time I was nervous about the silent layer-violation in `voices.ts` but the right fix turned out to be not "add a normalization helper" but **"write down the invariant the code already depends on"**.

**`RequestId` / `IssueId` lexical shape.** 3-digit (legacy) and 4-digit (current) sequence suffixes are both valid on read; generation always produces the wider form. Per-day ceiling is 9999. Pinned so the 0.1.x → 0.2.x shape widening doesn't get silently rolled back by a future "clean up legacy support" refactor.

### 2. `domain/diagnostic/` and `domain/repair/` (partially stable)

These layers are newer than the rest of the domain (landed in 0.2.0) and their shape is still settling. Declared **partially stable**:

- **Top-level JSON shapes** of `DiagnosticReport` and `RepairResult` are frozen for a given 0.x line. Adding new fields is backward-compat.
- **Enum variants** (`DiagnosticKind`, `RepairActionKind`, outcome statuses) are **additive only**. New variants MAY appear in any release — including patch — as the taxonomy grows to cover previously-invisible failure modes. Consumers that pipe `gate doctor --format json` into dashboards or migration scripts MUST treat unknown variants as opaque pass-through values and surface them to a human operator rather than crashing.

This closes the implicit-curation ambiguity that surfaced in the PR #17 retrospective: `yaml_parse_error` was added as an additive variant but POLICY did not explicitly say that was the contract. External tool authors now have a written rule to code against:

> **code against the shape, not the enum exhaustiveness**. Let unknown values fall through to a human-readable "unrecognized, inspect manually" path and you'll get clean forward-compat as the taxonomy grows.

## Devil review fold-in

First-pass devil (noir, `[devil/concern]`) caught one real issue:

> POLICY 追加 2 条項の devil レビュー。両方とも「implicit な assumption を explicit な契約にする」方向性として正しい。[...] しかし devil 観点で懸念が1点、これは fold in すべき:
>
> **ASCII-only 契約が test で pinned されていない**。POLICY は「`MemberName` の regex は *promised shape*、将来の relaxation は breaking」と書いたが、実際に test suite を見ると、非 ASCII 入力を明示的に拒否する test がない。現在の regex は非 ASCII を拒否するので振る舞いは正しいが、**将来の「i18n 対応しよう」という善意の maintainer が regex を広げたとき、既存 tests は全通過する**。POLICY の文章は commit log でしか自分を守れず、コードと一緒に diff に出てこない — これは noir が何度も指摘してきた「policy as prose vs policy as test」のパターン。

**Folded in**: a new test `MemberName rejects non-ASCII (ASCII-only invariant per POLICY.md)` covering:

- Latin-1 supplement NFC (`café`)
- NFC escape form (`caf\u00e9`) — pins the NFC rejection explicitly
- NFD decomposed (`café` with combining U+0301)
- CJK ideographs (`日本語`)
- RTL Hebrew (`עברית`)
- Shortest-possible Greek single letter (`α`)
- Unicode letter-like Roman numeral (`Ⅸ`)
- Zero-width-space invisible sneak (`a\u200b`)

The test name names `POLICY.md` explicitly so a future maintainer whose regex widening breaks this test is routed back to the policy document rather than to a commit log. This creates the self-enforcing loop that was missing:

1. Maintainer widens the regex for "better i18n support"
2. Existing domain tests pass except this one
3. Test name says "per POLICY.md" → they open POLICY
4. POLICY § "Value-object invariants (stable)" says ASCII-only is contract
5. They understand this is a breaking change and route it through the minor bump process

**policy as prose → policy as test**. The test's 15-line comment block is deliberately educational so the future maintainer who stumbles in doesn't just silence the test; they learn why it exists.

Second-pass devil: `[devil/ok]`.

## Stats

- **192 tests** (191 → 192, +1 ASCII-only pinning test)
- **0 code changes outside tests**
- **POLICY.md**: +60 lines (2 new subsections)
- **CHANGELOG.md**: +27 lines under `[Unreleased]` `### Added`
- **patch-level change** (0.2.1 candidate): no stable-surface behavior change, pure contract tightening + one new test

## Why patch (not minor)

Under POLICY.md's strict 0.x variant:

- `0.x.Y` (patch) = MUST be backward-compatible
- `0.X.0` (minor) = MAY contain breaking changes

This PR adds **no breaking changes**. It:

- Tightens existing implicit contracts into explicit ones (docs)
- Adds one new test that passes against the current regex
- Changes no runtime behavior
- Adds no new stable-surface elements (the value-object invariants are clarifications of shapes that were *already* stable via `MemberName` / `RequestId` being on the stable-surface list; the diagnostic/repair partial stability is a refinement of the earlier implicit "unlisted = unstable" interpretation, not a new commitment to something that wasn't already in practice frozen)

This PR is therefore a valid `0.2.1` candidate under strict 0.x variant.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 192/192 passing (191 → 192)
- [x] New test `MemberName rejects non-ASCII (ASCII-only invariant per POLICY.md)` passes with 8 non-ASCII inputs, all correctly rejected by the existing regex
- [x] POLICY.md renders correctly (markdown preview sanity check)
- [x] CHANGELOG `[Unreleased]` section has the new `### Added` entries above `[0.2.0]`
- [x] No `bin/` changes (3-line shims are unaffected, as designed)

## Follow-ups carried over from the 0.2.0 retro (not in this PR)

- **Chain range-notation parsing** (`〜007`) — **closed as out-of-scope** by design decision in PR #17; no action required, memo preserved in README § Chain
- **listAll TOCTOU true elimination** — requires flat storage layout, **0.3.0 minor** material
- **Deprecation policy execution example** — first candidate is `gate review` positional comment → `--comment` migration, **0.3.0 minor**
- **Field-level patch repair** (`i-2026-04-15-0026` remainder) — requires `RepairActionKind = 'patch_field'` + `--interactive` mode + backup-before-patch, **0.3.0 major work**

https://claude.ai/code/session_01G9UdoygPCyGa3oYchRYLXf