### PR TITLE
fix: address 4-lens review (concurrency, DDD duplication, MCP stdio, UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **Atomic writes for request files.** `YamlRequestRepository.save()` now
+  writes via `.tmp-<pid>-<rand>-<basename>` + `rename()` so readers never
+  observe a torn or partial YAML. Temp files are cleaned up on failure.
+- **Optimistic lock on save.** `Request.loadedVersion` snapshots the
+  total mutation count (`status_log.length + reviews.length`) at load
+  time. If the on-disk total has grown before save, the repo throws
+  `RequestVersionConflict` instead of overwriting. Catches both
+  transition races (concurrent `approve`/`execute`) and review races
+  (concurrent `addReview`, which does not touch `status_log`).
+- **`gate deny` / `gate fail` accept `--note <s>` or `--reason <s>`** in
+  addition to the legacy positional argument. Aligns muscle memory
+  with `approve`/`execute`/`complete`.
+
+### Changed
+- **Closure notes have a single source of truth.** The domain no
+  longer writes `completion_note` / `deny_reason` / `failure_reason`
+  as separate Request fields; they are derived at `toJSON()` time
+  from `status_log[-1].note`. External shape is unchanged — the
+  top-level keys are still emitted for backward compatibility with
+  consumers of the YAML / JSON output. **On next save, the status_log
+  entry is authoritative**: if a legacy file has the two disagreeing,
+  the top-level value is dropped. Hydration warns via `onMalformed`
+  when disagreement is detected.
+- **`host_names` are validated via `MemberName.of()`** at config-load
+  time. Entries that were previously accepted but could collide with
+  path-traversal, shell metachars, or reserved names now fail loudly
+  with `Invalid host_names entry ...`.
+- **`findById` now scans every state directory** and dedupes by total
+  mutation count, so a file mid-transition (present under two dirs
+  between atomic-write and old-file-unlink) deterministically returns
+  the newer representation. The previous first-hit-wins behavior could
+  return the stale pending/ file while the newer approved/ file also
+  existed.
+- **`gate` MCP (`mcp/gate_mcp.py`) stops mixing stderr into stdout.**
+  `--format json` output is no longer corrupted by `[stderr] ...`
+  suffixes. Stderr is forwarded to the host's stderr for observability.
+
 ## [0.3.0] — 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -363,10 +363,10 @@ gate status [--for <m>] [--format json|text]         (default: json)
 gate whoami                                          (needs GUILD_ACTOR)
 gate chain <id>                                      (request or issue)
 gate approve <id>  --by <m> [--note <s>]
-gate deny    <id>  --by <m> <reason>
+gate deny    <id>  --by <m> [--note <s> | --reason <s> | <reason>]
 gate execute <id>  --by <m> [--note <s>]
 gate complete <id> --by <m> [--note <s>]
-gate fail    <id>  --by <m> <reason>
+gate fail    <id>  --by <m> [--note <s> | --reason <s> | <reason>]
 gate review  <id>  --by <m> --lense <devil|layer|cognitive|user>
                    --verdict <ok|concern|reject>
                    [--comment <s> | --comment - | <comment>]

--- a/mcp/gate_mcp.py
+++ b/mcp/gate_mcp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -54,7 +55,12 @@ def _cwd() -> str | None:
 
 
 async def _run_gate(*args: str, stdin_text: str | None = None) -> str:
-    """Run gate CLI and return stdout. Raises on non-zero exit."""
+    """Run gate CLI and return stdout unmodified. Raises on non-zero exit.
+
+    stderr is never mixed into stdout: agents consuming --format json would
+    otherwise see "[stderr] ..." suffixed after valid JSON and fail to parse.
+    Diagnostic stderr is forwarded to the MCP host's stderr for observability.
+    """
     cmd = ["node", GATE_BIN, *args]
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -66,18 +72,17 @@ async def _run_gate(*args: str, stdin_text: str | None = None) -> str:
     stdout, stderr = await proc.communicate(
         input=stdin_text.encode() if stdin_text else None
     )
-    out = stdout.decode().strip()
+    out = stdout.decode()
     err = stderr.decode().strip()
     if proc.returncode != 0:
-        raise RuntimeError(f"gate exited {proc.returncode}: {err or out}")
-    # Append stderr warnings if any
+        raise RuntimeError(f"gate exited {proc.returncode}: {err or out.strip()}")
     if err:
-        out = f"{out}\n[stderr] {err}"
+        print(f"[gate stderr] {err}", file=sys.stderr)
     return out
 
 
 async def _run_guild(*args: str) -> str:
-    """Run guild CLI and return stdout."""
+    """Run guild CLI and return stdout unmodified. stderr goes to host stderr."""
     cmd = ["node", GUILD_BIN, *args]
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -86,12 +91,12 @@ async def _run_guild(*args: str) -> str:
         cwd=_cwd(),
     )
     stdout, stderr = await proc.communicate()
-    out = stdout.decode().strip()
+    out = stdout.decode()
     err = stderr.decode().strip()
     if proc.returncode != 0:
-        raise RuntimeError(f"guild exited {proc.returncode}: {err or out}")
+        raise RuntimeError(f"guild exited {proc.returncode}: {err or out.strip()}")
     if err:
-        out = f"{out}\n[stderr] {err}"
+        print(f"[guild stderr] {err}", file=sys.stderr)
     return out
 
 

--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -32,3 +32,22 @@ export class RequestIdCollision extends Error {
     this.name = 'RequestIdCollision';
   }
 }
+
+/**
+ * Thrown when `save()` detects that the on-disk status_log has grown
+ * since the request was loaded — i.e. another writer committed a
+ * transition in the meantime. Callers should reload and retry rather
+ * than blindly overwrite.
+ */
+export class RequestVersionConflict extends Error {
+  constructor(
+    public readonly id: string,
+    public readonly expectedVersion: number,
+    public readonly actualVersion: number,
+  ) {
+    super(
+      `Request ${id} changed on disk (expected status_log length ${expectedVersion}, found ${actualVersion}); reload and retry`,
+    );
+    this.name = 'RequestVersionConflict';
+  }
+}

--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -34,9 +34,10 @@ export class RequestIdCollision extends Error {
 }
 
 /**
- * Thrown when `save()` detects that the on-disk status_log has grown
- * since the request was loaded — i.e. another writer committed a
- * transition in the meantime. Callers should reload and retry rather
+ * Thrown when `save()` detects that the on-disk total mutation count
+ * (status_log.length + reviews.length) has grown since the request
+ * was loaded — i.e. another writer committed a transition or a
+ * review in the meantime. Callers should reload and retry rather
  * than blindly overwrite.
  */
 export class RequestVersionConflict extends Error {
@@ -46,7 +47,7 @@ export class RequestVersionConflict extends Error {
     public readonly actualVersion: number,
   ) {
     super(
-      `Request ${id} changed on disk (expected status_log length ${expectedVersion}, found ${actualVersion}); reload and retry`,
+      `Request ${id} changed on disk (expected version ${expectedVersion}, found ${actualVersion}); reload and retry`,
     );
     this.name = 'RequestVersionConflict';
   }

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -31,13 +31,21 @@ export interface RequestProps {
   createdAt: string;
   reviews: Review[];
   statusLog: StatusLogEntry[];
-  completionNote?: string;
-  denyReason?: string;
-  failureReason?: string;
 }
 
+/**
+ * Closure notes (completed/denied/failed) live in `status_log[-1].note`
+ * as the single source of truth. toJSON derives the legacy top-level
+ * keys (`completion_note` / `deny_reason` / `failure_reason`) from the
+ * log so external readers stay stable while the domain keeps one place
+ * to write. Restore may receive the legacy keys from older files; they
+ * are used only to backfill a missing log note, never stored separately.
+ */
 export class Request {
-  private constructor(private props: RequestProps) {}
+  private constructor(
+    private props: RequestProps,
+    private readonly _loadedVersion: number,
+  ) {}
 
   static create(input: {
     id: RequestId;
@@ -74,11 +82,17 @@ export class Request {
     if (input.target !== undefined) {
       props.target = sanitizeText(input.target, 'target');
     }
-    return new Request(props);
+    // New requests have no on-disk predecessor; loadedVersion=0 marks
+    // "never seen" for the optimistic-lock check in save().
+    return new Request(props, 0);
   }
 
   static restore(props: RequestProps): Request {
-    return new Request({ ...props });
+    // loadedVersion snapshots the statusLog length AT LOAD time. After
+    // a mutation (approve/execute/...), statusLog.length becomes
+    // loadedVersion + 1, and the repository compares the on-disk
+    // length against loadedVersion to detect lost-update races.
+    return new Request({ ...props }, props.statusLog.length);
   }
 
   get id(): RequestId {
@@ -108,6 +122,15 @@ export class Request {
   get statusLog(): readonly StatusLogEntry[] {
     return this.props.statusLog;
   }
+  /**
+   * Number of `statusLog` entries observed when this aggregate was loaded
+   * from disk (0 for freshly-created instances). The repository uses it
+   * as an optimistic-lock version: if the on-disk log has grown since,
+   * another writer won the race and our save must be rejected.
+   */
+  get loadedVersion(): number {
+    return this._loadedVersion;
+  }
 
   approve(by: MemberName, note?: string): void {
     this.transition('approved', by, note);
@@ -115,7 +138,6 @@ export class Request {
 
   deny(by: MemberName, reason: string): void {
     this.transition('denied', by, reason);
-    this.props.denyReason = sanitizeText(reason, 'reason');
   }
 
   execute(by: MemberName, note?: string): void {
@@ -124,14 +146,10 @@ export class Request {
 
   complete(by: MemberName, note?: string): void {
     this.transition('completed', by, note);
-    if (note !== undefined) {
-      this.props.completionNote = sanitizeText(note, 'note');
-    }
   }
 
   fail(by: MemberName, reason: string): void {
     this.transition('failed', by, reason);
-    this.props.failureReason = sanitizeText(reason, 'reason');
   }
 
   addReview(review: Review): void {
@@ -180,12 +198,15 @@ export class Request {
     if (this.props.autoReview)
       out['auto_review'] = this.props.autoReview.value;
     if (this.props.target !== undefined) out['target'] = this.props.target;
-    if (this.props.completionNote !== undefined)
-      out['completion_note'] = this.props.completionNote;
-    if (this.props.denyReason !== undefined)
-      out['deny_reason'] = this.props.denyReason;
-    if (this.props.failureReason !== undefined)
-      out['failure_reason'] = this.props.failureReason;
+    // Derive legacy closure keys from the last status_log entry so
+    // external consumers (chain / voices / show --format text) keep
+    // working unchanged. Single source of truth: status_log[-1].note.
+    const last = this.props.statusLog[this.props.statusLog.length - 1];
+    if (last && last.note !== undefined) {
+      if (last.state === 'completed') out['completion_note'] = last.note;
+      else if (last.state === 'denied') out['deny_reason'] = last.note;
+      else if (last.state === 'failed') out['failure_reason'] = last.note;
+    }
     return out;
   }
 }

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -88,11 +88,14 @@ export class Request {
   }
 
   static restore(props: RequestProps): Request {
-    // loadedVersion snapshots the statusLog length AT LOAD time. After
-    // a mutation (approve/execute/...), statusLog.length becomes
-    // loadedVersion + 1, and the repository compares the on-disk
-    // length against loadedVersion to detect lost-update races.
-    return new Request({ ...props }, props.statusLog.length);
+    // loadedVersion snapshots the TOTAL mutation count at load time —
+    // status_log entries PLUS reviews. Using status_log alone would
+    // miss concurrent addReview races (reviews push into reviews[]
+    // without touching status_log), letting two simultaneous reviewers
+    // silently lose one review on last-writer-wins. See
+    // `computeVersion` below for the single place that defines the
+    // invariant.
+    return new Request({ ...props }, computeVersion(props.statusLog.length, props.reviews.length));
   }
 
   get id(): RequestId {
@@ -123,13 +126,23 @@ export class Request {
     return this.props.statusLog;
   }
   /**
-   * Number of `statusLog` entries observed when this aggregate was loaded
-   * from disk (0 for freshly-created instances). The repository uses it
-   * as an optimistic-lock version: if the on-disk log has grown since,
-   * another writer won the race and our save must be rejected.
+   * Total mutation count observed when this aggregate was loaded from
+   * disk (0 for freshly-created instances). Defined as
+   * `status_log.length + reviews.length` — both arrays are append-only,
+   * so their combined length is a monotonic version. The repository
+   * uses it as an optimistic-lock token: if the on-disk total has
+   * grown since, another writer won the race and our save is rejected.
    */
   get loadedVersion(): number {
     return this._loadedVersion;
+  }
+
+  /**
+   * Current total mutation count. Equivalent to the version the
+   * repository will write with, so `loadedVersion` + delta = `currentVersion`.
+   */
+  get currentVersion(): number {
+    return computeVersion(this.props.statusLog.length, this.props.reviews.length);
   }
 
   approve(by: MemberName, note?: string): void {
@@ -209,6 +222,16 @@ export class Request {
     }
     return out;
   }
+}
+
+/**
+ * Total mutation count: status_log entries + reviews. Both arrays are
+ * append-only so the sum is monotonic across any legal transition.
+ * Kept as a module-private helper so the invariant is defined in one
+ * place and the repository can reuse it when reading raw YAML.
+ */
+export function computeVersion(statusLogLen: number, reviewsLen: number): number {
+  return statusLogLen + reviewsLen;
 }
 
 function sanitizeText(raw: unknown, field: string): string {

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -2,6 +2,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve, isAbsolute, join } from 'node:path';
 import YAML from 'yaml';
 import { DomainError } from '../../domain/shared/DomainError.js';
+import { MemberName } from '../../domain/member/MemberName.js';
 import { isUnderBase } from '../persistence/pathSafety.js';
 import { DEFAULT_LENSES } from '../../domain/shared/Lense.js';
 
@@ -80,7 +81,7 @@ export class GuildConfig implements GuildConfigProps {
     const hostNames = Array.isArray(raw.host_names)
       ? raw.host_names
           .filter((x: unknown): x is string => typeof x === 'string')
-          .map((x: string) => x.toLowerCase())
+          .map((x: string) => validateHostName(x))
       : [...DEFAULT_HOSTS];
     const lenses = Array.isArray(raw.lenses)
       ? raw.lenses
@@ -140,6 +141,24 @@ function findConfig(start: string): string | null {
  * startup because the literal `/` never matched a backslash-separated
  * subpath.
  */
+/**
+ * Pass host names through the same validation gate as members so a
+ * malformed host_names entry (shell metachars, path traversal, reserved
+ * names) surfaces at config-load time rather than leaking into
+ * `--from` / `--by` / `--to` where hosts are otherwise accepted.
+ */
+function validateHostName(raw: string): string {
+  try {
+    return MemberName.of(raw).value;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new DomainError(
+      `Invalid host_names entry "${raw}": ${msg}`,
+      'host_names',
+    );
+  }
+}
+
 function resolveUnder(base: string, path: string): string {
   const absBase = resolve(base);
   const target = isAbsolute(path) ? resolve(path) : resolve(absBase, path);

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -12,13 +12,15 @@ import { MemberName } from '../../domain/member/MemberName.js';
 import {
   RequestRepository,
   RequestIdCollision,
+  RequestVersionConflict,
 } from '../../application/ports/RequestRepository.js';
 import {
   existsSafe,
   listDirSafe,
   readTextSafe,
   writeTextSafe,
-  moveSafe,
+  writeTextSafeAtomic,
+  unlinkSafe,
 } from './safeFs.js';
 import { GuildConfig } from '../config/GuildConfig.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
@@ -33,17 +35,23 @@ export class YamlRequestRepository implements RequestRepository {
   constructor(private readonly config: GuildConfig) {}
 
   async findById(id: RequestId): Promise<Request | null> {
+    // Scan every state dir so a file mid-transition (present under two
+    // dirs between atomic-write and old-file-unlink) is still found,
+    // and dedupe picks the newer representation by status_log length.
+    const found: Request[] = [];
     for (const state of REQUEST_STATES) {
       const rel = join(state, `${id.value}.yaml`);
-      if (existsSafe(this.config.paths.requests, rel)) {
-        const raw = readTextSafe(this.config.paths.requests, rel);
-        const absSource = join(this.config.paths.requests, rel);
-        const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
-        if (parsed === undefined) return null;
-        return hydrate(parsed, state, absSource, this.config.onMalformed, this.config.lenses);
-      }
+      if (!existsSafe(this.config.paths.requests, rel)) continue;
+      const raw = readTextSafe(this.config.paths.requests, rel);
+      const absSource = join(this.config.paths.requests, rel);
+      const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
+      if (parsed === undefined) continue;
+      const r = hydrate(parsed, state, absSource, this.config.onMalformed, this.config.lenses);
+      if (r) found.push(r);
     }
-    return null;
+    if (found.length === 0) return null;
+    if (found.length === 1) return found[0]!;
+    return dedupeRequestsById(found)[0] ?? null;
   }
 
   async listByState(state: RequestState): Promise<Request[]> {
@@ -97,19 +105,51 @@ export class YamlRequestRepository implements RequestRepository {
   }
 
   async save(request: Request): Promise<void> {
-    const currentState = request.state;
-    const currentRel = join(currentState, `${request.id.value}.yaml`);
-    // Locate any existing file under another state dir
+    const id = request.id.value;
+    const newState = request.state;
+    const newRel = join(newState, `${id}.yaml`);
+
+    // 1. Scan every state dir; collect existing locations. A concurrent
+    //    transition may have left stragglers under multiple dirs.
+    const existing: Array<{ state: RequestState; rel: string; logLen: number }> = [];
     for (const state of REQUEST_STATES) {
-      if (state === currentState) continue;
-      const rel = join(state, `${request.id.value}.yaml`);
-      if (existsSafe(this.config.paths.requests, rel)) {
-        moveSafe(this.config.paths.requests, rel, currentRel);
-        break;
-      }
+      const rel = join(state, `${id}.yaml`);
+      if (!existsSafe(this.config.paths.requests, rel)) continue;
+      const raw = readTextSafe(this.config.paths.requests, rel);
+      const absSource = join(this.config.paths.requests, rel);
+      const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
+      const logLen = countStatusLogEntries(parsed);
+      existing.push({ state, rel, logLen });
     }
+
+    // 2. Optimistic-lock check: the highest on-disk status_log length
+    //    must equal the version we loaded (request.loadedVersion). If
+    //    someone else transitioned in the meantime, refuse the write.
+    //    loadedVersion === 0 means the aggregate was freshly created
+    //    and save() was called on it — that path should go through
+    //    saveNew(); treat any existing file as a conflict.
+    const maxOnDisk = existing.reduce((m, e) => Math.max(m, e.logLen), 0);
+    if (maxOnDisk !== request.loadedVersion) {
+      throw new RequestVersionConflict(
+        id,
+        request.loadedVersion,
+        maxOnDisk,
+      );
+    }
+
+    // 3. Atomic write of the new content to the new state dir. The
+    //    .tmp-*+rename keeps readers from ever seeing a torn file.
     const text = YAML.stringify(request.toJSON());
-    writeTextSafe(this.config.paths.requests, currentRel, text);
+    writeTextSafeAtomic(this.config.paths.requests, newRel, text);
+
+    // 4. Remove leftover files from any state dir that isn't the new
+    //    one. Done AFTER the atomic write so a crash between steps 3
+    //    and 4 leaves the newer file in place; findById's dedupe
+    //    returns it deterministically (longer status_log wins).
+    for (const e of existing) {
+      if (e.state === newState) continue;
+      unlinkSafe(this.config.paths.requests, e.rel);
+    }
   }
 
   async nextSequence(dateKey: string): Promise<number> {
@@ -146,6 +186,18 @@ export class YamlRequestRepository implements RequestRepository {
  * Pure and synchronous so it can be unit-tested independently of the
  * repository.
  */
+/**
+ * Count status_log entries from raw parsed YAML. Used by the optimistic
+ * lock in save(): a torn or unparseable file returns 0, which correctly
+ * signals "unknown on-disk version" and forces the caller to reload.
+ */
+function countStatusLogEntries(parsed: unknown): number {
+  if (!parsed || typeof parsed !== 'object') return 0;
+  const log = (parsed as Record<string, unknown>)['status_log'];
+  if (!Array.isArray(log)) return 0;
+  return log.length;
+}
+
 export function dedupeRequestsById(
   requests: ReadonlyArray<Request>,
 ): Request[] {
@@ -264,12 +316,25 @@ function hydrate(
     if (typeof obj['auto_review'] === 'string')
       props.autoReview = MemberName.of(obj['auto_review']);
     if (typeof obj['target'] === 'string') props.target = obj['target'] as string;
-    if (typeof obj['completion_note'] === 'string')
-      props.completionNote = obj['completion_note'] as string;
-    if (typeof obj['deny_reason'] === 'string')
-      props.denyReason = obj['deny_reason'] as string;
-    if (typeof obj['failure_reason'] === 'string')
-      props.failureReason = obj['failure_reason'] as string;
+    // Legacy backfill: if an older file has the top-level closure key
+    // but the matching status_log entry has no note (shouldn't happen
+    // with code that wrote both, but defends against hand-edited YAML),
+    // copy it onto the last log entry so the new single-source derivation
+    // still shows the closure note.
+    const legacyClosureKey =
+      state === 'completed'
+        ? 'completion_note'
+        : state === 'denied'
+          ? 'deny_reason'
+          : state === 'failed'
+            ? 'failure_reason'
+            : undefined;
+    if (legacyClosureKey && typeof obj[legacyClosureKey] === 'string') {
+      const last = statusLog[statusLog.length - 1];
+      if (last && last.state === state && last.note === undefined) {
+        last.note = obj[legacyClosureKey] as string;
+      }
+    }
     return Request.restore(props);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -1,6 +1,6 @@
 import YAML from 'yaml';
 import { join } from 'node:path';
-import { Request, StatusLogEntry } from '../../domain/request/Request.js';
+import { Request, StatusLogEntry, computeVersion } from '../../domain/request/Request.js';
 import { RequestId } from '../../domain/request/RequestId.js';
 import {
   RequestState,
@@ -109,26 +109,37 @@ export class YamlRequestRepository implements RequestRepository {
     const newState = request.state;
     const newRel = join(newState, `${id}.yaml`);
 
+    // Defensive: save() is for updates. Fresh aggregates (loadedVersion=0,
+    // meaning "never on disk") must go through saveNew() so the O_EXCL
+    // create path catches collisions. Otherwise a misused call could
+    // silently overwrite a file created by a concurrent saveNew.
+    if (request.loadedVersion === 0) {
+      throw new Error(
+        `save() called on a freshly-created request ${id}; use saveNew() instead`,
+      );
+    }
+
     // 1. Scan every state dir; collect existing locations. A concurrent
     //    transition may have left stragglers under multiple dirs.
-    const existing: Array<{ state: RequestState; rel: string; logLen: number }> = [];
+    const existing: Array<{ state: RequestState; rel: string; version: number }> = [];
     for (const state of REQUEST_STATES) {
       const rel = join(state, `${id}.yaml`);
       if (!existsSafe(this.config.paths.requests, rel)) continue;
       const raw = readTextSafe(this.config.paths.requests, rel);
       const absSource = join(this.config.paths.requests, rel);
       const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
-      const logLen = countStatusLogEntries(parsed);
-      existing.push({ state, rel, logLen });
+      const version = readVersion(parsed);
+      existing.push({ state, rel, version });
     }
 
-    // 2. Optimistic-lock check: the highest on-disk status_log length
-    //    must equal the version we loaded (request.loadedVersion). If
-    //    someone else transitioned in the meantime, refuse the write.
-    //    loadedVersion === 0 means the aggregate was freshly created
-    //    and save() was called on it — that path should go through
-    //    saveNew(); treat any existing file as a conflict.
-    const maxOnDisk = existing.reduce((m, e) => Math.max(m, e.logLen), 0);
+    // 2. Optimistic-lock check: the highest on-disk total mutation
+    //    count (status_log.length + reviews.length) must equal the
+    //    version we loaded. Using status_log alone would miss
+    //    concurrent addReview races — two reviewers writing at once
+    //    both touch reviews[] without growing status_log, so a
+    //    status_log-only check would let one review silently vanish
+    //    under last-writer-wins.
+    const maxOnDisk = existing.reduce((m, e) => Math.max(m, e.version), 0);
     if (maxOnDisk !== request.loadedVersion) {
       throw new RequestVersionConflict(
         id,
@@ -169,35 +180,39 @@ export class YamlRequestRepository implements RequestRepository {
 }
 
 /**
+ * Read the total mutation count from raw parsed YAML using the same
+ * `computeVersion` invariant the domain uses. Defined here (not just
+ * on Request) so the repository can compare on-disk state without
+ * hydrating — a malformed or torn file returns 0, forcing the caller
+ * to reload rather than proceed on incomplete data.
+ */
+function readVersion(parsed: unknown): number {
+  if (!parsed || typeof parsed !== 'object') return 0;
+  const obj = parsed as Record<string, unknown>;
+  const log = Array.isArray(obj['status_log']) ? obj['status_log'].length : 0;
+  const reviews = Array.isArray(obj['reviews']) ? obj['reviews'].length : 0;
+  return computeVersion(log, reviews);
+}
+
+/**
  * Deduplicate a list of Requests by id, keeping the newest
  * representation when the same id appears more than once (this can
- * happen under concurrent state transitions where listAll's per-state
- * reads race with a moving file).
+ * happen under concurrent state transitions or review races where
+ * listAll's per-state reads see a moving file).
  *
  * Tie-break order:
- *   1. More status_log entries wins. status_log is append-only, so a
- *      representation with more entries is strictly newer in time.
- *   2. On equal log length, later position in REQUEST_STATES wins.
- *      The ordering there (pending < approved < executing < completed
- *      < failed < denied) doesn't encode a total temporal order —
+ *   1. Higher total mutation count (status_log + reviews) wins. Both
+ *      arrays are append-only so the sum is a monotonic version
+ *      across any legal mutation — transitions AND reviews.
+ *   2. On equal version, later position in REQUEST_STATES wins. The
+ *      ordering there (pending < approved < executing < completed <
+ *      failed < denied) doesn't encode a total temporal order —
  *      failed/denied are divergent terminals — but for tiebreaker
  *      purposes it gives a stable, deterministic result.
  *
  * Pure and synchronous so it can be unit-tested independently of the
  * repository.
  */
-/**
- * Count status_log entries from raw parsed YAML. Used by the optimistic
- * lock in save(): a torn or unparseable file returns 0, which correctly
- * signals "unknown on-disk version" and forces the caller to reload.
- */
-function countStatusLogEntries(parsed: unknown): number {
-  if (!parsed || typeof parsed !== 'object') return 0;
-  const log = (parsed as Record<string, unknown>)['status_log'];
-  if (!Array.isArray(log)) return 0;
-  return log.length;
-}
-
 export function dedupeRequestsById(
   requests: ReadonlyArray<Request>,
 ): Request[] {
@@ -208,9 +223,11 @@ export function dedupeRequestsById(
       byId.set(r.id.value, r);
       continue;
     }
-    if (r.statusLog.length > existing.statusLog.length) {
+    const rv = r.currentVersion;
+    const ev = existing.currentVersion;
+    if (rv > ev) {
       byId.set(r.id.value, r);
-    } else if (r.statusLog.length === existing.statusLog.length) {
+    } else if (rv === ev) {
       const newRank = REQUEST_STATES.indexOf(r.state);
       const oldRank = REQUEST_STATES.indexOf(existing.state);
       if (newRank > oldRank) byId.set(r.id.value, r);
@@ -316,11 +333,16 @@ function hydrate(
     if (typeof obj['auto_review'] === 'string')
       props.autoReview = MemberName.of(obj['auto_review']);
     if (typeof obj['target'] === 'string') props.target = obj['target'] as string;
-    // Legacy backfill: if an older file has the top-level closure key
-    // but the matching status_log entry has no note (shouldn't happen
-    // with code that wrote both, but defends against hand-edited YAML),
-    // copy it onto the last log entry so the new single-source derivation
-    // still shows the closure note.
+    // Legacy top-level closure keys (completion_note / deny_reason /
+    // failure_reason) are no longer written separately — status_log[-1].note
+    // is the single source of truth. Handle the three migration cases
+    // explicitly so silent data loss is impossible:
+    //   (a) log note present, top-level absent → normal; no-op
+    //   (b) log note absent, top-level present → backfill
+    //   (c) both present AND agreeing → normal; no-op
+    //   (d) both present AND disagreeing → warn via onMalformed so the
+    //       operator sees it in stderr and `gate doctor`, rather than
+    //       a silent drop on next save.
     const legacyClosureKey =
       state === 'completed'
         ? 'completion_note'
@@ -331,8 +353,19 @@ function hydrate(
             : undefined;
     if (legacyClosureKey && typeof obj[legacyClosureKey] === 'string') {
       const last = statusLog[statusLog.length - 1];
-      if (last && last.state === state && last.note === undefined) {
-        last.note = obj[legacyClosureKey] as string;
+      const topLevel = obj[legacyClosureKey] as string;
+      if (last && last.state === state) {
+        if (last.note === undefined) {
+          // case (b): backfill so the new derivation surfaces it
+          last.note = topLevel;
+        } else if (last.note !== topLevel) {
+          // case (d): legacy field and log disagree; surface loudly
+          // since the next save() will emit only the log entry.
+          onMalformed(
+            source,
+            `legacy top-level ${legacyClosureKey} disagrees with status_log[-1].note; the log entry wins on next save`,
+          );
+        }
       }
     }
     return Request.restore(props);

--- a/src/infrastructure/persistence/safeFs.ts
+++ b/src/infrastructure/persistence/safeFs.ts
@@ -6,8 +6,10 @@ import {
   writeFileSync,
   readdirSync,
   renameSync,
+  unlinkSync,
 } from 'node:fs';
-import { resolve, join, dirname, isAbsolute } from 'node:path';
+import { resolve, join, dirname, isAbsolute, basename } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { isUnderBase } from './pathSafety.js';
 
@@ -81,6 +83,46 @@ export function writeTextSafe(
   } else {
     writeFileSync(p, content);
   }
+}
+
+/**
+ * Write `content` to `relOrAbs` atomically: a sibling temp file is
+ * written fully, then `rename()`d into place. Readers never observe a
+ * torn or half-written file — they see either the previous content or
+ * the new content. Temp and target are in the same directory, which
+ * keeps the rename on a single filesystem (the atomicity guarantee on
+ * POSIX and Windows NTFS).
+ *
+ * On failure (disk full, permission), the temp is best-effort removed
+ * so leftover `.tmp-*` files don't accumulate. Successful rename
+ * implicitly replaces any existing target.
+ */
+export function writeTextSafeAtomic(
+  base: string,
+  relOrAbs: string,
+  content: string,
+): void {
+  const p = assertUnder(base, relOrAbs);
+  const dir = dirname(p);
+  mkdirSync(dir, { recursive: true });
+  const tmpName = `.tmp-${process.pid}-${randomBytes(6).toString('hex')}-${basename(p)}`;
+  const tmp = join(dir, tmpName);
+  try {
+    writeFileSync(tmp, content, { flag: 'wx' });
+    renameSync(tmp, p);
+  } catch (e) {
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp);
+    } catch {
+      // ignore cleanup failure — original error is what matters
+    }
+    throw e;
+  }
+}
+
+export function unlinkSafe(base: string, relOrAbs: string): void {
+  const p = assertUnder(base, relOrAbs);
+  if (existsSync(p)) unlinkSync(p);
 }
 
 export function listDirSafe(base: string, relOrAbs: string): string[] {

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -199,8 +199,12 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  const reason = args.positional.slice(1).join(' ');
-  if (!id || !reason) throw new Error('Usage: gate deny <id> --by <m> <reason>');
+  const reason = resolveReason(args, 'deny');
+  if (!id || !reason) {
+    throw new Error(
+      'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]',
+    );
+  }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   await c.requestUC.deny(id, by, reason);
   process.stdout.write(`✓ denied: ${id}\n`);
@@ -237,12 +241,29 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  const reason = args.positional.slice(1).join(' ');
-  if (!id || !reason) throw new Error('Usage: gate fail <id> --by <m> <reason>');
+  const reason = resolveReason(args, 'fail');
+  if (!id || !reason) {
+    throw new Error(
+      'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]',
+    );
+  }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   await c.requestUC.fail(id, by, reason);
   process.stdout.write(`✓ failed: ${id}\n`);
   return 0;
+}
+
+// Resolve the closure reason for deny/fail accepting any of:
+//   --reason <s>    explicit & semantically precise
+//   --note <s>      muscle-memory parity with approve/execute/complete
+//   <positional>    legacy form retained for back-compat
+// Explicit options take precedence over positional.
+function resolveReason(args: ParsedArgs, _verb: string): string {
+  const reasonOpt = optionalOption(args, 'reason');
+  const noteOpt = optionalOption(args, 'note');
+  if (reasonOpt !== undefined && reasonOpt.trim()) return reasonOpt;
+  if (noteOpt !== undefined && noteOpt.trim()) return noteOpt;
+  return args.positional.slice(1).join(' ');
 }
 
 export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -53,10 +53,10 @@ Requests:
   gate whoami                                     (needs GUILD_ACTOR)
   gate chain <id>                                 (request or issue)
   gate approve <id> --by <m> [--note <s>]
-  gate deny <id> --by <m> <reason>
+  gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]
   gate execute <id> --by <m> [--note <s>]
   gate complete <id> --by <m> [--note <s>]
-  gate fail <id> --by <m> <reason>
+  gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]
   gate review <id> --by <m> --lense <l> --verdict <v>
                    [--comment <s> | --comment - | <comment>]
   gate fast-track --from <m> --action <a> --reason <r>

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -138,3 +138,103 @@ test('Review strips control chars', () => {
   });
   assert.equal(rev.comment, 'helloworld');
 });
+
+test('Request.create starts with loadedVersion=0 (never on disk)', () => {
+  const r = mkReq();
+  assert.equal(r.loadedVersion, 0);
+  assert.equal(r.currentVersion, 1); // 1 status_log entry
+});
+
+test('Request.restore snapshots loadedVersion as status_log + reviews', () => {
+  // Hand-build a request with 3 log entries and 2 reviews to prove
+  // version counts both. If someone narrows version back to
+  // status_log alone, this test fails.
+  const r = Request.restore({
+    id: RequestId.generate(d, 1),
+    from: MemberName.of('alice'),
+    action: 'a',
+    reason: 'r',
+    state: 'completed',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    statusLog: [
+      { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+      { state: 'approved', by: 'eris', at: '2026-04-14T00:00:01.000Z' },
+      { state: 'completed', by: 'alice', at: '2026-04-14T00:00:02.000Z' },
+    ],
+    reviews: [
+      Review.create({ by: 'eris', lense: 'devil', verdict: 'ok', comment: 'a' }),
+      Review.create({ by: 'eris', lense: 'layer', verdict: 'ok', comment: 'b' }),
+    ],
+  });
+  assert.equal(r.loadedVersion, 5);
+  assert.equal(r.currentVersion, 5);
+});
+
+test('Request.addReview increments currentVersion but not loadedVersion', () => {
+  // After addReview, on-disk is stale by one; the repo compares
+  // on-disk.version to loadedVersion, so loadedVersion must NOT
+  // move with in-memory mutations.
+  const r = Request.restore({
+    id: RequestId.generate(d, 1),
+    from: MemberName.of('alice'),
+    action: 'a',
+    reason: 'r',
+    state: 'completed',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    statusLog: [
+      { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+      { state: 'completed', by: 'alice', at: '2026-04-14T00:00:02.000Z' },
+    ],
+    reviews: [],
+  });
+  assert.equal(r.loadedVersion, 2);
+  r.addReview(Review.create({ by: 'eris', lense: 'devil', verdict: 'ok', comment: 'x' }));
+  assert.equal(r.loadedVersion, 2, 'loadedVersion is the load-time snapshot, never bumped');
+  assert.equal(r.currentVersion, 3);
+});
+
+test('Request.toJSON derives completion_note from status_log[-1].note', () => {
+  const r = mkReq();
+  r.approve(MemberName.of('eris'));
+  r.execute(MemberName.of('bob'));
+  r.complete(MemberName.of('bob'), 'shipped');
+  const j = r.toJSON();
+  assert.equal(j['completion_note'], 'shipped');
+  assert.equal(j['deny_reason'], undefined);
+  assert.equal(j['failure_reason'], undefined);
+});
+
+test('Request.toJSON derives deny_reason and failure_reason from status_log[-1].note', () => {
+  const denied = mkReq();
+  denied.deny(MemberName.of('eris'), 'not now');
+  assert.equal(denied.toJSON()['deny_reason'], 'not now');
+  assert.equal(denied.toJSON()['completion_note'], undefined);
+
+  const failed = mkReq();
+  failed.approve(MemberName.of('eris'));
+  failed.execute(MemberName.of('bob'));
+  failed.fail(MemberName.of('bob'), 'broken');
+  assert.equal(failed.toJSON()['failure_reason'], 'broken');
+  assert.equal(failed.toJSON()['completion_note'], undefined);
+});
+
+test('Request.toJSON: closure-note derivation is single-sourced from status_log', () => {
+  // The old duplication bug wrote the note into both props.completionNote
+  // and status_log[-1].note. If someone mutates status_log out of band
+  // (only possible via restore), toJSON must still reflect what the
+  // log says, proving there is no shadow field.
+  const r = Request.restore({
+    id: RequestId.generate(d, 1),
+    from: MemberName.of('alice'),
+    action: 'a',
+    reason: 'r',
+    state: 'completed',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    statusLog: [
+      { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+      { state: 'completed', by: 'alice', at: '2026-04-14T00:00:01.000Z', note: 'log-wins' },
+    ],
+    reviews: [],
+  });
+  assert.equal(r.toJSON()['completion_note'], 'log-wins');
+});

--- a/tests/infrastructure/YamlRequestRepository.test.ts
+++ b/tests/infrastructure/YamlRequestRepository.test.ts
@@ -1,0 +1,254 @@
+// YamlRequestRepository — optimistic lock, findById dedupe, save() guards.
+//
+// Focused on the invariants added in the "fix: address 4-lens review"
+// commit: concurrent writes must conflict, mid-transition state is
+// deterministically resolvable, and save() refuses fresh aggregates.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import YAML from 'yaml';
+import { GuildConfig } from '../../src/infrastructure/config/GuildConfig.js';
+import { YamlRequestRepository } from '../../src/infrastructure/persistence/YamlRequestRepository.js';
+import { Request } from '../../src/domain/request/Request.js';
+import { RequestId } from '../../src/domain/request/RequestId.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+import { Review } from '../../src/domain/request/Review.js';
+import { RequestVersionConflict } from '../../src/application/ports/RequestRepository.js';
+
+function makeRoot(): { root: string; cfg: GuildConfig; repo: YamlRequestRepository; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-repo-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  const cfg = GuildConfig.load(root, () => {});
+  const repo = new YamlRequestRepository(cfg);
+  return { root, cfg, repo, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+async function createSaved(repo: YamlRequestRepository, seq = 1): Promise<Request> {
+  const id = RequestId.generate(new Date('2026-04-16T00:00:00Z'), seq);
+  const r = Request.create({ id, from: 'alice', action: 'a', reason: 'r' });
+  await repo.saveNew(r);
+  return r;
+}
+
+test('save() rejects a freshly-created Request (loadedVersion=0)', async () => {
+  const { repo, cleanup } = makeRoot();
+  try {
+    const fresh = Request.create({
+      id: RequestId.generate(new Date('2026-04-16T00:00:00Z'), 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+    });
+    await assert.rejects(
+      () => repo.save(fresh),
+      /use saveNew/i,
+      'save() on a fresh aggregate must refuse to prevent silent overwrites',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('save() throws RequestVersionConflict when on-disk grew since load', async () => {
+  const { repo, cleanup } = makeRoot();
+  try {
+    await createSaved(repo, 1);
+    const idStr = '2026-04-16-0001';
+
+    // Process A loads
+    const aCopy = await repo.findById(RequestId.of(idStr));
+    assert.ok(aCopy);
+    assert.equal(aCopy!.loadedVersion, 1); // one status_log entry, no reviews
+
+    // Process B loads and commits a transition
+    const bCopy = await repo.findById(RequestId.of(idStr));
+    bCopy!.approve(MemberName.of('human'), 'B');
+    await repo.save(bCopy!);
+
+    // A now tries to transition on its stale copy
+    aCopy!.approve(MemberName.of('human'), 'A');
+    await assert.rejects(
+      () => repo.save(aCopy!),
+      (e) =>
+        e instanceof RequestVersionConflict &&
+        e.expectedVersion === 1 &&
+        e.actualVersion === 2,
+      'expected A.save() to surface a version conflict with concrete version numbers',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('save() optimistic lock covers review races (not only transitions)', async () => {
+  const { repo, cleanup } = makeRoot();
+  try {
+    // Advance to completed so review is legal
+    await createSaved(repo, 1);
+    const id = RequestId.of('2026-04-16-0001');
+    {
+      const r = await repo.findById(id);
+      r!.approve(MemberName.of('human'));
+      await repo.save(r!);
+    }
+    {
+      const r = await repo.findById(id);
+      r!.execute(MemberName.of('alice'));
+      await repo.save(r!);
+    }
+    {
+      const r = await repo.findById(id);
+      r!.complete(MemberName.of('alice'));
+      await repo.save(r!);
+    }
+
+    // Two reviewers both load at version=4 (4 status_log entries, 0 reviews)
+    const reviewerA = await repo.findById(id);
+    const reviewerB = await repo.findById(id);
+    assert.equal(reviewerA!.loadedVersion, 4);
+    assert.equal(reviewerB!.loadedVersion, 4);
+
+    // B writes first: reviews becomes 1 → version 5 on disk
+    reviewerB!.addReview(
+      Review.create({ by: 'alice', lense: 'devil', verdict: 'ok', comment: 'lgtm' }),
+    );
+    await repo.save(reviewerB!);
+
+    // A tries to commit on stale version — must conflict, even
+    // though status_log is unchanged. A status_log-only check would
+    // miss this and silently drop B's review.
+    reviewerA!.addReview(
+      Review.create({ by: 'alice', lense: 'layer', verdict: 'ok', comment: 'also lgtm' }),
+    );
+    await assert.rejects(
+      () => repo.save(reviewerA!),
+      (e) =>
+        e instanceof RequestVersionConflict &&
+        e.expectedVersion === 4 &&
+        e.actualVersion === 5,
+      'review race must trigger version conflict (the status_log-only bug we fixed)',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('findById dedupes a file that exists under two state dirs', async () => {
+  const { root, cfg, repo, cleanup } = makeRoot();
+  try {
+    await createSaved(repo, 1);
+    const idStr = '2026-04-16-0001';
+    const r = await repo.findById(RequestId.of(idStr));
+    r!.approve(MemberName.of('human'));
+    await repo.save(r!);
+    // Post-save, only approved/ should exist
+    assert.equal(
+      existsSync(join(cfg.paths.requests, 'approved', `${idStr}.yaml`)),
+      true,
+    );
+    assert.equal(
+      existsSync(join(cfg.paths.requests, 'pending', `${idStr}.yaml`)),
+      false,
+    );
+
+    // Simulate a crash mid-transition: re-introduce the stale pending
+    // file alongside the fresher approved file.
+    const staleYaml = YAML.stringify({
+      id: idStr,
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+      state: 'pending',
+      created_at: '2026-04-16T00:00:00.000Z',
+      status_log: [
+        { state: 'pending', by: 'alice', at: '2026-04-16T00:00:00.000Z', note: 'created' },
+      ],
+      reviews: [],
+    });
+    mkdirSync(join(root, 'requests', 'pending'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'pending', `${idStr}.yaml`), staleYaml);
+
+    // findById must return the newer (approved, 2 entries) not the
+    // older (pending, 1 entry) — regression guard against the old
+    // "first state dir wins" behavior.
+    const resolved = await repo.findById(RequestId.of(idStr));
+    assert.ok(resolved);
+    assert.equal(resolved!.state, 'approved');
+    assert.equal(resolved!.statusLog.length, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test('save() cleans up straggler files from old state dirs', async () => {
+  const { root, repo, cleanup } = makeRoot();
+  try {
+    await createSaved(repo, 1);
+    const idStr = '2026-04-16-0001';
+    const r = await repo.findById(RequestId.of(idStr));
+    r!.approve(MemberName.of('human'));
+    await repo.save(r!);
+    // pending/ entry must be gone after the successful transition
+    assert.equal(
+      existsSync(join(root, 'requests', 'pending', `${idStr}.yaml`)),
+      false,
+    );
+    assert.equal(
+      existsSync(join(root, 'requests', 'approved', `${idStr}.yaml`)),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('save() produces no top-level duplicated completion_note in writer path', async () => {
+  // Regression guard for layer 1+2: the domain must not re-emit
+  // completion_note separately from status_log[-1].note on disk.
+  // toJSON() derives it, but re-hydrating then re-saving should not
+  // cause the two to drift, and status_log[-1].note is the source.
+  const { repo, root, cleanup } = makeRoot();
+  try {
+    await createSaved(repo, 1);
+    const id = RequestId.of('2026-04-16-0001');
+    const a = await repo.findById(id);
+    a!.approve(MemberName.of('human'));
+    await repo.save(a!);
+    const b = await repo.findById(id);
+    b!.execute(MemberName.of('alice'));
+    await repo.save(b!);
+    const c = await repo.findById(id);
+    c!.complete(MemberName.of('alice'), 'the real note');
+    await repo.save(c!);
+
+    const yamlText = readFileSync(
+      join(root, 'requests', 'completed', '2026-04-16-0001.yaml'),
+      'utf8',
+    );
+    const doc = YAML.parse(yamlText);
+    // Source of truth check: status_log[-1].note carries the note
+    assert.equal(
+      doc.status_log[doc.status_log.length - 1].note,
+      'the real note',
+    );
+    // External shape contract: completion_note still emitted for
+    // backward compat, and must match the status_log entry.
+    assert.equal(doc.completion_note, 'the real note');
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/infrastructure/hydrateErrorSurface.test.ts
+++ b/tests/infrastructure/hydrateErrorSurface.test.ts
@@ -47,6 +47,101 @@ test('YamlRequestRepository: malformed request YAML surfaces via onMalformed', a
   }
 });
 
+test('YamlRequestRepository: disagreement between status_log[-1].note and legacy completion_note is warned', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // Legacy file where someone hand-edited the top-level field
+    // without updating status_log (or vice versa). The log entry is
+    // authoritative on the next save, so we must warn the operator
+    // rather than silently drop the top-level value.
+    mkdirSync(join(root, 'requests', 'completed'), { recursive: true });
+    const p = join(root, 'requests', 'completed', '2026-04-15-001.yaml');
+    writeFileSync(
+      p,
+      [
+        'id: 2026-04-15-001',
+        'from: alice',
+        'action: a',
+        'reason: r',
+        'state: completed',
+        'created_at: 2026-04-15T00:00:00.000Z',
+        'status_log:',
+        '  - state: pending',
+        '    by: alice',
+        '    at: 2026-04-15T00:00:00.000Z',
+        '  - state: completed',
+        '    by: alice',
+        '    at: 2026-04-15T00:00:01.000Z',
+        '    note: log-value',
+        'reviews: []',
+        'completion_note: top-value-that-disagrees',
+        '',
+      ].join('\n'),
+    );
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (_s, msg) => warnings.push(msg));
+    const repo = new YamlRequestRepository(config);
+    const r = await repo.findById(
+      (await import('../../src/domain/request/RequestId.js')).RequestId.of('2026-04-15-001'),
+    );
+    assert.ok(r);
+    assert.equal(
+      r!.statusLog[r!.statusLog.length - 1]?.note,
+      'log-value',
+      'log entry is authoritative',
+    );
+    assert.ok(
+      warnings.some((w) => /completion_note disagrees/i.test(w)),
+      `expected disagreement warning, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlRequestRepository: agreeing legacy completion_note is silent', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    mkdirSync(join(root, 'requests', 'completed'), { recursive: true });
+    const p = join(root, 'requests', 'completed', '2026-04-15-001.yaml');
+    writeFileSync(
+      p,
+      [
+        'id: 2026-04-15-001',
+        'from: alice',
+        'action: a',
+        'reason: r',
+        'state: completed',
+        'created_at: 2026-04-15T00:00:00.000Z',
+        'status_log:',
+        '  - state: pending',
+        '    by: alice',
+        '    at: 2026-04-15T00:00:00.000Z',
+        '  - state: completed',
+        '    by: alice',
+        '    at: 2026-04-15T00:00:01.000Z',
+        '    note: same',
+        'reviews: []',
+        'completion_note: same',
+        '',
+      ].join('\n'),
+    );
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (_s, msg) => warnings.push(msg));
+    const repo = new YamlRequestRepository(config);
+    await repo.findById(
+      (await import('../../src/domain/request/RequestId.js')).RequestId.of('2026-04-15-001'),
+    );
+    assert.deepEqual(
+      warnings.filter((w) => /completion_note/i.test(w)),
+      [],
+      'agreeing legacy field must not warn',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('YamlRequestRepository: malformed status_log entry surfaces per-entry', async () => {
   const { root, cleanup } = makeRoot();
   try {

--- a/tests/infrastructure/writeTextSafeAtomic.test.ts
+++ b/tests/infrastructure/writeTextSafeAtomic.test.ts
@@ -1,0 +1,100 @@
+// writeTextSafeAtomic — atomicity and cleanup invariants.
+//
+// Verifies:
+//   1. normal writes land at the target path with exact content
+//   2. the final path never contains a torn/partial file: if write
+//      succeeds, content is complete; readers never see an empty
+//      or half-written target
+//   3. no .tmp-* leftovers after success
+//   4. .tmp-* is cleaned up when the write fails (e.g. EACCES)
+//   5. overwriting an existing file works (rename replaces)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  chmodSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeTextSafeAtomic } from '../../src/infrastructure/persistence/safeFs.js';
+
+function makeBase(): { base: string; cleanup: () => void } {
+  const base = mkdtempSync(join(tmpdir(), 'guild-cli-atomic-'));
+  return { base, cleanup: () => rmSync(base, { recursive: true, force: true }) };
+}
+
+test('writeTextSafeAtomic: writes content to target path', () => {
+  const { base, cleanup } = makeBase();
+  try {
+    writeTextSafeAtomic(base, 'a.yaml', 'hello');
+    assert.equal(readFileSync(join(base, 'a.yaml'), 'utf8'), 'hello');
+  } finally {
+    cleanup();
+  }
+});
+
+test('writeTextSafeAtomic: no .tmp-* leftovers after success', () => {
+  const { base, cleanup } = makeBase();
+  try {
+    writeTextSafeAtomic(base, 'a.yaml', 'hello');
+    const leftovers = readdirSync(base).filter((f) => f.startsWith('.tmp-'));
+    assert.deepEqual(leftovers, [], `expected no tmp files, got ${leftovers.join(',')}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('writeTextSafeAtomic: overwrites existing target', () => {
+  const { base, cleanup } = makeBase();
+  try {
+    writeTextSafeAtomic(base, 'a.yaml', 'v1');
+    writeTextSafeAtomic(base, 'a.yaml', 'v2');
+    assert.equal(readFileSync(join(base, 'a.yaml'), 'utf8'), 'v2');
+    const leftovers = readdirSync(base).filter((f) => f.startsWith('.tmp-'));
+    assert.deepEqual(leftovers, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test('writeTextSafeAtomic: large content arrives intact (no tearing)', () => {
+  const { base, cleanup } = makeBase();
+  try {
+    // 1 MiB payload: exceeds a single page buffer so a non-atomic
+    // write path would be likely to show torn reads under stress.
+    const payload = 'x'.repeat(1024 * 1024);
+    writeTextSafeAtomic(base, 'big.yaml', payload);
+    assert.equal(readFileSync(join(base, 'big.yaml'), 'utf8').length, payload.length);
+  } finally {
+    cleanup();
+  }
+});
+
+test('writeTextSafeAtomic: cleans up .tmp-* when target directory is read-only', () => {
+  if (process.platform === 'win32') return; // chmod semantics differ
+  if (process.getuid?.() === 0) return; // root bypasses perms
+  const { base, cleanup } = makeBase();
+  try {
+    writeFileSync(join(base, 'existing.yaml'), 'v1');
+    chmodSync(base, 0o500); // r-x only: no new files allowed
+    let threw = false;
+    try {
+      writeTextSafeAtomic(base, 'new.yaml', 'v2');
+    } catch {
+      threw = true;
+    }
+    chmodSync(base, 0o700); // restore so readdir works
+    assert.equal(threw, true, 'expected atomic write to fail on read-only dir');
+    const leftovers = readdirSync(base).filter((f) => f.startsWith('.tmp-'));
+    assert.deepEqual(leftovers, [], `expected no tmp leftovers, got ${leftovers.join(',')}`);
+    assert.equal(readFileSync(join(base, 'existing.yaml'), 'utf8'), 'v1', 'existing file untouched');
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
devil 1+2 (concurrency):
- atomic writes via .tmp+rename in safeFs.writeTextSafeAtomic
- optimistic lock: Request.loadedVersion snapshots status_log length
  at load; save() compares against highest on-disk length and throws
  RequestVersionConflict on mismatch
- findById now scans every state dir and dedupes so a file mid-
  transition (present under two dirs between atomic-write and
  old-file-unlink) returns the newer representation deterministically

layer 1+2 (DDD purity):
- remove completionNote/denyReason/failureReason props from Request;
  complete/deny/fail only push to status_log
- toJSON derives the legacy top-level closure keys from status_log[-1]
  so external consumers (chain/voices/show) see an unchanged shape
- hydrate backfills a missing status_log[-1].note from a legacy
  top-level key (defensive for hand-edited YAML)

user 2 (MCP stdio separation):
- mcp/gate_mcp.py no longer appends "[stderr] ..." to stdout;
  agents parsing --format json output no longer break
- stderr is forwarded to the MCP host's stderr for observability

UX:
- gate deny/fail accept --note <s> or --reason <s> in addition to the
  legacy positional reason, matching the --note muscle memory from
  approve/execute/complete
- GuildConfig validates host_names via MemberName.of() so malformed
  entries surface at config-load time instead of leaking into actor
  fields

https://claude.ai/code/session_01AEP2rdAuiJAPf9PG8tG5E2