### PR TITLE
feat(boot): detect misconfigured cwd via new hints field

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -141,6 +141,41 @@ Explicit flags always win. `--executor` and `--auto-review` are never env-filled
 `gate show`, `gate voices`, `gate status` default to **JSON**.
 Add `--format text` for human-readable output.
 
+## Troubleshooting
+
+### `Invalid --from/--by/--with: "xxx" — no such member or host`
+
+gate resolves config by walking up from `cwd` looking for
+`guild.config.yaml`. If you run from outside your content_root,
+**the CLI silently falls back to `cwd` as the content_root** with
+zero members, and every actor name becomes "unknown".
+
+Fix one of:
+
+1. `cd <content_root>` before running (recommended for interactive use).
+2. Write a wrapper that `cd`s and then `exec`s `gate.mjs`
+   (recommended when another tool invokes gate from an arbitrary cwd,
+   e.g. MCP hosts, editor extensions, background daemons).
+3. Symlink `guild.config.yaml` into an ancestor of your working
+   directory.
+
+**As of v0.3.x, no env var (`GATE_CONTENT_ROOT`,
+`GUILD_CONFIG_DIR`, ...) is read by the CLI for config
+resolution.** If you see such a var in an MCP server config, it is
+handled by the wrapper that sets the subprocess `cwd` — not by gate
+itself. Calling `gate.mjs` directly with that env set has no
+effect. (Future versions may add env-based override; check the
+CHANGELOG before relying on either behavior.)
+
+This affects AI agents particularly often: an agent reading
+`.mcp.json` may assume the env works for direct CLI calls, and the
+error message ("no such member") points at the actor name rather
+than the real cause (cwd). `gate boot` surfaces this via
+`hints.misconfigured_cwd: true` (JSON) and a warning block
+(text) — it fires only when no `guild.config.yaml` was found
+AND the fallback content_root is empty, so intentional fresh
+starts are not flagged.
+
 ## Deep dives
 
 - [`docs/verbs.md`](./docs/verbs.md) — per-verb examples and design notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate boot` `hints` field — misconfigured-cwd detection.**
+  boot payload gains `hints: { misconfigured_cwd, config_file,
+  resolved_content_root }`. `misconfigured_cwd` is `true` iff no
+  `guild.config.yaml` was found up the tree AND the fallback
+  content_root is empty — the concrete signature of "wrong cwd",
+  distinct from an intentional fresh start (config present, 0 data).
+  Text output surfaces a fix hint with the resolved path. Purely
+  additive to the boot payload contract. Motivation: AI agents
+  reading `.mcp.json` often assume `GATE_CONTENT_ROOT` works for
+  direct CLI invocation (it doesn't — only the MCP wrapper sets
+  subprocess `cwd`), then hit cryptic "no such member" errors on the
+  next verb. See `AGENT.md` § Troubleshooting.
+- **`GuildConfig.configFile`.** New readonly field on
+  `GuildConfig`: absolute path of the loaded `guild.config.yaml`, or
+  `null` when `cwd` was used as a fallback root. Lets callers tell
+  "fresh start" apart from "misconfigured cwd".
+
+### Documentation
+- **`AGENT.md` § Troubleshooting.** Walks through the "no such
+  member" trap: `cwd` fallback semantics, that no config-resolution
+  env var is read by the CLI as of v0.3.x, and three workarounds
+  (`cd`, wrapper, symlink).
+
 ### Added (agent-first)
 - **Pair-mode Layer 1 — `Request.with`.** `gate request` and `gate
   fast-track` accept `--with <n1>[,<n2>...]` to record dialogue

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -54,6 +54,14 @@ export class GuildConfig implements GuildConfigProps {
     readonly lenses: readonly string[],
     readonly doctorPlugins: readonly string[],
     readonly onMalformed: OnMalformed,
+    /**
+     * Absolute path to the `guild.config.yaml` that produced this
+     * config, or `null` when no config was found and `cwd` was used
+     * as a fallback content_root. Lets callers distinguish
+     * "intentional fresh start" (config present, 0 data) from
+     * "misconfigured cwd" (no config, 0 data).
+     */
+    readonly configFile: string | null,
   ) {}
 
   static load(
@@ -94,7 +102,7 @@ export class GuildConfig implements GuildConfigProps {
           .filter((x: unknown): x is string => typeof x === 'string')
           .map((x: string) => resolveUnder(root, x))
       : [];
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, onMalformed);
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, onMalformed, configPath);
   }
 
   static default(
@@ -115,6 +123,7 @@ export class GuildConfig implements GuildConfigProps {
       [...DEFAULT_LENSES],
       [],
       onMalformed,
+      null,
     );
   }
 }

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -37,6 +37,25 @@ interface BootPayload {
   your_recent: ReturnType<typeof collectUtterances> | null;
   inbox_unread: Array<{ at: string; from: string; text: string; type: string }>;
   last_activity: string | null;
+  /**
+   * Diagnostic hints to help agents detect misconfiguration early.
+   *
+   * `misconfigured_cwd`: true iff NO `guild.config.yaml` was found up
+   * the tree AND the fallback content_root has zero data. This is
+   * the actionable signal: the caller almost certainly ran gate from
+   * the wrong directory. Intentional fresh starts (new content_root
+   * bootstrapped with an explicit config file) are NOT flagged.
+   *
+   * `config_file`: absolute path to the `guild.config.yaml` in use,
+   * or `null` when cwd is being used as a fallback root.
+   *
+   * `resolved_content_root`: absolute path gate is reading data from.
+   */
+  hints: {
+    misconfigured_cwd: boolean;
+    config_file: string | null;
+    resolved_content_root: string;
+  };
 }
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -53,9 +72,11 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   // Resolve role without rejecting when GUILD_ACTOR is unset — boot
   // must always succeed, even without identity, so unknown-identity
   // sessions can still use it for orientation.
+  // Load members unconditionally: we need the count for fresh-root
+  // detection below, and the cost (YAML directory scan) is bounded.
+  const members = await c.memberUC.list();
   let role: BootPayload['role'] = null;
   if (actor) {
-    const members = await c.memberUC.list();
     const actorLower = actor.toLowerCase();
     const isMember = members.some((m) => m.name.value === actorLower);
     const isHost = c.config.hostNames.includes(actorLower);
@@ -101,6 +122,16 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     ? collectUtterances(allJson, { name: actor, limit: personalLimit, order: 'desc' })
     : null;
 
+  // Misconfigured-cwd detection: warn ONLY when no config file was
+  // found AND the fallback content_root is empty. This distinguishes
+  // "cwd is wrong" (no config + no data → cryptic "no such member"
+  // errors incoming) from "intentional fresh start" (explicit config
+  // present + no data yet → do not scare the user).
+  const misconfiguredCwd =
+    c.config.configFile === null &&
+    members.length === 0 &&
+    allRequests.length === 0;
+
   const payload: BootPayload = {
     actor,
     role,
@@ -109,6 +140,11 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     your_recent: yourRecent,
     inbox_unread: inboxUnread,
     last_activity: status.last_activity,
+    hints: {
+      misconfigured_cwd: misconfiguredCwd,
+      config_file: c.config.configFile,
+      resolved_content_root: c.config.contentRoot,
+    },
   };
 
   if (format === 'json') {
@@ -125,6 +161,22 @@ function renderBootText(p: BootPayload): string {
     lines.push(`── you are ${p.actor} (${p.role}) ──`);
   } else {
     lines.push('── boot (no GUILD_ACTOR; global view) ──');
+  }
+  if (p.hints.misconfigured_cwd) {
+    lines.push('');
+    lines.push(
+      `⚠️  no guild.config.yaml found, falling back to cwd`,
+    );
+    lines.push(`   resolved: ${p.hints.resolved_content_root}`);
+    lines.push(
+      `   (0 members, 0 requests — likely wrong cwd, not a fresh start)`,
+    );
+    lines.push(
+      `   fix: cd into the directory that contains guild.config.yaml,`,
+    );
+    lines.push(
+      `        or use a wrapper that cd's before invoking gate.mjs.`,
+    );
   }
   lines.push('');
   lines.push(

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -58,6 +58,7 @@ test('gate boot: JSON top-level keys are stable', () => {
       keys,
       [
         'actor',
+        'hints',
         'inbox_unread',
         'last_activity',
         'role',
@@ -118,5 +119,61 @@ test('gate boot: --format text renders a human-readable summary', () => {
     assert.match(stdout, /boot|queues:/);
   } finally {
     cleanup();
+  }
+});
+
+test('gate boot: misconfigured_cwd is false when config + members exist', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.hints.misconfigured_cwd, false);
+    assert.equal(typeof payload.hints.config_file, 'string');
+    assert.match(payload.hints.config_file, /guild\.config\.yaml$/);
+    assert.equal(typeof payload.hints.resolved_content_root, 'string');
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: misconfigured_cwd IS true when no config found AND no data', () => {
+  // No guild.config.yaml written — cwd falls back to itself, and
+  // there is no members/ nor requests/ either.
+  const empty = mkdtempSync(join(tmpdir(), 'guild-empty-'));
+  try {
+    const { stdout, status } = runGate(empty, ['boot']);
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.hints.misconfigured_cwd, true);
+    assert.equal(payload.hints.config_file, null);
+    // text format surfaces the warning so interactive users see it too.
+    const { stdout: textOut } = runGate(empty, ['boot', '--format', 'text']);
+    assert.match(textOut, /no guild\.config\.yaml found/);
+    assert.match(textOut, /likely wrong cwd/);
+    assert.match(textOut, /cd into/);
+  } finally {
+    rmSync(empty, { recursive: true, force: true });
+  }
+});
+
+test('gate boot: fresh-start (config present, 0 members/requests) is NOT flagged', () => {
+  // Bootstrap a content_root with config and an empty members dir.
+  // This is a legitimate fresh start — warning would scare new users.
+  const fresh = mkdtempSync(join(tmpdir(), 'guild-fresh-'));
+  try {
+    writeFileSync(
+      join(fresh, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    mkdirSync(join(fresh, 'members'));
+    const { stdout } = runGate(fresh, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.hints.misconfigured_cwd, false);
+    assert.equal(typeof payload.hints.config_file, 'string');
+    // Text output must NOT contain the misconfig warning.
+    const { stdout: textOut } = runGate(fresh, ['boot', '--format', 'text']);
+    assert.doesNotMatch(textOut, /no guild\.config\.yaml found/);
+  } finally {
+    rmSync(fresh, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- Add `hints: { misconfigured_cwd, config_file, resolved_content_root }` to the `gate boot` payload.
- `misconfigured_cwd` is `true` **only** when no `guild.config.yaml` was found up the tree AND the fallback content_root is empty — the concrete signature of running gate from the wrong cwd. An intentional fresh start (config present, 0 data yet) is **not** flagged.
- Add `GuildConfig.configFile` (readonly path, or `null` when `cwd` was used as a fallback root) so callers can distinguish the two empty-root cases without reaching into fs.
- `AGENT.md` § Troubleshooting explains the trap, the env-var caveat, and three workarounds.

The boot payload change is purely additive per POLICY.md's "fields may be ADDED" rule — patch-bump compatible.

## Motivation

AI agents reading `.mcp.json` commonly assume that `GATE_CONTENT_ROOT` works for direct CLI invocation. It doesn't — only the MCP wrapper (`gate_mcp.py`) sets the subprocess `cwd` from that env. When an agent calls `gate.mjs` directly with `GATE_CONTENT_ROOT` set, gate silently falls back to `cwd` as an empty content_root, and the next verb fails with `Invalid --from/--by/--with: no such member or host` — pointing at the actor name instead of the real cause (cwd).

I hit this myself today while dogfooding `gate` from a content_root stored elsewhere, and spent time chasing the actor validation error before realizing cwd was the problem. This PR surfaces the same signal via a structured boolean so agents can self-correct before that happens, and via a text warning block so interactive users see the same.

## Design notes

- The predicate is `configFile === null && members === 0 && requests === 0`, not just "empty content_root". This is deliberate: a legitimate fresh start is `configFile !== null && empty`, and flagging that would scare new users every time they bootstrap.
- `GuildConfig.configFile` lives on `infrastructure/`, not on the POLICY.md-stable domain surface, so adding the field is a non-breaking infra refinement.
- The text warning intentionally says "likely wrong cwd, not a fresh start" so the reader immediately understands why we're warning at all.
- AGENT.md phrases the env-var note as "as of v0.3.x" so future env-based override doesn't turn the doc into a lie.

## Test plan

- [x] `npm test` — 280/280 pass (adds 3 new scenarios: misconfigured, fresh-start, normal)
- [x] `npm run typecheck` — clean
- [x] Manual: run `node bin/gate.mjs boot --format text` from `/tmp` → sees warning with resolved path and fix suggestion
- [x] Manual: run the same from a freshly bootstrapped content_root (config + empty `members/`) → no warning, no scare
- [x] Manual: run from a populated content_root → no warning, history intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)