### PR TITLE
feat(ux): severity aliases + lense extension hint

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -46,7 +46,13 @@ gate fast-track --from <m> --action "..." --reason "..."   # one-shot create→c
 gate review <id> --by <m> --lense <l> --verdict <v> --comment "..."
 ```
 
-- Lenses: `devil | layer | cognitive | user` (configurable in guild.config.yaml)
+- Lenses: `devil | layer | cognitive | user` (configurable in guild.config.yaml).
+  The four defaults are meta-perspectives ("what breaks", "which
+  layer", "where you hesitate", "whose happiness"). Add
+  domain-specific lenses by listing them — e.g.
+  `lenses: [devil, layer, cognitive, user, security, perf, a11y]`
+  — so reviews can carry `--lense security` verdicts in addition to
+  the meta four.
 - Verdicts: `ok | concern | reject`
 - Reviews are append-only. Corrections are new entries, not edits.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`parseIssueSeverity` accepts common aliases.** `medium`, `mid`,
+  `crit`, `hi`, `lo`, and single-letter shortcuts (`l`/`m`/`h`/`c`)
+  now normalize to the canonical 4 values. Matching is case-
+  insensitive after trim. The canonical set (`low | med | high |
+  critical`) is unchanged — this is interface-layer convenience for
+  muscle memory from Jira/Linear/GitHub. The rejection error now
+  lists both the canonical values and the accepted aliases so a
+  first-time user who typed `medium` and got rejected learns the
+  extension without reading source.
+- **`parseLense` error points at `guild.config.yaml`.** When a
+  domain-specific lense (`security`, `perf`, ...) is rejected
+  because the config didn't opt into it, the error now names the
+  exact extension path (`lenses:` in `guild.config.yaml`). The
+  extension mechanism has always existed; this just surfaces it
+  in the moment of friction.
+- **`AGENT.md` documents domain-specific lenses.** Example
+  `lenses: [..., security, perf, a11y]` with an explanation that
+  the four defaults are meta-perspectives and domain lenses layer
+  on top.
 - **`gate boot` `hints` field — misconfigured-cwd detection.**
   boot payload gains `hints: { misconfigured_cwd, config_file,
   resolved_content_root }`. `misconfigured_cwd` is `true` iff no

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -83,11 +83,41 @@ export class IssueId {
   }
 }
 
+/**
+ * Common aliases mapped to canonical severities. Interface-layer
+ * convenience: users coming from Jira/Linear/GitHub reach for
+ * `medium` / `mid` / `crit` / `hi` before `med` / `critical` / `high`.
+ * The canonical set (`low | med | high | critical`) is unchanged;
+ * aliases are normalized on input so the domain invariant is
+ * preserved. Matching is case-insensitive after trim.
+ */
+const SEVERITY_ALIASES: Record<string, IssueSeverity> = {
+  medium: 'med',
+  mid: 'med',
+  m: 'med',
+  lo: 'low',
+  l: 'low',
+  hi: 'high',
+  h: 'high',
+  crit: 'critical',
+  c: 'critical',
+};
+
 export function parseIssueSeverity(value: string): IssueSeverity {
-  if ((ISSUE_SEVERITIES as readonly string[]).includes(value)) {
-    return value as IssueSeverity;
+  const normalized = value.trim().toLowerCase();
+  if ((ISSUE_SEVERITIES as readonly string[]).includes(normalized)) {
+    return normalized as IssueSeverity;
   }
-  throw new DomainError(`Invalid severity: "${value}"`, 'severity');
+  const aliased = SEVERITY_ALIASES[normalized];
+  if (aliased !== undefined) {
+    return aliased;
+  }
+  throw new DomainError(
+    `Invalid severity: "${value}". Must be one of: ${ISSUE_SEVERITIES.join(', ')} ` +
+      `(aliases accepted: medium→med, mid→med, crit→critical, hi→high, lo→low, ` +
+      `single-letter l/m/h/c, plus case variants).`,
+    'severity',
+  );
 }
 
 export function parseIssueState(value: string): IssueState {

--- a/src/domain/shared/Lense.ts
+++ b/src/domain/shared/Lense.ts
@@ -6,6 +6,17 @@ export type Lense = string;
 /**
  * Parse and validate a lense value against an allowed set.
  * Pure function — no module-level mutable state.
+ *
+ * The four defaults (`devil | layer | cognitive | user`) are
+ * meta-perspectives: "what breaks", "which structural layer",
+ * "where you hesitate", "whose happiness (LDD)". Domain-specific
+ * lenses (`security`, `perf`, `a11y`, ...) can be added per
+ * project by listing them in `guild.config.yaml`:
+ *
+ *     lenses: [devil, layer, cognitive, user, security]
+ *
+ * The error message below surfaces this extension path so first-time
+ * users don't have to discover it from source.
  */
 export function parseLense(
   value: string,
@@ -16,7 +27,9 @@ export function parseLense(
     return value;
   }
   throw new DomainError(
-    `Invalid lense: "${value}". Must be one of: ${effectiveAllowed.join(', ')}`,
+    `Invalid lense: "${value}". Must be one of: ${effectiveAllowed.join(', ')}. ` +
+      `To accept a new lense (e.g. "security", "perf"), add it to ` +
+      `\`lenses:\` in guild.config.yaml.`,
     'lense',
   );
 }

--- a/tests/domain/Issue.test.ts
+++ b/tests/domain/Issue.test.ts
@@ -6,6 +6,7 @@ import {
   IssueState,
   canTransitionIssue,
   assertIssueTransition,
+  parseIssueSeverity,
 } from '../../src/domain/issue/Issue.js';
 import { MemberName } from '../../src/domain/member/MemberName.js';
 import { DomainError } from '../../src/domain/shared/DomainError.js';
@@ -95,4 +96,53 @@ test('Issue.restore bypasses transition validation (historical truth)', () => {
   assert.equal(i.state, 'resolved');
   // But *new* transitions from that state must still follow the rules.
   assert.throws(() => i.setState('deferred'), DomainError);
+});
+
+// ── parseIssueSeverity — canonical + aliases + rejects ──
+
+test('parseIssueSeverity accepts all 4 canonical values', () => {
+  assert.equal(parseIssueSeverity('low'), 'low');
+  assert.equal(parseIssueSeverity('med'), 'med');
+  assert.equal(parseIssueSeverity('high'), 'high');
+  assert.equal(parseIssueSeverity('critical'), 'critical');
+});
+
+test('parseIssueSeverity normalizes alias inputs from other tools', () => {
+  // Jira/Linear/GitHub muscle memory
+  assert.equal(parseIssueSeverity('medium'), 'med');
+  assert.equal(parseIssueSeverity('mid'), 'med');
+  assert.equal(parseIssueSeverity('crit'), 'critical');
+  assert.equal(parseIssueSeverity('hi'), 'high');
+  assert.equal(parseIssueSeverity('lo'), 'low');
+  // single-letter shortcuts
+  assert.equal(parseIssueSeverity('l'), 'low');
+  assert.equal(parseIssueSeverity('m'), 'med');
+  assert.equal(parseIssueSeverity('h'), 'high');
+  assert.equal(parseIssueSeverity('c'), 'critical');
+});
+
+test('parseIssueSeverity is case-insensitive and trims whitespace', () => {
+  assert.equal(parseIssueSeverity('MEDIUM'), 'med');
+  assert.equal(parseIssueSeverity('Critical'), 'critical');
+  assert.equal(parseIssueSeverity('  high  '), 'high');
+});
+
+test('parseIssueSeverity rejects truly unknown values', () => {
+  assert.throws(() => parseIssueSeverity('watch'), DomainError);
+  assert.throws(() => parseIssueSeverity('p0'), DomainError);
+  assert.throws(() => parseIssueSeverity(''), DomainError);
+});
+
+test('parseIssueSeverity error message lists canonical values + aliases', () => {
+  // The error itself is the onboarding: a first-time user who typed
+  // `medium` and got rejected should learn the canonical set and the
+  // accepted aliases without having to read the source.
+  try {
+    parseIssueSeverity('p1');
+    assert.fail('expected throw');
+  } catch (err) {
+    assert.ok(err instanceof DomainError);
+    assert.match(err.message, /low, med, high, critical/);
+    assert.match(err.message, /medium.*med/);
+  }
 });

--- a/tests/domain/Verdict.test.ts
+++ b/tests/domain/Verdict.test.ts
@@ -25,3 +25,24 @@ test('parseLense accepts valid values', () => {
 test('parseLense rejects unknown', () => {
   assert.throws(() => parseLense('security'), DomainError);
 });
+
+test('parseLense accepts domain-specific lense when config lists it', () => {
+  const allowed = ['devil', 'layer', 'cognitive', 'user', 'security', 'perf'];
+  assert.equal(parseLense('security', allowed), 'security');
+  assert.equal(parseLense('perf', allowed), 'perf');
+  assert.equal(parseLense('user', allowed), 'user');
+});
+
+test('parseLense error message points users at guild.config.yaml', () => {
+  // The hint is the onboarding signal: surfacing the extension path
+  // in the error itself means a first-time user doesn't have to
+  // grep the source to learn domain lenses are possible.
+  try {
+    parseLense('security');
+    assert.fail('expected throw');
+  } catch (err) {
+    assert.ok(err instanceof DomainError);
+    assert.match(err.message, /guild\.config\.yaml/);
+    assert.match(err.message, /lenses:/);
+  }
+});


### PR DESCRIPTION
## Summary

Two small onboarding frictions I hit while dogfooding `gate` today. Both are interface-layer conveniences — no domain changes, patch-bump compatible.

### 1. `parseIssueSeverity` accepts common aliases

- `medium`, `mid`, `m` → `med`
- `lo`, `l` → `low`
- `hi`, `h` → `high`
- `crit`, `c` → `critical`
- Case-insensitive after trim (`MEDIUM`, `Critical`, `  high  ` all work)

The canonical 4 values and the `IssueSeverity` type are **unchanged**. Aliases are normalized on input; the domain never sees them. Rejection error now lists both canonical values and accepted aliases so users learn the extension from the error itself.

**Why:** Jira/Linear/GitHub use `medium` as the standard word for the middle severity. Users reach for that before `med`, hit a silent "Invalid severity", and lose flow. Accepting the alias costs nothing and removes a real onboarding friction.

### 2. `parseLense` error points at `guild.config.yaml`

The four defaults (`devil | layer | cognitive | user`) are meta-perspectives. Domain lenses (`security`, `perf`, `a11y`, ...) can be added via `lenses:` in `guild.config.yaml` — **the mechanism already exists**. This PR just surfaces it in the error so a first-time user who typed `--lense security` learns how to accept it without reading source.

Also adds an `AGENT.md` paragraph explaining the four defaults as meta-perspectives and demonstrating domain lens extension.

## Test plan

- [x] `npm test` — 287 pass (+7 new: 5 for severity, 2 for lense)
- [x] `npm run typecheck` — clean
- [x] Rejection error messages pinned so onboarding signal can't regress silently
- [x] Canonical values still work unchanged (backward compat)

## POLICY

Patch-bump compatible. `IssueSeverity` / `Lense` domain types unchanged; both changes are interface-layer (parse normalization + error text + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)