### PR TITLE
feat(ux): onboarding V2 — concept docs + verdict aliases + layered signposts

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,10 +1,19 @@
 # guild-cli — agent quick reference
 
 > This is the short-form reference for AI agents.
-> For design rationale and onboarding, see [`README.md`](./README.md).
+> Brand-new to the concepts?
+> [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md)
+> is a 30-second map. Design rationale lives in
+> [`README.md`](./README.md).
 
 File-based coordination for AI agents. No daemon, no DB, no network.
 State lives in YAML files under a `content_root`. Git gives you history.
+
+**You don't need to read all of this to be productive.** The
+[Session start](#session-start) and [Agent-first knobs](#agent-first-knobs)
+sections are enough for most days. Sections further down
+(Diagnostic, Configuration, File layout, Troubleshooting) become
+useful when something breaks or you want to extend the system.
 
 ## Session start
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`parseVerdict` accepts grammatical and muscle-memory aliases.**
+  `approve`/`approved`/`pass`/`lgtm`/`yes` → `ok`,
+  `concerned`/`concerning`/`worried`/`warn` → `concern`,
+  `rejected`/`block`/`blocked`/`veto` → `reject`.
+  Case-insensitive after trim. The canonical 3 values and the
+  `Verdict` type are unchanged — interface-layer convenience for
+  reviewers (especially AI agents) who reach for the grammatical
+  adjective (`concerned`) before the noun (`concern`). Rejection
+  error lists both canonical values and accepted aliases.
+- **Concept map for newcomers.**
+  [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md)
+  — a 30-second mental map from Jira / Linear / ADR / PR review /
+  Slack to the guild-cli vocabulary. Elevator pitch, "coming from"
+  table, quick vocabulary list, core loop diagram, and the one
+  thing most newcomers miss. `README.md` links this as the first
+  stop before the command surface.
+
+### Changed (onboarding ergonomics)
+- **Layered documentation signposts.** The README now has a
+  "How much of this do I need to read?" table naming every doc
+  with the time cost and when it's enough. `AGENT.md` says
+  upfront "you don't need to read all of this to be productive"
+  and names which sections are essential. `docs/verbs.md` now
+  opens with "you probably don't need this yet — come back when
+  a verb surprises you." The intent is zero reading pressure at
+  each layer; you keep going only if the value warrants it.
+- **`suggested_next` description softened.** Schema and
+  inline comments now make explicit that the field is a
+  convenience hint for orchestrators — safe to ignore if you
+  have other plans. The lifecycle does not demand progression
+  along the suggested axis.
+
+### Added
 - **`parseIssueSeverity` accepts common aliases.** `medium`, `mid`,
   `crit`, `hi`, `lo`, and single-letter shortcuts (`l`/`m`/`h`/`c`)
   now normalize to the canonical 4 values. Matching is case-

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ single self-contained loop reliably misses.
 > release history lives in [`CHANGELOG.md`](./CHANGELOG.md).
 > See [`SECURITY.md`](./SECURITY.md) for the threat model.
 
+### How much of this do I need to read?
+
+Pick a depth. Every layer works on its own; you keep going only if
+the value you're getting is worth the reading.
+
+| Depth | File | When it's enough |
+|-------|------|------------------|
+| 30 sec | the paragraphs above | you want to know what this is |
+| 5 min | [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) | you came from Jira / PR review / ADR and want the translation |
+| 10 min | [`AGENT.md`](./AGENT.md) | you're an AI agent about to run `gate` and want the verb map |
+| 30 min | **this README** (below) | you want the design rationale, first-time setup, verb cookbook |
+| 1 hour | [`docs/verbs.md`](./docs/verbs.md) + [`examples/dogfood-session/`](./examples/dogfood-session/) | you're adopting this seriously and want to see real sessions |
+| when needed | [`POLICY.md`](./POLICY.md) / [`SECURITY.md`](./SECURITY.md) | you're embedding guild-cli and need the stability / threat contract |
+
+If a layer is enough for what you're doing, stop there. Nothing
+deeper is hidden value you're missing — it's scaffolding that
+only matters when your use case grows into it.
+
 ---
 
 ## For AI agents (Claude, GPT, local LLMs, etc.)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ live — on disk, in YAML, across sessions, across models. No daemon,
 no DB, no network. The `content_root` you work in is the whole world.
 
 > 日本語の概要は [`README.ja.md`](./README.ja.md) を参照してください。
+>
+> **New to the concepts?** Read
+> [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md)
+> first — a 30-second map from Jira / Linear / ADR / PR review to
+> the guild-cli vocabulary.
 
 ### What you can do with it
 

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -61,7 +61,15 @@ of accrued reviews across four lenses become an agent's memory.
 
 ## Where to go next
 
-- [AGENT.md](../AGENT.md) — agent-first quick reference
-- [README.md § Verb cookbook](../README.md#verb-cookbook) — each verb with examples
-- [docs/verbs.md](./verbs.md) — deeper per-verb design notes
-- [examples/dogfood-session/](../examples/dogfood-session/) — a real multi-actor session you can read end-to-end
+The documentation is layered. **Stop at whichever layer is enough for what you're doing** — depth isn't hidden value, it's scaffolding for when your use case grows.
+
+| Next step | File | Time |
+|-----------|------|------|
+| You're an AI agent about to run `gate` | [AGENT.md](../AGENT.md) | 10 min |
+| You want design rationale + first-time setup | [README.md](../README.md) | 30 min |
+| You want to see a real multi-actor session | [examples/dogfood-session/](../examples/dogfood-session/) | 15 min |
+| You want deeper per-verb notes and surprises | [docs/verbs.md](./verbs.md) | 1 hour |
+| You're embedding guild-cli as a library | [POLICY.md](../POLICY.md) (stable surface) | when needed |
+| You're operating it in a sensitive context | [SECURITY.md](../SECURITY.md) (threat model) | when needed |
+
+A 30-second pitch plus one `gate boot` is often enough to start being productive. The rest is available when the moment calls for it.

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -1,0 +1,67 @@
+# Concepts for newcomers
+
+30-second mental map for anyone arriving from another tool. Once you
+see the rough shape, the full [README](../README.md) and
+[AGENT.md](../AGENT.md) start making sense.
+
+## Elevator pitch
+
+`guild-cli` is a **file-based log of decisions and the dialogue
+around them**. Actors (humans or AI agents) file `request`s, move
+them through a lifecycle, and leave multi-perspective `review`s.
+Everything is YAML under `content_root/` — git gives you the
+history, no DB, no network.
+
+It is **not** a task tracker. It is not for doing things. It is for
+deciding, recording the why, and keeping the dialogue visible so
+the next session — or the next agent — can pick up where you left off.
+
+## Coming from another tool?
+
+| You used… | Closest guild-cli concept | Key difference |
+|-----------|--------------------------|----------------|
+| **Jira / Linear** (issues + assignees) | `request` has `executor` like assignee, `state` like status | `request` also carries multi-lens `review`s and forced `reason`; it's closer to an ADR + ticket fused together |
+| **`issues` in guild-cli** | `issue` | In guild-cli, `issue` is a lightweight observation that hasn't become a decision yet. Promote it to a `request` when someone commits to act. |
+| **GitHub pull request review** | `gate review --lense X --verdict Y` | Reviews in gate attach to *requests* (decisions), not diffs. Multiple reviewers can each apply different lenses to the same request. |
+| **Slack / Discord DM** | `gate message --from A --to B` | Push-based messaging with an `inbox`, same channel as the decision log — you can DM about a specific `request` and the reference persists. |
+| **ADR** (architecture decision record) | `request` + `reason` + `review`s | Same spirit, but *alive*: reviews and messages keep accruing after the decision is made. |
+| **Standup / retro notes** | `gate tail` / `gate voices <actor>` | Replay the content_root's dialogue, filtered by actor or lens, instead of scrolling chat history. |
+
+## Quick vocabulary
+
+- **actor** — a human or AI agent. Has a `MemberName` (lowercase ASCII) and lives as `members/<name>.yaml`.
+- **host** — an actor that runs the content_root (not a member, but can `--by` / `--from` anything). Listed under `host_names:` in `guild.config.yaml`.
+- **request** — a decision-in-motion. Has `action`, `reason`, optional `executor` / `auto-review`, and moves through `pending → approved → executing → completed` (or `denied` / `failed`).
+- **review** — multi-perspective feedback on a request. Carries a `lense` (one of `devil | layer | cognitive | user` by default — extend via config) and a `verdict` (`ok | concern | reject`).
+- **lense** — the angle a reviewer is taking. `devil` = "what breaks?", `layer` = "which structural layer is this on?", `cognitive` = "where would someone hesitate?", `user` = "whose happiness (LDD)?". Add domain lenses (`security`, `perf`, `a11y`, ...) in `guild.config.yaml`.
+- **verdict** — `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). The word is deliberately soft — `concern` is usable, not a veto.
+- **fast-track** — single-actor shortcut for the full lifecycle when self-approved work is appropriate. Still requires `reason`; `review`s can be attached after.
+- **issue** — a standalone observation that has not yet become a decision. Lightweight, optional `severity` / `area`. Promote to `request` via `gate issues promote <id>`.
+- **pair-mode (`--with`)** — records who you were thinking with when you shaped a request. Surfaces in `show`, `voices`, and `resume` prose ("shaped with eris").
+- **content_root** — the YAML directory gate reads from. Contains `members/`, `requests/`, `issues/`, `inbox/`, and `guild.config.yaml`. Git it for history. See AGENT.md § File layout.
+
+## Core loop
+
+```
+observe → file an issue (maybe) → decide → file a request
+   ↓                                          ↓
+   ────── promote to request ─────────►  approve → execute → complete
+                                              ↓         ↓         ↓
+                                          review ←── review ←── review
+                                         (devil) (layer) (cognitive) (user)
+```
+
+## The one thing most newcomers miss
+
+guild-cli is **not** trying to *automate* the decision. It's trying
+to make the decision and its dialogue **legible later** — to you,
+to another agent, to the next session of the same agent. The value
+compounds: one `fast-track` with one review is fine, ten sessions
+of accrued reviews across four lenses become an agent's memory.
+
+## Where to go next
+
+- [AGENT.md](../AGENT.md) — agent-first quick reference
+- [README.md § Verb cookbook](../README.md#verb-cookbook) — each verb with examples
+- [docs/verbs.md](./verbs.md) — deeper per-verb design notes
+- [examples/dogfood-session/](../examples/dogfood-session/) — a real multi-actor session you can read end-to-end

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -5,6 +5,12 @@
 > per verb; this file is for "I want to actually use this — show me a
 > real session and explain the surprising bits."
 >
+> **You probably don't need this yet.** If you've read
+> [`concepts-for-newcomers.md`](./concepts-for-newcomers.md)
+> (30 seconds) and can run `gate boot`, you're productive. Come back
+> when a specific verb starts behaving in a way that surprises you —
+> this cookbook is organized around those surprises.
+>
 > If a verb is missing here, see [`README.md` § Two CLIs](../README.md#two-clis)
 > for the full signature list.
 

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -113,9 +113,16 @@ export function parseIssueSeverity(value: string): IssueSeverity {
     return aliased;
   }
   throw new DomainError(
-    `Invalid severity: "${value}". Must be one of: ${ISSUE_SEVERITIES.join(', ')} ` +
-      `(aliases accepted: medium→med, mid→med, crit→critical, hi→high, lo→low, ` +
-      `single-letter l/m/h/c, plus case variants).`,
+    [
+      `Invalid severity: "${value}"`,
+      `  canonical values: ${ISSUE_SEVERITIES.join(', ')}`,
+      `  aliases:`,
+      `    low      ← lo, l`,
+      `    med      ← medium, mid, m`,
+      `    high     ← hi, h`,
+      `    critical ← crit, c`,
+      `  (case-insensitive, whitespace trimmed)`,
+    ].join('\n'),
     'severity',
   );
 }

--- a/src/domain/shared/Lense.ts
+++ b/src/domain/shared/Lense.ts
@@ -27,9 +27,12 @@ export function parseLense(
     return value;
   }
   throw new DomainError(
-    `Invalid lense: "${value}". Must be one of: ${effectiveAllowed.join(', ')}. ` +
-      `To accept a new lense (e.g. "security", "perf"), add it to ` +
-      `\`lenses:\` in guild.config.yaml.`,
+    [
+      `Invalid lense: "${value}"`,
+      `  accepted: ${effectiveAllowed.join(', ')}`,
+      `  To accept more (e.g. "security", "perf"),`,
+      `  add them to \`lenses:\` in guild.config.yaml.`,
+    ].join('\n'),
     'lense',
   );
 }

--- a/src/domain/shared/Verdict.ts
+++ b/src/domain/shared/Verdict.ts
@@ -50,10 +50,15 @@ export function parseVerdict(value: string): Verdict {
     return aliased;
   }
   throw new DomainError(
-    `Invalid verdict: "${value}". Must be one of: ${VERDICTS.join(', ')} ` +
-      `(aliases accepted: approve/approved/pass/lgtm→ok, ` +
-      `concerned/warn/worried→concern, rejected/block/veto→reject, ` +
-      `plus case variants).`,
+    [
+      `Invalid verdict: "${value}"`,
+      `  canonical values: ${VERDICTS.join(', ')}`,
+      `  aliases:`,
+      `    ok      ← approve, approved, pass, passed, lgtm, yes, y`,
+      `    concern ← concerned, concerning, worried, worry, warn, warning`,
+      `    reject  ← rejected, block, blocked, no, n, veto`,
+      `  (case-insensitive, whitespace trimmed)`,
+    ].join('\n'),
     'verdict',
   );
 }

--- a/src/domain/shared/Verdict.ts
+++ b/src/domain/shared/Verdict.ts
@@ -3,12 +3,57 @@ import { DomainError } from './DomainError.js';
 export const VERDICTS = ['ok', 'concern', 'reject'] as const;
 export type Verdict = (typeof VERDICTS)[number];
 
+/**
+ * Common aliases mapped to canonical verdicts. Reviewers routinely
+ * reach for `concerned` (the adjective) before `concern` (the noun),
+ * or for GitHub-muscle-memory like `approved` / `lgtm` / `block`.
+ * This shows up especially often in AI-agent reviews, where the
+ * model's language instinct produces the grammatical form rather
+ * than the canonical noun.
+ *
+ * The canonical set (`ok | concern | reject`) is unchanged; aliases
+ * are normalized on input so the domain invariant is preserved.
+ * Matching is case-insensitive after trim.
+ */
+const VERDICT_ALIASES: Record<string, Verdict> = {
+  // ok family
+  approve: 'ok',
+  approved: 'ok',
+  pass: 'ok',
+  passed: 'ok',
+  lgtm: 'ok',
+  yes: 'ok',
+  y: 'ok',
+  // concern family (grammatical variants + soft warnings)
+  concerned: 'concern',
+  concerning: 'concern',
+  worry: 'concern',
+  worried: 'concern',
+  warn: 'concern',
+  warning: 'concern',
+  // reject family (hard blockers)
+  rejected: 'reject',
+  block: 'reject',
+  blocked: 'reject',
+  no: 'reject',
+  n: 'reject',
+  veto: 'reject',
+};
+
 export function parseVerdict(value: string): Verdict {
-  if ((VERDICTS as readonly string[]).includes(value)) {
-    return value as Verdict;
+  const normalized = value.trim().toLowerCase();
+  if ((VERDICTS as readonly string[]).includes(normalized)) {
+    return normalized as Verdict;
+  }
+  const aliased = VERDICT_ALIASES[normalized];
+  if (aliased !== undefined) {
+    return aliased;
   }
   throw new DomainError(
-    `Invalid verdict: "${value}". Must be one of: ${VERDICTS.join(', ')}`,
+    `Invalid verdict: "${value}". Must be one of: ${VERDICTS.join(', ')} ` +
+      `(aliases accepted: approve/approved/pass/lgtm→ok, ` +
+      `concerned/warn/worried→concern, rejected/block/veto→reject, ` +
+      `plus case variants).`,
     'verdict',
   );
 }

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -48,10 +48,23 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   }
 
   const updated = await c.requestUC.review({ id, by, lense, verdict, comment });
+  // Display the canonical verdict/lense (from the stored review)
+  // rather than the raw input: the user may have typed an alias
+  // (e.g. `--verdict concerned`, normalized to `concern` on save),
+  // and the success message should reflect the value that actually
+  // landed in YAML, not the input form.
+  //
+  // `reviews` is guaranteed non-empty here because `requestUC.review`
+  // just appended one. Fall back to the raw input only if that
+  // invariant ever breaks — the fallback won't be canonical but also
+  // won't crash.
+  const stored = updated.reviews[updated.reviews.length - 1];
+  const displayLense = stored?.lense ?? lense;
+  const displayVerdict = stored?.verdict ?? verdict;
   emitWriteResponse(
     parseFormat(args),
     updated,
-    `✓ review recorded: ${id} [${lense}/${verdict}]`,
+    `✓ review recorded: ${id} [${displayLense}/${displayVerdict}]`,
     c.config,
   );
   return 0;

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -73,7 +73,11 @@ const writeResponseSchema: JsonSchema = {
     message: str,
     suggested_next: {
       type: 'object',
-      description: 'null when the lifecycle has no deterministic next step',
+      description:
+        'Optional hint for the next verb a caller *might* invoke. ' +
+        'Derived deterministically from the post-mutation state — no LLM call. ' +
+        'Safe to ignore if you have other plans; this field is a convenience for ' +
+        'orchestrators, not a directive. null when the lifecycle has no obvious next step.',
       ...suggestedNextSchema,
     },
   },

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -43,7 +43,14 @@ export interface WriteResponse {
 }
 
 export interface SuggestedNext {
-  /** The verb an agent should invoke next, e.g. "review" or "execute". */
+  /**
+   * The verb an agent *might* invoke next (e.g. "review" or
+   * "execute"). This is a hint, not a directive — the field exists
+   * so orchestrators can chain tool calls without re-deriving
+   * state transitions locally. A caller who has other plans
+   * should feel free to ignore it; the lifecycle doesn't demand
+   * progression along this axis.
+   */
   verb: string;
   /** Arguments pre-filled from the record. Actor fields are hints,
    *  not assertions — the agent may override when it knows better. */

--- a/tests/domain/Issue.test.ts
+++ b/tests/domain/Issue.test.ts
@@ -143,6 +143,7 @@ test('parseIssueSeverity error message lists canonical values + aliases', () => 
   } catch (err) {
     assert.ok(err instanceof DomainError);
     assert.match(err.message, /low, med, high, critical/);
-    assert.match(err.message, /medium.*med/);
+    // `s` flag so the dot matches across the newline-separated alias table
+    assert.match(err.message, /medium.*med/s);
   }
 });

--- a/tests/domain/Verdict.test.ts
+++ b/tests/domain/Verdict.test.ts
@@ -43,7 +43,8 @@ test('parseVerdict rejects truly unknown values with an informative error', () =
   } catch (err) {
     assert.ok(err instanceof DomainError);
     assert.match(err.message, /ok, concern, reject/);
-    assert.match(err.message, /concerned.*concern/);
+    // `s` flag so the dot matches across the newline-separated alias table
+    assert.match(err.message, /concerned.*concern/s);
   }
 });
 

--- a/tests/domain/Verdict.test.ts
+++ b/tests/domain/Verdict.test.ts
@@ -10,10 +10,41 @@ test('parseVerdict accepts valid values', () => {
   assert.equal(parseVerdict('reject'), 'reject');
 });
 
-test('parseVerdict rejects unknown', () => {
-  assert.throws(() => parseVerdict('approved'), DomainError);
+test('parseVerdict accepts common aliases (grammatical + muscle memory)', () => {
+  // ok family
+  assert.equal(parseVerdict('approve'), 'ok');
+  assert.equal(parseVerdict('approved'), 'ok');
+  assert.equal(parseVerdict('pass'), 'ok');
+  assert.equal(parseVerdict('lgtm'), 'ok');
+  assert.equal(parseVerdict('yes'), 'ok');
+  // concern family (the adjective is the natural reach)
+  assert.equal(parseVerdict('concerned'), 'concern');
+  assert.equal(parseVerdict('concerning'), 'concern');
+  assert.equal(parseVerdict('worried'), 'concern');
+  assert.equal(parseVerdict('warn'), 'concern');
+  // reject family
+  assert.equal(parseVerdict('rejected'), 'reject');
+  assert.equal(parseVerdict('block'), 'reject');
+  assert.equal(parseVerdict('veto'), 'reject');
+});
+
+test('parseVerdict is case-insensitive and trims whitespace', () => {
+  assert.equal(parseVerdict('OK'), 'ok');
+  assert.equal(parseVerdict('  Concerned  '), 'concern');
+  assert.equal(parseVerdict('LGTM'), 'ok');
+});
+
+test('parseVerdict rejects truly unknown values with an informative error', () => {
+  assert.throws(() => parseVerdict('maybe'), DomainError);
   assert.throws(() => parseVerdict(''), DomainError);
-  assert.throws(() => parseVerdict('OK'), DomainError);
+  try {
+    parseVerdict('maybe');
+    assert.fail('expected throw');
+  } catch (err) {
+    assert.ok(err instanceof DomainError);
+    assert.match(err.message, /ok, concern, reject/);
+    assert.match(err.message, /concerned.*concern/);
+  }
 });
 
 test('parseLense accepts valid values', () => {


### PR DESCRIPTION
## Summary

Three changes that share one intent: make the shallow layer of the tool genuinely sufficient, and make every deeper layer opt-in. No pressure to go deep; maximum pull once you want to.

### 1. Concept map for newcomers (docs)

[`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) — a 30-second mental map for anyone arriving from Jira, Linear, ADR, PR review, or Slack. Covers:

- Elevator pitch: file-based log of decisions + dialogue.
- "Coming from" translation table.
- Quick vocabulary (actor / host / request / review / lense / verdict / fast-track / issue / pair-mode / content_root).
- Core loop diagram.
- "The one thing most newcomers miss": the value *compounds* — one request with one review is fine, ten sessions of accrued reviews across four lenses become an agent's memory.

README now points here first, before the command surface, so the Jira-muscle-memory question ("what's the difference between `request` and `issue`?") is answered in the first minute.

### 2. `parseVerdict` accepts grammatical + muscle-memory aliases

The canonical 3 values (`ok | concern | reject`) are nouns, but reviewers reach for `concerned` (adjective) first because "I am concerned about X" is the natural phrasing. AI-agent reviews hit this especially hard. GitHub reviewers reach for `approved` / `lgtm` / `block` on muscle memory.

Now accepted:
- `approve` / `approved` / `pass` / `passed` / `lgtm` / `yes` / `y` → `ok`
- `concerned` / `concerning` / `worried` / `worry` / `warn` / `warning` → `concern`
- `rejected` / `block` / `blocked` / `no` / `n` / `veto` → `reject`

Case-insensitive after trim. Canonical 3 values and the `Verdict` type are unchanged — interface-layer only, patch-bump compatible. Rejection error lists both canonical values and accepted aliases.

### 3. Layered onboarding signposts + softened `suggested_next` tone

Every major doc now tells the reader "you don't need to read further than this layer unless the use case warrants it":

- **README** gains a "How much of this do I need to read?" table with every doc (concepts, AGENT, README, verbs, POLICY, SECURITY) listed by time cost and use case. Explicit: "if a layer is enough, stop there. Nothing deeper is hidden value you're missing."
- **AGENT.md** opens with "you don't need to read all of this to be productive", names which sections matter daily vs which are there when something breaks.
- **docs/verbs.md** leads with "you probably don't need this yet — come back when a verb surprises you."
- **docs/concepts-for-newcomers.md** closes with a layered "Where to go next" table for the same depth-picking.
- **`suggested_next` schema + type comment** made explicit that this field is a hint, not a directive. Safe to ignore if you have other plans; the lifecycle does not demand progression along the suggested axis.

No behaviour change for `suggested_next` — tone-only shift in the contract documentation so first-time consumers don't feel locked in.

## Test plan

- [x] `npm test` — 289 pass (+2 new verdict alias tests)
- [x] `npm run typecheck` — clean
- [x] Rejection error messages pinned (verdict + severity from #31) so onboarding signal can't regress silently

## POLICY

All three changes are patch-bump compatible:
- verdict alias normalization is interface-layer; domain `Verdict` unchanged
- docs + schema description + type-comment changes
- no stable-surface renames or removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)