### PR TITLE
feat(register): one-shot member registration + onboarding hint

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -18,6 +18,10 @@ useful when something breaks or you want to extend the system.
 ## Session start
 
 ```bash
+# First time in this content_root? Register yourself:
+gate register --name <you>              # category defaults to "professional"
+
+# Every session after:
 gate boot                # identity + status + tail + your_recent + inbox_unread (1 JSON)
 gate resume              # picking up where the last session ended (needs GUILD_ACTOR)
 # (old 3-command recipe — use boot above if you can consume JSON)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate register` — one-shot member registration.** Writes
+  `members/<name>.yaml` without the newcomer having to hand-author
+  YAML, figure out the schema from `members.example/`, or risk a
+  typo. Category defaults to `professional` (the right bucket for
+  most agents), aliases accepted (`pro`, `prof`, `member` →
+  `professional`, `assigned` → `assignee`, `try`/`tryout` →
+  `trial`). `--dry-run` previews the YAML without touching disk,
+  showing the canonical category so what you see is what gets
+  written. Already-existing names fail loudly rather than silently
+  overwriting. `--category host` is rejected — hosts are declared
+  in `guild.config.yaml` directly, not registered at runtime.
+  JSON output mirrors the write-response shape with
+  `suggested_next: { verb: "boot", ... }` pointing the orchestrator
+  at the next obvious step.
+- **`assertActor` surfaces the register hint.** When an unknown
+  actor is passed to `--from` / `--by` / `--executor` / etc, the
+  error now includes `gate register --name <raw>` as a concrete
+  way out. This is the onboarding loop's keystone: newcomers
+  hitting the wall learn the one-command unlock from the error
+  itself.
+- **`MemberCategory` accepts aliases with a vertical-format error.**
+  Same pattern as severity/verdict — interface-layer convenience,
+  domain invariant unchanged. The rejection error walks the canonical
+  set and the alias table in a scannable table and gently suggests
+  "professional" as the default for most agents.
+- **Concept doc gains "30-second first touch".** `docs/concepts-for-newcomers.md`
+  now leads with the three commands a newcomer needs to exist in a
+  content_root: `register` → `boot` → `fast-track`. Everything else
+  is positioned as "what unlocks as you keep using it."
+- **AGENT.md session-start block** now shows `gate register` as the
+  first-time step before the recurring `boot` / `resume` loop, so an
+  AI agent's first read of the quick reference includes the
+  registration path.
+- **`gate schema`** lists `register` as a first-class verb so LLM
+  tool layers can invoke it without out-of-band knowledge.
+
+### Added
 - **`parseVerdict` accepts grammatical and muscle-memory aliases.**
   `approve`/`approved`/`pass`/`lgtm`/`yes` → `ok`,
   `concerned`/`concerning`/`worried`/`warn` → `concern`,

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -40,6 +40,24 @@ the next session — or the next agent — can pick up where you left off.
 - **pair-mode (`--with`)** — records who you were thinking with when you shaped a request. Surfaces in `show`, `voices`, and `resume` prose ("shaped with eris").
 - **content_root** — the YAML directory gate reads from. Contains `members/`, `requests/`, `issues/`, `inbox/`, and `guild.config.yaml`. Git it for history. See AGENT.md § File layout.
 
+## The 30-second first touch
+
+```bash
+# 1. Register yourself. One command, no YAML hand-authoring.
+gate register --name <you>
+
+# 2. Start a session.
+export GUILD_ACTOR=<you>
+gate boot
+
+# 3. Record your first decision (single-actor, self-approved lane).
+gate fast-track --from <you> --action "first-touch" \
+  --reason "getting oriented" --executor <you>
+```
+
+That's enough to exist in the content_root. Everything below is
+what unlocks as you keep using it.
+
 ## Core loop
 
 ```

--- a/src/application/shared/assertActor.ts
+++ b/src/application/shared/assertActor.ts
@@ -16,8 +16,20 @@ export async function assertActor(
   if (await members.exists(name)) return name;
   const hosts = await members.listHostNames();
   if (hosts.includes(name.value)) return name;
+  // Include a register hint in the error so a newcomer whose first
+  // touch hits this wall learns the one-command way out. The
+  // lowercase pre-validation already ran via MemberName.of above,
+  // so `name.value` is a safe name to suggest. The hint is
+  // deliberately short — the vertical table format used by
+  // severity/verdict/lense would be overkill here because the
+  // signal is "you're not registered yet, here's the fix."
   throw new DomainError(
-    `Invalid ${field}: "${raw}" — no such member or host`,
+    [
+      `Invalid ${field}: "${raw}" — no such member or host.`,
+      `  To register yourself as a member:`,
+      `    gate register --name ${name.value}     # category defaults to "professional"`,
+      `  Or set GUILD_ACTOR to an already-registered actor.`,
+    ].join('\n'),
     field,
   );
 }

--- a/src/domain/member/MemberCategory.ts
+++ b/src/domain/member/MemberCategory.ts
@@ -11,12 +11,40 @@ export const MEMBER_CATEGORIES = [
 
 export type MemberCategory = (typeof MEMBER_CATEGORIES)[number];
 
+/**
+ * Common aliases mapped to canonical categories. Same pattern as
+ * severity/verdict: interface-layer convenience for users reaching
+ * for natural-language forms. The canonical 6 are unchanged.
+ */
+const CATEGORY_ALIASES: Record<string, MemberCategory> = {
+  pro: 'professional',
+  prof: 'professional',
+  member: 'professional', // most common default for a new agent
+  assigned: 'assignee',
+  try: 'trial',
+  tryout: 'trial',
+};
+
 export function parseMemberCategory(value: string): MemberCategory {
-  if ((MEMBER_CATEGORIES as readonly string[]).includes(value)) {
-    return value as MemberCategory;
+  const normalized = value.trim().toLowerCase();
+  if ((MEMBER_CATEGORIES as readonly string[]).includes(normalized)) {
+    return normalized as MemberCategory;
+  }
+  const aliased = CATEGORY_ALIASES[normalized];
+  if (aliased !== undefined) {
+    return aliased;
   }
   throw new DomainError(
-    `Invalid member category: "${value}". Must be one of: ${MEMBER_CATEGORIES.join(', ')}`,
+    [
+      `Invalid member category: "${value}"`,
+      `  canonical values: ${MEMBER_CATEGORIES.join(', ')}`,
+      `  aliases:`,
+      `    professional ← pro, prof, member`,
+      `    assignee     ← assigned`,
+      `    trial        ← try, tryout`,
+      `  (case-insensitive, whitespace trimmed)`,
+      `  Pick "professional" if you're not sure — it's the default for most agents.`,
+    ].join('\n'),
     'category',
   );
 }

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -1,0 +1,136 @@
+import { ParsedArgs, optionalOption, requireOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { MemberName } from '../../../domain/member/MemberName.js';
+import { parseMemberCategory } from '../../../domain/member/MemberCategory.js';
+
+/**
+ * gate register --name <n> [--category <c>] [--display-name <s>] [--dry-run] [--format json|text]
+ *
+ * Register a new member in the content_root. One-shot onboarding:
+ * before this verb existed, an agent encountering gate for the
+ * first time had to hand-author YAML under `members/<name>.yaml`,
+ * figure out the schema from `members.example/`, and then still
+ * risk a typo. Now: one command.
+ *
+ * Design intent — "initial registration must be frictionless":
+ *   - `--category` defaults to `professional` (the right bucket
+ *     for most agents). Explicit overrides are still accepted,
+ *     including aliases (pro / prof / member → professional).
+ *   - Name invariants (ASCII, lowercase, 1-32 chars, not reserved)
+ *     are the same as everywhere — surfaced via MemberName.of's
+ *     usual error, which lists the pattern.
+ *   - Re-registering the same name is a no-op error ("already
+ *     exists") — safer than silently overwriting a live member.
+ *   - `--dry-run` prints the YAML that would be written without
+ *     touching disk, so an agent can sanity-check the shape before
+ *     committing to it.
+ *   - JSON output mirrors the write-response shape other verbs
+ *     use so orchestrators can parse it the same way.
+ *
+ * Host registration is NOT handled here. Hosts go in
+ * `guild.config.yaml` under `host_names:` and are managed by
+ * whoever runs the content_root. This verb is for members only;
+ * passing `--category host` is rejected (see below) to keep
+ * host assignment an intentional, human-edited decision.
+ */
+export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
+  const name = requireOption(args, 'name', '--name required');
+  const category = optionalOption(args, 'category') ?? 'professional';
+  const displayName = optionalOption(args, 'display-name');
+  const dryRun = args.options['dry-run'] === true || args.options['dry-run'] === '';
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  // Host assignment is intentionally a guild.config.yaml concern,
+  // not a CLI-drive-by. Block it here with an explicit message
+  // so a user who typed `--category host` understands why.
+  const categoryNormalized = category.trim().toLowerCase();
+  if (categoryNormalized === 'host') {
+    throw new Error(
+      `--category host is not registerable via CLI.\n` +
+        `  Hosts are declared in guild.config.yaml under \`host_names:\`.\n` +
+        `  Edit that file directly and commit; there is no runtime registration.`,
+    );
+  }
+
+  // Pre-flight: does the name already resolve to a member?
+  // If it does, this is almost always a typo, not an intentional
+  // overwrite — fail loud rather than silently replace a record.
+  const parsedName = MemberName.of(name);
+  const existing = await c.memberUC.show(parsedName.value);
+  if (existing) {
+    throw new Error(
+      `Member "${parsedName.value}" already exists.\n` +
+        `  Use \`gate whoami\` (with GUILD_ACTOR=${parsedName.value}) to see your current record,\n` +
+        `  or edit members/${parsedName.value}.yaml directly if you need to change it.`,
+    );
+  }
+
+  if (dryRun) {
+    // Compose the YAML shape without hitting disk. Lets an agent
+    // confirm what's about to land before committing. Run the
+    // category through the real parser so aliases are surfaced as
+    // their canonical form in the preview — otherwise `--category
+    // pro` would preview as `category: "pro"` but save as
+    // `professional`, a subtle surprise.
+    const canonicalCategory = parseMemberCategory(category);
+    const preview = {
+      name: parsedName.value,
+      category: canonicalCategory,
+      active: true,
+      // Key name mirrors the written YAML (`displayName`, camelCase)
+      // to preserve "what-you-see-is-what-gets-saved" parity.
+      ...(displayName ? { displayName } : {}),
+    };
+    if (format === 'json') {
+      process.stdout.write(
+        JSON.stringify({ ok: true, dry_run: true, preview }, null, 2) + '\n',
+      );
+    } else {
+      process.stdout.write(
+        `dry-run: would write members/${parsedName.value}.yaml:\n` +
+          Object.entries(preview)
+            .map(([k, v]) => `  ${k}: ${JSON.stringify(v)}`)
+            .join('\n') +
+          '\n',
+      );
+    }
+    return 0;
+  }
+
+  const member = await c.memberUC.create({
+    name: parsedName.value,
+    category,
+    ...(displayName ? { displayName } : {}),
+  });
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          id: member.name.value,
+          state: 'active',
+          message: `registered: ${member.name.value} (${member.category})`,
+          suggested_next: {
+            verb: 'boot',
+            args: {},
+            reason:
+              'Run `gate boot` with GUILD_ACTOR set to see your personal dashboard ' +
+              '(status, tail, inbox) — you are now a recognized actor.',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(
+      `✓ registered: ${member.name.value} [${member.category}]\n` +
+        `  next: export GUILD_ACTOR=${member.name.value} && gate boot\n`,
+    );
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -228,6 +228,31 @@ const VERBS: readonly VerbSchema[] = [
     output: { type: 'array' },
   },
   {
+    name: 'register',
+    category: 'write',
+    summary:
+      'one-shot member registration. Writes members/<name>.yaml. ' +
+      'Category defaults to "professional"; aliases accepted (pro, prof, member → professional). ' +
+      '--dry-run previews the YAML without touching disk.',
+    input: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'new member name (lowercase ASCII, 1-32 chars, matches /^[a-z][a-z0-9_-]{0,31}$/)',
+        },
+        category: strOpt(
+          'member category; defaults to "professional". Canonical: core/professional/assignee/trial/special/host. Host is NOT accepted via CLI (edit guild.config.yaml).',
+        ),
+        'display-name': strOpt('human-readable display label, optional'),
+        'dry-run': strOpt('preview the YAML without writing to disk'),
+        format: formatField,
+      },
+      required: ['name'],
+    },
+    output: { type: 'object' },
+  },
+  {
     name: 'request',
     category: 'write',
     summary: 'file a new request',

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -26,6 +26,7 @@ import { repairCmd } from './handlers/repair.js';
 import { bootCmd } from './handlers/boot.js';
 import { schemaCmd } from './handlers/schema.js';
 import { resumeCmd } from './handlers/resume.js';
+import { reqRegister } from './handlers/register.js';
 import {
   msgSend,
   msgBroadcast,
@@ -42,6 +43,16 @@ export {
 } from './handlers/request.js';
 
 const HELP = `gate — request lifecycle & dialogue CLI
+
+Getting started:
+  gate register --name <n> [--category <c>] [--display-name <s>]
+                 [--dry-run] [--format json|text]
+                       Register yourself (or another member) as an
+                       actor. Category defaults to "professional";
+                       aliases accepted (pro, prof, member). Host is
+                       NOT registerable via CLI — edit
+                       guild.config.yaml directly. --dry-run shows
+                       the YAML that would be written.
 
 Requests:
   gate request --from <m> --action <a> --reason <r>
@@ -161,6 +172,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await reqTail(c, args);
       case 'whoami':
         return await reqWhoami(c, args);
+      case 'register':
+        return await reqRegister(c, args);
       case 'chain':
         return await reqChain(c, args);
       case 'approve':

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -1,0 +1,187 @@
+// gate register — onboarding's first verb.
+//
+// Registration was the first real wall a newcomer hit before
+// this verb existed (hand-author YAML, figure out the schema,
+// risk a typo). These tests pin the happy path plus every
+// friction surface: alias normalization, name collision, host
+// refusal, and dry-run parity with the real write.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-register-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  // Seed a pre-existing member so we can exercise the collision path.
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status ?? -1,
+  };
+}
+
+test('register: happy path writes members/<name>.yaml with canonical fields', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stdout } = runGate(root, [
+      'register',
+      '--name',
+      'klee',
+      '--display-name',
+      'Klee',
+    ]);
+    assert.equal(status, 0);
+    assert.match(stdout, /✓ registered: klee \[professional\]/);
+    const yaml = readFileSync(join(root, 'members', 'klee.yaml'), 'utf8');
+    assert.match(yaml, /name: klee/);
+    assert.match(yaml, /category: professional/);
+    assert.match(yaml, /active: true/);
+    assert.match(yaml, /displayName: Klee/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: --category alias normalizes on write and in dry-run preview', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // dry-run: preview must show canonical, not the raw alias.
+    const dry = runGate(root, [
+      'register',
+      '--name',
+      'tester',
+      '--category',
+      'pro',
+      '--dry-run',
+    ]);
+    assert.equal(dry.status, 0);
+    assert.match(dry.stdout, /category: "professional"/);
+    assert.ok(!existsSync(join(root, 'members', 'tester.yaml')));
+
+    // real: the YAML written must match what dry-run claimed.
+    const real = runGate(root, [
+      'register',
+      '--name',
+      'tester',
+      '--category',
+      'pro',
+    ]);
+    assert.equal(real.status, 0);
+    const yaml = readFileSync(join(root, 'members', 'tester.yaml'), 'utf8');
+    assert.match(yaml, /category: professional/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: already-exists fails loudly instead of silently overwriting', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(root, ['register', '--name', 'alice']);
+    assert.notEqual(status, 0);
+    assert.match(stderr, /Member "alice" already exists/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: --category host is rejected (guild.config.yaml is the source of truth)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(root, [
+      'register',
+      '--name',
+      'foo',
+      '--category',
+      'host',
+    ]);
+    assert.notEqual(status, 0);
+    assert.match(stderr, /not registerable via CLI/);
+    assert.match(stderr, /guild\.config\.yaml/);
+    assert.ok(!existsSync(join(root, 'members', 'foo.yaml')));
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: --dry-run does not touch disk and yields parseable JSON', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stdout } = runGate(root, [
+      'register',
+      '--name',
+      'ghost',
+      '--dry-run',
+      '--format',
+      'json',
+    ]);
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.dry_run, true);
+    assert.equal(payload.preview.name, 'ghost');
+    assert.equal(payload.preview.category, 'professional');
+    assert.ok(!existsSync(join(root, 'members', 'ghost.yaml')));
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: assertActor error surfaces the register hint', () => {
+  // The onboarding loop: an unregistered agent tries fast-track,
+  // the error tells them how to register. This is the whole reason
+  // assertActor carries the hint.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(root, [
+      'fast-track',
+      '--from',
+      'newcomer',
+      '--action',
+      'try',
+      '--reason',
+      'first touch',
+    ]);
+    assert.notEqual(status, 0);
+    assert.match(stderr, /no such member or host/);
+    assert.match(stderr, /gate register --name newcomer/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Collapses the "Invalid --from: no such member or host" wall — the first real friction a newcomer hits in a content_root — into "run this one command and try again."

### `gate register`

```bash
gate register --name <n> [--category <c>] [--display-name <s>] [--dry-run] [--format json|text]
```

- Non-interactive (agents don't prompt well). `--category` defaults to `professional`. Aliases: `pro`/`prof`/`member` → `professional`, `assigned` → `assignee`, `try`/`tryout` → `trial`. Case-insensitive, trimmed.
- **Already-exists fails loudly** with a fix suggestion; never silently overwrites a live member.
- **`--category host` rejected** with guidance — hosts are declared in `guild.config.yaml` directly, not at runtime. Keeps host assignment intentional.
- **`--dry-run`** previews the YAML without touching disk, running the category through the real parser so what you see is what lands. This was bug-fixed within the PR: the first draft showed the raw alias in the preview; the second draft runs it through `parseMemberCategory`.
- JSON output mirrors the write-response shape with `suggested_next: { verb: "boot", ... }` pointing at the next obvious step.

### `assertActor` surfaces the register hint

The onboarding keystone. When `--from`/`--by`/`--executor` receive an unknown name:

```
Invalid --from: "klee" — no such member or host.
  To register yourself as a member:
    gate register --name klee     # category defaults to "professional"
  Or set GUILD_ACTOR to an already-registered actor.
```

A newcomer's first stumble now carries its own unlock. This is what makes it possible to touch gate for the first time and never have to read docs to get unstuck.

### `MemberCategory` vertical-format error

Same pattern as the `severity` / `verdict` / `lense` errors from the recent onboarding-V1 / V2 PRs (#31 / #32): canonical set + alias table in a scannable vertical table, with a gentle "pick 'professional' if you're not sure" default-hint.

### Docs

- `docs/concepts-for-newcomers.md` gains a **"30-second first touch"** block — three commands (`register` → `boot` → `fast-track`) that are enough to exist in a content_root; everything deeper is positioned as "what unlocks later."
- `AGENT.md` session-start block shows `register` as the first-time step before the recurring `boot` / `resume` loop.
- `gate schema` lists `register` as a first-class verb so LLM tool layers pick it up automatically.

## Test plan

- [x] `npm test` — 295 pass (+6 new: happy path, alias parity between dry-run and real write, already-exists, host rejection, dry-run disk-safety + JSON, assertActor → register hint)
- [x] `npm run typecheck` — clean
- [x] Dogfooded end-to-end: untracked actor tries `fast-track` → error shows register hint → `gate register --name klee` → re-try succeeds. The loop works.

## POLICY

Patch-bump compatible. New verb + new interface-layer alias map (`MemberCategory`) + additive hint in an existing error — no stable-surface renames or removals.

## Continuity

This is onboarding-V3 after PRs #30 (misconfigured_cwd hint), #31 (severity + lense), #32 (concept docs + verdict aliases + layered signposts). The theme — "every first-touch wall should carry its own unlock" — keeps getting re-applied to the next wall the newcomer hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)