### PR TITLE
feat(message): surface guild-flow hints in message/inbox errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **Message errors surface guild-flow hints.** Four error paths
+  around `gate message` / `gate inbox` now name a concrete next verb
+  instead of just rejecting:
+  - `send --to <host>` → "hosts don't have inboxes; share a
+    request / fast-track / issue instead, host can read via
+    tail/voices".
+  - `send --to <unknown>` → "not registered; `gate register --name
+    <raw>` (or check the spelling)".
+  - `inbox --for <host>` → "hosts observe via `gate tail` /
+    `gate voices` / `gate list`, not their own inbox".
+  - `inbox --for <unknown>` → register hint, same as send.
+  Each is vertical-formatted (same shape as severity/verdict/lense)
+  so the guidance is scannable. No domain change; existing
+  substring assertions in downstream tests continue to match
+  because the canonical phrase is preserved as a prefix.
+
+### Added
 - **`gate register` — one-shot member registration.** Writes
   `members/<name>.yaml` without the newcomer having to hand-author
   YAML, figure out the schema from `members.example/`, or risk a

--- a/src/application/message/MessageUseCases.ts
+++ b/src/application/message/MessageUseCases.ts
@@ -40,11 +40,35 @@ export class MessageUseCases {
   }): Promise<void> {
     const from = await assertActor(input.from, '--from', this.deps.members);
     // --to must be a real registered member — we can't deliver to a host
-    // name because there's no inbox file for them.
-    const toMember = await this.deps.members.findByName(MemberName.of(input.to));
+    // name because there's no inbox file for them. Two distinct
+    // onboarding cues live here: if the target is a registered host,
+    // nudge toward guild-style "share a request they can see"; if it
+    // just doesn't exist yet, point at `gate register`.
+    const toName = MemberName.of(input.to);
+    const toMember = await this.deps.members.findByName(toName);
     if (!toMember) {
+      const hosts = await this.deps.members.listHostNames();
+      if (hosts.includes(toName.value)) {
+        throw new DomainError(
+          [
+            `Cannot message host "${toName.value}" — hosts do not have inboxes.`,
+            `  Hosts are content_root operators, not message recipients.`,
+            `  Share what you want to say where the host will see it:`,
+            `    gate request --from ${from.value} --action ... --reason ...`,
+            `    gate fast-track --from ${from.value} --action ... --reason ...`,
+            `    gate issues add --from ${from.value} --severity low --area ... "..."`,
+            `  The host can then read the guild via \`gate tail\` or \`gate voices\`.`,
+          ].join('\n'),
+          'to',
+        );
+      }
       throw new DomainError(
-        `recipient is not a registered member: ${input.to}`,
+        [
+          `Recipient "${toName.value}" is not a registered member.`,
+          `  If they should exist, register them:`,
+          `    gate register --name ${toName.value}`,
+          `  Or double-check the spelling — names are lowercase ASCII (see members/).`,
+        ].join('\n'),
         'to',
       );
     }
@@ -137,11 +161,25 @@ export class MessageUseCases {
     const hosts = await this.deps.members.listHostNames();
     if (hosts.includes(name)) {
       throw new DomainError(
-        `hosts do not have inboxes (${name} is a host; only registered members receive messages)`,
+        [
+          `"${name}" is a host, not a member — hosts do not have inboxes.`,
+          `  To observe the guild activity instead:`,
+          `    gate tail                # last events across all actors`,
+          `    gate voices <member>     # one actor's utterances`,
+          `    gate list --state <s>    # requests in a given state`,
+        ].join('\n'),
         'for',
       );
     }
-    throw new DomainError(`not a registered member: ${name}`, 'for');
+    throw new DomainError(
+      [
+        `"${name}" is not a registered member.`,
+        `  Register first:`,
+        `    gate register --name ${name}`,
+        `  Or pick an existing member (ls members/).`,
+      ].join('\n'),
+      'for',
+    );
   }
 }
 

--- a/tests/application/MessageUseCases.test.ts
+++ b/tests/application/MessageUseCases.test.ts
@@ -226,6 +226,25 @@ test('inbox for host name gives descriptive error', async () => {
   );
 });
 
+test('inbox for host surfaces guild-observation hints (tail / voices / list)', async () => {
+  // The hint is the onboarding signal: someone who ran `gate inbox
+  // --for <host>` almost certainly wants to see guild activity, and
+  // the error should say what the right verb is. Pinned so this
+  // guidance can't silently regress.
+  const { uc, members } = build();
+  members.add('kiri');
+  members.setHosts(['human']);
+  await assert.rejects(
+    () => uc.inbox('human'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /gate tail/);
+      assert.match(e.message, /gate voices/);
+      return true;
+    },
+  );
+});
+
 test('inbox for unknown-and-not-host gives plain error', async () => {
   const { uc, members } = build();
   members.add('kiri');
@@ -234,6 +253,53 @@ test('inbox for unknown-and-not-host gives plain error', async () => {
     (e: unknown) => {
       assert.ok(e instanceof DomainError);
       assert.match(e.message, /not a registered member/);
+      return true;
+    },
+  );
+});
+
+test('inbox for unknown surfaces the gate register hint', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  await assert.rejects(
+    () => uc.inbox('newcomer'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /gate register --name newcomer/);
+      return true;
+    },
+  );
+});
+
+test('send to host is rejected with share-a-request hint', async () => {
+  // A host cannot receive a message directly — that's the existing
+  // behaviour. The new hint tells the sender what to do instead:
+  // share a request/issue where the host can see it via tail/voices.
+  const { uc, members } = build();
+  members.add('kiri');
+  members.setHosts(['human']);
+  await assert.rejects(
+    () => uc.send({ from: 'kiri', to: 'human', text: 'hi' }),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /Cannot message host/);
+      assert.match(e.message, /gate request/);
+      assert.match(e.message, /gate fast-track/);
+      assert.match(e.message, /gate issues add/);
+      return true;
+    },
+  );
+});
+
+test('send to unknown recipient surfaces the gate register hint', async () => {
+  const { uc, members } = build();
+  members.add('kiri');
+  await assert.rejects(
+    () => uc.send({ from: 'kiri', to: 'ghost', text: 'hi' }),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /not a registered member/);
+      assert.match(e.message, /gate register --name ghost/);
       return true;
     },
   );


### PR DESCRIPTION
## Summary

Same onboarding-hint pattern as the recent PRs (#30 / #31 / #32 / #33), applied to the next wall I hit: sending a message to a host or to an unregistered name. Before this PR the error said what you couldn't do; now it names the concrete verb you *can* do instead.

### Changes

Four error paths, all vertical-formatted (scannable):

- **`send --to <host>` (new branch)**: "hosts don't have inboxes — share a `request` / `fast-track` / `issues add` where the host can see it via `tail` / `voices`."
- **`send --to <unknown>`**: register hint — `gate register --name <raw>` or check the spelling.
- **`inbox --for <host>`**: existing signal preserved, now adds "observe via `tail` / `voices` / `list`."
- **`inbox --for <unknown>`**: register hint, same shape.

The canonical phrases (`hosts do not have inboxes`, `not a registered member`) are kept as **prefixes** so existing substring assertions in downstream tests still match — change is backward-compatible at the test surface.

### Motivation

Dogfooded during the rest-verb design conversation: ran `gate message --from eris --to nao` while nao is a host, got the generic "not registered" error, realized the error pointed me the wrong direction. This fixes the "couldn't" into a "try this".

The pattern keeps reappearing: every wall a first-time user hits should carry its own unlock. `assertActor` (#33), `parseVerdict` / `parseLense` / `parseIssueSeverity` (#31 / #32), `gate boot` misconfigured_cwd (#30), and now message/inbox errors.

### Test plan

- [x] `npm test` — 299 pass (+4 new: inbox-host hint, inbox-unknown register hint, send-to-host share-a-request hint, send-to-unknown register hint)
- [x] `npm run typecheck` — clean
- [x] Existing 295 tests remain green (canonical phrases preserved as prefixes)
- [x] Dogfooded end-to-end from `data/guild` content_root

### POLICY

Patch-bump compatible. Error-text only — no domain, no stable-surface renames/removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)