### PR TITLE
feat(boot): add content_root_health hint + one-command fix path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate boot` reports `content_root_health`.** boot payload
+  gains `hints.content_root_health` with `malformed_count`, a
+  per-area breakdown (`members` / `requests` / `issues` with
+  totals and malformed counts), and a `fix_hint` naming the
+  exact two commands to reach for when anything is malformed
+  (`gate doctor` to inspect, `gate doctor --format json | gate repair --apply`
+  to quarantine). Text output adds a corresponding warning
+  block when `malformed_count > 0`; clean roots stay silent.
+  Catches test leftovers and schema-drifted records in the
+  orientation moment, so the recurring hydration warning on
+  every subsequent verb becomes a named one-command fix
+  instead of background noise. The malformed probe is wrapped
+  in try/catch so a failing diagnostic can never break boot.
+
+### Added
 - **Message errors surface guild-flow hints.** Four error paths
   around `gate message` / `gate inbox` now name a concrete next verb
   instead of just rejecting:

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -50,11 +50,24 @@ interface BootPayload {
    * or `null` when cwd is being used as a fallback root.
    *
    * `resolved_content_root`: absolute path gate is reading data from.
+   *
+   * `content_root_health`: lightweight summary of whether any YAML
+   * records in the content_root failed to hydrate. Surfacing this at
+   * boot time catches test leftovers or schema-drifted records that
+   * would otherwise emit a warning on every subsequent verb. When
+   * `malformed_count > 0` the caller can reach for
+   * `gate doctor` (inspect) and `gate doctor --format json | gate repair --apply`
+   * (quarantine) — the onboarding unlock is named in `fix_hint`.
    */
   hints: {
     misconfigured_cwd: boolean;
     config_file: string | null;
     resolved_content_root: string;
+    content_root_health: {
+      malformed_count: number;
+      areas: Array<{ area: string; malformed: number; total: number }>;
+      fix_hint: string | null;
+    };
   };
 }
 
@@ -132,6 +145,46 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     members.length === 0 &&
     allRequests.length === 0;
 
+  // Content-root health: lightweight summary of malformed records.
+  // We piggyback on DiagnosticUseCases which already walks every
+  // area; its onMalformed collector picks up YAML that failed to
+  // hydrate (schema drift, test leftovers, half-written records).
+  // Errors during the health probe are non-fatal — a failing
+  // diagnostic shouldn't break boot, which agents depend on for
+  // orientation.
+  const contentRootHealth: BootPayload['hints']['content_root_health'] = {
+    malformed_count: 0,
+    areas: [],
+    fix_hint: null,
+  };
+  try {
+    const report = await c.diagnosticUC.run();
+    const summary = report.summary as unknown as Record<
+      string,
+      { total: number; malformed: number }
+    >;
+    for (const [area, s] of Object.entries(summary)) {
+      if (s && typeof s.total === 'number') {
+        contentRootHealth.areas.push({
+          area,
+          total: s.total,
+          malformed: s.malformed,
+        });
+        contentRootHealth.malformed_count += s.malformed;
+      }
+    }
+    if (contentRootHealth.malformed_count > 0) {
+      contentRootHealth.fix_hint =
+        'Run `gate doctor` to see each finding, then ' +
+        '`gate doctor --format json | gate repair --apply` to ' +
+        'quarantine malformed records out of the hot path. ' +
+        'Quarantine is reversible: files move under ' +
+        '`<content_root>/quarantine/<timestamp>/<area>/`.';
+    }
+  } catch {
+    // Diagnostic errored — skip health, keep boot usable.
+  }
+
   const payload: BootPayload = {
     actor,
     role,
@@ -144,6 +197,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       misconfigured_cwd: misconfiguredCwd,
       config_file: c.config.configFile,
       resolved_content_root: c.config.contentRoot,
+      content_root_health: contentRootHealth,
     },
   };
 
@@ -176,6 +230,24 @@ function renderBootText(p: BootPayload): string {
     );
     lines.push(
       `        or use a wrapper that cd's before invoking gate.mjs.`,
+    );
+  }
+  const health = p.hints.content_root_health;
+  if (health.malformed_count > 0) {
+    lines.push('');
+    lines.push(
+      `⚠️  ${health.malformed_count} malformed record(s) in content_root`,
+    );
+    for (const a of health.areas) {
+      if (a.malformed > 0) {
+        lines.push(
+          `   ${a.area}: ${a.malformed} malformed of ${a.total}`,
+        );
+      }
+    }
+    lines.push(`   fix: gate doctor   # inspect each finding`);
+    lines.push(
+      `        gate doctor --format json | gate repair --apply   # quarantine`,
     );
   }
   lines.push('');

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -156,6 +156,75 @@ test('gate boot: misconfigured_cwd IS true when no config found AND no data', ()
   }
 });
 
+test('gate boot: content_root_health reports clean when everything hydrates', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const h = payload.hints.content_root_health;
+    assert.equal(h.malformed_count, 0);
+    assert.equal(h.fix_hint, null);
+    assert.ok(Array.isArray(h.areas));
+    // text output must NOT print the malformed-record warning block
+    const { stdout: textOut } = runGate(root, ['boot', '--format', 'text']);
+    assert.doesNotMatch(textOut, /malformed record/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: content_root_health surfaces malformed records with a fix hint', () => {
+  // Seed a request with an invalid lense so hydration fails;
+  // the ID pattern must match YamlRequestRepository's listAll filter
+  // (YYYY-MM-DD-NNN[N]), otherwise the file is filtered out before
+  // hydration even attempts it — a subtlety worth asserting against.
+  const { root, cleanup } = bootstrap();
+  try {
+    mkdirSync(join(root, 'requests', 'completed'), { recursive: true });
+    writeFileSync(
+      join(root, 'requests', 'completed', '2099-04-17-9999.yaml'),
+      [
+        'id: 2099-04-17-9999',
+        'created: 2099-04-17T10:00:00.000Z',
+        'from: alice',
+        'action: test',
+        'reason: malformed probe',
+        'executor_preferred: null',
+        'executor_actual: alice',
+        'contract: null',
+        'target: null',
+        'auto_review: null',
+        'status_log:',
+        '  - state: pending',
+        '    at: 2099-04-17T10:00:00.000Z',
+        '    by: alice',
+        '    note: probe',
+        'reviews:',
+        '  - by: alice',
+        '    at: 2099-04-17T10:00:01.000Z',
+        '    lense: not_a_real_lense',
+        '    verdict: ok',
+        '    comment: test',
+        '',
+      ].join('\n'),
+    );
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const h = payload.hints.content_root_health;
+    assert.ok(h.malformed_count >= 1);
+    assert.ok(typeof h.fix_hint === 'string');
+    assert.match(h.fix_hint, /gate doctor/);
+    assert.match(h.fix_hint, /gate repair --apply/);
+    // text output surfaces the warning and the concrete fix commands
+    const { stdout: textOut } = runGate(root, ['boot', '--format', 'text']);
+    assert.match(textOut, /malformed record/);
+    assert.match(textOut, /gate doctor/);
+    assert.match(textOut, /gate repair --apply/);
+  } finally {
+    cleanup();
+  }
+});
+
 test('gate boot: fresh-start (config present, 0 members/requests) is NOT flagged', () => {
   // Bootstrap a content_root with config and an empty members dir.
   // This is a legitimate fresh start — warning would scare new users.


### PR DESCRIPTION
## Summary

`gate boot` now reports `hints.content_root_health` — a lightweight summary of whether any YAML records in the content_root failed to hydrate, with a per-area breakdown and a concrete fix hint naming the two commands to reach for.

```json
"content_root_health": {
  "malformed_count": 1,
  "areas": [
    { "area": "members",  "total": 8,  "malformed": 0 },
    { "area": "requests", "total": 42, "malformed": 1 },
    { "area": "issues",   "total": 10, "malformed": 0 }
  ],
  "fix_hint": "Run `gate doctor` to see each finding, then `gate doctor --format json | gate repair --apply` to quarantine malformed records out of the hot path. Quarantine is reversible: files move under `<content_root>/quarantine/<timestamp>/<area>/`."
}
```

Text output adds a warning block when `malformed_count > 0`; clean roots stay silent.

## Motivation

`gate doctor` and `gate repair` already exist as diagnostic and intervention verbs, but they were not wired into the orientation moment. A test leftover from days ago was producing a `hydrate failed ... Invalid lense: "null"` warning on every `resume` / `boot` / `tail`, which told the user *something was wrong* but not *what to do about it*.

Dogfooded this morning: ran `gate doctor --format json | gate repair --apply`, the file moved to quarantine, subsequent calls became clean. That's the loop the boot hint now names — the recurring noise turns into a one-shot fix.

This is the same onboarding pattern the recent PRs apply at every wall:
- #30 boot misconfigured_cwd
- #31 severity alias + lense hint
- #32 concept docs + verdict alias + layered signposts
- #33 register + assertActor hint
- #34 message/inbox host-and-unknown hint
- **#35 content_root_health hint (this PR)**

## Safety

The probe calls `DiagnosticUseCases.run()` inside a `try/catch`. A failing diagnostic cannot break boot — agents depend on boot for orientation, and an orientation verb that crashes because the diagnostic ran into something novel is strictly worse than one that silently skips health reporting.

## Test plan

- [x] `npm test` — 301 pass (+2 new: clean case, malformed case with fix-hint pinning)
- [x] `npm run typecheck` — clean
- [x] Dogfooded on real content_root: seeded a malformed yaml → boot warns with fix hint → ran the hinted command → content_root clean

## POLICY

Patch-bump compatible. `hints` gains a new field, which the `BootPayload` comment explicitly allows as additive shape evolution. Existing fields (`misconfigured_cwd` / `config_file` / `resolved_content_root`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)