### PR TITLE
feat(resume): unresponded_concerns — dialogue-level commitments in resume

### DIFF
--- a/src/application/concern/UnrespondedConcernsQuery.ts
+++ b/src/application/concern/UnrespondedConcernsQuery.ts
@@ -1,0 +1,192 @@
+import { Request } from '../../domain/request/Request.js';
+import { Issue } from '../../domain/issue/Issue.js';
+import { extractReferences } from '../../domain/shared/extractReferences.js';
+import { RequestRepository } from '../ports/RequestRepository.js';
+import { IssueRepository } from '../ports/IssueRepository.js';
+
+/**
+ * Read-model: "what concerns do I have on the record that nobody has
+ * written a follow-up about?"
+ *
+ * Answers the gap observed in `gate resume`'s open-loops view:
+ * state-machine open_loops don't surface `concern` / `reject` verdicts
+ * left on completed requests. Those are also commitments, just softer.
+ *
+ * Naive definition (deliberately coarse):
+ *   A concern is "unresponded" when NO later request/issue authored by
+ *   the request's authorship set ({R.from} ∪ R.with) mentions R.id in
+ *   its prose. If any follow-up exists, the whole request is dropped —
+ *   the tool does NOT pretend to detect partial-close (2 concerns
+ *   addressed by 1 follow-up that only covered one of them). That
+ *   judgment is returned to the reader; if they want to verify
+ *   coverage, `gate chain <id>` walks the actual references.
+ *
+ * Age cutoff avoids stale concerns from years ago creeping into every
+ * resume forever. 30 days is a deliberate middle — long enough that a
+ * genuine concern survives a weekend + a week of holidays, short
+ * enough that un-acted-on criticism doesn't become resume noise.
+ */
+
+export interface UnrespondedConcernInfo {
+  readonly by: string;
+  readonly lense: string;
+  readonly at: string;
+  readonly age_days: number;
+  readonly verdict: 'concern' | 'reject';
+}
+
+export interface UnrespondedConcernsEntry {
+  readonly request_id: string;
+  readonly action: string;
+  readonly concerns: ReadonlyArray<UnrespondedConcernInfo>;
+}
+
+export interface UnrespondedConcernsInput {
+  readonly actor: string;
+  readonly now: Date;
+  readonly maxAgeDays?: number;
+}
+
+export const DEFAULT_MAX_AGE_DAYS = 30;
+
+export class UnrespondedConcernsQuery {
+  constructor(
+    private readonly requests: RequestRepository,
+    private readonly issues: IssueRepository,
+  ) {}
+
+  async run(
+    input: UnrespondedConcernsInput,
+  ): Promise<UnrespondedConcernsEntry[]> {
+    const actorLower = input.actor.toLowerCase();
+    const maxAge = input.maxAgeDays ?? DEFAULT_MAX_AGE_DAYS;
+    const nowMs = input.now.getTime();
+    const allRequests = await this.requests.listAll();
+    const allIssues = await this.issues.listAll();
+
+    return computeUnrespondedConcerns(
+      allRequests,
+      allIssues,
+      actorLower,
+      nowMs,
+      maxAge,
+    );
+  }
+}
+
+/**
+ * Pure core of the query — extracted so it can be unit-tested against
+ * in-memory Request/Issue arrays without a repository. All behavior
+ * (authorship set, age cutoff, follow-up detection) lives here.
+ */
+export function computeUnrespondedConcerns(
+  allRequests: ReadonlyArray<Request>,
+  allIssues: ReadonlyArray<Issue>,
+  actorLower: string,
+  nowMs: number,
+  maxAgeDays: number,
+): UnrespondedConcernsEntry[] {
+  const entries: UnrespondedConcernsEntry[] = [];
+
+  for (const r of allRequests) {
+    const authorshipSet = authorshipSetOf(r);
+    if (!authorshipSet.has(actorLower)) continue;
+
+    const concerns: UnrespondedConcernInfo[] = [];
+    for (const rv of r.reviews) {
+      if (rv.verdict !== 'concern' && rv.verdict !== 'reject') continue;
+      const ageDays = computeAgeDays(rv.at, nowMs);
+      if (ageDays === null) continue;
+      if (ageDays > maxAgeDays) continue;
+      concerns.push({
+        by: rv.by.value,
+        lense: rv.lense,
+        at: rv.at,
+        age_days: ageDays,
+        verdict: rv.verdict as 'concern' | 'reject',
+      });
+    }
+    if (concerns.length === 0) continue;
+
+    if (hasFollowUp(r.id.value, authorshipSet, allRequests, allIssues)) {
+      continue;
+    }
+
+    entries.push({
+      request_id: r.id.value,
+      action: r.action,
+      concerns,
+    });
+  }
+
+  // Most-recent concern first so the agent sees the freshest unaddressed
+  // criticism at the top of resume output.
+  entries.sort((a, b) => latestAt(b) - latestAt(a));
+  return entries;
+}
+
+function authorshipSetOf(r: Request): Set<string> {
+  const set = new Set<string>();
+  set.add(r.from.value);
+  for (const partner of r.with) {
+    set.add(partner.value);
+  }
+  return set;
+}
+
+function computeAgeDays(at: string, nowMs: number): number | null {
+  const parsed = Date.parse(at);
+  if (!Number.isFinite(parsed)) return null;
+  const delta = nowMs - parsed;
+  if (delta < 0) return 0;
+  return Math.floor(delta / 86_400_000);
+}
+
+function latestAt(entry: UnrespondedConcernsEntry): number {
+  let max = 0;
+  for (const c of entry.concerns) {
+    const t = Date.parse(c.at);
+    if (Number.isFinite(t) && t > max) max = t;
+  }
+  return max;
+}
+
+/**
+ * Return true if any request or issue other than `targetId`, authored
+ * by someone in `authorshipSet`, mentions `targetId` in its free text.
+ * This is the "follow-up exists" check. Does NOT try to detect whether
+ * the follow-up actually addresses the concerns — that is the reader's
+ * judgment, documented as a deliberate limitation.
+ */
+function hasFollowUp(
+  targetId: string,
+  authorshipSet: ReadonlySet<string>,
+  allRequests: ReadonlyArray<Request>,
+  allIssues: ReadonlyArray<Issue>,
+): boolean {
+  for (const r of allRequests) {
+    if (r.id.value === targetId) continue;
+    if (!authorshipSet.has(r.from.value)) continue;
+    if (proseMentionsId(gatherRequestProse(r), targetId)) return true;
+  }
+  for (const i of allIssues) {
+    if (!authorshipSet.has(i.from.value)) continue;
+    if (proseMentionsId(i.text, targetId)) return true;
+  }
+  return false;
+}
+
+function gatherRequestProse(r: Request): string {
+  const parts: string[] = [r.action, r.reason];
+  for (const entry of r.statusLog) {
+    if (entry.note) parts.push(entry.note);
+  }
+  for (const rv of r.reviews) {
+    parts.push(rv.comment);
+  }
+  return parts.join('\n');
+}
+
+function proseMentionsId(prose: string, id: string): boolean {
+  return extractReferences(prose).requestIds.includes(id);
+}

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -207,6 +207,12 @@ export class Issue {
   get state(): IssueState {
     return this.props.state;
   }
+  get from(): MemberName {
+    return this.props.from;
+  }
+  get text(): string {
+    return this.props.text;
+  }
 
   setState(next: IssueState): void {
     assertIssueTransition(this.props.state, next);

--- a/src/domain/shared/extractReferences.ts
+++ b/src/domain/shared/extractReferences.ts
@@ -1,0 +1,63 @@
+// Pure id-scanner for request / issue references embedded in free text.
+//
+// Moved out of interface/gate/chain.ts once a second reader
+// (application/concern/UnrespondedConcernsQuery — "has this request's
+// concerns been followed up?") needed the same lexical scan. Belongs
+// next to compareSequenceIds as another pure function over the
+// well-known id formats.
+//
+// References are found by regex:
+//   requests: YYYY-MM-DD-NNN[N]
+//   issues:   i-YYYY-MM-DD-NNN[N]
+// Matching is lexical only. A prose string that happens to look like
+// an id is followed; false positives are rare because the shape is
+// distinctive.
+
+// \d{3,4} accepts both legacy (0.1.x) 3-digit and current 4-digit
+// sequence suffixes. The trailing (?!\d) forbids longer digit runs
+// so "2026-04-15-00123" (5+ digits) is not partially matched.
+const ID_PATTERN = /(?<!\w)(i-)?(\d{4}-\d{2}-\d{2}-\d{3,4})(?!\d)/g;
+
+export interface ExtractedReferences {
+  readonly requestIds: ReadonlyArray<string>;
+  readonly issueIds: ReadonlyArray<string>;
+}
+
+/**
+ * Scan a free-text string for request and issue ids. Returns the
+ * unique set of each, in first-seen order. Order is stable because
+ * duplicate renders are noisy to readers scanning the output.
+ */
+export function extractReferences(text: string): ExtractedReferences {
+  const requestIds = new Set<string>();
+  const issueIds = new Set<string>();
+  const requestOrder: string[] = [];
+  const issueOrder: string[] = [];
+
+  if (typeof text !== 'string' || text.length === 0) {
+    return { requestIds: [], issueIds: [] };
+  }
+
+  // Reset lastIndex on global regex between calls — otherwise the
+  // previous match position leaks across invocations when the same
+  // regex literal is reused.
+  ID_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ID_PATTERN.exec(text)) !== null) {
+    const hasIssuePrefix = match[1] === 'i-';
+    const core = match[2]!;
+    if (hasIssuePrefix) {
+      const id = `i-${core}`;
+      if (!issueIds.has(id)) {
+        issueIds.add(id);
+        issueOrder.push(id);
+      }
+    } else {
+      if (!requestIds.has(core)) {
+        requestIds.add(core);
+        requestOrder.push(core);
+      }
+    }
+  }
+  return { requestIds: requestOrder, issueIds: issueOrder };
+}

--- a/src/interface/gate/chain.ts
+++ b/src/interface/gate/chain.ts
@@ -1,79 +1,22 @@
 /**
- * Pure helpers for `gate chain <id>`. Separated from the CLI entry
- * point so the reference-extraction logic is unit-testable without
- * filesystem I/O.
+ * Helpers for `gate chain <id>`.
  *
  * The "chain" is a one-hop neighborhood graph around a root record:
  * given a request or issue id, find every other request or issue it
  * mentions in its free-text fields (action, reason, closure notes,
- * review comments, issue text). This lets a reader walk the narrative
- * of how a piece of work relates to others — promoted issues, cited
- * prior requests, cross-referenced audits — without grepping YAML.
+ * review comments, issue text).
  *
- * References are found by regex against the well-known id formats:
- *   requests: YYYY-MM-DD-NNN        (e.g. 2026-04-14-014)
- *   issues:   i-YYYY-MM-DD-NNN      (e.g. i-2026-04-14-003)
- *
- * Matching is lexical only — we do not chase ambiguous prose.
- * A prose string that happens to look like an id will be followed;
- * this is acceptable because YYYY-MM-DD-NNN is distinctive enough
- * that false positives are rare.
+ * The id-scanner itself (`extractReferences`) lives in
+ * `domain/shared/extractReferences.ts` — it is reused by the
+ * `UnrespondedConcernsQuery` read model. This file holds the
+ * request/issue text-gathering helpers that are coupled to the
+ * interface-layer JSON shape (legacy closure keys).
  */
 
-/**
- * Match either form. We scan once with a combined regex and then
- * disambiguate based on whether the match starts with "i-" so we
- * don't double-count requests that happen to share a suffix with an
- * issue id.
- */
-// \d{3,4} accepts both legacy (0.1.x) 3-digit and current 4-digit
-// sequence suffixes. The trailing (?!\d) forbids longer digit runs
-// so "2026-04-15-00123" (5+ digits) is not partially matched.
-const ID_PATTERN = /(?<!\w)(i-)?(\d{4}-\d{2}-\d{2}-\d{3,4})(?!\d)/g;
-
-export interface ExtractedReferences {
-  readonly requestIds: ReadonlyArray<string>;
-  readonly issueIds: ReadonlyArray<string>;
-}
-
-/**
- * Scan a free-text string for request and issue ids. Returns the
- * unique set of each, in first-seen order. Order is stable because
- * duplicate renders are noisy to readers scanning the output.
- */
-export function extractReferences(text: string): ExtractedReferences {
-  const requestIds = new Set<string>();
-  const issueIds = new Set<string>();
-  const requestOrder: string[] = [];
-  const issueOrder: string[] = [];
-
-  if (typeof text !== 'string' || text.length === 0) {
-    return { requestIds: [], issueIds: [] };
-  }
-
-  // Reset lastIndex on global regex between calls — otherwise the
-  // previous match position leaks across invocations when the same
-  // regex literal is reused.
-  ID_PATTERN.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = ID_PATTERN.exec(text)) !== null) {
-    const hasIssuePrefix = match[1] === 'i-';
-    const core = match[2]!;
-    if (hasIssuePrefix) {
-      const id = `i-${core}`;
-      if (!issueIds.has(id)) {
-        issueIds.add(id);
-        issueOrder.push(id);
-      }
-    } else {
-      if (!requestIds.has(core)) {
-        requestIds.add(core);
-        requestOrder.push(core);
-      }
-    }
-  }
-  return { requestIds: requestOrder, issueIds: issueOrder };
-}
+export {
+  extractReferences,
+  type ExtractedReferences,
+} from '../../domain/shared/extractReferences.js';
 
 /**
  * Collect every piece of searchable free text belonging to a request,

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -3,6 +3,7 @@ import { C } from './internal.js';
 import { Request, StatusLogEntry } from '../../../domain/request/Request.js';
 import { collectUtterances, Utterance, RequestJSON } from '../voices.js';
 import { deriveSuggestedNext, SuggestedNext } from './writeFormat.js';
+import { UnrespondedConcernsEntry } from '../../../application/concern/UnrespondedConcernsQuery.js';
 
 /**
  * gate resume [--format json|text]
@@ -53,6 +54,15 @@ interface ResumePayload {
     last_transition: (StatusLogEntry & { request_id: string }) | null;
     open_loops: OpenLoop[];
   };
+  // Deliberately a sibling of `last_context`, not merged into
+  // open_loops: the two are different kinds of commitment.
+  //   open_loops        = state-machine waits ("you must transition X")
+  //   unresponded_concerns = review criticism with no follow-up yet
+  //                       ("somebody named a concern and nothing later
+  //                        in the record references it")
+  // Merging them would muddy the state-vs-dialogue distinction that is
+  // actually load-bearing for readers. Kept narrow on purpose.
+  unresponded_concerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested_next: SuggestedNext | null;
   restoration_prose: string;
 }
@@ -119,6 +129,16 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     if (req) suggested = deriveSuggestedNext(req, c.config);
   }
 
+  // Unresponded concerns: concern/reject verdicts on the actor's
+  // authored (or pair-made) requests that have no follow-up yet. Pure
+  // derivation — no state, just a read over listAll. See
+  // UnrespondedConcernsQuery for the definition and its deliberate
+  // coarseness (does not detect partial-close; the reader does).
+  const unrespondedConcerns = await c.unrespondedConcernsQ.run({
+    actor,
+    now: new Date(),
+  });
+
   // Session hint: the last timestamp the actor appears at anywhere
   // in the record. Null when the actor hasn't spoken yet.
   const sessionHint = lastUtterance?.at ?? lastTransition?.at ?? null;
@@ -139,6 +159,7 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     lastUtterance,
     lastTransition,
     openLoops,
+    unrespondedConcerns,
     suggested,
     locale,
   });
@@ -152,6 +173,7 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
       last_transition: lastTransition,
       open_loops: openLoops,
     },
+    unresponded_concerns: unrespondedConcerns,
     suggested_next: suggested,
     restoration_prose: restorationProse,
   };
@@ -283,6 +305,7 @@ function composeRestorationProse(ctx: {
   lastUtterance: Utterance | null;
   lastTransition: (StatusLogEntry & { request_id: string }) | null;
   openLoops: readonly OpenLoop[];
+  unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
   locale: 'en' | 'ja';
 }): string {
@@ -295,9 +318,10 @@ function composeRestorationProseEn(ctx: {
   lastUtterance: Utterance | null;
   lastTransition: (StatusLogEntry & { request_id: string }) | null;
   openLoops: readonly OpenLoop[];
+  unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
 }): string {
-  const { actor, lastUtterance, lastTransition, openLoops, suggested } = ctx;
+  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested } = ctx;
   const lines: string[] = [];
   lines.push(`# resuming as ${actor}`);
   lines.push('');
@@ -356,6 +380,30 @@ function composeRestorationProseEn(ctx: {
     lines.push('No open loops — you are not blocking anyone.');
   }
 
+  if (unrespondedConcerns.length > 0) {
+    lines.push('');
+    lines.push(
+      `Unresponded concerns on your record (${unrespondedConcerns.length}):`,
+    );
+    lines.push(
+      '  (no follow-up yet references these; tool shows them but does not',
+    );
+    lines.push(
+      '   judge whether your eventual response addresses them — `gate chain`',
+    );
+    lines.push('   walks references if you want to verify coverage)');
+    for (const entry of unrespondedConcerns) {
+      lines.push(
+        `  - ${entry.request_id}: "${truncate(entry.action, 72)}"`,
+      );
+      for (const c of entry.concerns) {
+        lines.push(
+          `      [${c.lense}/${c.verdict}] by ${c.by} (${c.age_days}d ago)`,
+        );
+      }
+    }
+  }
+
   if (suggested) {
     // If multiple loops share the top-urgency type, the suggestion
     // picks one arbitrarily from the head of the sorted list.
@@ -387,9 +435,10 @@ function composeRestorationProseJa(ctx: {
   lastUtterance: Utterance | null;
   lastTransition: (StatusLogEntry & { request_id: string }) | null;
   openLoops: readonly OpenLoop[];
+  unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
 }): string {
-  const { actor, lastUtterance, lastTransition, openLoops, suggested } = ctx;
+  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested } = ctx;
   const lines: string[] = [];
   lines.push(`# ${actor} として再開`);
   lines.push('');
@@ -441,6 +490,32 @@ function composeRestorationProseJa(ctx: {
   } else {
     lines.push('');
     lines.push('open loop なし — あなたは誰もブロックしていません。');
+  }
+
+  if (unrespondedConcerns.length > 0) {
+    lines.push('');
+    lines.push(
+      `未応答の concern (${unrespondedConcerns.length} 件):`,
+    );
+    lines.push(
+      '  （これらを参照する後続 request/issue はまだ無い。tool は',
+    );
+    lines.push(
+      '   「参照が無い」ことだけ示し、応答が concern を addressed したか',
+    );
+    lines.push(
+      '   は判断しない — カバレッジ確認には `gate chain` を使う）',
+    );
+    for (const entry of unrespondedConcerns) {
+      lines.push(
+        `  - ${entry.request_id}: 「${truncate(entry.action, 72)}」`,
+      );
+      for (const c of entry.concerns) {
+        lines.push(
+          `      [${c.lense}/${c.verdict}] by ${c.by} (${c.age_days} 日前)`,
+        );
+      }
+    }
   }
 
   if (suggested) {

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -13,6 +13,7 @@ import {
   DiagnosticRepoBundle,
 } from '../../application/diagnostic/DiagnosticUseCases.js';
 import { RepairUseCases } from '../../application/repair/RepairUseCases.js';
+import { UnrespondedConcernsQuery } from '../../application/concern/UnrespondedConcernsQuery.js';
 import { SafeFsQuarantineStore } from '../../infrastructure/persistence/SafeFsQuarantineStore.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 
@@ -24,6 +25,7 @@ export interface Container {
   messageUC: MessageUseCases;
   diagnosticUC: DiagnosticUseCases;
   repairUC: RepairUseCases;
+  unrespondedConcernsQ: UnrespondedConcernsQuery;
 }
 
 export function buildContainer(): Container {
@@ -59,5 +61,6 @@ export function buildContainer(): Container {
       { root: config.root, contentRoot: config.contentRoot },
     ),
     repairUC: new RepairUseCases(quarantine),
+    unrespondedConcernsQ: new UnrespondedConcernsQuery(requests, issues),
   };
 }

--- a/tests/application/UnrespondedConcernsQuery.test.ts
+++ b/tests/application/UnrespondedConcernsQuery.test.ts
@@ -1,0 +1,334 @@
+// UnrespondedConcernsQuery — derives "concerns on my authored/paired
+// requests that nothing later in the record references yet."
+//
+// Key invariants under test:
+//   1. Concern with no follow-up → surfaced
+//   2. Concern with any follow-up → dropped (partial-close deliberately
+//      not detected; the reader judges coverage)
+//   3. Pair-mode: a partner's follow-up closes the loop
+//   4. Age cutoff: concerns older than maxAgeDays are dropped
+//   5. ok verdicts are never surfaced; only concern / reject
+//   6. Actor outside authorship set → request is invisible to them
+//   7. Issue as follow-up counts
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Request } from '../../src/domain/request/Request.js';
+import { RequestId } from '../../src/domain/request/RequestId.js';
+import { Review } from '../../src/domain/request/Review.js';
+import { Issue, IssueId } from '../../src/domain/issue/Issue.js';
+import {
+  computeUnrespondedConcerns,
+  DEFAULT_MAX_AGE_DAYS,
+} from '../../src/application/concern/UnrespondedConcernsQuery.js';
+
+const BASE_DATE = new Date('2026-04-17T00:00:00Z');
+
+function daysAgo(n: number): string {
+  return new Date(BASE_DATE.getTime() - n * 86_400_000).toISOString();
+}
+
+function makeRequest(opts: {
+  seq: number;
+  from: string;
+  action: string;
+  reason?: string;
+  with?: readonly string[];
+  createdAt?: string;
+  reviews?: Array<{ by: string; lense: string; verdict: string; at?: string; comment?: string }>;
+  extraNote?: string; // appended to status_log as a completion note
+}): Request {
+  const created = opts.createdAt ?? BASE_DATE.toISOString();
+  const createInput: Parameters<typeof Request.create>[0] = {
+    id: RequestId.generate(new Date(created), opts.seq),
+    from: opts.from,
+    action: opts.action,
+    reason: opts.reason ?? 'test reason',
+    createdAt: created,
+  };
+  if (opts.with && opts.with.length > 0) {
+    createInput.with = opts.with;
+  }
+  const r = Request.create(createInput);
+  for (const rv of opts.reviews ?? []) {
+    r.addReview(
+      Review.create({
+        by: rv.by,
+        lense: rv.lense,
+        verdict: rv.verdict,
+        comment: rv.comment ?? 'comment',
+        at: rv.at ?? created,
+      }),
+    );
+  }
+  return r;
+}
+
+function makeIssue(seq: number, from: string, text: string): Issue {
+  return Issue.create({
+    id: IssueId.generate(BASE_DATE, seq),
+    from,
+    severity: 'low',
+    area: 'test',
+    text,
+  });
+}
+
+test('empty inputs → empty result', () => {
+  const out = computeUnrespondedConcerns([], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.deepEqual(out, []);
+});
+
+test('concern with no follow-up → surfaced', () => {
+  const r = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'propose X',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(1) }],
+  });
+  const out = computeUnrespondedConcerns([r], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.request_id, r.id.value);
+  assert.equal(out[0]!.concerns.length, 1);
+  assert.equal(out[0]!.concerns[0]!.by, 'alice');
+  assert.equal(out[0]!.concerns[0]!.lense, 'devil');
+  assert.equal(out[0]!.concerns[0]!.verdict, 'concern');
+  assert.equal(out[0]!.concerns[0]!.age_days, 1);
+});
+
+test('follow-up request from author closes the loop', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'propose X',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(2) }],
+  });
+  const followUp = makeRequest({
+    seq: 2,
+    from: 'claude',
+    action: 'respond to concern',
+    reason: `addressing ${target.id.value}`,
+    createdAt: daysAgo(1),
+  });
+  const out = computeUnrespondedConcerns(
+    [target, followUp],
+    [],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  assert.deepEqual(out, []);
+});
+
+test('partial-close: 2 concerns, 1 follow-up → entire request still dropped (documented limitation)', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'propose X',
+    reviews: [
+      { by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(2), comment: 'a' },
+      { by: 'alice', lense: 'cognitive', verdict: 'concern', at: daysAgo(2), comment: 'b' },
+    ],
+  });
+  const followUp = makeRequest({
+    seq: 2,
+    from: 'claude',
+    action: 'half-response',
+    reason: `partial ack of ${target.id.value}`,
+    createdAt: daysAgo(1),
+  });
+  const out = computeUnrespondedConcerns(
+    [target, followUp],
+    [],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  // The tool deliberately does NOT try to detect partial close. Follow-up
+  // exists → whole request is dropped. Limitation is documented.
+  assert.deepEqual(out, []);
+});
+
+test('pair-mode: partner is in authorship set and sees the concern', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'pair proposal',
+    with: ['noir'],
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(1) }],
+  });
+  const forNoir = computeUnrespondedConcerns([target], [], 'noir', BASE_DATE.getTime(), 30);
+  assert.equal(forNoir.length, 1);
+  const forClaude = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.equal(forClaude.length, 1);
+});
+
+test('pair-mode: partner\'s follow-up closes the loop for the author too', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'pair proposal',
+    with: ['noir'],
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(2) }],
+  });
+  const partnerFollowUp = makeRequest({
+    seq: 2,
+    from: 'noir',
+    action: 'addressing concern',
+    reason: `see ${target.id.value}`,
+    createdAt: daysAgo(1),
+  });
+  const out = computeUnrespondedConcerns(
+    [target, partnerFollowUp],
+    [],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  assert.deepEqual(out, []);
+});
+
+test('age cutoff: concern older than maxAgeDays is dropped', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'ancient',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(100) }],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.deepEqual(out, []);
+});
+
+test('age cutoff: concern at exactly maxAgeDays is included', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'borderline',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(30) }],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.concerns[0]!.age_days, 30);
+});
+
+test('ok verdict is not surfaced', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'blessed',
+    reviews: [
+      { by: 'alice', lense: 'devil', verdict: 'ok', at: daysAgo(1) },
+      { by: 'alice', lense: 'layer', verdict: 'ok', at: daysAgo(1) },
+    ],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.deepEqual(out, []);
+});
+
+test('reject verdict is surfaced (harsher than concern, same treatment)', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'rejected',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'reject', at: daysAgo(1) }],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.concerns[0]!.verdict, 'reject');
+});
+
+test('actor not in authorship set → request is invisible to them', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'someone else\'s work',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(1) }],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'noir', BASE_DATE.getTime(), 30);
+  assert.deepEqual(out, []);
+});
+
+test('issue as follow-up counts as a response', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'propose X',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(2) }],
+  });
+  const issue = makeIssue(1, 'claude', `tracking concern from ${target.id.value}`);
+  const out = computeUnrespondedConcerns(
+    [target],
+    [issue],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  assert.deepEqual(out, []);
+});
+
+test('issue follow-up must be from authorship set', () => {
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'propose X',
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(2) }],
+  });
+  // Issue filed by alice mentioning claude's request doesn't close
+  // claude's loop — alice is the critic, not co-author.
+  const issue = makeIssue(1, 'alice', `re ${target.id.value}`);
+  const out = computeUnrespondedConcerns(
+    [target],
+    [issue],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  assert.equal(out.length, 1);
+});
+
+test('most-recent concern sorted first', () => {
+  const older = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'older',
+    createdAt: daysAgo(5),
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(5) }],
+  });
+  const newer = makeRequest({
+    seq: 2,
+    from: 'claude',
+    action: 'newer',
+    createdAt: daysAgo(1),
+    reviews: [{ by: 'alice', lense: 'devil', verdict: 'concern', at: daysAgo(1) }],
+  });
+  const out = computeUnrespondedConcerns(
+    [older, newer],
+    [],
+    'claude',
+    BASE_DATE.getTime(),
+    30,
+  );
+  assert.equal(out.length, 2);
+  assert.equal(out[0]!.request_id, newer.id.value);
+  assert.equal(out[1]!.request_id, older.id.value);
+});
+
+test('default maxAgeDays is 30', () => {
+  // Not a behavior test — just a contract pin so the constant isn't
+  // silently changed without a corresponding docs update.
+  assert.equal(DEFAULT_MAX_AGE_DAYS, 30);
+});
+
+test('self-review on own request still counts as a concern to track', () => {
+  // Edge case: a review by the author themselves on their own request
+  // (rare but possible via fast-track self-review flows). Still a
+  // concern that needs a response.
+  const target = makeRequest({
+    seq: 1,
+    from: 'claude',
+    action: 'self-crit',
+    reviews: [{ by: 'claude', lense: 'cognitive', verdict: 'concern', at: daysAgo(1) }],
+  });
+  const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
+  assert.equal(out.length, 1);
+});

--- a/tests/interface/resume.test.ts
+++ b/tests/interface/resume.test.ts
@@ -75,6 +75,7 @@ test('gate resume: fresh actor with no activity → empty loops, "arriving fresh
     assert.equal(payload.actor, 'claude');
     assert.equal(payload.last_context.last_utterance, null);
     assert.deepEqual(payload.last_context.open_loops, []);
+    assert.deepEqual(payload.unresponded_concerns, []);
     assert.equal(payload.suggested_next, null);
     assert.match(payload.restoration_prose, /arriving fresh/i);
   } finally {
@@ -150,6 +151,58 @@ test('gate resume: pending review → pending_review loop + review suggestion wi
       undefined,
       'review suggestion must NOT pre-fill verdict — same guard as writeFormat',
     );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume: unresponded concern on completed request surfaces in payload + prose', () => {
+  // End-to-end: claude authors a fast-track, alice leaves a concern
+  // with no follow-up, resume as claude surfaces the concern.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGate(root, [
+      'fast-track',
+      '--from', 'claude',
+      '--action', 'propose refactor',
+      '--reason', 'tech debt',
+      '--auto-review', 'alice',
+    ]);
+    const list = runGate(root, ['list', '--state', 'completed', '--format', 'text']);
+    const id = list.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
+    assert.ok(id);
+    runGate(root, [
+      'review', id!,
+      '--by', 'alice',
+      '--lense', 'devil',
+      '--verdict', 'concern',
+      '--comment', 'edge case X breaks this',
+    ]);
+
+    const { stdout } = runGate(root, ['resume'], { GUILD_ACTOR: 'claude' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.unresponded_concerns.length, 1);
+    const entry = payload.unresponded_concerns[0];
+    assert.equal(entry.request_id, id);
+    assert.equal(entry.concerns.length, 1);
+    assert.equal(entry.concerns[0].lense, 'devil');
+    assert.equal(entry.concerns[0].verdict, 'concern');
+    assert.equal(entry.concerns[0].by, 'alice');
+    assert.match(payload.restoration_prose, /Unresponded concerns/i);
+
+    // Follow-up request from claude mentioning the id should close it.
+    runGate(root, [
+      'fast-track',
+      '--from', 'claude',
+      '--action', 'respond',
+      '--reason', `addressing ${id}`,
+    ]);
+    const after = JSON.parse(
+      runGate(root, ['resume'], { GUILD_ACTOR: 'claude' }).stdout,
+    );
+    assert.deepEqual(after.unresponded_concerns, []);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary

`gate resume`'s `open_loops` only tracks state-machine waits (transitions the actor must drive). Review concerns with verdict `concern` / `reject` on the actor's authored or pair-made requests are also commitments — but they were invisible unless the agent ran `gate voices <critic>` each session. This PR adds a second read-side projection, `unresponded_concerns`, that surfaces them.

The gap was discovered by dogfooding the tool on its own design decisions: concerns sat on completed requests with no way to come back to them at session restart, because resume reported "open loop なし". The new key is a sibling of `open_loops`, deliberately not merged — they are different kinds of commitment:

- `open_loops` = state-machine waits ("you must transition X")
- `unresponded_concerns` = review criticism with no follow-up yet ("somebody named a concern and nothing later in the record references it")

## Definition

An unresponded concern for actor X =
- a `concern` / `reject` verdict on a request R where `X ∈ {R.from} ∪ R.with`
- with NO later request/issue authored by someone in the same authorship set that mentions `R.id` in prose
- and the concern is within the configurable age cutoff (default 30 days)

Closing a loop is "write a follow-up that mentions the id." Any prose mention counts — no new verb.

## Deliberate limitations (documented in code and CLI output)

- **Partial-close is not detected.** 2 concerns + 1 follow-up that addresses only one → the whole request drops. The tool does not pretend to know coverage. Reader uses `gate chain <id>` to verify.
- **30-day age cutoff** so stale criticism doesn't pile up in every resume forever.
- **Author-only (+ pair) ownership.** A critic's own follow-up does not close their concern; the authorship set is what matters.
- **`open_loops` and `unresponded_concerns` never merge.** Different semantic categories.

## Structural changes

- **Promoted `extractReferences` to `domain/shared/`** (matches the `compareSequenceIds` precedent — pure id-format helper). `interface/gate/chain.ts` now re-exports from there for backward compat.
- **Added `get from()` / `get text()` to `Issue`** (additive, patch-stable per POLICY).
- **New `application/concern/UnrespondedConcernsQuery`** with a pure `computeUnrespondedConcerns` core for unit testing, exposed via container to `resume` handler.
- **No schema changes.** Existing YAML / JSON consumers ignore the new key per forward-compat rule.

## POLICY impact

Patch-stable. Additive to resume JSON output (consumers ignore unknown keys). Domain getters are additive. No existing signatures changed.

## Dogfood validation

Ran against a content_root with four committed decisions including concern/reject reviews. Confirmed:
- Concerns on a request that is referenced by a later request → correctly excluded
- Concerns on requests with no follow-up → correctly surfaced, sorted newest-first
- Fresh content_root → empty array, no regression to existing resume behavior

## Test plan

- [x] 15 new unit tests on pure `computeUnrespondedConcerns`: partial-close, age cutoff, pair-mode author+partner, issue-as-follow-up, verdict filter (`ok` excluded), authorship scoping, ordering, `reject` parity, default constant pin, self-review edge case
- [x] 2 new integration tests on resume handler: empty on fresh actor, end-to-end surface-then-close after follow-up
- [x] All 318 existing tests still pass
- [x] `tsc` clean
- [x] Manual dogfood against a pre-existing content_root

## Why this, why now

Two-Persona Devil Review is the tool's core discipline. Leaving critics' concerns silently unretrievable across sessions undermines the discipline the tool is built to enforce. This fix is small (<400 lines incl. tests), additive, POLICY-safe, and sets up the scanner promotion that Issue #36 Phase 1 plugins will want anyway.

Closes part of the "dialogue-level continuity" gap observed during dogfood sessions.

https://claude.ai/code/session_01CqZj25RRwvp6mUYgQpE3qN