### PR TITLE
feat(ux): 5 UX refinements from field-test feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate issues note <id>`.** Append-only annotation for existing
+  issues. The original `severity` / `area` / `text` stay immutable
+  by design (Two-Persona Devil: the first-frame record is preserved,
+  not overwritten) — but the *understanding* of an issue evolves, and
+  without a notes mechanism users had to spawn a whole new issue that
+  referenced the old one just to say "sev should be med in hindsight"
+  or "not reproducible on macOS". Notes take `--by <m>`, `--text <s>`,
+  `--text -` (STDIN), or a positional; they appear under the parent
+  issue in `gate issues list` as `└ note by <who> at <when>: <text>`.
+  No edit, no delete — still append-only.
+- **`read_by` on inbox mark-read.** Mark-read now records the actor
+  that ran the command alongside `read_at`, so audits can distinguish
+  "sentinel acknowledged this" from "eris marked it read on sentinel's
+  behalf" (`--for <other>`). When `GUILD_ACTOR` differs from the inbox
+  owner, stderr surfaces a `# mark-read by <actor> on behalf of
+  <owner>` line so the delegation is visible in the session transcript.
+  `gate inbox` display now shows `(read <at> by <actor>)` when read_by
+  differs from the owner; identical reads stay formatted as before.
+- **`--reason -` reads from STDIN.** `gate request`, `gate deny`,
+  `gate fail`, and `gate fast-track` now accept `--reason -` the same
+  way `gate review --comment -` already did. Long multi-line reasons
+  can come from `$(cat reason.txt)` or a heredoc without shell
+  quoting gymnastics. `--note -` on deny/fail works too for
+  muscle-memory parity.
+
+### Changed
+- **`gate list` without `--state` points at `status`.** The error that
+  used to read `Missing --state` now spells out the list-vs-status
+  distinction: `status` for counts across every state, `list --state
+  <s>` for the contents of one. First-time users who reach for `gate
+  list` to "see everything" get the right verb in one hop instead of
+  reading `--help` twice. Schema entry gets the same clarification.
+- **`gate review` warns on self-review.** When `--by` equals the
+  request author, a `⚠ self-review` line prints to stderr. The review
+  still lands (history may legitimately need self-annotations), but
+  the Two-Persona Devil frame expects a different voice, and the
+  warning makes the choice visible in the transcript instead of
+  silently laundering it into YAML.
+
 - **`gate boot` reports `content_root_health`.** boot payload
   gains `hints.content_root_health` with `malformed_count`, a
   per-area breakdown (`members` / `requests` / `issues` with

--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -1,6 +1,7 @@
 import {
   Issue,
   IssueId,
+  IssueNote,
   IssueState,
   parseIssueState,
 } from '../../domain/issue/Issue.js';
@@ -84,6 +85,26 @@ export class IssueUseCases {
     issue.setState(parseIssueState(state) as IssueState);
     await this.issues.save(issue);
     return issue;
+  }
+
+  /**
+   * Append a note (free-form comment) to an existing issue. The issue's
+   * original severity/area/text remain immutable — notes are the
+   * mechanism for revised understanding, follow-up observations, or
+   * cross-references without destroying the first-frame record.
+   */
+  async addNote(input: {
+    id: string;
+    by: string;
+    text: string;
+  }): Promise<{ issue: Issue; note: IssueNote }> {
+    await assertActor(input.by, '--by', this.members);
+    const issueId = IssueId.of(input.id);
+    const issue = await this.issues.findById(issueId);
+    if (!issue) throw new DomainError(`Issue not found: ${input.id}`, 'id');
+    const note = issue.addNote(input.by, input.text, this.clock.now().toISOString());
+    await this.issues.save(issue);
+    return { issue, note };
   }
 }
 

--- a/src/application/message/MessageUseCases.ts
+++ b/src/application/message/MessageUseCases.ts
@@ -142,15 +142,23 @@ export class MessageUseCases {
    * trace that "I received this and acknowledged it". The --unread
    * filter on `gate inbox` depends on this verb existing to be
    * meaningful.
+   *
+   * `by` is the actor that ran the command — stored alongside
+   * `read_at` so audits can distinguish "sentinel read this" from
+   * "eris marked it read on sentinel's behalf". Defaults to the
+   * inbox owner when omitted (typical self-reader case).
    */
   async markRead(
     name: string,
+    by?: string,
     index?: number,
   ): Promise<MarkReadResult> {
     await this.assertInboxOwner(name);
+    const actor = by ?? name;
     return this.deps.notifier.markRead(
       MemberName.of(name),
       this.deps.clock.now().toISOString(),
+      actor,
       index,
     );
   }

--- a/src/application/ports/NotificationPort.ts
+++ b/src/application/ports/NotificationPort.ts
@@ -22,6 +22,15 @@ export interface InboxMessage {
   read: boolean;
   /** ISO-8601 timestamp when mark-read was applied. Undefined until read. */
   readAt?: string;
+  /**
+   * Actor who ran `mark-read`. Usually equals the inbox owner, but may
+   * differ when someone else uses `--for <other>` (e.g. a human
+   * operator acknowledging on an AI's behalf). Recorded so that
+   * "sentinel acknowledged this" vs "eris marked it read for sentinel"
+   * stays distinguishable in audits. Undefined for messages read
+   * before this field was introduced.
+   */
+  readBy?: string;
   related?: string;
 }
 
@@ -47,11 +56,17 @@ export interface NotificationPort {
    * message is marked. Already-read messages are left alone
    * (idempotent) and counted separately.
    *
+   * `readBy` is the actor that issued the mark — usually equal to
+   * `member`, but may differ when one actor acknowledges on another's
+   * behalf via `--for`. Persisted alongside `readAt` so the trace
+   * stays honest about who did the reading.
+   *
    * Throws `DomainError` if `index` is out of range.
    */
   markRead(
     member: MemberName,
     readAt: string,
+    readBy: string,
     index?: number,
   ): Promise<MarkReadResult>;
 }

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -158,6 +158,27 @@ function sanitizeText(raw: unknown, field: string): string {
   return cleaned;
 }
 
+/**
+ * An append-only annotation on an existing issue. Notes exist because
+ * the original `text`, `severity`, and `area` fields are immutable by
+ * design (Two-Persona Devil: the earlier frame of the problem is
+ * preserved, not overwritten). But the *understanding* of an issue
+ * evolves — severity re-evaluations, cross-references to related
+ * issues, a "I tried this and it didn't repro" follow-up. Without a
+ * notes mechanism those updates have to spawn a whole new issue that
+ * references the old one, which is heavy and fragments the audit
+ * trail.
+ *
+ * Notes are strictly additive: the tool exposes no edit or delete.
+ */
+export interface IssueNote {
+  by: string;
+  text: string;
+  at: string;
+}
+
+const MAX_NOTES = 50;
+
 export interface IssueProps {
   id: IssueId;
   from: MemberName;
@@ -166,6 +187,8 @@ export interface IssueProps {
   text: string;
   state: IssueState;
   createdAt: string;
+  /** Optional — historical YAML pre-dates notes; restore backfills []. */
+  notes?: IssueNote[];
 }
 
 export class Issue {
@@ -187,6 +210,7 @@ export class Issue {
       text: sanitizeText(input.text, 'text'),
       state: 'open',
       createdAt: input.createdAt ?? new Date().toISOString(),
+      notes: [],
     });
   }
 
@@ -198,7 +222,9 @@ export class Issue {
    * state, the operator must fix the YAML by hand.
    */
   static restore(props: IssueProps): Issue {
-    return new Issue({ ...props });
+    // Older on-disk issues have no `notes` array. Treat missing as
+    // empty so hydration of historical YAML keeps working.
+    return new Issue({ ...props, notes: props.notes ?? [] });
   }
 
   get id(): IssueId {
@@ -219,8 +245,31 @@ export class Issue {
     this.props.state = next;
   }
 
+  get notes(): readonly IssueNote[] {
+    return this.props.notes ?? [];
+  }
+
+  addNote(by: string, text: string, at?: string): IssueNote {
+    // `notes` is optional on IssueProps so historical YAML can restore
+    // without an explicit empty array; lazily initialize on first add.
+    if (!this.props.notes) this.props.notes = [];
+    if (this.props.notes.length >= MAX_NOTES) {
+      throw new DomainError(
+        `Too many notes on ${this.props.id.value} (max ${MAX_NOTES})`,
+        'notes',
+      );
+    }
+    const note: IssueNote = {
+      by: MemberName.of(by).value,
+      text: sanitizeText(text, 'note'),
+      at: at ?? new Date().toISOString(),
+    };
+    this.props.notes.push(note);
+    return note;
+  }
+
   toJSON(): Record<string, unknown> {
-    return {
+    const out: Record<string, unknown> = {
       id: this.props.id.value,
       from: this.props.from.value,
       severity: this.props.severity,
@@ -229,5 +278,12 @@ export class Issue {
       state: this.props.state,
       created_at: this.props.createdAt,
     };
+    // Backward compat: omit the `notes` key when empty so pre-notes
+    // YAML stays byte-identical after a round-trip through restore/save.
+    const notes = this.props.notes;
+    if (notes && notes.length > 0) {
+      out['notes'] = notes.map((n) => ({ ...n }));
+    }
+    return out;
   }
 }

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -64,6 +64,7 @@ export class FsInboxNotification implements NotificationPort {
   async markRead(
     member: MemberName,
     readAt: string,
+    readBy: string,
     index?: number,
   ): Promise<MarkReadResult> {
     const rel = `${member.value}.yaml`;
@@ -103,6 +104,11 @@ export class FsInboxNotification implements NotificationPort {
       // receipt" from "read three days later". The post timestamp
       // (at) is preserved untouched.
       entry['read_at'] = readAt;
+      // read_by records who actually ran the mark — usually the inbox
+      // owner, but may differ when `--for <other>` is used. Without
+      // this, an eris-as-sentinel mark-read is indistinguishable from
+      // a real sentinel acknowledgment.
+      entry['read_by'] = readBy;
       marked++;
     }
 
@@ -124,6 +130,7 @@ function normalizeMessage(raw: Record<string, unknown>): InboxMessage {
     read: raw['read'] === true,
   };
   if (typeof raw['read_at'] === 'string') msg.readAt = raw['read_at'];
+  if (typeof raw['read_by'] === 'string') msg.readBy = raw['read_by'];
   if (typeof raw['related'] === 'string') msg.related = raw['related'];
   return msg;
 }

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -2,6 +2,7 @@ import YAML from 'yaml';
 import {
   Issue,
   IssueId,
+  IssueNote,
   IssueState,
   parseIssueSeverity,
   parseIssueState,
@@ -115,6 +116,7 @@ function hydrate(
       text: String(obj['text']),
       state: parseIssueState(String(obj['state'] ?? 'open')),
       createdAt: String(obj['created_at'] ?? new Date().toISOString()),
+      notes: hydrateNotes(obj['notes'], source, onMalformed),
     });
     return issue;
   } catch (e) {
@@ -126,4 +128,33 @@ function hydrate(
     );
     return null;
   }
+}
+
+function hydrateNotes(
+  raw: unknown,
+  source: string,
+  onMalformed: OnMalformed,
+): IssueNote[] {
+  if (!Array.isArray(raw)) return [];
+  const out: IssueNote[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const entry = raw[i];
+    if (!entry || typeof entry !== 'object') {
+      onMalformed(source, `notes[${i}] is not a mapping; skipping`);
+      continue;
+    }
+    const r = entry as Record<string, unknown>;
+    const by = typeof r['by'] === 'string' ? r['by'] : '';
+    const text = typeof r['text'] === 'string' ? r['text'] : '';
+    const at = typeof r['at'] === 'string' ? r['at'] : '';
+    if (!by || !text || !at) {
+      onMalformed(
+        source,
+        `notes[${i}] missing required fields (by/text/at); skipping`,
+      );
+      continue;
+    }
+    out.push({ by, text, at });
+  }
+  return out;
 }

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -3,12 +3,15 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C, truncateCodePoints } from './internal.js';
+import { C, readStdin, truncateCodePoints } from './internal.js';
 
 export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
   if (sub === 'promote') {
     return await issuesPromote(c, args);
+  }
+  if (sub === 'note') {
+    return await issuesNote(c, args);
   }
   if (sub === 'add') {
     const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
@@ -28,6 +31,12 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
       process.stdout.write(
         `${j['id']} [${j['severity']}/${j['area']}] ${j['state']} — ${j['text']}\n`,
       );
+      const notes = Array.isArray(j['notes']) ? j['notes'] : [];
+      for (const n of notes as Array<Record<string, unknown>>) {
+        process.stdout.write(
+          `  └ note by ${n['by']} at ${n['at']}: ${n['text']}\n`,
+        );
+      }
     }
     return 0;
   }
@@ -103,6 +112,46 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
   }
   process.stdout.write(
     `✓ promoted ${id} → ${req.id.value} (issue resolved)\n`,
+  );
+  return 0;
+}
+
+async function issuesNote(c: C, args: ParsedArgs): Promise<number> {
+  // Issues are otherwise immutable by design: the original severity /
+  // area / text freeze the first-frame record. A `note` is the
+  // escape hatch for revised understanding — "severity should be med
+  // in hindsight", "actually not reproducible on macOS", "see i-...
+  // for the follow-up". Append-only, no edit, no delete.
+  const id = args.positional[1];
+  if (!id) {
+    throw new Error(
+      'Usage: gate issues note <id> --by <m> [--text <s> | --text - | <text>]',
+    );
+  }
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
+  // Text resolution mirrors `gate review --comment`:
+  //   --text <s>       inline short note
+  //   --text -         STDIN until EOF
+  //   <positional>     everything after the id
+  const textOpt = optionalOption(args, 'text');
+  const positional = args.positional.slice(2).join(' ');
+  let text: string;
+  if (textOpt === '-') {
+    text = (await readStdin()).trim();
+  } else if (textOpt !== undefined) {
+    text = textOpt;
+  } else {
+    text = positional;
+  }
+  if (!text.trim()) {
+    throw new Error(
+      'note text is required (use --text <s>, --text - for STDIN, ' +
+        'or pass as positional argument)',
+    );
+  }
+  const { note } = await c.issueUC.addNote({ id, by, text });
+  process.stdout.write(
+    `✓ note added to ${id} by ${note.by} at ${note.at}\n`,
   );
   return 0;
 }

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -76,7 +76,9 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
     const related = m.related ? ` (ref: ${m.related})` : '';
     const readTag = m.read
       ? m.readAt
-        ? ` (read ${m.readAt})`
+        ? m.readBy && m.readBy !== forName
+          ? ` (read ${m.readAt} by ${m.readBy})`
+          : ` (read ${m.readAt})`
         : ' (read)'
       : ' (unread)';
     process.stdout.write(
@@ -104,7 +106,21 @@ async function msgInboxMarkRead(c: C, args: ParsedArgs): Promise<number> {
     index = parsed;
   }
 
-  const result = await c.messageUC.markRead(forName, index);
+  // The actor that ran the command (GUILD_ACTOR), which can legitimately
+  // differ from the inbox owner when `--for <other>` is used. We pass
+  // both so the audit trail records "who read for whom". Fall back to
+  // the inbox owner when GUILD_ACTOR is unset — same-actor self-reader
+  // is the common case, and stamping `read_by: <owner>` is correct.
+  const envActor = process.env['GUILD_ACTOR'];
+  const by = envActor && envActor.length > 0 ? envActor : forName;
+  const result = await c.messageUC.markRead(forName, by, index);
+  if (by !== forName) {
+    // Surface the delegation so the operator sees that the trail will
+    // say "by=<actor> for=<owner>" rather than a plain self-read.
+    process.stderr.write(
+      `# mark-read by ${by} on behalf of ${forName} (read_by recorded as ${by})\n`,
+    );
+  }
   if (result.total === 0) {
     process.stdout.write(`(inbox empty for ${forName})\n`);
     return 0;

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -5,7 +5,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta } from '../voices.js';
-import { C } from './internal.js';
+import { C, readStdin } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
@@ -16,7 +16,11 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
     'GUILD_ACTOR',
   );
   const action = requireOption(args, 'action', '--action required');
-  const reason = requireOption(args, 'reason', '--reason required');
+  let reason = requireOption(args, 'reason', '--reason required');
+  // `--reason -` reads from stdin — parity with `gate review --comment -`.
+  // Trim because heredoc / echo append a trailing newline that clutters
+  // the rendered status_log note.
+  if (reason === '-') reason = (await readStdin()).trim();
   const input: Parameters<typeof c.requestUC.create>[0] = {
     from,
     action,
@@ -210,7 +214,7 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  const reason = resolveReason(args, 'deny');
+  const reason = await resolveReason(args, 'deny');
   if (!id || !reason) {
     throw new Error(
       'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]',
@@ -253,7 +257,7 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  const reason = resolveReason(args, 'fail');
+  const reason = await resolveReason(args, 'fail');
   if (!id || !reason) {
     throw new Error(
       'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]',
@@ -281,13 +285,17 @@ function parseWithList(raw: string | undefined): string[] {
 
 // Resolve the closure reason for deny/fail accepting any of:
 //   --reason <s>    explicit & semantically precise
+//   --reason -      STDIN (parity with `gate review --comment -`)
 //   --note <s>      muscle-memory parity with approve/execute/complete
+//   --note -        STDIN
 //   <positional>    legacy form retained for back-compat
 // Explicit options take precedence over positional.
-function resolveReason(args: ParsedArgs, _verb: string): string {
+async function resolveReason(args: ParsedArgs, _verb: string): Promise<string> {
   const reasonOpt = optionalOption(args, 'reason');
   const noteOpt = optionalOption(args, 'note');
+  if (reasonOpt === '-') return (await readStdin()).trim();
   if (reasonOpt !== undefined && reasonOpt.trim()) return reasonOpt;
+  if (noteOpt === '-') return (await readStdin()).trim();
   if (noteOpt !== undefined && noteOpt.trim()) return noteOpt;
   return args.positional.slice(1).join(' ');
 }
@@ -295,7 +303,8 @@ function resolveReason(args: ParsedArgs, _verb: string): string {
 export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const action = requireOption(args, 'action', '--action required');
-  const reason = requireOption(args, 'reason', '--reason required');
+  let reason = requireOption(args, 'reason', '--reason required');
+  if (reason === '-') reason = (await readStdin()).trim();
   const executor = optionalOption(args, 'executor') ?? from;
   const autoReview = optionalOption(args, 'auto-review');
   const note = optionalOption(args, 'note');

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -48,6 +48,21 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   }
 
   const updated = await c.requestUC.review({ id, by, lense, verdict, comment });
+  // Self-review warning. The tool permits `--by` to equal the
+  // request author (the YAML is just an append-only record and
+  // doesn't know intent), but the Two-Persona Devil frame is
+  // undermined when the critic is the author. We surface a stderr
+  // marker rather than reject — history may need self-annotations
+  // (e.g. "I want to flag this myself") and the caller's own
+  // judgement wins. The warning exists so the choice is visible in
+  // the session transcript and not silently laundered into YAML.
+  if (updated.from.value === by) {
+    process.stderr.write(
+      `⚠ self-review: ${by} reviewed their own request ${id}. ` +
+        `The Two-Persona Devil frame expects a different voice — ` +
+        `consider asking another member to review instead.\n`,
+    );
+  }
   // Display the canonical verdict/lense (from the stored review)
   // rather than the raw input: the user may have typed an alias
   // (e.g. `--verdict concerned`, normalized to `concern` on save),

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -206,11 +206,17 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'list',
     category: 'read',
-    summary: 'filter requests by state + optional actor filters',
+    summary:
+      'filter requests by state + optional actor filters. Requires --state; for counts across every state use `status`.',
     input: {
       type: 'object',
       properties: {
-        state: { type: 'string', enum: ['pending', 'approved', 'executing', 'completed', 'failed', 'denied'] },
+        state: {
+          type: 'string',
+          enum: ['pending', 'approved', 'executing', 'completed', 'failed', 'denied'],
+          description:
+            'required. Contents of one state. `status` is the sibling verb that returns counts across every state.',
+        },
         for: str,
         from: str,
         executor: str,
@@ -379,11 +385,16 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'issues',
     category: 'write',
-    summary: 'subcommands: add|list|resolve|defer|start|reopen|promote',
+    summary: 'subcommands: add|list|note|resolve|defer|start|reopen|promote',
     input: {
       type: 'object',
       properties: {
-        subcommand: { type: 'string', enum: ['add', 'list', 'resolve', 'defer', 'start', 'reopen', 'promote'] },
+        subcommand: {
+          type: 'string',
+          enum: ['add', 'list', 'note', 'resolve', 'defer', 'start', 'reopen', 'promote'],
+          description:
+            "`note` appends an annotation without mutating severity/area/text — the issue record is otherwise immutable.",
+        },
       },
     },
     output: { type: 'object' },

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -1,6 +1,7 @@
 import { buildContainer } from '../shared/container.js';
-import { parseArgs, requireOption } from '../shared/parseArgs.js';
+import { parseArgs, optionalOption } from '../shared/parseArgs.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
+import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
 import {
   reqCreate,
@@ -82,6 +83,7 @@ Issues:
   gate issues add --from <m> --severity <s> --area <a> <text>
   gate issues list [--state <s>]
   gate issues resolve|defer|start|reopen <id>
+  gate issues note <id> --by <m> [--text <s> | --text - | <text>]
   gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>]
                                       [--action <a>] [--reason <r>]
 
@@ -161,7 +163,21 @@ export async function main(argv: readonly string[]): Promise<number> {
       case 'pending':
         return await reqList(c, 'pending', args);
       case 'list': {
-        const state = requireOption(args, 'state', 'gate list --state <s>');
+        // `gate list` without --state is a common first-try ("show me
+        // everything"). Rather than just erroring on the missing flag,
+        // spell out the list vs status distinction — the question most
+        // first-time users actually have is "which verb do I want?"
+        const state = optionalOption(args, 'state');
+        if (state === undefined) {
+          const states = REQUEST_STATES.join('|');
+          process.stderr.write(
+            `gate list needs --state <s> (${states}).\n` +
+              '  For just counts across every state, use:  gate status\n' +
+              '  For the contents of one state,     use:  gate list --state <s>\n' +
+              `  States: ${REQUEST_STATES.join(' | ')}\n`,
+          );
+          return 1;
+        }
         return await reqList(c, state, args);
       }
       case 'show':

--- a/tests/application/MessageUseCases.test.ts
+++ b/tests/application/MessageUseCases.test.ts
@@ -46,6 +46,7 @@ class FakeNotifier implements NotificationPort {
   // `readMarks[i]` tracks whether posted[i] has been flipped to read.
   readMarks: boolean[] = [];
   readAtStamps: (string | undefined)[] = [];
+  readByStamps: (string | undefined)[] = [];
   failFor: Set<string> = new Set();
   async post(n: Notification): Promise<void> {
     if (this.failFor.has(n.to.value)) {
@@ -54,6 +55,7 @@ class FakeNotifier implements NotificationPort {
     this.posted.push(n);
     this.readMarks.push(false);
     this.readAtStamps.push(undefined);
+    this.readByStamps.push(undefined);
   }
   async listFor(member: MemberName): Promise<InboxMessage[]> {
     const out: InboxMessage[] = [];
@@ -70,6 +72,8 @@ class FakeNotifier implements NotificationPort {
       };
       const readAt = this.readAtStamps[i];
       if (readAt !== undefined) msg.readAt = readAt;
+      const readBy = this.readByStamps[i];
+      if (readBy !== undefined) msg.readBy = readBy;
       out.push(msg);
     }
     return out;
@@ -77,6 +81,7 @@ class FakeNotifier implements NotificationPort {
   async markRead(
     member: MemberName,
     readAt: string,
+    readBy: string,
     index?: number,
   ): Promise<MarkReadResult> {
     // Map the recipient's 1-based index into the underlying flat
@@ -107,6 +112,7 @@ class FakeNotifier implements NotificationPort {
       }
       this.readMarks[i] = true;
       this.readAtStamps[i] = readAt;
+      this.readByStamps[i] = readBy;
       marked++;
     }
     return { marked, alreadyRead, total };
@@ -344,7 +350,7 @@ test('markRead with index marks just that message (1-based)', async () => {
   await uc.send({ from: 'kiri', to: 'noir', text: 'two' });
   await uc.send({ from: 'kiri', to: 'noir', text: 'three' });
 
-  const result = await uc.markRead('noir', 2);
+  const result = await uc.markRead('noir', undefined, 2);
   assert.equal(result.marked, 1);
   assert.equal(result.alreadyRead, 0);
   assert.equal(result.total, 3);
@@ -362,7 +368,7 @@ test('markRead with out-of-range index throws DomainError', async () => {
   await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
 
   await assert.rejects(
-    () => uc.markRead('noir', 5),
+    () => uc.markRead('noir', undefined, 5),
     (e: unknown) => {
       assert.ok(e instanceof DomainError);
       assert.match(e.message, /out of range/);
@@ -380,6 +386,32 @@ test('markRead for empty inbox returns zeros without error', async () => {
   assert.equal(result.marked, 0);
   assert.equal(result.alreadyRead, 0);
   assert.equal(result.total, 0);
+});
+
+test('markRead defaults read_by to the inbox owner (self-read)', async () => {
+  const { uc, members, notifier } = build();
+  members.add('kiri');
+  members.add('noir');
+  await uc.send({ from: 'kiri', to: 'noir', text: 'one' });
+  await uc.markRead('noir');
+  const msgs = await uc.inbox('noir');
+  assert.equal(msgs[0]!.readBy, 'noir');
+  void notifier;
+});
+
+test('markRead records read_by when a different actor reads on behalf', async () => {
+  // The audit trail must distinguish "sentinel acknowledged this"
+  // from "eris ran mark-read --for sentinel". Without read_by the
+  // two cases are indistinguishable in YAML.
+  const { uc, members } = build();
+  members.add('eris');
+  members.add('sentinel');
+  members.add('noir');
+  await uc.send({ from: 'noir', to: 'sentinel', text: 'hello' });
+  await uc.markRead('sentinel', 'eris');
+  const msgs = await uc.inbox('sentinel');
+  assert.equal(msgs[0]!.read, true);
+  assert.equal(msgs[0]!.readBy, 'eris');
 });
 
 test('markRead for host name raises the inbox-owner error', async () => {

--- a/tests/domain/Issue.test.ts
+++ b/tests/domain/Issue.test.ts
@@ -133,6 +133,48 @@ test('parseIssueSeverity rejects truly unknown values', () => {
   assert.throws(() => parseIssueSeverity(''), DomainError);
 });
 
+// ── addNote — append-only annotations ──
+
+test('Issue.addNote appends and does not mutate original text/severity', () => {
+  const i = mkIssue();
+  const note = i.addNote('eris', 'sev should probably be med, not low');
+  assert.equal(i.notes.length, 1);
+  assert.equal(note.by, 'eris');
+  assert.equal(i.notes[0]!.text, 'sev should probably be med, not low');
+  // Original fact-of-record stays untouched — the note is the
+  // revision mechanism, not an edit.
+  const j = i.toJSON();
+  assert.equal(j['severity'], 'med');
+  assert.equal(j['text'], 'something is broken');
+  assert.ok(Array.isArray(j['notes']));
+});
+
+test('Issue.addNote rejects empty text (domain sanitization)', () => {
+  const i = mkIssue();
+  assert.throws(() => i.addNote('eris', '   '), DomainError);
+});
+
+test('Issue.addNote preserves order across multiple calls', () => {
+  const i = mkIssue();
+  i.addNote('eris', 'first');
+  i.addNote('noir', 'second');
+  i.addNote('eris', 'third');
+  assert.deepEqual(
+    i.notes.map((n) => n.text),
+    ['first', 'second', 'third'],
+  );
+  assert.deepEqual(
+    i.notes.map((n) => n.by),
+    ['eris', 'noir', 'eris'],
+  );
+});
+
+test('Issue.toJSON omits `notes` when empty (backward-compat)', () => {
+  const i = mkIssue();
+  const j = i.toJSON();
+  assert.equal('notes' in j, false);
+});
+
 test('parseIssueSeverity error message lists canonical values + aliases', () => {
   // The error itself is the onboarding: a first-time user who typed
   // `medium` and got rejected should learn the canonical set and the


### PR DESCRIPTION
## Summary

A full-session walkthrough surfaced 5 friction points; each gets a targeted fix.

- **`gate list` without `--state` now guides instead of blocking.** stderr spells out the list vs. status distinction (`status` = counts across every state; `list --state <s>` = contents of one). State list pulls from `REQUEST_STATES` so list / schema / help stay aligned.
- **`--reason -` reads STDIN.** `gate request` / `deny` / `fail` / `fast-track` accept the same convention as `gate review --comment -`. Removes quoting friction for multi-paragraph reasons piped from `$(cat …)` or a heredoc. `--note -` works too on deny/fail for muscle-memory parity.
- **Self-review warning on `gate review`.** When `--by` equals the request author, stderr emits a `⚠ self-review` marker. The review still lands (history may legitimately need self-annotations), but the Two-Persona Devil frame expects a different voice — the warning makes the choice visible in the transcript instead of silently laundering it into YAML.
- **`read_by` on inbox mark-read.** `NotificationPort.markRead` gains a `readBy` param; `FsInbox` persists it; `gate inbox` renders `(read <at> by <actor>)` when it differs from the owner. When `GUILD_ACTOR` differs from `--for`, stderr surfaces a delegation notice so the audit trail distinguishes "sentinel acknowledged this" from "eris marked it for sentinel".
- **`gate issues note <id>`.** Append-only annotation for existing issues. The original `severity` / `area` / `text` stay immutable by design, but understanding evolves — notes carry the revision ("sev should be med in hindsight", "not reproducible on macOS") without spawning a whole new issue that cross-references the old one. `--by` required, `--text <s>` / `--text -` / positional accepted. Surfaces under the parent in `gate issues list` as `└ note by <who> at <when>`. No edit, no delete — still append-only.

## Test plan

- [x] `npm test` — 324 tests passing (+6 new: `Issue.addNote` ×4, `MessageUseCases` `read_by` ×2).
- [x] `npx tsc --noEmit` clean.
- [x] `gate list` without `--state` prints the hint with the right exit code.
- [x] `gate issues note` / `gate --help` / `gate schema` reflect the new verb.
- [ ] Manual: round-trip a `read_by: eris` YAML through mark-read and confirm display shows `(read … by eris)` for `--for sentinel`.
- [ ] Manual: run `gate review` with `--by == from` and confirm the ⚠ self-review stderr line appears.
- [ ] Manual: pipe a multi-line heredoc into `gate request --reason -` and confirm the `status_log` note is trimmed.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu