### PR TITLE
feat(audit): invoked_by on status_log + reviews — record AI proxy writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`invoked_by` on status_log and reviews.** When `GUILD_ACTOR`
+  differs from the explicit `--by` (an AI agent acting on a
+  human's behalf), write verbs (`approve` / `deny` / `execute` /
+  `complete` / `fail` / `review` / `fast-track`) record
+  `invoked_by: <GUILD_ACTOR>` on the status_log entry (or review)
+  and print a one-line delegation notice to stderr. The on-record
+  actor (`by`) still wins for attribution; `invoked_by` preserves
+  the delegation so "eris approved" and "an AI approved on eris's
+  behalf" stop being indistinguishable in YAML. Same pattern as
+  inbox `read_by`. Omitted when `by` and the invoker agree (no
+  YAML clutter for the self-invocation common case). `gate show
+  --format text` renders `[invoked_by=<actor>]` inline on the
+  matching log entry or review header.
+
 - **`gate issues note <id>`.** Append-only annotation for existing
   issues. The original `severity` / `area` / `text` stay immutable
   by design (Two-Persona Devil: the first-frame record is preserved,

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -124,42 +124,67 @@ export class RequestUseCases {
     return this.deps.requests.findById(RequestId.of(id));
   }
 
-  async approve(id: string, by: string, note?: string): Promise<Request> {
+  async approve(
+    id: string,
+    by: string,
+    note?: string,
+    invokedBy?: string,
+  ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.approve(actor, note);
+    req.approve(actor, note, invokedBy);
     await this.deps.requests.save(req);
     return req;
   }
 
-  async deny(id: string, by: string, reason: string): Promise<Request> {
+  async deny(
+    id: string,
+    by: string,
+    reason: string,
+    invokedBy?: string,
+  ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.deny(actor, reason);
+    req.deny(actor, reason, invokedBy);
     await this.deps.requests.save(req);
     return req;
   }
 
-  async execute(id: string, by: string, note?: string): Promise<Request> {
+  async execute(
+    id: string,
+    by: string,
+    note?: string,
+    invokedBy?: string,
+  ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.execute(actor, note);
+    req.execute(actor, note, invokedBy);
     await this.deps.requests.save(req);
     return req;
   }
 
-  async complete(id: string, by: string, note?: string): Promise<Request> {
+  async complete(
+    id: string,
+    by: string,
+    note?: string,
+    invokedBy?: string,
+  ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.complete(actor, note);
+    req.complete(actor, note, invokedBy);
     await this.deps.requests.save(req);
     return req;
   }
 
-  async fail(id: string, by: string, reason: string): Promise<Request> {
+  async fail(
+    id: string,
+    by: string,
+    reason: string,
+    invokedBy?: string,
+  ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.fail(actor, reason);
+    req.fail(actor, reason, invokedBy);
     await this.deps.requests.save(req);
     return req;
   }
@@ -170,6 +195,7 @@ export class RequestUseCases {
     lense: string;
     verdict: string;
     comment: string;
+    invokedBy?: string;
   }): Promise<Request> {
     const req = await this.loadOrThrow(input.id);
     await assertActor(input.by, '--by', this.deps.members);
@@ -179,6 +205,7 @@ export class RequestUseCases {
       verdict: input.verdict,
       comment: input.comment,
       at: this.deps.clock.now().toISOString(),
+      ...(input.invokedBy !== undefined ? { invokedBy: input.invokedBy } : {}),
       ...(this.deps.allowedLenses ? { allowedLenses: this.deps.allowedLenses } : {}),
     });
     req.addReview(review);

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -17,6 +17,16 @@ export interface StatusLogEntry {
   by: string;
   at: string;
   note?: string;
+  /**
+   * Actual invoker when different from `by`. Mirrors inbox.read_by:
+   * `by` is to whom the act is attributed (the member on record);
+   * `invoked_by` is who actually ran the CLI command. Typically this
+   * is the AI agent proxying for a human operator — without the
+   * field, "eris approved" and "an AI approved on eris's behalf"
+   * are indistinguishable in YAML. Undefined when the two agree
+   * (the common case, so existing records stay byte-identical).
+   */
+  invokedBy?: string;
 }
 
 export interface RequestProps {
@@ -176,24 +186,24 @@ export class Request {
     return computeVersion(this.props.statusLog.length, this.props.reviews.length);
   }
 
-  approve(by: MemberName, note?: string): void {
-    this.transition('approved', by, note);
+  approve(by: MemberName, note?: string, invokedBy?: string): void {
+    this.transition('approved', by, note, invokedBy);
   }
 
-  deny(by: MemberName, reason: string): void {
-    this.transition('denied', by, reason);
+  deny(by: MemberName, reason: string, invokedBy?: string): void {
+    this.transition('denied', by, reason, invokedBy);
   }
 
-  execute(by: MemberName, note?: string): void {
-    this.transition('executing', by, note);
+  execute(by: MemberName, note?: string, invokedBy?: string): void {
+    this.transition('executing', by, note, invokedBy);
   }
 
-  complete(by: MemberName, note?: string): void {
-    this.transition('completed', by, note);
+  complete(by: MemberName, note?: string, invokedBy?: string): void {
+    this.transition('completed', by, note, invokedBy);
   }
 
-  fail(by: MemberName, reason: string): void {
-    this.transition('failed', by, reason);
+  fail(by: MemberName, reason: string, invokedBy?: string): void {
+    this.transition('failed', by, reason, invokedBy);
   }
 
   addReview(review: Review): void {
@@ -207,6 +217,7 @@ export class Request {
     to: RequestState,
     by: MemberName,
     note?: string,
+    invokedBy?: string,
   ): void {
     assertTransition(this.props.state, to);
     this.props.state = to;
@@ -224,6 +235,12 @@ export class Request {
     if (note !== undefined) {
       entry.note = sanitizeText(note, 'note');
     }
+    // Only stamp `invoked_by` when it genuinely differs from `by` —
+    // a same-actor invocation is the common case and would just clutter
+    // YAML with redundant fields.
+    if (invokedBy !== undefined && invokedBy !== by.value) {
+      entry.invokedBy = invokedBy;
+    }
     this.props.statusLog.push(entry);
   }
 
@@ -235,7 +252,7 @@ export class Request {
       reason: this.props.reason,
       state: this.props.state,
       created_at: this.props.createdAt,
-      status_log: this.props.statusLog,
+      status_log: this.props.statusLog.map((e) => statusLogEntryToJSON(e)),
       reviews: this.props.reviews.map((r) => r.toJSON()),
     };
     if (this.props.executor) out['executor'] = this.props.executor.value;
@@ -255,6 +272,21 @@ export class Request {
     }
     return out;
   }
+}
+
+// Serialize a status_log entry with the wire-level field names
+// (snake_case). The camelCase `invokedBy` lives in memory only so
+// consumers reading YAML / JSON see `invoked_by` consistently with
+// `read_by` on inbox entries.
+function statusLogEntryToJSON(e: StatusLogEntry): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    state: e.state,
+    by: e.by,
+    at: e.at,
+  };
+  if (e.note !== undefined) out['note'] = e.note;
+  if (e.invokedBy !== undefined) out['invoked_by'] = e.invokedBy;
+  return out;
 }
 
 /**

--- a/src/domain/request/Review.ts
+++ b/src/domain/request/Review.ts
@@ -11,6 +11,8 @@ export interface ReviewProps {
   verdict: Verdict;
   comment: string;
   at: string;
+  /** See StatusLogEntry.invokedBy — same semantics here. */
+  invokedBy?: string;
 }
 
 export class Review {
@@ -22,6 +24,7 @@ export class Review {
     verdict: string;
     comment: string;
     at?: string;
+    invokedBy?: string;
     allowedLenses?: readonly string[];
   }): Review {
     const by = MemberName.of(input.by);
@@ -29,7 +32,11 @@ export class Review {
     const verdict = parseVerdict(input.verdict);
     const comment = sanitizeComment(input.comment);
     const at = input.at ?? new Date().toISOString();
-    return new Review({ by, lense, verdict, comment, at });
+    const props: ReviewProps = { by, lense, verdict, comment, at };
+    if (input.invokedBy !== undefined && input.invokedBy !== by.value) {
+      props.invokedBy = input.invokedBy;
+    }
+    return new Review(props);
   }
 
   get by(): MemberName {
@@ -48,14 +55,22 @@ export class Review {
     return this.props.at;
   }
 
+  get invokedBy(): string | undefined {
+    return this.props.invokedBy;
+  }
+
   toJSON(): Record<string, unknown> {
-    return {
+    const out: Record<string, unknown> = {
       by: this.props.by.value,
       lense: this.props.lense,
       verdict: this.props.verdict,
       comment: this.props.comment,
       at: this.props.at,
     };
+    if (this.props.invokedBy !== undefined) {
+      out['invoked_by'] = this.props.invokedBy;
+    }
+    return out;
   }
 }
 

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -270,6 +270,8 @@ function hydrate(
           comment: String(ro['comment'] ?? ''),
         };
         if (typeof ro['at'] === 'string') rc.at = ro['at'] as string;
+        if (typeof ro['invoked_by'] === 'string')
+          rc.invokedBy = ro['invoked_by'] as string;
         // Hydrate with config lenses so custom lenses in saved data are accepted
         if (allowedLenses) rc.allowedLenses = allowedLenses;
         reviews.push(Review.create(rc));
@@ -293,6 +295,8 @@ function hydrate(
           at: String(so['at'] ?? new Date().toISOString()),
         };
         if (typeof so['note'] === 'string') entry.note = so['note'] as string;
+        if (typeof so['invoked_by'] === 'string')
+          entry.invokedBy = so['invoked_by'] as string;
         statusLog.push(entry);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -48,6 +48,32 @@ export async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf8');
 }
 
+/**
+ * Return the value of GUILD_ACTOR when it differs from `by`, and also
+ * print a one-line delegation notice to stderr. Returns undefined
+ * when the two match (the common self-invocation case) — callers
+ * should pass that straight through to the use case, which in turn
+ * only stamps `invoked_by` on the status_log entry when it's set.
+ *
+ * Mirrors the inbox `read_by` pattern: `by` is who the act is
+ * attributed to, GUILD_ACTOR is who actually ran the CLI command,
+ * and the trail keeps both honest when they disagree.
+ */
+export function resolveInvokedBy(
+  by: string,
+  verb: string,
+  id: string,
+): string | undefined {
+  const envActor = process.env['GUILD_ACTOR'];
+  if (!envActor || envActor.length === 0) return undefined;
+  if (envActor === by) return undefined;
+  process.stderr.write(
+    `# ${verb} ${id}: invoked by ${envActor} on behalf of ${by} ` +
+      `(invoked_by recorded as ${envActor})\n`,
+  );
+  return envActor;
+}
+
 // --- Editor fallback for long-form review comments ---------------------
 //
 // When `gate review` is called without --comment / positional / STDIN

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -5,7 +5,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta } from '../voices.js';
-import { C, readStdin } from './internal.js';
+import { C, readStdin, resolveInvokedBy } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
@@ -170,8 +170,11 @@ function formatRequestText(r: Request): string {
       const at = String(entry['at']);
       const note = entry['note'] ? ` — ${entry['note']}` : '';
       const delta = prevAt ? ` (${formatDelta(prevAt, at)})` : '';
+      const invokedBy = entry['invoked_by']
+        ? ` [invoked_by=${entry['invoked_by']}]`
+        : '';
       lines.push(
-        `    ${at}  ${entry['state']}  by ${entry['by']}${delta}${note}`,
+        `    ${at}  ${entry['state']}  by ${entry['by']}${invokedBy}${delta}${note}`,
       );
       prevAt = at;
     }
@@ -189,8 +192,11 @@ function formatRequestText(r: Request): string {
     for (const rv of reviews as Array<Record<string, unknown>>) {
       const at = String(rv['at']);
       const delta = prevAt ? ` (${formatDelta(prevAt, at)})` : '';
+      const invokedBy = rv['invoked_by']
+        ? ` [invoked_by=${rv['invoked_by']}]`
+        : '';
       lines.push(
-        `    [${rv['lense']}/${rv['verdict']}] by ${rv['by']} at ${at}${delta}`,
+        `    [${rv['lense']}/${rv['verdict']}] by ${rv['by']}${invokedBy} at ${at}${delta}`,
       );
       const comment = String(rv['comment'] ?? '');
       for (const line of comment.split('\n')) {
@@ -207,7 +213,8 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   if (!id) throw new Error('Usage: gate approve <id> --by <m>');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
-  const r = await c.requestUC.approve(id, by, note);
+  const invokedBy = resolveInvokedBy(by, 'approve', id);
+  const r = await c.requestUC.approve(id, by, note, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ approved: ${id}`, c.config);
   return 0;
 }
@@ -221,7 +228,8 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
-  const r = await c.requestUC.deny(id, by, reason);
+  const invokedBy = resolveInvokedBy(by, 'deny', id);
+  const r = await c.requestUC.deny(id, by, reason, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ denied: ${id}`, c.config);
   return 0;
 }
@@ -231,7 +239,8 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   if (!id) throw new Error('Usage: gate execute <id> --by <m>');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
-  const r = await c.requestUC.execute(id, by, note);
+  const invokedBy = resolveInvokedBy(by, 'execute', id);
+  const r = await c.requestUC.execute(id, by, note, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ executing: ${id}`, c.config);
   return 0;
 }
@@ -241,7 +250,8 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   if (!id) throw new Error('Usage: gate complete <id> --by <m>');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
-  const r = await c.requestUC.complete(id, by, note);
+  const invokedBy = resolveInvokedBy(by, 'complete', id);
+  const r = await c.requestUC.complete(id, by, note, invokedBy);
   const extraLines: string[] = [];
   if (r.autoReview) {
     const reviewer = r.autoReview.value;
@@ -264,7 +274,8 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
-  const r = await c.requestUC.fail(id, by, reason);
+  const invokedBy = resolveInvokedBy(by, 'fail', id);
+  const r = await c.requestUC.fail(id, by, reason, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ failed: ${id}`, c.config);
   return 0;
 }
@@ -321,9 +332,21 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
   const created = await c.requestUC.create(createInput);
   const id = created.id.value;
 
-  await c.requestUC.approve(id, from, 'fast-track: self-approved');
-  await c.requestUC.execute(id, executor, 'fast-track: self-executed');
-  const completed = await c.requestUC.complete(id, executor, note);
+  // Fast-track is one user-facing command even though it executes
+  // three transitions. Resolve the invoker once (which also prints
+  // the delegation notice exactly once) and pass it to each step.
+  const invokedByFrom = resolveInvokedBy(from, 'fast-track', id);
+  // `executor` may legitimately differ from `from`; when it does we
+  // don't emit a second notice here — the env actor vs executor
+  // mismatch is the same delegation already surfaced above.
+  const envActor = process.env['GUILD_ACTOR'];
+  const invokedByExec =
+    envActor && envActor.length > 0 && envActor !== executor
+      ? envActor
+      : undefined;
+  await c.requestUC.approve(id, from, 'fast-track: self-approved', invokedByFrom);
+  await c.requestUC.execute(id, executor, 'fast-track: self-executed', invokedByExec);
+  const completed = await c.requestUC.complete(id, executor, note, invokedByExec);
 
   const extraLines: string[] = [];
   if (completed.autoReview) {

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -3,7 +3,7 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C, readStdin, readCommentViaEditor } from './internal.js';
+import { C, readStdin, readCommentViaEditor, resolveInvokedBy } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
@@ -47,7 +47,15 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     );
   }
 
-  const updated = await c.requestUC.review({ id, by, lense, verdict, comment });
+  const invokedBy = resolveInvokedBy(by, 'review', id);
+  const updated = await c.requestUC.review({
+    id,
+    by,
+    lense,
+    verdict,
+    comment,
+    ...(invokedBy !== undefined ? { invokedBy } : {}),
+  });
   // Self-review warning. The tool permits `--by` to equal the
   // request author (the YAML is just an append-only record and
   // doesn't know intent), but the Two-Persona Devil frame is

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -104,6 +104,14 @@ Environment:
                        (export it in your shell profile or direnv).
                        Automations should continue to pass --from / --by
                        explicitly.
+                       When GUILD_ACTOR differs from the explicit --by
+                       (e.g. an AI agent acting for a human), write
+                       verbs record invoked_by=<GUILD_ACTOR> on the
+                       status_log entry (or review) and print a
+                       one-line delegation notice to stderr. The on-
+                       record actor (--by) still wins for attribution;
+                       invoked_by preserves the delegation for audits.
+                       Same pattern as inbox read_by.
 
 Diagnostic / Repair:
   gate doctor [--summary | --format json]

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -305,3 +305,79 @@ test('Request.toJSON: closure-note derivation is single-sourced from status_log'
   });
   assert.equal(r.toJSON()['completion_note'], 'log-wins');
 });
+
+// ── invoked_by: agent proxy vs on-record actor ──
+
+test('Request.approve stamps invoked_by when it differs from by', () => {
+  const r = mkReq();
+  r.approve(MemberName.of('alice'), 'ok', 'claude');
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  const last = log[log.length - 1]!;
+  assert.equal(last['by'], 'alice');
+  assert.equal(last['invoked_by'], 'claude');
+});
+
+test('Request.approve omits invoked_by when it equals by (no clutter)', () => {
+  const r = mkReq();
+  r.approve(MemberName.of('alice'), 'ok', 'alice');
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  const last = log[log.length - 1]!;
+  assert.equal(last['by'], 'alice');
+  assert.equal('invoked_by' in last, false);
+});
+
+test('Request.approve without invokedBy emits no invoked_by key', () => {
+  const r = mkReq();
+  r.approve(MemberName.of('alice'), 'ok');
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  const last = log[log.length - 1]!;
+  assert.equal('invoked_by' in last, false);
+});
+
+test('Review.create stamps invoked_by when it differs from by', () => {
+  const review = Review.create({
+    by: 'alice',
+    lense: 'devil',
+    verdict: 'ok',
+    comment: 'looks fine',
+    invokedBy: 'claude',
+  });
+  const j = review.toJSON();
+  assert.equal(j['by'], 'alice');
+  assert.equal(j['invoked_by'], 'claude');
+});
+
+test('Review.create omits invoked_by when it equals by', () => {
+  const review = Review.create({
+    by: 'alice',
+    lense: 'devil',
+    verdict: 'ok',
+    comment: 'looks fine',
+    invokedBy: 'alice',
+  });
+  const j = review.toJSON();
+  assert.equal('invoked_by' in j, false);
+});
+
+test('Request restore preserves invoked_by round-trip', () => {
+  const r = Request.restore({
+    id: RequestId.generate(d, 1),
+    from: MemberName.of('alice'),
+    action: 'a',
+    reason: 'r',
+    state: 'approved',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    statusLog: [
+      { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+      {
+        state: 'approved',
+        by: 'alice',
+        at: '2026-04-14T00:00:01.000Z',
+        invokedBy: 'claude',
+      },
+    ],
+    reviews: [],
+  });
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal(log[1]!['invoked_by'], 'claude');
+});


### PR DESCRIPTION
## Summary

Closes the last outstanding friction from #38's field-test feedback — point 5:

> 5. AI代理書き込みパターンがスキーマで表現できない。今回みたいに「人間が打鍵できず AI が代理approve」のケース、noteに書くしかない

`invoked_by` mirrors inbox `read_by`. When `GUILD_ACTOR` differs from the explicit `--by` (an AI agent acting on a human's behalf), write verbs stamp the actual invoker on the status_log entry or review, and surface a one-line delegation notice to stderr:

```
$ GUILD_ACTOR=claude gate approve 2026-04-18-0001 --by eris --note "eris asked"
# approve 2026-04-18-0001: invoked by claude on behalf of eris (invoked_by recorded as claude)
✓ approved: 2026-04-18-0001

$ gate show 2026-04-18-0001 --format text
  …
    2026-04-18T00:55:12.693Z  approved  by eris [invoked_by=claude] (+0s) — eris asked
```

On-record attribution (`by`) is unchanged. `invoked_by` is additive and only stamped when the two genuinely differ — self-invocation (the common case) stays byte-identical in YAML.

**Scope**: `approve` / `deny` / `execute` / `complete` / `fail` / `review` / `fast-track`. Fast-track resolves the invoker once and passes it to all three internal transitions so the stderr notice doesn't repeat.

**Invariant**: `invoked_by` is for disagreement only. Both `Request.transition` and `Review.create` drop the field when it equals `by`, so a hand-edited YAML with `invoked_by: <same-as-by>` will shed the redundancy on the next save.

**Layering**
- Domain: `StatusLogEntry.invokedBy?`, `ReviewProps.invokedBy?`, snake_case projection in `toJSON`
- Persistence: `YamlRequestRepository` hydrates `invoked_by` on restore, for both log entries and reviews
- Interface: `resolveInvokedBy()` in `handlers/internal.ts` encapsulates env-lookup + stderr notice, shared by all 6 write handlers

## Test plan

- [x] `npm test` — 330 passing (+6 new: `Request.approve` invoked_by ×3, `Review.create` invoked_by ×2, restore round-trip ×1)
- [x] `npx tsc --noEmit` clean
- [x] End-to-end sandbox:
  - `GUILD_ACTOR=claude gate approve --by eris` → stderr notice + `invoked_by: claude` in YAML
  - `GUILD_ACTOR=eris gate execute --by eris` → no notice, no `invoked_by` (self-invoke suppressed)
  - `gate complete --by eris` (no env) → no notice, no `invoked_by`
  - Review path: same behavior, renders `[invoked_by=<actor>]` in show text
- [ ] Manual follow-up: chain / voices output so `invoked_by` surfaces there too

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu