### PR TITLE
fix(parser): support POSIX `--` separator + clearer error on dashed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **Values beginning with `--` can now be passed to every flag.** The
+  arg parser refuses to consume a next-token that starts with `--`
+  (it can't tell a literal from a genuine next flag without per-flag
+  metadata), which made notes like `gate issues note <id> --by eris
+  --text "--reason - 実装済"` silently drop the value. Same shape
+  affected every STDIN-accepting verb (`gate request --reason`,
+  `gate deny --reason`, `gate fail --reason`, `gate review --comment`,
+  `gate issues note --text`) whenever the literal itself started
+  with `--`. The fix is twofold:
+  - **POSIX `--` end-of-options separator.** After a bare `--`, every
+    remaining token becomes positional, even if it starts with `--`:
+    `gate issues note <id> --by eris -- "--reason - foo"`.
+  - **Clearer errors.** When a value-expecting flag lands as boolean
+    (the surface symptom of this ambiguity), the error now names the
+    two escape valves — `--key=<value>` and `-- <value>` — so the
+    user isn't left staring at "text is required" after they did
+    pass text.
+
+  `--key=<value>` always worked and is pinned with a regression test.
+  `gate --help` gains a short "Values beginning with `--`" section.
+
 ### Added
 - **`invoked_by` on status_log and reviews.** When `GUILD_ACTOR`
   differs from the explicit `--by` (an AI agent acting on a

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -144,9 +144,19 @@ async function issuesNote(c: C, args: ParsedArgs): Promise<number> {
     text = positional;
   }
   if (!text.trim()) {
+    // If args.options.text landed as boolean, the user did pass --text
+    // but with a value that began with "--" and the parser refused it.
+    // Point at the POSIX escape valves explicitly — the stock error
+    // wouldn't explain why the value they typed vanished.
+    const hint =
+      args.options['text'] === true
+        ? '\n  (Your --text value began with "--" and was not consumed. ' +
+          'Use --text=<value> or put "-- <value>" after the other flags.)'
+        : '';
     throw new Error(
       'note text is required (use --text <s>, --text - for STDIN, ' +
-        'or pass as positional argument)',
+        'or pass as positional argument)' +
+        hint,
     );
   }
   const { note } = await c.issueUC.addNote({ id, by, text });

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -224,7 +224,8 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const reason = await resolveReason(args, 'deny');
   if (!id || !reason) {
     throw new Error(
-      'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]',
+      'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]' +
+        dashedValueHint(args, ['reason', 'note']),
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
@@ -270,7 +271,8 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const reason = await resolveReason(args, 'fail');
   if (!id || !reason) {
     throw new Error(
-      'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]',
+      'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]' +
+        dashedValueHint(args, ['reason', 'note']),
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
@@ -278,6 +280,22 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const r = await c.requestUC.fail(id, by, reason, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ failed: ${id}`, c.config);
   return 0;
+}
+
+// Append a short hint to usage errors when one of the string-valued
+// flags landed as boolean (meaning the user passed a value that began
+// with "--" and the parser refused to consume it). Parallels the same
+// hint added inline in requireOption. Returns an empty string when no
+// flag is in that state, so the usage message stays clean in the
+// common forgot-the-arg case.
+function dashedValueHint(args: ParsedArgs, keys: readonly string[]): string {
+  const tripped = keys.filter((k) => args.options[k] === true);
+  if (tripped.length === 0) return '';
+  const pairs = tripped.map((k) => `--${k}=<value>`).join(' / ');
+  return (
+    `\n  (Your ${tripped.map((k) => '--' + k).join(' / ')} value began with "--" ` +
+    `and was not consumed. Use ${pairs} or put "-- <value>" after the other flags.)`
+  );
 }
 
 /**

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -41,9 +41,15 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     comment = '';
   }
   if (!comment.trim()) {
+    const hint =
+      args.options['comment'] === true
+        ? '\n  (Your --comment value began with "--" and was not consumed. ' +
+          'Use --comment=<value> or put "-- <value>" after the other flags.)'
+        : '';
     throw new Error(
       'review comment is required (use --comment <s>, --comment - for STDIN, ' +
-        'a positional argument, or run interactively so $EDITOR opens)',
+        'a positional argument, or run interactively so $EDITOR opens)' +
+        hint,
     );
   }
 

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -97,6 +97,15 @@ States: pending | approved | executing | completed | failed | denied
 Verdicts: ok | concern | reject
 Lenses: devil | layer | cognitive | user (configurable via guild.config.yaml)
 
+Values beginning with "--":
+  Bare \`--key <value>\` will not consume a value that itself starts
+  with "--" (the parser can't tell it from the next flag). Use either
+  form below to pass such literals:
+    --key=<value>                            # inline, any content
+    ... -- <value> [<value>...]              # POSIX end-of-options marker
+  Example:
+    gate issues note <id> --by eris -- "the --reason - sentinel is cool"
+
 Environment:
   GUILD_ACTOR=<name>   If set, used as the default for --from / --by /
                        --for when those flags are omitted. Explicit flags

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -2,8 +2,18 @@
  * Minimal arg parser. Supports:
  *   --flag            → { flag: true }
  *   --key value       → { key: 'value' }
- *   --key=value       → { key: 'value' }
+ *   --key=value       → { key: 'value' }   (value may begin with "--")
+ *   --                → POSIX end-of-options separator; every
+ *                       subsequent token is positional, even if it
+ *                       begins with "--". Use to pass values like
+ *                       `gate issues note <id> --by eris -- "--reason"`.
  *   positional tokens → args[]
+ *
+ * The `--` separator is the escape valve for the one-token-per-value
+ * ambiguity: without it, `--key` followed by `--looks-like-a-flag`
+ * stays boolean-true because the parser can't tell a value-that-
+ * happens-to-start-with-dashes apart from a genuine next flag. This
+ * is the standard POSIX resolution to that ambiguity.
  */
 export interface ParsedArgs {
   readonly options: Readonly<Record<string, string | boolean>>;
@@ -13,8 +23,19 @@ export interface ParsedArgs {
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const options: Record<string, string | boolean> = {};
   const positional: string[] = [];
+  let sawDoubleDash = false;
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i] as string;
+    // Once we've seen `--`, every remaining token is positional — even
+    // if it begins with dashes. The separator itself is consumed.
+    if (sawDoubleDash) {
+      positional.push(token);
+      continue;
+    }
+    if (token === '--') {
+      sawDoubleDash = true;
+      continue;
+    }
     if (token.startsWith('--')) {
       const eq = token.indexOf('=');
       if (eq >= 0) {
@@ -48,6 +69,17 @@ export function requireOption(
   if (envFallback) {
     const envVal = process.env[envFallback];
     if (envVal && envVal.length > 0) return envVal;
+  }
+  // When the flag is present but landed as boolean, the user almost
+  // certainly passed a value beginning with `--` (quoting another
+  // flag name in a literal). The default parser refuses to consume
+  // such tokens, so point at the two escape valves explicitly.
+  if (v === true) {
+    throw new Error(
+      `Missing --${key} value. ${usage}\n` +
+        `  (If your value begins with "--", use --${key}=<value> ` +
+        `or place "-- <value>" after the other flags.)`,
+    );
   }
   throw new Error(`Missing --${key}. ${usage}`);
 }

--- a/tests/interface/parseArgs.test.ts
+++ b/tests/interface/parseArgs.test.ts
@@ -89,3 +89,69 @@ test('optionalOption: explicit value wins over env', () => {
     else process.env['GUILD_ACTOR'] = prev;
   }
 });
+
+// ── POSIX `--` end-of-options separator ──
+//
+// Regression: bare `--text "--reason - foo"` stayed boolean because
+// the parser refuses to consume values that start with `--`. The
+// escape valves are `--text=<value>` (already worked) and `--`
+// (added here). Both need to deliver the same value unchanged.
+
+test('parseArgs: -- separator makes subsequent tokens positional even if they start with --', () => {
+  const args = parseArgs(['note', 'i-0001', '--by', 'eris', '--', '--reason', '-', '実装済']);
+  assert.deepEqual(args.options, { by: 'eris' });
+  assert.deepEqual(args.positional, ['note', 'i-0001', '--reason', '-', '実装済']);
+});
+
+test('parseArgs: -- separator consumes itself (not kept as a positional)', () => {
+  const args = parseArgs(['foo', '--', 'bar']);
+  assert.deepEqual(args.positional, ['foo', 'bar']);
+});
+
+test('parseArgs: -- separator with no following tokens is a no-op', () => {
+  const args = parseArgs(['foo', '--']);
+  assert.deepEqual(args.positional, ['foo']);
+  assert.deepEqual(args.options, {});
+});
+
+test('parseArgs: --key=value still accepts values starting with --', () => {
+  // This form already worked pre-fix (the = branch bypasses the
+  // startsWith check). Pinned to prevent regression.
+  const args = parseArgs(['--text=--reason - foo']);
+  assert.equal(args.options['text'], '--reason - foo');
+});
+
+test('parseArgs: bare --key followed by --value still lands as boolean (ambiguous)', () => {
+  // This is the documented ambiguity the separator resolves — the
+  // parser has no per-flag schema so it cannot tell `--value` apart
+  // from a legitimate next flag. `--key true` is the only safe call.
+  const args = parseArgs(['--text', '--reason']);
+  assert.equal(args.options['text'], true);
+  assert.equal(args.options['reason'], true);
+});
+
+test('requireOption: boolean-landing emits a hint pointing at the escape valves', () => {
+  const args = parseArgs(['--reason', '--another-flag']);
+  assert.throws(
+    () => requireOption(args, 'reason', 'usage'),
+    (e: unknown) => {
+      assert.ok(e instanceof Error);
+      assert.match(e.message, /Missing --reason value/);
+      assert.match(e.message, /--reason=<value>/);
+      assert.match(e.message, /"-- <value>"/);
+      return true;
+    },
+  );
+});
+
+test('requireOption: plain missing flag does NOT emit the -- hint (stays terse)', () => {
+  const args = parseArgs([]);
+  try {
+    requireOption(args, 'reason', 'usage');
+    assert.fail('expected throw');
+  } catch (e) {
+    assert.ok(e instanceof Error);
+    assert.match(e.message, /Missing --reason\./);
+    assert.equal(/begin/.test(e.message), false);
+  }
+});


### PR DESCRIPTION
## Summary

Addresses the bug report: **`gate issues note --text` (and every other string-valued flag) silently drops values that begin with `--`**.

**Root cause**: `parseArgs.ts` refuses to consume a next-token value that starts with `--` because it cannot tell a literal value apart from a genuine next flag (no per-flag schema). The value is lost before any verb-specific logic runs. The reporter's proposed fix (tighten STDIN sentinel to strict `-`) wouldn't help — the STDIN check is already strict; it just never gets reached.

**Fix**:

1. **POSIX `--` end-of-options separator.** After a bare `--`, every remaining token is positional regardless of leading dashes:
   ```
   gate issues note <id> --by eris -- "--reason - 実装済"
   ```

2. **Clearer error message.** When a value-expecting flag lands as boolean (the surface symptom), `requireOption` and the usage errors on `deny`/`fail`/`issues note`/`review` now name both escape valves — `--key=<value>` and `-- <value>`. Users who hit this wall learn the way out from the error itself:
   ```
   error: Missing --reason value. --reason required
     (If your value begins with "--", use --reason=<value> or place "-- <value>" after the other flags.)
   ```

3. **`--key=<value>` always worked** (the `=` branch bypasses the `startsWith` check). Pinned with a regression test.

4. **`gate --help`** gains a short "Values beginning with `--`" block documenting both escape forms.

**Why this matters**: the tool exists to record CLI deliberations, so literals that mention CLI syntax (`"the --reason - sentinel fires when..."`) are a first-class use case. The reporter hit this while logging that the `--reason -` feature from #38 worked — the note *about the feature* failed because it contained the feature's name. That's the specific failure mode this PR removes.

## Test plan

- [x] `npm test` — 331 passing (+7: POSIX `--` separator semantics ×3, regression pins for `--key=value` and bare-flag ambiguity ×2, requireOption dashed-value hint + non-regression ×2)
- [x] End-to-end sandbox reproducing the reporter's exact command:
  - Before: `gate issues note <id> --by eris --text "--reason - 実装済"` → silently drops value
  - After: same command → explanatory error pointing at `--key=` and `--` escapes
  - Escape 1: `--text="--reason - 実装済"` → note lands with literal text ✓
  - Escape 2: `-- "--reason - 実装済"` → note lands with literal text ✓
- [x] Same three escapes verified for `gate request --reason`, `gate deny --reason`, `gate review --comment`
- [x] `npx tsc --noEmit` clean

Reported in the dogfood-session issue log for #38.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu