### PR TITLE
polish: invoked_by on voices/tail/resume + tighter list hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Changed
+- **`invoked_by` surfaces in `gate voices`, `gate tail`, and `gate resume`.**
+  Previously `gate show <id>` was the only read path that rendered
+  `invoked_by`, so an AI agent that ghost-wrote ten operations on a
+  member's behalf was invisible in the streams where people actually
+  read their activity. voices and tail now append `[invoked_by=<actor>]`
+  to review lines when the proxy differs from `by`; resume's
+  `last_transition` JSON emits `invoked_by` (snake_case, matching
+  `status_log` on the wire) and the restoration prose names the
+  proxy ("invoked by claude" / "claude が代行"). Same-actor
+  invocations stay unchanged — no clutter for the common case.
+- **`gate list` without `--state` prints a tighter hint.** The prior
+  version listed the state enum twice (once inline, once on a
+  "States:" line); collapsed to one listing, and trimmed the
+  "For X, use" phrasing so the hint is 3 lines instead of 5.
+
 ### Fixed
 - **Values beginning with `--` can now be passed to every flag.** The
   arg parser refuses to consume a next-token that starts with `--`

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -45,13 +45,27 @@ interface OpenLoop {
   readonly since: string;
 }
 
+// Wire-format projection of StatusLogEntry for JSON emission. The
+// in-memory field is `invokedBy` (camelCase); every YAML / JSON
+// surface uses `invoked_by` (snake_case). Request.toJSON already
+// does this conversion for status_log; resume has its own payload
+// shape and needs the same flattening.
+interface TransitionJSON {
+  state: string;
+  by: string;
+  at: string;
+  note?: string;
+  invoked_by?: string;
+  request_id: string;
+}
+
 interface ResumePayload {
   actor: string;
   session_hint: string | null;
   last_context: {
     summary: string;
     last_utterance: Utterance | null;
-    last_transition: (StatusLogEntry & { request_id: string }) | null;
+    last_transition: TransitionJSON | null;
     open_loops: OpenLoop[];
   };
   // Deliberately a sibling of `last_context`, not merged into
@@ -170,7 +184,8 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     last_context: {
       summary,
       last_utterance: lastUtterance,
-      last_transition: lastTransition,
+      last_transition:
+        lastTransition === null ? null : transitionToJSON(lastTransition),
       open_loops: openLoops,
     },
     unresponded_concerns: unrespondedConcerns,
@@ -184,6 +199,20 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(restorationProse + '\n');
   }
   return 0;
+}
+
+function transitionToJSON(
+  entry: StatusLogEntry & { request_id: string },
+): TransitionJSON {
+  const out: TransitionJSON = {
+    state: entry.state,
+    by: entry.by,
+    at: entry.at,
+    request_id: entry.request_id,
+  };
+  if (entry.note !== undefined) out.note = entry.note;
+  if (entry.invokedBy !== undefined) out.invoked_by = entry.invokedBy;
+  return out;
 }
 
 function findLastTransition(
@@ -360,9 +389,12 @@ function composeRestorationProseEn(ctx: {
     (!lastUtterance || lastTransition.at !== lastUtterance.at)
   ) {
     const age = ageHint(lastTransition.at, new Date().toISOString());
+    const proxy = lastTransition.invokedBy
+      ? ` (invoked by ${lastTransition.invokedBy})`
+      : '';
     lines.push('');
     lines.push(
-      `Your last lifecycle step (transition, ${age}): req=${lastTransition.request_id} → ${lastTransition.state}${lastTransition.note ? ` — ${truncate(lastTransition.note, 180)}` : ''}`,
+      `Your last lifecycle step (transition, ${age}): req=${lastTransition.request_id} → ${lastTransition.state}${proxy}${lastTransition.note ? ` — ${truncate(lastTransition.note, 180)}` : ''}`,
     );
   }
 
@@ -472,9 +504,12 @@ function composeRestorationProseJa(ctx: {
     (!lastUtterance || lastTransition.at !== lastUtterance.at)
   ) {
     const age = ageHint(lastTransition.at, new Date().toISOString());
+    const proxy = lastTransition.invokedBy
+      ? `（${lastTransition.invokedBy} が代行）`
+      : '';
     lines.push('');
     lines.push(
-      `直近の所作 (transition, ${age}): req=${lastTransition.request_id} → ${lastTransition.state}${lastTransition.note ? ` — ${truncate(lastTransition.note, 180)}` : ''}`,
+      `直近の所作 (transition, ${age}): req=${lastTransition.request_id} → ${lastTransition.state}${proxy}${lastTransition.note ? ` — ${truncate(lastTransition.note, 180)}` : ''}`,
     );
   }
 

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -186,12 +186,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         // first-time users actually have is "which verb do I want?"
         const state = optionalOption(args, 'state');
         if (state === undefined) {
-          const states = REQUEST_STATES.join('|');
           process.stderr.write(
-            `gate list needs --state <s> (${states}).\n` +
-              '  For just counts across every state, use:  gate status\n' +
-              '  For the contents of one state,     use:  gate list --state <s>\n' +
-              `  States: ${REQUEST_STATES.join(' | ')}\n`,
+            `gate list needs --state <s> (${REQUEST_STATES.join(' | ')}).\n` +
+              '  For counts across every state:  gate status\n' +
+              '  For the contents of one state:  gate list --state <s>\n',
           );
           return 1;
         }

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -35,6 +35,11 @@ export type ReviewJSON = {
   readonly verdict: string;
   readonly comment: string;
   readonly at: string;
+  // Actual invoker when different from `by`. Persisted by Review.toJSON
+  // in snake_case; voices surfaces it so a reviewer who ghost-wrote
+  // through an AI agent is visible in tail / whoami / voices instead
+  // of only in `gate show <id>`.
+  readonly invoked_by?: string;
 };
 
 export type AuthoredUtterance = {
@@ -65,6 +70,9 @@ export type ReviewUtterance = {
   readonly requestId: string;
   // Who wrote the review. Same rationale as AuthoredUtterance.from.
   readonly by: string;
+  // Actual CLI invoker when different from `by` (typically an AI
+  // agent acting on the member's behalf). Undefined when they agree.
+  readonly invokedBy?: string;
   // The action of the containing request, so the reader has context
   // for what the review was *about* without chasing the id.
   readonly action: string;
@@ -148,7 +156,7 @@ export function collectUtterances(
       if (filter.verdict !== undefined && rv.verdict !== filter.verdict) {
         continue;
       }
-      out.push({
+      const reviewUtterance: ReviewUtterance = {
         kind: 'review',
         at: rv.at,
         requestId: r.id,
@@ -157,7 +165,11 @@ export function collectUtterances(
         lense: rv.lense,
         verdict: rv.verdict,
         comment: rv.comment,
-      });
+      };
+      if (rv.invoked_by !== undefined) {
+        (reviewUtterance as { invokedBy?: string }).invokedBy = rv.invoked_by;
+      }
+      out.push(reviewUtterance);
     }
   }
 
@@ -230,9 +242,14 @@ export function renderUtterance(
     if (u.denyReason) lines.push(`  denied: ${u.denyReason}`);
     if (u.failureReason) lines.push(`  failed: ${u.failureReason}`);
   } else {
+    // Always expose `invoked_by` when present, even when includeActor
+    // is false (voices groups by actor, so the `by` is redundant —
+    // but the proxy-invoker isn't). Keeps the stream honest about
+    // who actually ran the command vs who the act is attributed to.
     const actor = includeActor ? ` by ${u.by}` : '';
+    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
     lines.push(
-      `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]${actor}`,
+      `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]${actor}${proxy}`,
     );
     lines.push(`  re: ${u.action}`);
     for (const line of u.comment.split('\n')) {

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -287,3 +287,112 @@ test('renderUtterance: authored text includes closure labels when present', () =
   const text = renderUtterance(authored, false);
   assert.match(text, /denied: scope creep/);
 });
+
+
+// ── invoked_by on review utterances ──
+//
+// When a review was recorded by GUILD_ACTOR acting on another
+// member's behalf, Review.toJSON stamps `invoked_by` on the wire.
+// voices must carry that through so tail / whoami / voices readers
+// see the proxy, not just `show <id>`.
+
+test('collectUtterances: review invoked_by flows onto the utterance', () => {
+  const proxied: RequestJSON[] = [
+    {
+      id: '2026-04-18-0001',
+      from: 'eris',
+      action: 'do thing',
+      reason: 'because',
+      created_at: '2026-04-18T00:00:00.000Z',
+      reviews: [
+        {
+          by: 'sentinel',
+          lense: 'devil',
+          verdict: 'ok',
+          comment: 'looks fine',
+          at: '2026-04-18T01:00:00.000Z',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(proxied, { name: 'sentinel' });
+  assert.ok(u);
+  assert.equal(u.kind, 'review');
+  if (u.kind === 'review') {
+    assert.equal(u.invokedBy, 'claude');
+  }
+});
+
+test('collectUtterances: review without invoked_by leaves invokedBy undefined', () => {
+  const [u] = collectUtterances(corpus, { name: 'noir', lense: 'devil' });
+  assert.ok(u);
+  if (u.kind === 'review') {
+    assert.equal(u.invokedBy, undefined);
+  }
+});
+
+test('renderUtterance: review shows [invoked_by=<actor>] when proxied', () => {
+  const proxied: RequestJSON[] = [
+    {
+      id: '2026-04-18-0001',
+      from: 'eris',
+      action: 'do thing',
+      reason: 'because',
+      created_at: '2026-04-18T00:00:00.000Z',
+      reviews: [
+        {
+          by: 'sentinel',
+          lense: 'devil',
+          verdict: 'concern',
+          comment: 'hmm',
+          at: '2026-04-18T01:00:00.000Z',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(proxied, { name: 'sentinel' });
+  assert.ok(u);
+  const text = renderUtterance(u, true);
+  assert.match(text, /\[devil\/concern\] by sentinel \[invoked_by=claude\]/);
+});
+
+test('renderUtterance: review omits [invoked_by=...] when same-actor', () => {
+  // Pinned so we don't start emitting redundant markers on the
+  // self-invoke common case.
+  const [u] = collectUtterances(corpus, { name: 'noir', lense: 'devil' });
+  assert.ok(u);
+  const text = renderUtterance(u, true);
+  assert.equal(/invoked_by/.test(text), false);
+});
+
+test('renderUtterance: invoked_by shows even when includeActor=false (voices grouping)', () => {
+  // voices groups by actor so `by <name>` is redundant — but the
+  // proxy invoker is NOT redundant in that context. Pinned so we
+  // don't accidentally suppress it alongside the actor label.
+  const proxied: RequestJSON[] = [
+    {
+      id: '2026-04-18-0001',
+      from: 'eris',
+      action: 'do thing',
+      reason: 'because',
+      created_at: '2026-04-18T00:00:00.000Z',
+      reviews: [
+        {
+          by: 'sentinel',
+          lense: 'devil',
+          verdict: 'ok',
+          comment: 'fine',
+          at: '2026-04-18T01:00:00.000Z',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(proxied, { name: 'sentinel' });
+  assert.ok(u);
+  const text = renderUtterance(u, false);
+  assert.match(text, /\[invoked_by=claude\]/);
+  assert.equal(/by sentinel/.test(text), false);
+});


### PR DESCRIPTION
## Summary

Read-path polish on top of #39's `invoked_by` plumbing.

`gate show <id>` was the only place `invoked_by` surfaced after #39, so an AI agent that proxied ten operations on a member's behalf stayed invisible in the streams people actually use to read their activity. This PR extends rendering to the three places that matter for ambient awareness:

- **`gate voices`** — review lines append `[invoked_by=<actor>]` when the proxy differs from `by`.
- **`gate tail`** — same (shares the voices renderer).
- **`gate resume`** — `last_transition` JSON emits `invoked_by` (snake_case, matching the rest of the wire format); prose renderers in English and Japanese append `(invoked by claude)` / `（claude が代行）`.

Also trims the `gate list` no-`--state` hint — the prior version listed the state enum twice (inline + on a "States:" line). One listing now, 3 lines instead of 5.

### Before / after

```
# gate voices sentinel — before
[2026-04-18T...] req=... [devil/concern]
  re: bug X
  claude代行でsentinelが気になる

# gate voices sentinel — after
[2026-04-18T...] req=... [devil/concern] [invoked_by=claude]
  re: bug X
  claude代行でsentinelが気になる

# gate resume --format text — after
Your last lifecycle step (transition, 0s ago): req=... → executing (invoked by claude) — starting

# 日本語 (GUILD_LOCALE=ja)
直近の所作 (transition, 0s ago): req=... → executing（claude が代行）— starting
```

Same-actor invocations stay unchanged. No clutter added to the common case.

### Scope discipline

- No domain changes. No persistence changes. No new verbs.
- This is purely making the `invoked_by` I already wrote to YAML actually _visible_ in the paths users read.
- 5 new tests pin: propagation through `collectUtterances`, rendering with `[invoked_by=X]`, suppression when same-actor, and display even when `includeActor=false` (voices groups by actor, so `by <name>` is redundant — but the proxy invoker isn't).

## Test plan

- [x] `npm test` — 342 passing (+5 new)
- [x] `npx tsc --noEmit` clean
- [x] Sandbox end-to-end:
  - `GUILD_ACTOR=claude gate review ... --by sentinel` → `gate voices sentinel` renders `[invoked_by=claude]` ✓
  - `gate tail` renders same ✓
  - `gate resume --format json` → `last_transition.invoked_by: claude` ✓
  - `gate resume --format text` → "(invoked by claude)" ✓
  - Same-actor case → no `[invoked_by=...]` marker (pinned) ✓
- [x] `gate list` hint manually verified: 3 lines, single state enum listing

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu