### PR TITLE
polish: boot suggested_next + multi-line value indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate boot` emits `suggested_next` for pre-onboarding shapes.** When
+  the caller has no identity yet, boot now prescribes a concrete first
+  action instead of handing back a silent empty payload. Three branches:
+  - `GUILD_ACTOR` unset, no members on this content_root → `register`
+    (fresh root, new agent);
+  - `GUILD_ACTOR` unset, members exist → `export GUILD_ACTOR=<...>`
+    with a short list of existing member names (returning user);
+  - `GUILD_ACTOR` set but unknown to the guild → `register --name
+    <that-name>` (they already picked a handle; just file the record).
+  Registered members and hosts get `suggested_next: null` — boot has
+  no unambiguous next action for them. Text format renders a `→ next:`
+  line with the exact shell command to paste.
+
+### Changed
+- **Multi-line values in `gate show --format text` / `gate voices` /
+  `gate tail` align continuation lines with the value column.** Long
+  `--reason` heredocs used to lose their indent on the second line
+  onward, which broke the visual grouping of the field. Applied to
+  `action`, `reason`, `completion_note`, `deny_reason`, and
+  `failure_reason` via a shared `pushMultilineField` helper so all
+  three read paths stay in lockstep.
+
 ### Changed
 - **`invoked_by` surfaces in `gate voices`, `gate tail`, and `gate resume`.**
   Previously `gate show <id>` was the only read path that rendered

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -4,6 +4,19 @@ import { collectStatus, StatusSummary } from './status.js';
 import { collectUtterances } from '../voices.js';
 
 /**
+ * Next-step hint embedded in boot. Mirrors the SuggestedNext shape
+ * used by write responses (see writeFormat.ts) so orchestrators can
+ * dispatch against the same consumer. Null when boot has no
+ * prescription — e.g. the caller is already a registered member
+ * with no outstanding state.
+ */
+interface BootSuggestedNext {
+  verb: string;
+  args: Record<string, string>;
+  reason: string;
+}
+
+/**
  * gate boot [--format json|text] [--tail <N>] [--utterances <N>]
  *
  * Single-command session orientation for agents. Composes the
@@ -69,6 +82,20 @@ interface BootPayload {
       fix_hint: string | null;
     };
   };
+  /**
+   * First-step prescription for the caller. Populated when boot can
+   * infer an obvious "do this next" — typically pre-onboarding (no
+   * GUILD_ACTOR, or GUILD_ACTOR set to an unregistered name) where
+   * new agents need a signpost toward `gate register`. Null once the
+   * caller has an identity and no outstanding bootstrap work.
+   *
+   * Note: this is orientation-time guidance, distinct from the
+   * write-response `suggested_next` that follows a transition. Kept
+   * as a sibling field on the boot payload rather than merged with
+   * `hints` because it's directive (a verb to call), not diagnostic
+   * (a condition to notice).
+   */
+  suggested_next: BootSuggestedNext | null;
 }
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -185,6 +212,8 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     // Diagnostic errored — skip health, keep boot usable.
   }
 
+  const suggestedNext = deriveBootSuggestedNext(actor, role, members);
+
   const payload: BootPayload = {
     actor,
     role,
@@ -199,6 +228,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       resolved_content_root: c.config.contentRoot,
       content_root_health: contentRootHealth,
     },
+    suggested_next: suggestedNext,
   };
 
   if (format === 'json') {
@@ -207,6 +237,59 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(renderBootText(payload));
   }
   return 0;
+}
+
+/**
+ * Derive the orientation-time "do this next" hint. Fires only in the
+ * pre-onboarding shapes where a newcomer would otherwise stare at an
+ * empty payload with no signpost:
+ *
+ *   - actor=null + no members exist → suggest `register` (fresh root)
+ *   - actor=null + members exist    → suggest exporting GUILD_ACTOR
+ *                                     (returning user just forgot)
+ *   - role='unknown'                → suggest `register` with the
+ *                                     name they already set
+ *
+ * Returns null for registered members and hosts — they have no
+ * unambiguous next action from boot alone.
+ */
+function deriveBootSuggestedNext(
+  actor: string | null,
+  role: BootPayload['role'],
+  members: ReadonlyArray<{ name: { value: string } }>,
+): BootSuggestedNext | null {
+  if (actor === null) {
+    if (members.length === 0) {
+      return {
+        verb: 'register',
+        args: { name: '<your-name>' },
+        reason:
+          'No GUILD_ACTOR and no members on this content_root — register yourself to join.',
+      };
+    }
+    // Members exist; this is most likely a returning session that
+    // just hasn't exported GUILD_ACTOR yet. Name a few concrete
+    // options so the hint is actionable.
+    const sample = members.slice(0, 3).map((m) => m.name.value);
+    return {
+      verb: 'export',
+      args: { GUILD_ACTOR: '<your-name>' },
+      reason:
+        `No GUILD_ACTOR set. Existing members: ${sample.join(', ')}` +
+        (members.length > 3 ? ` (+${members.length - 3} more)` : '') +
+        `. Export GUILD_ACTOR=<your-name>, or run gate register --name <your-name> if new.`,
+    };
+  }
+  if (role === 'unknown') {
+    return {
+      verb: 'register',
+      args: { name: actor },
+      reason:
+        `GUILD_ACTOR=${actor} but "${actor}" is not a registered member or host. ` +
+        `Run gate register --name ${actor} to create the member file.`,
+    };
+  }
+  return null;
 }
 
 function renderBootText(p: BootPayload): string {
@@ -283,6 +366,23 @@ function renderBootText(p: BootPayload): string {
         lines.push(`  ${u.at}  req=${u.requestId}  authored`);
       }
     }
+  }
+  if (p.suggested_next) {
+    lines.push('');
+    // Render the hint as a concrete shell command so the reader can
+    // copy-paste. `export` is special-cased because it's a shell
+    // builtin, not a gate subcommand.
+    const n = p.suggested_next;
+    if (n.verb === 'export') {
+      const [k, v] = Object.entries(n.args)[0] ?? ['GUILD_ACTOR', '<your-name>'];
+      lines.push(`→ next: export ${k}=${v}`);
+    } else {
+      const argsStr = Object.entries(n.args)
+        .map(([k, v]) => `--${k} ${v}`)
+        .join(' ');
+      lines.push(`→ next: gate ${n.verb}${argsStr ? ' ' + argsStr : ''}`);
+    }
+    lines.push(`  (${n.reason})`);
   }
   return lines.join('\n') + '\n';
 }

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -4,7 +4,7 @@ import {
   optionalOption,
 } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
-import { formatDelta } from '../voices.js';
+import { formatDelta, pushMultilineField } from '../voices.js';
 import { C, readStdin, resolveInvokedBy } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
@@ -155,11 +155,17 @@ function formatRequestText(r: Request): string {
   }
   lines.push(`  created:  ${j['created_at']}`);
   lines.push('');
-  lines.push(`  action:   ${j['action']}`);
-  lines.push(`  reason:   ${j['reason']}`);
-  if (j['completion_note']) lines.push(`  note:     ${j['completion_note']}`);
-  if (j['deny_reason']) lines.push(`  denied:   ${j['deny_reason']}`);
-  if (j['failure_reason']) lines.push(`  failed:   ${j['failure_reason']}`);
+  pushMultilineField(lines, '  action:   ', String(j['action']));
+  pushMultilineField(lines, '  reason:   ', String(j['reason']));
+  if (j['completion_note']) {
+    pushMultilineField(lines, '  note:     ', String(j['completion_note']));
+  }
+  if (j['deny_reason']) {
+    pushMultilineField(lines, '  denied:   ', String(j['deny_reason']));
+  }
+  if (j['failure_reason']) {
+    pushMultilineField(lines, '  failed:   ', String(j['failure_reason']));
+  }
 
   const log = Array.isArray(j['status_log']) ? j['status_log'] : [];
   if (log.length > 0) {

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -186,6 +186,36 @@ export function collectUtterances(
 }
 
 /**
+ * Push a single `label: value` field where `value` may contain
+ * newlines, aligning continuation lines with the start of the
+ * value column so the output reads as one structured field rather
+ * than a field with a stray paragraph hanging off the left margin.
+ *
+ * `labelWithPadding` is the full prefix including leading indent
+ * and trailing space padding (e.g. `"  action:   "`). Continuation
+ * lines receive the same width in spaces. Single-line values are
+ * a no-op so existing single-line rendering stays byte-identical.
+ *
+ * Shared between `gate show --format text` and `gate voices` /
+ * `gate tail` renderers so multi-line reasons read the same way
+ * everywhere.
+ */
+export function pushMultilineField(
+  lines: string[],
+  labelWithPadding: string,
+  body: string,
+): void {
+  const parts = body.split('\n');
+  const head = parts[0] ?? '';
+  lines.push(labelWithPadding + head);
+  if (parts.length === 1) return;
+  const continuationIndent = ' '.repeat(labelWithPadding.length);
+  for (let i = 1; i < parts.length; i++) {
+    lines.push(continuationIndent + parts[i]);
+  }
+}
+
+/**
  * Render a chronological delta between two ISO-8601 timestamps in a
  * compact human-readable form. Returns an empty string if the inputs
  * are unparseable or if `curr` precedes `prev` (which shouldn't happen
@@ -234,13 +264,13 @@ export function renderUtterance(
     const withSuffix =
       u.with && u.with.length > 0 ? ` (with ${u.with.join(', ')})` : '';
     lines.push(`[${u.at}] req=${u.requestId} authored${actor}${withSuffix}`);
-    lines.push(`  action: ${u.action}`);
-    lines.push(`  reason: ${u.reason}`);
+    pushMultilineField(lines, '  action: ', u.action);
+    pushMultilineField(lines, '  reason: ', u.reason);
     // At most one of these is set per request (completed / denied /
     // failed are mutually exclusive terminal states).
-    if (u.completionNote) lines.push(`  note:   ${u.completionNote}`);
-    if (u.denyReason) lines.push(`  denied: ${u.denyReason}`);
-    if (u.failureReason) lines.push(`  failed: ${u.failureReason}`);
+    if (u.completionNote) pushMultilineField(lines, '  note:   ', u.completionNote);
+    if (u.denyReason) pushMultilineField(lines, '  denied: ', u.denyReason);
+    if (u.failureReason) pushMultilineField(lines, '  failed: ', u.failureReason);
   } else {
     // Always expose `invoked_by` when present, even when includeActor
     // is false (voices groups by actor, so the `by` is redundant —

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -63,6 +63,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'last_activity',
         'role',
         'status',
+        'suggested_next',
         'tail',
         'your_recent',
       ],
@@ -244,5 +245,60 @@ test('gate boot: fresh-start (config present, 0 members/requests) is NOT flagged
     assert.doesNotMatch(textOut, /no guild\.config\.yaml found/);
   } finally {
     rmSync(fresh, { recursive: true, force: true });
+  }
+});
+
+test('gate boot: suggested_next=register when no actor and no members', () => {
+  const root = mkdtempSync(join(tmpdir(), 'guild-boot-fresh-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\n');
+  mkdirSync(join(root, 'members'));
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.actor, null);
+    assert.equal(payload.suggested_next?.verb, 'register');
+    const { stdout: textOut } = runGate(root, ['boot', '--format', 'text']);
+    assert.match(textOut, /gate register --name/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('gate boot: suggested_next=export when no actor but members exist', () => {
+  // Returning-user case: members exist, but GUILD_ACTOR isn't set.
+  // The hint names existing members and the export path.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'export');
+    assert.match(payload.suggested_next?.reason ?? '', /alice/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: suggested_next=register when GUILD_ACTOR set but unregistered', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'newbie' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.role, 'unknown');
+    assert.equal(payload.suggested_next?.verb, 'register');
+    assert.equal(payload.suggested_next?.args?.name, 'newbie');
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: suggested_next=null for registered member', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.role, 'member');
+    assert.equal(payload.suggested_next, null);
+  } finally {
+    cleanup();
   }
 });

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   collectUtterances,
+  pushMultilineField,
   renderUtterance,
   RequestJSON,
 } from '../../src/interface/gate/voices.js';
@@ -395,4 +396,46 @@ test('renderUtterance: invoked_by shows even when includeActor=false (voices gro
   const text = renderUtterance(u, false);
   assert.match(text, /\[invoked_by=claude\]/);
   assert.equal(/by sentinel/.test(text), false);
+});
+
+// ── pushMultilineField: continuation indent for multi-line values ──
+
+test('pushMultilineField: single-line value is unchanged from a plain push', () => {
+  // Byte-identical when there are no newlines — ensures we don't
+  // regress the common short-value case where no indent work is needed.
+  const lines: string[] = [];
+  pushMultilineField(lines, '  reason: ', 'short text');
+  assert.deepEqual(lines, ['  reason: short text']);
+});
+
+test('pushMultilineField: multi-line value aligns continuation lines with value column', () => {
+  const lines: string[] = [];
+  pushMultilineField(lines, '  reason:   ', 'first\nsecond\nthird');
+  // '  reason:   ' is 12 chars, so continuation lines must be indented
+  // by 12 spaces so they align with the start of "first".
+  assert.deepEqual(lines, [
+    '  reason:   first',
+    '            second',
+    '            third',
+  ]);
+});
+
+test('renderUtterance authored: multi-line reason indents continuation lines', () => {
+  // Regression: pre-fix, multi-line reasons started each continuation
+  // line at column 0, breaking the visual grouping of the field.
+  const reqs: RequestJSON[] = [
+    {
+      id: '2026-04-18-0099',
+      from: 'alice',
+      action: 'ship',
+      reason: 'first paragraph\nsecond paragraph',
+      created_at: '2026-04-18T00:00:00.000Z',
+    },
+  ];
+  const [u] = collectUtterances(reqs, { name: 'alice' });
+  assert.ok(u);
+  const text = renderUtterance(u, true);
+  // The 'second paragraph' line must be indented to align with the
+  // value column, not hang off the left margin.
+  assert.match(text, /  reason: first paragraph\n          second paragraph/);
 });


### PR DESCRIPTION
## Summary

Two small polish fixes surfaced by dogfooding the session tool on itself (see i-0001 and i-0002 in the prior session transcript).

### i-0001 — `gate boot` signpost for pre-onboarding

`gate boot` without `GUILD_ACTOR` returned a dense payload with no "do this next" hint. `gate register` already emits one (`next: export GUILD_ACTOR=...`), so boot's silence was asymmetric for the same onboarding moment.

Added `suggested_next` with three branches:

```
# Cold start, no members
→ next: gate register --name <your-name>
  (No GUILD_ACTOR and no members on this content_root — register yourself to join.)

# Cold start, members exist (returning user)
→ next: export GUILD_ACTOR=<your-name>
  (No GUILD_ACTOR set. Existing members: eris, noir. Export GUILD_ACTOR=<your-name>, or run gate register --name <your-name> if new.)

# GUILD_ACTOR=newbie where newbie isn't registered
→ next: gate register --name newbie
  (GUILD_ACTOR=newbie but "newbie" is not a registered member or host. Run gate register --name newbie to create the member file.)
```

Registered members and hosts stay at `suggested_next: null` — boot has no unambiguous next action for them.

**Contract**: `suggested_next` is a new top-level key in the boot payload. The contract docstring already allows additive fields; `boot.test.ts` key-stability snapshot was updated to include it.

### i-0002 — multi-line value indent

Multi-line `--reason` values (common from heredocs) lost their indent on continuation lines in `gate show --format text`, `gate voices`, and `gate tail`:

```
# Before
  reason: first line of reason
second line indented now
third line too

# After
  reason: first line of reason
          second line indented now
          third line too
```

Added a small `pushMultilineField(lines, label, body)` helper shared between the `show` and utterance renderers. Applied to `action`, `reason`, `completion_note`, `deny_reason`, `failure_reason`.

## Test plan

- [x] `npm test` — 349 passing (+7: 4 branches of `suggested_next`, 2 for `pushMultilineField` shape, 1 utterance indent regression)
- [x] `npx tsc --noEmit` clean
- [x] Sandbox: all 4 boot branches verified (cold/members/unknown/registered); `gate show` and `gate voices` both align multi-line reasons to the value column.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu