### PR TITLE
feat(audit): extend invoked_by invariant to all proxy-eligible write verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`invoked_by` extended to every proxy-eligible write verb.** Previously
+  scoped to the five transitions + `review` + `fast-track` (#39). Dogfooding
+  surfaced the gap — `GUILD_ACTOR=X gate request --from Y` was silently
+  attributed to Y with no audit trail of X. The invariant now applies to:
+  - `gate request` — initial `pending` status_log entry stamps `invoked_by`
+  - `gate issues add` — issue-level `invoked_by` on the first-frame record
+  - `gate issues note` — per-note `invoked_by`
+  - `gate issues promote` — the created request's initial status_log entry
+  - `gate message` — per-notification envelope
+  - `gate broadcast` — every fan-out envelope
+  Each verb also emits the standard one-line stderr delegation notice.
+  Omitted from YAML when `invokedBy` equals the nominal actor, so
+  same-actor invocations stay byte-identical. `gate issues list` renders
+  `[invoked_by=<actor>]` on the issue header and on each note; `gate
+  inbox` shows it alongside the sender on every incoming message.
+
+  A shared helper pair (`deriveInvokedBy` + `emitInvokedByNotice`) lets
+  creation paths (id unknown until save) defer the stderr notice until
+  after the record is allocated. The existing `resolveInvokedBy` wrapper
+  is unchanged for same-id call sites.
 - **`gate boot` emits `suggested_next` for pre-onboarding shapes.** When
   the caller has no identity yet, boot now prescribes a concrete first
   action instead of handing back a silent empty payload. Three branches:

--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -27,6 +27,7 @@ export class IssueUseCases {
     severity: string;
     area: string;
     text: string;
+    invokedBy?: string;
   }): Promise<Issue> {
     await assertActor(input.from, '--from', this.members);
     const now = this.clock.now();
@@ -35,14 +36,18 @@ export class IssueUseCases {
       .padStart(2, '0')}-${now.getUTCDate().toString().padStart(2, '0')}`;
     let seq = await this.issues.nextSequence(key);
     for (let attempt = 0; attempt < 10; attempt++) {
-      const issue = Issue.create({
+      const createInput: Parameters<typeof Issue.create>[0] = {
         id: IssueId.generate(now, seq),
         from: input.from,
         severity: input.severity,
         area: input.area,
         text: input.text,
         createdAt: now.toISOString(),
-      });
+      };
+      if (input.invokedBy !== undefined) {
+        createInput.invokedBy = input.invokedBy;
+      }
+      const issue = Issue.create(createInput);
       try {
         await this.issues.saveNew(issue);
         return issue;
@@ -97,12 +102,18 @@ export class IssueUseCases {
     id: string;
     by: string;
     text: string;
+    invokedBy?: string;
   }): Promise<{ issue: Issue; note: IssueNote }> {
     await assertActor(input.by, '--by', this.members);
     const issueId = IssueId.of(input.id);
     const issue = await this.issues.findById(issueId);
     if (!issue) throw new DomainError(`Issue not found: ${input.id}`, 'id');
-    const note = issue.addNote(input.by, input.text, this.clock.now().toISOString());
+    const note = issue.addNote(
+      input.by,
+      input.text,
+      this.clock.now().toISOString(),
+      input.invokedBy,
+    );
     await this.issues.save(issue);
     return { issue, note };
   }

--- a/src/application/message/MessageUseCases.ts
+++ b/src/application/message/MessageUseCases.ts
@@ -37,6 +37,7 @@ export class MessageUseCases {
     text: string;
     type?: string;
     related?: string;
+    invokedBy?: string;
   }): Promise<void> {
     const from = await assertActor(input.from, '--from', this.deps.members);
     // --to must be a real registered member — we can't deliver to a host
@@ -73,12 +74,17 @@ export class MessageUseCases {
       );
     }
     const text = sanitizeMessageText(input.text);
+    const invokedBy =
+      input.invokedBy !== undefined && input.invokedBy !== from.value
+        ? input.invokedBy
+        : undefined;
     await this.deps.notifier.post({
       from: from.value,
       to: toMember.name,
       type: input.type ?? 'message',
       text,
       ...(input.related !== undefined ? { related: input.related } : {}),
+      ...(invokedBy !== undefined ? { invokedBy } : {}),
       at: this.deps.clock.now().toISOString(),
     });
   }
@@ -95,6 +101,7 @@ export class MessageUseCases {
     from: string;
     text: string;
     type?: string;
+    invokedBy?: string;
   }): Promise<BroadcastResult> {
     const from = await assertActor(input.from, '--from', this.deps.members);
     const text = sanitizeMessageText(input.text);
@@ -103,6 +110,10 @@ export class MessageUseCases {
       .filter((m) => m.active && m.name.value !== from.value)
       .map((m) => m.name);
     const now = this.deps.clock.now().toISOString();
+    const invokedBy =
+      input.invokedBy !== undefined && input.invokedBy !== from.value
+        ? input.invokedBy
+        : undefined;
     const delivered: string[] = [];
     const failed: Array<{ to: string; error: string }> = [];
     for (const to of targets) {
@@ -113,6 +124,7 @@ export class MessageUseCases {
           type: input.type ?? 'broadcast',
           text,
           at: now,
+          ...(invokedBy !== undefined ? { invokedBy } : {}),
         });
         delivered.push(to.value);
       } catch (e) {

--- a/src/application/ports/NotificationPort.ts
+++ b/src/application/ports/NotificationPort.ts
@@ -7,6 +7,14 @@ export interface Notification {
   text: string;
   related?: string;
   at?: string;
+  /**
+   * Actual CLI invoker when different from `from`. Mirrors the
+   * `read_by` pattern on the receive side: `from` is who the
+   * message is attributed to (the member on record); `invokedBy`
+   * is who actually ran `gate message` / `gate broadcast`. Only
+   * stamped when they disagree.
+   */
+  invokedBy?: string;
 }
 
 /**
@@ -31,6 +39,13 @@ export interface InboxMessage {
    * before this field was introduced.
    */
   readBy?: string;
+  /**
+   * Actor who ran `gate message` / `gate broadcast` when different
+   * from `from`. Same invariant as the rest: stamped only when they
+   * disagree. Receivers can see which messages were ghost-sent
+   * without having to chase the sender's status log.
+   */
+  invokedBy?: string;
   related?: string;
 }
 

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -45,6 +45,7 @@ export class RequestUseCases {
     target?: string;
     autoReview?: string;
     with?: readonly string[];
+    invokedBy?: string;
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -81,6 +82,7 @@ export class RequestUseCases {
       createArgs.autoReview = input.autoReview;
     if (input.with !== undefined && input.with.length > 0)
       createArgs.with = input.with;
+    if (input.invokedBy !== undefined) createArgs.invokedBy = input.invokedBy;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -170,11 +170,15 @@ function sanitizeText(raw: unknown, field: string): string {
  * trail.
  *
  * Notes are strictly additive: the tool exposes no edit or delete.
+ * `invokedBy` mirrors the status_log / review field: stamped only
+ * when GUILD_ACTOR differs from the nominal `by`, so same-actor
+ * notes stay byte-identical to pre-invariant records.
  */
 export interface IssueNote {
   by: string;
   text: string;
   at: string;
+  invokedBy?: string;
 }
 
 const MAX_NOTES = 50;
@@ -189,6 +193,8 @@ export interface IssueProps {
   createdAt: string;
   /** Optional — historical YAML pre-dates notes; restore backfills []. */
   notes?: IssueNote[];
+  /** See IssueNote.invokedBy — same invariant on the creation act. */
+  invokedBy?: string;
 }
 
 export class Issue {
@@ -201,17 +207,26 @@ export class Issue {
     area: string;
     text: string;
     createdAt?: string;
+    invokedBy?: string;
   }): Issue {
-    return new Issue({
+    const from = MemberName.of(input.from);
+    const props: IssueProps = {
       id: input.id,
-      from: MemberName.of(input.from),
+      from,
       severity: parseIssueSeverity(input.severity),
       area: parseArea(input.area),
       text: sanitizeText(input.text, 'text'),
       state: 'open',
       createdAt: input.createdAt ?? new Date().toISOString(),
       notes: [],
-    });
+    };
+    if (
+      input.invokedBy !== undefined &&
+      input.invokedBy !== from.value
+    ) {
+      props.invokedBy = input.invokedBy;
+    }
+    return new Issue(props);
   }
 
   /**
@@ -249,7 +264,12 @@ export class Issue {
     return this.props.notes ?? [];
   }
 
-  addNote(by: string, text: string, at?: string): IssueNote {
+  addNote(
+    by: string,
+    text: string,
+    at?: string,
+    invokedBy?: string,
+  ): IssueNote {
     // `notes` is optional on IssueProps so historical YAML can restore
     // without an explicit empty array; lazily initialize on first add.
     if (!this.props.notes) this.props.notes = [];
@@ -259,11 +279,15 @@ export class Issue {
         'notes',
       );
     }
+    const byName = MemberName.of(by).value;
     const note: IssueNote = {
-      by: MemberName.of(by).value,
+      by: byName,
       text: sanitizeText(text, 'note'),
       at: at ?? new Date().toISOString(),
     };
+    if (invokedBy !== undefined && invokedBy !== byName) {
+      note.invokedBy = invokedBy;
+    }
     this.props.notes.push(note);
     return note;
   }
@@ -278,12 +302,30 @@ export class Issue {
       state: this.props.state,
       created_at: this.props.createdAt,
     };
+    if (this.props.invokedBy !== undefined) {
+      out['invoked_by'] = this.props.invokedBy;
+    }
     // Backward compat: omit the `notes` key when empty so pre-notes
     // YAML stays byte-identical after a round-trip through restore/save.
     const notes = this.props.notes;
     if (notes && notes.length > 0) {
-      out['notes'] = notes.map((n) => ({ ...n }));
+      out['notes'] = notes.map((n) => noteToJSON(n));
     }
     return out;
   }
+}
+
+/**
+ * Wire-format projection of an IssueNote. `invokedBy` in memory →
+ * `invoked_by` on disk, matching the snake_case convention used by
+ * status_log / reviews. Only emitted when present.
+ */
+function noteToJSON(n: IssueNote): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    by: n.by,
+    text: n.text,
+    at: n.at,
+  };
+  if (n.invokedBy !== undefined) out['invoked_by'] = n.invokedBy;
+  return out;
 }

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -78,11 +78,31 @@ export class Request {
     autoReview?: string;
     with?: readonly string[];
     createdAt?: string;
+    /**
+     * Actual CLI invoker when different from `from`. Same invariant
+     * as status_log transitions: stamped only when the two diverge
+     * (typical case = an AI agent filing on a human's behalf), so
+     * same-actor creation leaves the initial status_log entry
+     * byte-identical to pre-invariant YAML.
+     */
+    invokedBy?: string;
   }): Request {
     const from = MemberName.of(input.from);
     const action = sanitizeText(input.action, 'action');
     const reason = sanitizeText(input.reason, 'reason');
     const createdAt = input.createdAt ?? new Date().toISOString();
+    const initialEntry: StatusLogEntry = {
+      state: 'pending',
+      by: from.value,
+      at: createdAt,
+      note: 'created',
+    };
+    if (
+      input.invokedBy !== undefined &&
+      input.invokedBy !== from.value
+    ) {
+      initialEntry.invokedBy = input.invokedBy;
+    }
     const props: RequestProps = {
       id: input.id,
       from,
@@ -91,9 +111,7 @@ export class Request {
       state: 'pending',
       createdAt,
       reviews: [],
-      statusLog: [
-        { state: 'pending', by: from.value, at: createdAt, note: 'created' },
-      ],
+      statusLog: [initialEntry],
     };
     if (input.executor !== undefined) {
       props.executor = MemberName.of(input.executor);

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -44,6 +44,7 @@ export class FsInboxNotification implements NotificationPort {
       read: false,
     };
     if (n.related !== undefined) entry['related'] = n.related;
+    if (n.invokedBy !== undefined) entry['invoked_by'] = n.invokedBy;
     file.messages.push(entry);
     if (file.messages.length > MAX_INBOX_SIZE) {
       file.messages = file.messages.slice(-MAX_INBOX_SIZE);
@@ -131,6 +132,7 @@ function normalizeMessage(raw: Record<string, unknown>): InboxMessage {
   };
   if (typeof raw['read_at'] === 'string') msg.readAt = raw['read_at'];
   if (typeof raw['read_by'] === 'string') msg.readBy = raw['read_by'];
+  if (typeof raw['invoked_by'] === 'string') msg.invokedBy = raw['invoked_by'];
   if (typeof raw['related'] === 'string') msg.related = raw['related'];
   return msg;
 }

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -108,7 +108,7 @@ function hydrate(
   const obj = data as Record<string, unknown>;
   try {
     const id = IssueId.of(obj['id']);
-    const issue = Issue.restore({
+    const restoreInput: Parameters<typeof Issue.restore>[0] = {
       id,
       from: MemberName.of(obj['from']),
       severity: parseIssueSeverity(String(obj['severity'])),
@@ -117,7 +117,11 @@ function hydrate(
       state: parseIssueState(String(obj['state'] ?? 'open')),
       createdAt: String(obj['created_at'] ?? new Date().toISOString()),
       notes: hydrateNotes(obj['notes'], source, onMalformed),
-    });
+    };
+    if (typeof obj['invoked_by'] === 'string') {
+      restoreInput.invokedBy = obj['invoked_by'];
+    }
+    const issue = Issue.restore(restoreInput);
     return issue;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -154,7 +158,9 @@ function hydrateNotes(
       );
       continue;
     }
-    out.push({ by, text, at });
+    const note: IssueNote = { by, text, at };
+    if (typeof r['invoked_by'] === 'string') note.invokedBy = r['invoked_by'];
+    out.push(note);
   }
   return out;
 }

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -49,12 +49,39 @@ export async function readStdin(): Promise<string> {
 }
 
 /**
- * Return the value of GUILD_ACTOR when it differs from `by`, and also
- * print a one-line delegation notice to stderr. Returns undefined
- * when the two match (the common self-invocation case) — callers
- * should pass that straight through to the use case, which in turn
- * only stamps `invoked_by` on the status_log entry when it's set.
- *
+ * Pure derivation of the invoker: returns the GUILD_ACTOR value when
+ * it differs from `by`, undefined otherwise. No side effects. Use
+ * this when the id isn't known yet (e.g. the verb creates a fresh
+ * record) and you need to pass the value into the use case before
+ * emitting the user-facing delegation notice.
+ */
+export function deriveInvokedBy(by: string): string | undefined {
+  const envActor = process.env['GUILD_ACTOR'];
+  if (!envActor || envActor.length === 0) return undefined;
+  if (envActor === by) return undefined;
+  return envActor;
+}
+
+/**
+ * Print the one-line stderr delegation notice. Kept separate from
+ * `deriveInvokedBy` so creation paths can call it after the new
+ * record's id is available. `target` is the record identity (a
+ * request / issue id, or a recipient name for message).
+ */
+export function emitInvokedByNotice(
+  by: string,
+  invokedBy: string,
+  verb: string,
+  target: string,
+): void {
+  process.stderr.write(
+    `# ${verb} ${target}: invoked by ${invokedBy} on behalf of ${by} ` +
+      `(invoked_by recorded as ${invokedBy})\n`,
+  );
+}
+
+/**
+ * Convenience wrapper: derive + emit when the id is already known.
  * Mirrors the inbox `read_by` pattern: `by` is who the act is
  * attributed to, GUILD_ACTOR is who actually ran the CLI command,
  * and the trail keeps both honest when they disagree.
@@ -64,14 +91,11 @@ export function resolveInvokedBy(
   verb: string,
   id: string,
 ): string | undefined {
-  const envActor = process.env['GUILD_ACTOR'];
-  if (!envActor || envActor.length === 0) return undefined;
-  if (envActor === by) return undefined;
-  process.stderr.write(
-    `# ${verb} ${id}: invoked by ${envActor} on behalf of ${by} ` +
-      `(invoked_by recorded as ${envActor})\n`,
-  );
-  return envActor;
+  const invokedBy = deriveInvokedBy(by);
+  if (invokedBy !== undefined) {
+    emitInvokedByNotice(by, invokedBy, verb, id);
+  }
+  return invokedBy;
 }
 
 // --- Editor fallback for long-form review comments ---------------------

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -3,7 +3,14 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C, readStdin, truncateCodePoints } from './internal.js';
+import {
+  C,
+  readStdin,
+  truncateCodePoints,
+  deriveInvokedBy,
+  emitInvokedByNotice,
+  resolveInvokedBy,
+} from './internal.js';
 
 export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
@@ -19,7 +26,20 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     const area = requireOption(args, 'area', '--area required');
     const text = args.positional.slice(1).join(' ');
     if (!text) throw new Error('Usage: gate issues add ... <text>');
-    const i = await c.issueUC.add({ from, severity, area, text });
+    // Proxy creation: derive pre-save (id unknown), emit notice after
+    // the issue is allocated. Same pattern as gate request.
+    const invokedBy = deriveInvokedBy(from);
+    const addInput: Parameters<typeof c.issueUC.add>[0] = {
+      from,
+      severity,
+      area,
+      text,
+    };
+    if (invokedBy !== undefined) addInput.invokedBy = invokedBy;
+    const i = await c.issueUC.add(addInput);
+    if (invokedBy !== undefined) {
+      emitInvokedByNotice(from, invokedBy, 'issues add', i.id.value);
+    }
     process.stdout.write(`✓ issue: ${i.id.value}\n`);
     return 0;
   }
@@ -28,13 +48,19 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     const items = await c.issueUC.list(state);
     for (const i of items) {
       const j = i.toJSON();
+      const proxyTag = j['invoked_by']
+        ? ` [invoked_by=${j['invoked_by']}]`
+        : '';
       process.stdout.write(
-        `${j['id']} [${j['severity']}/${j['area']}] ${j['state']} — ${j['text']}\n`,
+        `${j['id']} [${j['severity']}/${j['area']}] ${j['state']} from=${j['from']}${proxyTag} — ${j['text']}\n`,
       );
       const notes = Array.isArray(j['notes']) ? j['notes'] : [];
       for (const n of notes as Array<Record<string, unknown>>) {
+        const noteProxy = n['invoked_by']
+          ? ` [invoked_by=${n['invoked_by']}]`
+          : '';
         process.stdout.write(
-          `  └ note by ${n['by']} at ${n['at']}: ${n['text']}\n`,
+          `  └ note by ${n['by']}${noteProxy} at ${n['at']}: ${n['text']}\n`,
         );
       }
     }
@@ -92,11 +118,20 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
   };
   if (executor !== undefined) input.executor = executor;
   if (autoReview !== undefined) input.autoReview = autoReview;
+  // Promote creates a request on `from`'s behalf; when GUILD_ACTOR
+  // differs, the invariant applies the same way as plain `gate
+  // request`. Stamp invoked_by on the created request so proxy-
+  // promotion is visible in the new request's initial status_log.
+  const invokedByPromote = deriveInvokedBy(from);
+  if (invokedByPromote !== undefined) input.invokedBy = invokedByPromote;
 
   // Non-atomic by design: create request first, then resolve issue.
   // If the second step fails we emit the request id so the operator
   // knows the partial state and can manually resolve the issue.
   const req = await c.requestUC.create(input);
+  if (invokedByPromote !== undefined) {
+    emitInvokedByNotice(from, invokedByPromote, 'issues promote', req.id.value);
+  }
   try {
     await c.issueUC.setState(id, 'resolved');
   } catch (e) {
@@ -159,7 +194,14 @@ async function issuesNote(c: C, args: ParsedArgs): Promise<number> {
         hint,
     );
   }
-  const { note } = await c.issueUC.addNote({ id, by, text });
+  const invokedBy = resolveInvokedBy(by, 'issues note', id);
+  const addNoteInput: Parameters<typeof c.issueUC.addNote>[0] = {
+    id,
+    by,
+    text,
+  };
+  if (invokedBy !== undefined) addNoteInput.invokedBy = invokedBy;
+  const { note } = await c.issueUC.addNote(addNoteInput);
   process.stdout.write(
     `✓ note added to ${id} by ${note.by} at ${note.at}\n`,
   );

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -3,19 +3,24 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C } from './internal.js';
+import { C, deriveInvokedBy, emitInvokedByNotice } from './internal.js';
 
 export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const to = requireOption(args, 'to', '--to required');
   const text = requireOption(args, 'text', '--text required');
   const type = optionalOption(args, 'type');
+  const invokedBy = deriveInvokedBy(from);
   await c.messageUC.send({
     from,
     to,
     text,
     ...(type !== undefined ? { type } : {}),
+    ...(invokedBy !== undefined ? { invokedBy } : {}),
   });
+  if (invokedBy !== undefined) {
+    emitInvokedByNotice(from, invokedBy, 'message →', to);
+  }
   process.stdout.write(`✓ message sent: ${from} → ${to}\n`);
   return 0;
 }
@@ -24,10 +29,15 @@ export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const text = requireOption(args, 'text', '--text required');
   const type = optionalOption(args, 'type');
+  const invokedBy = deriveInvokedBy(from);
+  if (invokedBy !== undefined) {
+    emitInvokedByNotice(from, invokedBy, 'broadcast from', from);
+  }
   const { delivered, failed } = await c.messageUC.broadcast({
     from,
     text,
     ...(type !== undefined ? { type } : {}),
+    ...(invokedBy !== undefined ? { invokedBy } : {}),
   });
   if (delivered.length === 0 && failed.length === 0) {
     process.stdout.write(
@@ -81,8 +91,12 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
           : ` (read ${m.readAt})`
         : ' (read)'
       : ' (unread)';
+    // Show invoked_by on the sender side so a recipient can tell a
+    // ghost-sent message from a hand-typed one at a glance. The
+    // mark-read side already has its own "by ..." marker on readTag.
+    const sendProxy = m.invokedBy ? ` [invoked_by=${m.invokedBy}]` : '';
     process.stdout.write(
-      `  ${idx}. [${m.at}] ${m.type} from ${m.from}${related}${readTag}\n  ${m.text}\n`,
+      `  ${idx}. [${m.at}] ${m.type} from ${m.from}${sendProxy}${related}${readTag}\n  ${m.text}\n`,
     );
   }
   return 0;

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -5,7 +5,13 @@ import {
 } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
-import { C, readStdin, resolveInvokedBy } from './internal.js';
+import {
+  C,
+  readStdin,
+  deriveInvokedBy,
+  emitInvokedByNotice,
+  resolveInvokedBy,
+} from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
@@ -34,7 +40,17 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   if (target !== undefined) input.target = target;
   if (autoReview !== undefined) input.autoReview = autoReview;
   if (withPartners.length > 0) input.with = withPartners;
+  // Request creation is a proxy-eligible verb same as approve/review:
+  // when GUILD_ACTOR differs from --from, the agent is filing on a
+  // member's behalf. Derive the invoker pre-create so it lands on
+  // the initial status_log entry; emit the stderr notice after the
+  // id is allocated.
+  const invokedBy = deriveInvokedBy(from);
+  if (invokedBy !== undefined) input.invokedBy = invokedBy;
   const r = await c.requestUC.create(input);
+  if (invokedBy !== undefined) {
+    emitInvokedByNotice(from, invokedBy, 'request', r.id.value);
+  }
   emitWriteResponse(
     parseFormat(args),
     r,

--- a/tests/application/MessageUseCases.test.ts
+++ b/tests/application/MessageUseCases.test.ts
@@ -427,3 +427,42 @@ test('markRead for host name raises the inbox-owner error', async () => {
     },
   );
 });
+
+// ── invoked_by on send / broadcast ──
+
+test('send stamps invoked_by on the Notification when differs from from', () => {
+  const { uc, members, notifier } = build();
+  members.add('eris');
+  members.add('noir');
+  return uc
+    .send({ from: 'eris', to: 'noir', text: 'hi', invokedBy: 'claude' })
+    .then(() => {
+      assert.equal(notifier.posted[0]!.invokedBy, 'claude');
+    });
+});
+
+test('send drops invoked_by when it equals from (no clutter)', () => {
+  const { uc, members, notifier } = build();
+  members.add('eris');
+  members.add('noir');
+  return uc
+    .send({ from: 'eris', to: 'noir', text: 'hi', invokedBy: 'eris' })
+    .then(() => {
+      assert.equal(notifier.posted[0]!.invokedBy, undefined);
+    });
+});
+
+test('broadcast stamps invoked_by on every fan-out envelope', () => {
+  const { uc, members, notifier } = build();
+  members.add('eris');
+  members.add('noir');
+  members.add('rin');
+  return uc
+    .broadcast({ from: 'eris', text: 'hi', invokedBy: 'claude' })
+    .then(() => {
+      assert.equal(notifier.posted.length, 2);
+      for (const p of notifier.posted) {
+        assert.equal(p.invokedBy, 'claude');
+      }
+    });
+});

--- a/tests/domain/Issue.test.ts
+++ b/tests/domain/Issue.test.ts
@@ -189,3 +189,45 @@ test('parseIssueSeverity error message lists canonical values + aliases', () => 
     assert.match(err.message, /medium.*med/s);
   }
 });
+
+// ── invoked_by on Issue.create + Issue.addNote ──
+
+test('Issue.create stamps invoked_by when differs from from', () => {
+  const i = Issue.create({
+    id: IssueId.generate(d, 1),
+    from: 'alice',
+    severity: 'med',
+    area: 'core',
+    text: 'x',
+    invokedBy: 'claude',
+  });
+  assert.equal(i.toJSON()['invoked_by'], 'claude');
+});
+
+test('Issue.create omits invoked_by when equals from', () => {
+  const i = Issue.create({
+    id: IssueId.generate(d, 1),
+    from: 'alice',
+    severity: 'med',
+    area: 'core',
+    text: 'x',
+    invokedBy: 'alice',
+  });
+  assert.equal('invoked_by' in i.toJSON(), false);
+});
+
+test('Issue.addNote stamps invoked_by when differs from by', () => {
+  const i = mkIssue();
+  const note = i.addNote('eris', 'n', undefined, 'claude');
+  assert.equal(note.invokedBy, 'claude');
+  const j = i.toJSON();
+  const notes = j['notes'] as Array<Record<string, unknown>>;
+  assert.equal(notes[0]!['invoked_by'], 'claude');
+});
+
+test('Issue.addNote omits invoked_by when equals by', () => {
+  const i = mkIssue();
+  i.addNote('eris', 'n', undefined, 'eris');
+  const notes = i.toJSON()['notes'] as Array<Record<string, unknown>>;
+  assert.equal('invoked_by' in notes[0]!, false);
+});

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -381,3 +381,42 @@ test('Request restore preserves invoked_by round-trip', () => {
   const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
   assert.equal(log[1]!['invoked_by'], 'claude');
 });
+
+// ── invoked_by on Request.create (initial status_log entry) ──
+
+test('Request.create stamps invoked_by on initial status_log when differs from from', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    invokedBy: 'claude',
+  });
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal(log[0]!['by'], 'alice');
+  assert.equal(log[0]!['invoked_by'], 'claude');
+});
+
+test('Request.create omits invoked_by on initial entry when equals from', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    invokedBy: 'alice',
+  });
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal(log[0]!['by'], 'alice');
+  assert.equal('invoked_by' in log[0]!, false);
+});
+
+test('Request.create without invokedBy leaves initial entry clean', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+  });
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal('invoked_by' in log[0]!, false);
+});


### PR DESCRIPTION
## Summary

Extends the `invoked_by` invariant from #39 (five transitions + review + fast-track) to **every proxy-eligible write verb**. Closes i-0003 from the dogfood session log, which surfaced that `GUILD_ACTOR=X gate request --from Y` was silently attributed to Y with no audit trail of X.

The rule is now uniform: if `GUILD_ACTOR` differs from the nominal actor (`--from` / `--by`), stamp `invoked_by` on the record and print a one-line stderr delegation notice. Stays byte-identical to pre-invariant YAML when same-actor.

### New stamp sites

| Verb | Record | Field location |
|------|--------|----------------|
| `gate request` | Request | `status_log[0].invoked_by` |
| `gate issues add` | Issue | issue-level `invoked_by` (creation act) |
| `gate issues note` | IssueNote | per-note `invoked_by` |
| `gate issues promote` | created Request | `status_log[0].invoked_by` (delegated-create) |
| `gate message` | Notification envelope | `invoked_by` |
| `gate broadcast` | each fan-out envelope | `invoked_by` |

### Rendering

- `gate issues list` now shows `from=X [invoked_by=Y]` on the header and `└ note by X [invoked_by=Y]` on each note
- `gate inbox` shows `from X [invoked_by=Y]` alongside the sender on every message

(`gate voices` / `tail` / `resume` already covered their scope in #41 — transitions and reviews. This PR adds the creation + message surfaces that weren't in that scope.)

### Implementation note

Creation paths can't pass an id into `resolveInvokedBy` (it's allocated during save). Split the helper:

- `deriveInvokedBy(by)` — pure, no side effects; call pre-create to thread into the record
- `emitInvokedByNotice(by, invokedBy, verb, target)` — stderr only; call post-create with the generated id
- `resolveInvokedBy(by, verb, id)` — unchanged convenience wrapper for same-id call sites (approve, deny, execute, complete, fail, review, issues note)

### Example

```
$ GUILD_ACTOR=claude gate request --from eris --action "fix X" --reason "r"
# request 2026-04-18-0001: invoked by claude on behalf of eris (invoked_by recorded as claude)
✓ created: 2026-04-18-0001 (state=pending)

$ GUILD_ACTOR=claude gate issues note i-2026-04-18-0001 --by eris --text "hmm"
# issues note i-2026-04-18-0001: invoked by claude on behalf of eris (invoked_by recorded as claude)
✓ note added to i-2026-04-18-0001 by eris at ...

$ gate issues list
i-2026-04-18-0001 [low/ux] open from=eris — ...
  └ note by eris [invoked_by=claude] at ...: hmm
```

## Test plan

- [x] `npm test` — 352 passing (+10 new)
- [x] `npx tsc --noEmit` clean
- [x] Sandbox e2e — all 6 verbs emit the delegation notice with the correct `target` and stamp `invoked_by` in YAML; same-actor cases remain byte-identical (verified: no notice, no field)

## Closes

`i-0003` from the dogfood session record (transcript in `/tmp/session` during the prior turn). Flagged medium severity; now resolved.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu