### PR TITLE
polish: authored invoked_by in read paths + pad state column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Changed
+- **`invoked_by` surfaces on authored utterances in `gate voices` /
+  `gate tail` / `gate resume`.** #43 stamped the creator's invoker
+  onto `status_log[0]`, but the read paths for authored utterances
+  (vs review utterances, handled in #41) still hid it. The gap
+  surfaced by dogfooding: `GUILD_ACTOR=claude gate request --from eris`
+  showed up on `gate show` but vanished on `gate voices eris` and
+  in resume's "Your last voice was authoring req=X" prose. Now:
+  - `gate voices` / `gate tail` render `[invoked_by=<actor>]` on
+    the authored header (same shape as the review branch);
+  - `gate resume` prose (en + ja) appends `(invoked by <actor>)` /
+    `（<actor> が代行）`;
+  - `AuthoredUtterance` gains an optional `invokedBy`, lifted from
+    `status_log[0].invoked_by` at collection time;
+  - `RequestJSON` gains an optional `status_log` projection so
+    voices can read it without pulling in the full domain object.
+  Same-actor creation is untouched.
+- **`gate show --format text` pads the state column in `status_log`.**
+  Ragged widths (`pending` 7ch vs `executing` 9ch) made the `by X`
+  column shift per row. Padded per-render to the max state length
+  in *this* log, so logs that never reached executing/completed
+  stay compact.
+
 ### Added
 - **`invoked_by` extended to every proxy-eligible write verb.** Previously
   scoped to the five transitions + `review` + `fast-track` (#39). Dogfooding

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -187,6 +187,15 @@ function formatRequestText(r: Request): string {
   if (log.length > 0) {
     lines.push('');
     lines.push(`  status_log (${log.length}):`);
+    // Pad the state column to the max width in *this* log so the
+    // `by X` column doesn't shuffle column-wise per row. Computed
+    // per-render rather than hard-coded to the REQUEST_STATES max,
+    // so logs that never reached executing/completed stay compact.
+    const stateWidth = Math.max(
+      ...(log as Array<Record<string, unknown>>).map(
+        (e) => String(e['state']).length,
+      ),
+    );
     let prevAt: string | undefined;
     for (const entry of log as Array<Record<string, unknown>>) {
       const at = String(entry['at']);
@@ -195,8 +204,9 @@ function formatRequestText(r: Request): string {
       const invokedBy = entry['invoked_by']
         ? ` [invoked_by=${entry['invoked_by']}]`
         : '';
+      const state = String(entry['state']).padEnd(stateWidth);
       lines.push(
-        `    ${at}  ${entry['state']}  by ${entry['by']}${invokedBy}${delta}${note}`,
+        `    ${at}  ${state}  by ${entry['by']}${invokedBy}${delta}${note}`,
       );
       prevAt = at;
     }

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -363,8 +363,11 @@ function composeRestorationProseEn(ctx: {
   if (lastUtterance) {
     const age = ageHint(lastUtterance.at, new Date().toISOString());
     if (lastUtterance.kind === 'review') {
+      const proxyHint = lastUtterance.invokedBy
+        ? ` (invoked by ${lastUtterance.invokedBy})`
+        : '';
       lines.push(
-        `Your last voice (utterance, ${age}) was a review on req=${lastUtterance.requestId} — [${lastUtterance.lense}/${lastUtterance.verdict}]:`,
+        `Your last voice (utterance, ${age}) was a review on req=${lastUtterance.requestId} — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  "${truncate(lastUtterance.comment, 240)}"`);
     } else {
@@ -372,8 +375,11 @@ function composeRestorationProseEn(ctx: {
         lastUtterance.with && lastUtterance.with.length > 0
           ? ` (shaped with ${lastUtterance.with.join(', ')})`
           : '';
+      const proxyHint = lastUtterance.invokedBy
+        ? ` (invoked by ${lastUtterance.invokedBy})`
+        : '';
       lines.push(
-        `Your last voice (utterance, ${age}) was authoring req=${lastUtterance.requestId}${withHint}:`,
+        `Your last voice (utterance, ${age}) was authoring req=${lastUtterance.requestId}${proxyHint}${withHint}:`,
       );
       lines.push(`  action: ${truncate(lastUtterance.action, 120)}`);
       if (lastUtterance.completionNote) {
@@ -478,8 +484,11 @@ function composeRestorationProseJa(ctx: {
   if (lastUtterance) {
     const age = ageHint(lastUtterance.at, new Date().toISOString());
     if (lastUtterance.kind === 'review') {
+      const proxyHint = lastUtterance.invokedBy
+        ? `（${lastUtterance.invokedBy} が代行）`
+        : '';
       lines.push(
-        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} へのレビュー — [${lastUtterance.lense}/${lastUtterance.verdict}]:`,
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} へのレビュー — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  「${truncate(lastUtterance.comment, 240)}」`);
     } else {
@@ -487,8 +496,11 @@ function composeRestorationProseJa(ctx: {
         lastUtterance.with && lastUtterance.with.length > 0
           ? `（${lastUtterance.with.join('、')} と一緒に）`
           : '';
+      const proxyHint = lastUtterance.invokedBy
+        ? `（${lastUtterance.invokedBy} が代行）`
+        : '';
       lines.push(
-        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} の起票${withHint}:`,
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} の起票${proxyHint}${withHint}:`,
       );
       lines.push(`  action: ${truncate(lastUtterance.action, 120)}`);
       if (lastUtterance.completionNote) {

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -16,6 +16,22 @@
  * the full domain constructor chain.
  */
 
+/**
+ * Structural projection of what voices reads off a Request. The
+ * optional `status_log` lets collectUtterances surface the creator's
+ * `invoked_by` on AuthoredUtterance — the actual field lives on
+ * status_log[0] (the "created" entry), and we don't want to hoist
+ * it to a flat top-level key because the derivation is already
+ * first-class in the on-disk YAML.
+ */
+export type StatusLogEntryJSON = {
+  readonly state: string;
+  readonly by: string;
+  readonly at: string;
+  readonly note?: string;
+  readonly invoked_by?: string;
+};
+
 export type RequestJSON = {
   readonly id: string;
   readonly from: string;
@@ -27,6 +43,7 @@ export type RequestJSON = {
   readonly failure_reason?: string;
   readonly with?: ReadonlyArray<string>;
   readonly reviews?: ReadonlyArray<ReviewJSON>;
+  readonly status_log?: ReadonlyArray<StatusLogEntryJSON>;
 };
 
 export type ReviewJSON = {
@@ -50,6 +67,11 @@ export type AuthoredUtterance = {
   // utterances from every actor and the reader needs to see who said
   // what without looking up the id.
   readonly from: string;
+  // Actual CLI invoker when the creation was proxied (GUILD_ACTOR
+  // differed from --from). Same semantic as ReviewUtterance.invokedBy;
+  // the source is the `invoked_by` field on the status_log[0] entry.
+  // Undefined for the self-invocation common case.
+  readonly invokedBy?: string;
   readonly action: string;
   readonly reason: string;
   // Any closure text the lifecycle ended on. Only one of these is
@@ -132,6 +154,14 @@ export function collectUtterances(
         action: r.action,
         reason: r.reason,
       };
+      // Creator's invoked_by lives on status_log[0] (the "created"
+      // entry). Lift it onto the utterance so tail / voices / resume
+      // surface proxy-authoring the same way they already surface
+      // proxy-reviews. Guarded so pre-invoked_by records stay clean.
+      const createdEntry = r.status_log?.[0];
+      if (createdEntry && createdEntry.invoked_by !== undefined) {
+        (u as { invokedBy?: string }).invokedBy = createdEntry.invoked_by;
+      }
       // Pick whichever closure field the lifecycle produced. A request
       // can only be in one terminal state at a time, so at most one of
       // these is set.
@@ -263,7 +293,12 @@ export function renderUtterance(
     const actor = includeActor ? ` ${u.from}` : '';
     const withSuffix =
       u.with && u.with.length > 0 ? ` (with ${u.with.join(', ')})` : '';
-    lines.push(`[${u.at}] req=${u.requestId} authored${actor}${withSuffix}`);
+    // Always show `[invoked_by=<actor>]` when present, even when
+    // includeActor=false (voices groups by actor so `from` is
+    // redundant, but the proxy invoker isn't). Matches the review
+    // branch's treatment.
+    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
+    lines.push(`[${u.at}] req=${u.requestId} authored${actor}${proxy}${withSuffix}`);
     pushMultilineField(lines, '  action: ', u.action);
     pushMultilineField(lines, '  reason: ', u.reason);
     // At most one of these is set per request (completed / denied /

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -439,3 +439,101 @@ test('renderUtterance authored: multi-line reason indents continuation lines', (
   // value column, not hang off the left margin.
   assert.match(text, /  reason: first paragraph\n          second paragraph/);
 });
+
+// ── invoked_by on authored utterances (from status_log[0]) ──
+
+test('collectUtterances: authored utterance lifts invoked_by from status_log[0]', () => {
+  const reqs: RequestJSON[] = [
+    {
+      id: '2026-04-18-0099',
+      from: 'eris',
+      action: 'proxy create',
+      reason: 'r',
+      created_at: '2026-04-18T00:00:00.000Z',
+      status_log: [
+        {
+          state: 'pending',
+          by: 'eris',
+          at: '2026-04-18T00:00:00.000Z',
+          note: 'created',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(reqs, { name: 'eris' });
+  assert.ok(u);
+  assert.equal(u.kind, 'authored');
+  if (u.kind === 'authored') {
+    assert.equal(u.invokedBy, 'claude');
+  }
+});
+
+test('collectUtterances: authored utterance leaves invokedBy undefined when not proxied', () => {
+  const reqs: RequestJSON[] = [
+    {
+      id: '2026-04-18-0099',
+      from: 'eris',
+      action: 'self',
+      reason: 'r',
+      created_at: '2026-04-18T00:00:00.000Z',
+      status_log: [
+        { state: 'pending', by: 'eris', at: '2026-04-18T00:00:00.000Z' },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(reqs, { name: 'eris' });
+  assert.ok(u);
+  if (u.kind === 'authored') assert.equal(u.invokedBy, undefined);
+});
+
+test('renderUtterance authored: shows [invoked_by=<actor>] when present', () => {
+  const reqs: RequestJSON[] = [
+    {
+      id: '2026-04-18-0099',
+      from: 'eris',
+      action: 'x',
+      reason: 'r',
+      created_at: '2026-04-18T00:00:00.000Z',
+      status_log: [
+        {
+          state: 'pending',
+          by: 'eris',
+          at: '2026-04-18T00:00:00.000Z',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(reqs, { name: 'eris' });
+  assert.ok(u);
+  const text = renderUtterance(u, true);
+  assert.match(text, /authored eris \[invoked_by=claude\]/);
+});
+
+test('renderUtterance authored: shows invoked_by even when includeActor=false', () => {
+  // voices groups by actor so `from` is redundant — but the proxy
+  // invoker is NOT redundant in that view. Mirrors the review branch.
+  const reqs: RequestJSON[] = [
+    {
+      id: '2026-04-18-0099',
+      from: 'eris',
+      action: 'x',
+      reason: 'r',
+      created_at: '2026-04-18T00:00:00.000Z',
+      status_log: [
+        {
+          state: 'pending',
+          by: 'eris',
+          at: '2026-04-18T00:00:00.000Z',
+          invoked_by: 'claude',
+        },
+      ],
+    },
+  ];
+  const [u] = collectUtterances(reqs, { name: 'eris' });
+  assert.ok(u);
+  const text = renderUtterance(u, false);
+  assert.match(text, /\[invoked_by=claude\]/);
+  assert.equal(/authored eris /.test(text), false);
+});


### PR DESCRIPTION
## Summary

Two small polish items found by dogfooding after #43 landed. Same root-cause family as #41 — "`invoked_by` lives in YAML but doesn't reach every read path."

### i-0002 [med/audit] — authored utterances miss the creator's invoker

#43 stamps `status_log[0].invoked_by` when `GUILD_ACTOR` differs from `--from`. `gate show` renders it. But `gate voices`, `gate tail`, and `gate resume` didn't — the equivalent plumbing I did for `ReviewUtterance` in #41 got missed for `AuthoredUtterance`. Asymmetric result: proxy reviews were visible everywhere, proxy authoring showed up on `show` and nowhere else.

**Before:**
```
$ GUILD_ACTOR=claude gate request --from eris --action "..." --reason "..."
# request 2026-04-18-0001: invoked by claude on behalf of eris

$ gate voices eris --format text
[...] req=2026-04-18-0001 authored     # ← no [invoked_by=claude]
  action: ...
```

**After:**
```
$ gate voices eris --format text
[...] req=2026-04-18-0001 authored [invoked_by=claude]
  action: ...

$ gate resume --format text
Your last voice was authoring req=... (invoked by claude):
  直近の発話: req=... の起票（claude が代行）:
```

Also picked up the matching `lastUtterance.kind === 'review'` branches in resume prose (en + ja) — same bug in the same neighborhood.

### i-0003 [low/readability] — ragged `status_log` state column

`pending` (7 chars) vs `executing` (9 chars) shifted the `by X` column per row:

```
# Before
  2026-04-18T...  pending  by eris [invoked_by=claude] — created
  2026-04-18T...  approved  by sentinel [invoked_by=claude] (+0s)
  2026-04-18T...  executing  by sentinel [invoked_by=claude]
  2026-04-18T...  completed  by sentinel [invoked_by=claude]

# After
  2026-04-18T...  pending    by eris [invoked_by=claude] — created
  2026-04-18T...  approved   by sentinel [invoked_by=claude] (+0s)
  2026-04-18T...  executing  by sentinel [invoked_by=claude]
  2026-04-18T...  completed  by sentinel [invoked_by=claude]
```

Padded to max state length in *this* log (not hard-coded to the full enum) so logs that stopped at `pending` / `approved` stay compact.

### Types / scope

- `RequestJSON` gains `readonly status_log?: ReadonlyArray<StatusLogEntryJSON>` — structural, kept out of the domain import.
- `AuthoredUtterance` gains `readonly invokedBy?: string`.
- `collectUtterances` reads `r.status_log?.[0]?.invoked_by` when present.
- `renderUtterance` authored branch mirrors the review branch: always show the `[invoked_by=…]` tag when set, even when `includeActor=false` (voices groups by actor; the proxy invoker is still not redundant).

## Test plan

- [x] `npm test` — 363 passing (+4 new for `AuthoredUtterance` invokedBy propagation + render, both with and without `includeActor`).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox e2e: 4-transition proxy chain (all by claude-proxy) — `gate show` column aligns; `gate voices eris` surfaces `[invoked_by=claude]` on the authored header; `gate resume --format text` prose appends the proxy hint.

## Closes

`i-0002` and `i-0003` from the dogfood session immediately after #43.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu