### PR TITLE
feat(chain): walk inbound refs + include issue notes in scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate chain <id>` walks inbound references too.** Previously
+  only forward: chain scanned the root's own text and listed the
+  ids it mentioned. Chain in reverse (who mentions ME) was silent,
+  so an issue promoted to a request could be followed
+  request→issue but not issue→request. Now renders up to four
+  sections — `referenced issues`, `referenced requests`,
+  `referenced by issues`, `referenced by requests` — joined by
+  standard tree glyphs. O(N) scan over the corpus; typical
+  content_root size makes this cheap.
+
+### Changed
+- **`gate chain` sees issue notes.** `gatherIssueText` now
+  includes every note body in addition to the immutable `text`
+  field, so a cross-reference added post-hoc as a note is visible
+  to chain the same way it is to show/list. Same-shape fix that
+  joins with the inbound walk — an issue that got a late "see
+  2026-04-18-0003" note is now reachable from both directions.
+- **`gate chain` empty-state phrasing.** Updated from "no cross-
+  referenced records in action/reason/notes/reviews" (one-sided)
+  to "no cross-referenced records; nothing references this
+  either" (bidirectional), matching the new semantic.
+
 ### Changed
 - **`invoked_by` surfaces on authored utterances in `gate voices` /
   `gate tail` / `gate resume`.** #43 stamped the creator's invoker

--- a/src/interface/gate/chain.ts
+++ b/src/interface/gate/chain.ts
@@ -41,6 +41,20 @@ export function gatherRequestText(r: {
   return parts.join('\n');
 }
 
-export function gatherIssueText(i: { text: string }): string {
-  return i.text;
+/**
+ * Same treatment for issues: their notes (the #38 append-only
+ * annotations) can reference other records too. Without pulling
+ * note text into the scan, a cross-reference added post-hoc as
+ * "see i-..." would be invisible to `gate chain`, even though
+ * show/list render it.
+ */
+export function gatherIssueText(i: {
+  text: string;
+  notes?: ReadonlyArray<{ text: string }>;
+}): string {
+  const parts: string[] = [i.text];
+  if (i.notes) {
+    for (const n of i.notes) parts.push(n.text);
+  }
+  return parts.join('\n');
 }

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -246,30 +246,110 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   const linkedRequestIds = refs.requestIds.filter((id) => id !== rootId);
   const linkedIssueIds = refs.issueIds.filter((id) => id !== rootId);
 
+  // Inbound references: scan every other record's text for rootId so
+  // an issue that was promoted to a request can `gate chain` the
+  // resolving request, not just the other way around. Without this
+  // the tool only walks one direction — an asymmetry that shows up
+  // the moment you try to follow a resolution backwards. O(N) scan,
+  // acceptable for the typical content_root.
+  const inboundRequestRecords: typeof allRequests = [];
+  for (const r of allRequests) {
+    if (r.id.value === rootId) continue;
+    const rj = r.toJSON() as unknown as RequestJSON;
+    const text = gatherRequestText({
+      action: rj.action,
+      reason: rj.reason,
+      ...(rj.completion_note !== undefined
+        ? { completion_note: rj.completion_note }
+        : {}),
+      ...(rj.deny_reason !== undefined ? { deny_reason: rj.deny_reason } : {}),
+      ...(rj.failure_reason !== undefined
+        ? { failure_reason: rj.failure_reason }
+        : {}),
+      ...(rj.reviews !== undefined
+        ? { reviews: rj.reviews.map((rv) => ({ comment: rv.comment })) }
+        : {}),
+    });
+    const inboundRefs = extractReferences(text);
+    if (
+      inboundRefs.requestIds.includes(rootId) ||
+      inboundRefs.issueIds.includes(rootId)
+    ) {
+      inboundRequestRecords.push(r);
+    }
+  }
+  const inboundIssueRecords: typeof allIssues = [];
+  for (const i of allIssues) {
+    if (i.id.value === rootId) continue;
+    const ij = i.toJSON();
+    const notesRaw = Array.isArray(ij['notes'])
+      ? (ij['notes'] as Array<Record<string, unknown>>).map((n) => ({
+          text: String(n['text'] ?? ''),
+        }))
+      : undefined;
+    const text = gatherIssueText({
+      text: String(ij['text'] ?? ''),
+      ...(notesRaw ? { notes: notesRaw } : {}),
+    });
+    const inboundRefs = extractReferences(text);
+    if (
+      inboundRefs.requestIds.includes(rootId) ||
+      inboundRefs.issueIds.includes(rootId)
+    ) {
+      inboundIssueRecords.push(i);
+    }
+  }
+
   type Resolved<T> = { id: string; record: T | undefined };
   const linkedRequests: Array<Resolved<ReturnType<typeof requestById.get>>> =
     linkedRequestIds.map((id) => ({ id, record: requestById.get(id) }));
   const linkedIssues: Array<Resolved<ReturnType<typeof issueById.get>>> =
     linkedIssueIds.map((id) => ({ id, record: issueById.get(id) }));
+  const inboundRequests: Array<Resolved<ReturnType<typeof requestById.get>>> =
+    inboundRequestRecords.map((r) => ({ id: r.id.value, record: r }));
+  const inboundIssues: Array<Resolved<ReturnType<typeof issueById.get>>> =
+    inboundIssueRecords.map((i) => ({ id: i.id.value, record: i }));
 
   process.stdout.write(`${rootHeader}\n`);
 
-  const haveIssues = linkedIssues.length > 0;
-  const haveRequests = linkedRequests.length > 0;
+  // Assemble the four possible sections. Rendered only when non-empty;
+  // the tree glyphs pick the correct last-child markers automatically
+  // based on position in the `sections` list, so adding a 5th category
+  // later wouldn't require re-juggling the ├/└ logic.
+  type Kind = 'issue' | 'request';
+  interface Section {
+    title: string;
+    items: Array<Resolved<ReturnType<typeof requestById.get> | ReturnType<typeof issueById.get>>>;
+    kind: Kind;
+  }
+  const sections: Section[] = [];
+  if (linkedIssues.length > 0) {
+    sections.push({ title: 'referenced issues', items: linkedIssues, kind: 'issue' });
+  }
+  if (linkedRequests.length > 0) {
+    sections.push({ title: 'referenced requests', items: linkedRequests, kind: 'request' });
+  }
+  if (inboundIssues.length > 0) {
+    sections.push({ title: 'referenced by issues', items: inboundIssues, kind: 'issue' });
+  }
+  if (inboundRequests.length > 0) {
+    sections.push({ title: 'referenced by requests', items: inboundRequests, kind: 'request' });
+  }
 
-  if (!haveIssues && !haveRequests) {
+  if (sections.length === 0) {
     process.stdout.write(
-      '└── (no cross-referenced records in action/reason/notes/reviews)\n',
+      '└── (no cross-referenced records; nothing references this either)\n',
     );
     return 0;
   }
 
-  if (haveIssues) {
-    const isLastBranch = !haveRequests;
-    const branchGlyph = isLastBranch ? '└──' : '├──';
-    const childPrefix = isLastBranch ? '    ' : '│   ';
-    process.stdout.write(`${branchGlyph} referenced issues\n`);
-    const sorted = [...linkedIssues].sort((a, b) =>
+  for (let s = 0; s < sections.length; s++) {
+    const section = sections[s]!;
+    const isLastSection = s === sections.length - 1;
+    const branchGlyph = isLastSection ? '└──' : '├──';
+    const childPrefix = isLastSection ? '    ' : '│   ';
+    process.stdout.write(`${branchGlyph} ${section.title}\n`);
+    const sorted = [...section.items].sort((a, b) =>
       compareSequenceIds(a.id, b.id),
     );
     for (let i = 0; i < sorted.length; i++) {
@@ -277,34 +357,13 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
       const last = i === sorted.length - 1;
       const glyph = last ? '└──' : '├──';
       if (item.record) {
-        const ij = item.record.toJSON();
+        const j = item.record.toJSON();
         const summary =
-          `${item.id}  [${ij['severity']}/${ij['area']}]  ${ij['state']}` +
-          `  ${truncateCodePoints(String(ij['text'] ?? ''), 70)}`;
-        process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
-      } else {
-        process.stdout.write(
-          `${childPrefix}${glyph} ${item.id}  (referenced but not found)\n`,
-        );
-      }
-    }
-  }
-
-  if (haveRequests) {
-    process.stdout.write(`└── referenced requests\n`);
-    const childPrefix = '    ';
-    const sorted = [...linkedRequests].sort((a, b) =>
-      compareSequenceIds(a.id, b.id),
-    );
-    for (let i = 0; i < sorted.length; i++) {
-      const item = sorted[i]!;
-      const last = i === sorted.length - 1;
-      const glyph = last ? '└──' : '├──';
-      if (item.record) {
-        const rj = item.record.toJSON();
-        const summary =
-          `${item.id}  [${rj['state']}]  from=${rj['from']}` +
-          `  ${truncateCodePoints(String(rj['action'] ?? ''), 70)}`;
+          section.kind === 'issue'
+            ? `${item.id}  [${j['severity']}/${j['area']}]  ${j['state']}` +
+              `  ${truncateCodePoints(String(j['text'] ?? ''), 70)}`
+            : `${item.id}  [${j['state']}]  from=${j['from']}` +
+              `  ${truncateCodePoints(String(j['action'] ?? ''), 70)}`;
         process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
       } else {
         process.stdout.write(

--- a/tests/interface/chain.test.ts
+++ b/tests/interface/chain.test.ts
@@ -158,3 +158,31 @@ test('extractReferences: end-to-end via gatherRequestText', () => {
     'i-2026-04-14-006',
   ]);
 });
+
+// ── gatherIssueText: now includes notes so cross-refs added
+//    post-hoc as annotations are still scannable. ──
+
+test('gatherIssueText: without notes returns bare text (backward compat)', () => {
+  const result = gatherIssueText({ text: 'original problem' });
+  assert.equal(result, 'original problem');
+});
+
+test('gatherIssueText: with notes concatenates text + every note body', () => {
+  const result = gatherIssueText({
+    text: 'original problem',
+    notes: [
+      { text: 'see 2026-04-14-001' },
+      { text: 'also i-2026-04-14-003' },
+    ],
+  });
+  // Join order preserves note order; extractReferences reads the
+  // full joined string.
+  assert.match(result, /original problem/);
+  assert.match(result, /2026-04-14-001/);
+  assert.match(result, /i-2026-04-14-003/);
+});
+
+test('gatherIssueText: empty notes array is same as no notes', () => {
+  const result = gatherIssueText({ text: 'x', notes: [] });
+  assert.equal(result, 'x');
+});


### PR DESCRIPTION
## Summary

Dogfooding after #44 landed surfaced a directional gap: `gate chain` only walks **forward** references. Running `gate chain i-<source-issue>` on an issue that had been promoted via `gate issues promote` returned `no cross-referenced records`, even though the resolving request (`2026-04-18-<N>`) was right there in the requests dir, with "Fix issue i-…" plain as day in its text. Chain was one-way.

Two related fixes in one PR.

### 1. Inbound reference walk

`reqChain` now also scans every *other* record's text for the root id, after the forward walk. When any non-empty, renders two new tree sections:

```
i-2026-04-18-0001  [med/chain]  resolved  chain should walk inbound too
└── referenced by requests
    └── 2026-04-18-0001  [pending]  from=eris  Fix issue i-2026-04-18-0001: ...
```

Mixed case (forward **and** inbound both non-empty) produces the expected tree:

```
2026-04-18-0001  [pending]  from=eris  Fix issue i-2026-04-18-0001: ...
├── referenced issues
│   └── i-2026-04-18-0001  ...
└── referenced by requests
    └── 2026-04-18-0002  [pending]  from=eris  unrelated
```

Empty-state phrasing updated: `no cross-referenced records in action/reason/notes/reviews` → `no cross-referenced records; nothing references this either` — matches the bidirectional semantic.

O(N) scan of the corpus; typical content_root size makes this trivially cheap.

### 2. `gatherIssueText` includes notes

Notes landed in #38 as post-hoc annotations on otherwise immutable issues. A cross-ref written there (`"see 2026-04-18-0003"`) was invisible to `gate chain` because the scan only read `i.text`. Fixed: `gatherIssueText` now joins text + every note body, so the inbound walk catches late-added refs too.

Backward-compat: when `notes` is undefined or empty, returns bare text unchanged.

### Rendering refactor

The old `├/└` glyph juggling hard-coded two branches. Rewrote as a single `sections.forEach` loop with `isLastSection` from position in the list. Adding a 5th category is now one `sections.push` line.

## Test plan

- [x] `npm test` — 366 passing (+3: `gatherIssueText` bare / with-notes / empty-notes). Chain tree rendering is a pure interface concern covered by the sandbox dogfood below.
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox e2e on `/tmp/chain-check`:
  - `gate chain i-<promoted-source>` → `referenced by requests: <resolving req>` (new)
  - `gate chain <req-mentioned-in-issue-note>` → `referenced by issues: <that issue>` (new via #2)
  - Mixed case with both forward and inbound refs → correct `├`/`└` tree
  - Truly-empty record → new phrasing "nothing references this either"

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu