### PR TITLE
docs(chain): refresh summary/HELP/JSDoc for bidirectional walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Changed
+- **Chain documentation refreshed to match bidirectional walk.**
+  `gate schema --verb chain` previously read "walk cross-references
+  one hop from id" — stale since #45 added inbound refs. LLM tool
+  layers consuming the schema would have built their wrapper docs
+  off the one-sided summary. Updated schema summary, `gate --help`
+  entry, and the chain module's JSDoc so every surface names the
+  forward-and-inbound behavior consistently.
+
 ### Added
 - **`gate chain <id>` walks inbound references too.** Previously
   only forward: chain scanned the root's own text and listed the

--- a/src/interface/gate/chain.ts
+++ b/src/interface/gate/chain.ts
@@ -1,10 +1,15 @@
 /**
  * Helpers for `gate chain <id>`.
  *
- * The "chain" is a one-hop neighborhood graph around a root record:
- * given a request or issue id, find every other request or issue it
- * mentions in its free-text fields (action, reason, closure notes,
- * review comments, issue text).
+ * The "chain" is a one-hop neighborhood graph around a root record,
+ * walked in both directions:
+ *
+ *   forward  — ids the root mentions in its own free-text fields
+ *              (request: action / reason / closure notes / review
+ *              comments; issue: text + per-note bodies).
+ *   inbound  — records elsewhere that mention the root id. Computed
+ *              in the handler (reqChain) by scanning every other
+ *              record's text with the same helpers below.
  *
  * The id-scanner itself (`extractReferences`) lives in
  * `domain/shared/extractReferences.ts` — it is reused by the

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -195,7 +195,8 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'chain',
     category: 'read',
-    summary: 'walk cross-references one hop from id',
+    summary:
+      'walk cross-references one hop in both directions (forward: ids the root mentions; inbound: records that mention the root)',
     input: {
       type: 'object',
       properties: { id: idStr },

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -67,7 +67,8 @@ Requests:
                      [--format json|text]          (default: json)
   gate tail [N]                                   (default 20)
   gate whoami                                     (needs GUILD_ACTOR)
-  gate chain <id>                                 (request or issue)
+  gate chain <id>                                 (request or issue;
+                                                   forward refs + inbound)
   gate approve <id> --by <m> [--note <s>]
   gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]
   gate execute <id> --by <m> [--note <s>]


### PR DESCRIPTION
## Summary

Drift fix. #45 extended `gate chain` to walk **inbound** refs as well as forward, but three documentation surfaces still read "one hop from id":

1. `gate schema --verb chain` — the LLM-facing descriptor that tool layers pull to build their wrappers.
2. `gate --help` — the human-facing entry.
3. `chain.ts` module JSDoc — what shows up in editors.

Dogfooding in this session surfaced the drift: `gate schema --verb chain` still said the one-sided phrase after #45 merged.

Updated all three so they say the same thing:

```
# schema
chain [read] — walk cross-references one hop in both directions (forward: ids the root mentions; inbound: records that mention the root)

# help
  gate chain <id>                                 (request or issue;
                                                   forward refs + inbound)
```

No code change, no test change. Pure documentation.

## Test plan

- [x] `npm test` — 366 passing (nothing changed).
- [x] `gate schema --verb chain --format text` — shows new summary.
- [x] `gate --help | grep -A1 'gate chain'` — shows the inbound clarifier.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu