### PR TITLE
polish: drop DomainError: prefix from user-facing error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Changed
+- **User-facing errors no longer leak the `DomainError:` class prefix.**
+  Errors from the domain layer used to come through the CLI as
+  `error: DomainError: Request not found: ... (id)`. The
+  `DomainError:` prefix was pure noise for the end user — the `error:`
+  cue is the universal CLI "this failed" marker, and naming the
+  internal class on top added no information. Dropped. The field
+  suffix (`(id)`, `(from)`, etc.) stays, because that actually names
+  which flag was bad.
 - **Chain documentation refreshed to match bidirectional walk.**
   `gate schema --verb chain` previously read "walk cross-references
   one hop from id" — stale since #45 added inbound refs. LLM tool

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -247,8 +247,13 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
     }
   } catch (e) {
+    // The `error:` prefix gives the CLI-universal "this failed" cue;
+    // prepending "DomainError:" on top leaked an internal class name
+    // into user-facing output without adding information. Keep the
+    // field suffix (`(id)`, `(from)`, etc.) — that actually names
+    // which flag was bad.
     const msg = e instanceof DomainError
-      ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
+      ? `${e.message}${e.field ? ` (${e.field})` : ''}`
       : e instanceof Error
         ? e.message
         : String(e);


### PR DESCRIPTION
## Summary

Dogfooding surfaced that tripping any domain validation leaked the internal class name:

```
error: DomainError: Request not found: 2099-01-01-9999 (id)
```

The `error:` prefix is the universal CLI "this failed" cue. Prepending `DomainError:` on top of that added no information — it's a TypeScript class name bleeding into user output. Dropped.

After:

```
error: Request not found: 2099-01-01-9999 (id)
```

The `(id)` / `(from)` / `(severity)` suffix is kept — that actually names which flag was bad.

Compare to `gate register`'s already-polished shape (unchanged):

```
error: Member "eris" already exists.
  Use `gate whoami` (with GUILD_ACTOR=eris) to see your current record,
  or edit members/eris.yaml directly if you need to change it.
```

Now every error across the CLI reads the same way.

## Test plan

- [x] `npm test` — 366 passing. Two tests in `DiagnosticUseCases.test.ts` assert on `"DomainError: X"` strings but those are hydration-report strings, not CLI-formatter output; unaffected.
- [x] Sandbox — confirmed on `show`, `review`, `issues note`, and `register` error paths.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu