### PR TITLE
fix(register): reject --name that collides with host_names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **`gate register --name <x>` now rejects `x` already in `host_names`.**
+  The existing guards blocked `--category host` and duplicate-member
+  names but missed the third way to create the same collision:
+  registering a plain member whose name is already a host in
+  `guild.config.yaml`. Post-fix, all three entry points end up at
+  the same invariant "a single name cannot be both a host and a
+  member," which is what downstream verbs assume when they resolve
+  an actor's role. Error names both remediation paths (pick a
+  different --name, or remove from `host_names:`).
+
 ### Changed
 - **User-facing errors no longer leak the `DomainError:` class prefix.**
   Errors from the domain layer used to come through the CLI as

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -55,10 +55,26 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
     );
   }
 
+  const parsedName = MemberName.of(name);
+
+  // Host/member name collision check. `host_names` in
+  // guild.config.yaml reserves those identifiers for the content-root
+  // operator role; making a member with the same name would give the
+  // identifier two meanings (host AND member) with no way for downstream
+  // verbs to resolve which applies. Reject the same way `--category host`
+  // is rejected — both guard the same invariant: hosts are config-only.
+  if (c.config.hostNames.includes(parsedName.value)) {
+    throw new Error(
+      `"${parsedName.value}" is already declared as a host in guild.config.yaml.\n` +
+        `  Hosts and members are different roles; a single name cannot be both.\n` +
+        `  Either pick a different --name, or remove "${parsedName.value}" from ` +
+        `host_names: in guild.config.yaml before registering as a member.`,
+    );
+  }
+
   // Pre-flight: does the name already resolve to a member?
   // If it does, this is almost always a typo, not an intentional
   // overwrite — fail loud rather than silently replace a record.
-  const parsedName = MemberName.of(name);
   const existing = await c.memberUC.show(parsedName.value);
   if (existing) {
     throw new Error(

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -140,6 +140,45 @@ test('register: --category host is rejected (guild.config.yaml is the source of 
   }
 });
 
+test('register: --name that collides with host_names is rejected (guards the host/member single-role invariant)', () => {
+  // Complement to the `--category host` guard above: that one catches
+  // the "trying to create a host via --category" path; this one
+  // catches "trying to create a member with a name already claimed
+  // as a host". Both end up as the same invariant violation from
+  // downstream verbs (which name resolves to which role?), so both
+  // must be rejected pre-save.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(root, ['register', '--name', 'human']);
+    assert.notEqual(status, 0);
+    assert.match(stderr, /already declared as a host/);
+    assert.match(stderr, /host_names:/);
+    assert.ok(!existsSync(join(root, 'members', 'human.yaml')));
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: host/member collision fires before --dry-run (disk untouched either way)', () => {
+  // Pin the ordering: the host check must happen before the dry-run
+  // branch, otherwise `register --name <host> --dry-run` would
+  // produce a preview that cannot ever be committed — a confusing
+  // dead-end. Test that the error surfaces regardless of --dry-run.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(root, [
+      'register',
+      '--name',
+      'human',
+      '--dry-run',
+    ]);
+    assert.notEqual(status, 0);
+    assert.match(stderr, /already declared as a host/);
+  } finally {
+    cleanup();
+  }
+});
+
 test('register: --dry-run does not touch disk and yields parseable JSON', () => {
   const { root, cleanup } = bootstrap();
   try {


### PR DESCRIPTION
## Summary

Dogfooding post-#47: `gate register --name alice` succeeded even though `alice` was listed under `host_names:` in `guild.config.yaml`. Result: alice became **simultaneously** a host (per config) and a member (per `members/alice.yaml`) — two roles under one identifier, with no well-defined way for downstream verbs to resolve which applies.

The existing handler already guards two of the three entry points to this state:

| Entry | Pre-fix | Post-fix |
|-------|---------|----------|
| `--category host` | rejected | rejected |
| name already a member on disk | rejected | rejected |
| **name already a host in config** | **accepted (gap)** | **rejected** |

All three should hit the same "a single name cannot be both a host and a member" invariant. Closed the last gap.

**Error output**:

```
$ gate register --name alice
error: "alice" is already declared as a host in guild.config.yaml.
  Hosts and members are different roles; a single name cannot be both.
  Either pick a different --name, or remove "alice" from host_names: in guild.config.yaml before registering as a member.
```

**Ordering**: the check fires *before* the `--dry-run` branch. Otherwise `gate register --name <host> --dry-run` would produce a preview that could never land — a confusing dead-end.

## Test plan

- [x] `npm test` — 368 passing (+2: collision rejected; collision rejected regardless of `--dry-run`).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox: `alice` (in config `host_names`) rejected; `charlie` (not in host_names) succeeds; `alice --dry-run` also rejected with disk untouched.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu