### PR TITLE
polish(resume): document same-actor scope + point at boot on empty path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Changed
+- **`gate resume` documents its same-actor scope and points at
+  `gate boot` when nothing is waiting.** Surfaced by a handoff
+  dogfood: a newcomer running resume as a first command saw
+  "Nothing is waiting" and walked away, not realizing their inbox
+  had 3 unread + they were named as --with on two pending
+  requests. resume's scope is "same-actor continuation" by
+  design; the orientation lens is boot. Pinned that boundary in
+  three places — schema summary, `gate --help` entry, and the
+  module JSDoc — and added a fallback line to the empty-path
+  prose (en + ja) so a newcomer who ran resume as part of a
+  handoff learns to try boot. No functional change to what
+  resume computes; this is a scope-clarification polish.
 - **User-facing errors no longer leak the `DomainError:` class prefix.**
   Errors from the domain layer used to come through the CLI as
   `error: DomainError: Request not found: ... (id)`. The

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -30,6 +30,22 @@ import { UnrespondedConcernsEntry } from '../../../application/concern/Unrespond
  * GUILD_ACTOR is required (resume is inherently first-person). The
  * actor may be a member, a host, or a name not otherwise in the
  * record — we report what we find.
+ *
+ * Scope — same-actor continuation, not full orientation:
+ *   resume reconstructs what THIS actor was doing. It intentionally
+ *   does not surface cross-actor signals:
+ *     - inbox unread (boot surfaces this)
+ *     - requests where the actor is named in `--with` but didn't
+ *       author or execute (pair-mode receiver)
+ *   These are orientation concerns, and the orientation lens is
+ *   `gate boot`. Resume's empty-path prose points at boot so a
+ *   newcomer who ran resume as part of a handoff learns the right
+ *   verb to reach for.
+ *
+ *   Requests where the actor IS executor (`approved` → waiting to
+ *   start, `executing` → waiting to complete) ARE surfaced as open
+ *   loops even when the actor never authored — those are direct
+ *   next-actions, not cross-actor signals.
  */
 
 interface OpenLoop {
@@ -463,6 +479,16 @@ function composeRestorationProseEn(ctx: {
     lines.push(
       'Nothing is waiting — pick up fresh work (`gate pending`) or file a new request.',
     );
+    // resume is a same-actor continuation lens: it reconstructs what
+    // THIS actor was doing. Cross-actor signals (inbox unread,
+    // named-as-`--with` on someone else's request, etc.) are not part
+    // of its scope by design. Point at `gate boot` so a newcomer who
+    // ran resume as part of a handoff doesn't walk away thinking
+    // there's no work — the incoming work is in boot's orientation
+    // payload.
+    lines.push(
+      'If you just arrived on this content_root, try `gate boot` — it surfaces cross-actor work (inbox, assignments, pair-mode partners) that resume does not.',
+    );
   }
 
   return lines.join('\n');
@@ -582,6 +608,9 @@ function composeRestorationProseJa(ctx: {
     lines.push('');
     lines.push(
       '待ちなし — `gate pending` で新しい仕事を拾うか、`gate request` で起票を。',
+    );
+    lines.push(
+      'この content_root に初めて降り立ったのなら `gate boot` を — resume が見ていない cross-actor の信号 (inbox、アサイン、pair-mode) が見える。',
     );
   }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -123,7 +123,8 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'resume',
     category: 'read',
-    summary: 'restoration prompt: last utterance, last transition, open loops, suggested next',
+    summary:
+      'same-actor continuation: last utterance, last transition, open loops, suggested next. Does not surface cross-actor signals (inbox, --with); for orientation after a handoff, use `gate boot` instead.',
     input: {
       type: 'object',
       properties: {

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -154,6 +154,9 @@ Status:
                        last transition, open loops (awaiting/
                        executing/pending review/unreviewed), and a
                        prose restoration note. Requires GUILD_ACTOR.
+                       Same-actor continuation only — for a newcomer
+                       arriving via handoff, use 'gate boot' to see
+                       cross-actor signals (inbox, --with assignments).
 
 Meta:
   gate schema [--verb <name>] [--format json|text]

--- a/tests/interface/resume.test.ts
+++ b/tests/interface/resume.test.ts
@@ -297,3 +297,39 @@ test('gate resume: utterance vs transition are labeled distinctly in prose', () 
     cleanup();
   }
 });
+
+test('resume: empty-path prose points at gate boot for cross-actor signals (en)', () => {
+  // A fresh actor (no utterances, no transitions, no loops) shouldn't
+  // walk away from resume thinking there's nothing for them — resume
+  // is same-actor-continuation-only, so cross-actor work (inbox
+  // unread, --with assignments) lives in boot. Pin the empty-path
+  // fallback so that scope boundary stays visible to readers.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['resume', '--format', 'text'], {
+      GUILD_ACTOR: 'freshface',
+    });
+    assert.match(stdout, /Nothing is waiting/);
+    assert.match(stdout, /gate boot/);
+    assert.match(stdout, /cross-actor/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('resume: empty-path prose points at gate boot (ja)', () => {
+  // Same invariant, Japanese prose path.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(
+      root,
+      ['resume', '--format', 'text', '--locale', 'ja'],
+      { GUILD_ACTOR: 'freshface' },
+    );
+    assert.match(stdout, /待ちなし/);
+    assert.match(stdout, /gate boot/);
+    assert.match(stdout, /cross-actor/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up (3) from the dogfood round-3 report.

resume is a same-actor continuation lens by design — it reconstructs what THIS actor was doing. Cross-actor signals (inbox unread, named in `--with`, named-as-executor when the actor never authored any record) belong to the orientation lens, which is `gate boot`.

The scope boundary wasn't visible to the reader. A newcomer running `gate resume` as the first command during a handoff saw:

```
Nothing is waiting — pick up fresh work (`gate pending`)...
```

…and walked away, not realizing their inbox had 3 unread plus they were named `--with` on two requests. boot had all of that; resume was silent because it wasn't in scope.

### Fix (Layer 1 + Layer 2)

**Layer 1 — scope visible in docs.** Three places a user or agent looks:

- `gate schema --verb resume` summary:
  > `same-actor continuation: ... Does not surface cross-actor signals; for orientation after a handoff, use gate boot instead.`
- `gate --help` entry: appended "Same-actor continuation only — for a newcomer arriving via handoff, use 'gate boot' to see cross-actor signals (inbox, --with assignments)."
- `resume.ts` module JSDoc: added a Scope section explaining same-actor-continuation vs orientation, and calling out that executor-role loops ARE surfaced (those are direct next-actions, not cross-actor signals).

**Layer 2 — empty-path fallback.** Prose in en + ja now appends:

```
Nothing is waiting — pick up fresh work (`gate pending`)...
If you just arrived on this content_root, try `gate boot` — it surfaces
cross-actor work (inbox, assignments, pair-mode partners) that resume
does not.
```

```
待ちなし — `gate pending` で新しい仕事を拾うか、`gate request` で起票を。
この content_root に初めて降り立ったのなら `gate boot` を — resume が
見ていない cross-actor の信号 (inbox、アサイン、pair-mode) が見える。
```

### What's NOT in this PR

No change to what resume computes. This is pure scope-clarification polish. The alternative "expand resume to surface inbox + --with" was considered and rejected: keeping resume's semantic clear (continuation vs orientation) is more valuable than merging the two into a fuzzier "full re-entry" verb.

## Test plan

- [x] `npm test` — 368 passing (+2: empty-path prose points at gate boot in en + ja).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox: a fresh actor (no utterances, no loops) sees both "Nothing is waiting" + the boot pointer, in both en and ja.

## Closes

Report item (3) from the post-a4b190f dogfood round-3 follow-up.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu