### PR TITLE
feat: add gate board verb (what's in flight)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate board` — "what's in flight" view.** New read verb that
+  answers "what's happening right now" in one call, grouping
+  pending + approved + executing rows under per-state headers.
+  Surfaces the question that `gate status` gave counts for and
+  `gate list --state <s>` gave single-state contents for, without
+  requiring three commands to see the whole board. Terminal states
+  (completed / failed / denied) and issues are out of scope: "in
+  flight" means "someone could still act on this." Filters mirror
+  `gate list`: `--for <m>` narrows each section to rows naming
+  that actor; GUILD_ACTOR is applied implicitly when `--for` is
+  omitted (same pattern, same stderr notice). Empty sections still
+  render their header so the board shape stays stable across calls.
+  JSON emits `{ pending: [...], approved: [...], executing: [...] }`
+  with a stable key set — consumers can rely on all three arrays
+  being present even when empty.
+
 ### Fixed
 - **`gate register --name <x>` now rejects `x` already in `host_names`.**
   The existing guards blocked `--category host` and duplicate-member

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -1,0 +1,113 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+import {
+  computeReviewMarkerWidth,
+  formatReviewMarkers,
+} from './request.js';
+
+/**
+ * gate board [--for <m>] [--format json|text]
+ *
+ * "What's in flight right now?" — the non-terminal subset of the
+ * request corpus, grouped by state. Answers the question that
+ * `gate status` gives counts for and `gate list` gives contents for
+ * one-state-at-a-time: a single view of the three active states
+ * stacked in the natural lifecycle order (pending → approved →
+ * executing).
+ *
+ * Scope deliberately excludes terminal states (completed / failed /
+ * denied) and issues. "In flight" means "someone could still act on
+ * this"; closed records belong to `gate tail` / `gate voices` /
+ * `gate show`, and issues belong to `gate issues list`.
+ *
+ * Filters mirror `gate list`: `--for <m>` scopes to requests where
+ * the given actor appears as `from` / `executor` / `auto-review`.
+ * When GUILD_ACTOR is set and `--for` is omitted, the filter is
+ * applied implicitly (same behaviour as `gate list`), with a stderr
+ * notice so the implicit narrowing is visible.
+ *
+ * Empty sections still render their header with "(0)" / "(none)" so
+ * the board shape stays stable across calls — a reader scanning for
+ * "executing" should always find the line even when nothing is mid-
+ * execution.
+ */
+const BOARD_STATES = ['pending', 'approved', 'executing'] as const;
+
+export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  const explicitFor = optionalOption(args, 'for');
+  const envActor =
+    explicitFor === undefined && process.env['GUILD_ACTOR']
+      ? process.env['GUILD_ACTOR']
+      : undefined;
+  const forFilter = explicitFor ?? envActor;
+
+  // Fetch per-state (not listAll) so each section's count matches
+  // the directory on disk exactly. No dedupe needed: a request is
+  // only in one state at a time.
+  const sections: Array<{ state: string; items: Request[] }> = [];
+  for (const state of BOARD_STATES) {
+    let items = await c.requestUC.listByState(state);
+    if (forFilter !== undefined) {
+      items = items.filter(
+        (r) =>
+          r.from.value === forFilter ||
+          r.executor?.value === forFilter ||
+          r.autoReview?.value === forFilter,
+      );
+    }
+    sections.push({ state, items });
+  }
+
+  if (envActor !== undefined) {
+    process.stderr.write(
+      `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
+    );
+  }
+
+  if (format === 'json') {
+    // Plain object keyed by state name in lifecycle order. Stable
+    // key set (pending/approved/executing) across calls; consumers
+    // can rely on all three being present even when empty.
+    const payload: Record<string, unknown> = {};
+    for (const { state, items } of sections) {
+      payload[state] = items.map((r) => r.toJSON());
+    }
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+
+  // Text format: shared review-marker width across all sections so
+  // the action column aligns down the whole board (not just per
+  // section). Same treatment `gate list` gives a single state list.
+  const allItems = sections.flatMap((s) => s.items);
+  const markerWidth = computeReviewMarkerWidth(allItems);
+
+  for (let s = 0; s < sections.length; s++) {
+    const { state, items } = sections[s]!;
+    if (s > 0) process.stdout.write('\n');
+    process.stdout.write(`${state} (${items.length}):\n`);
+    if (items.length === 0) {
+      process.stdout.write('  (none)\n');
+      continue;
+    }
+    for (const r of items) {
+      const j = r.toJSON();
+      const markers = formatReviewMarkers(j['reviews'], markerWidth);
+      // `exec=X` is informationally dense for approved/executing
+      // sections (executor is the next-action holder). For pending
+      // rows it's usually the same as `from`, so still useful to
+      // show but not redundant enough to suppress.
+      const executor = j['executor'] ? `  exec=${j['executor']}` : '';
+      process.stdout.write(
+        `  ${j['id']}  from=${j['from']}${executor}  ${markers}${String(j['action']).slice(0, 60)}\n`,
+      );
+    }
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -236,6 +236,24 @@ const VERBS: readonly VerbSchema[] = [
     output: { type: 'array' },
   },
   {
+    name: 'board',
+    category: 'read',
+    summary:
+      "what's in flight: pending + approved + executing, grouped by state. Sibling to status (counts) and list (single state). Terminal states (completed/failed/denied) and issues are out of scope.",
+    input: {
+      type: 'object',
+      properties: { for: str, format: formatField },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        pending: { type: 'array' },
+        approved: { type: 'array' },
+        executing: { type: 'array' },
+      },
+    },
+  },
+  {
     name: 'register',
     category: 'write',
     summary:

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -22,6 +22,7 @@ import {
   reqChain,
 } from './handlers/read.js';
 import { issuesCmd } from './handlers/issues.js';
+import { boardCmd } from './handlers/board.js';
 import { doctorCmd } from './handlers/doctor.js';
 import { repairCmd } from './handlers/repair.js';
 import { bootCmd } from './handlers/boot.js';
@@ -60,6 +61,9 @@ Requests:
                  [--executor <m>] [--target <s>] [--auto-review <m>]
                  [--with <n1>[,<n2>...]]
   gate pending [--for <m>]
+  gate board [--for <m>] [--format json|text]
+                       What's in flight: pending + approved +
+                       executing, grouped by state.
   gate list --state <state> [--for <m>] [--from <m>]
                             [--executor <m>] [--auto-review <m>]
   gate show <id> [--format json|text]          (default: json)
@@ -183,6 +187,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await reqCreate(c, args);
       case 'pending':
         return await reqList(c, 'pending', args);
+      case 'board':
+        return await boardCmd(c, args);
       case 'list': {
         // `gate list` without --state is a common first-try ("show me
         // everything"). Rather than just erroring on the missing flag,

--- a/tests/interface/board.test.ts
+++ b/tests/interface/board.test.ts
@@ -1,0 +1,219 @@
+// gate board — "what's in flight" view.
+//
+// Verbs around state already exist in two shapes: `gate status` gives
+// counts, `gate list --state <s>` gives contents of one state. What
+// was missing is "show me the board" — pending + approved + executing
+// in one view, grouped.
+//
+// Tests pin:
+//   1. All three sections render with headers + counts, even empty.
+//   2. Terminal states (completed/failed/denied) are OUT of scope.
+//   3. `--for <m>` filters each section to rows naming that actor.
+//   4. `--format json` emits all three keys unconditionally.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-board-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const dir of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, dir));
+  }
+  for (const name of ['eris', 'claude', 'sentinel']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status ?? -1,
+  };
+}
+
+function seedBoard(root: string): void {
+  // 2 pending, 1 approved, 1 executing, 1 completed.
+  // The completed one must NOT appear on the board.
+  runGate(
+    root,
+    ['request', '--action', 'pending-A', '--reason', 'r'],
+    { GUILD_ACTOR: 'eris' },
+  );
+  runGate(
+    root,
+    [
+      'request',
+      '--executor',
+      'claude',
+      '--action',
+      'pending-B',
+      '--reason',
+      'r',
+    ],
+    { GUILD_ACTOR: 'eris' },
+  );
+  runGate(
+    root,
+    [
+      'request',
+      '--executor',
+      'sentinel',
+      '--action',
+      'approved-C',
+      '--reason',
+      'r',
+    ],
+    { GUILD_ACTOR: 'eris' },
+  );
+  runGate(root, ['approve', '2026-04-18-0003', '--by', 'eris'], {
+    GUILD_ACTOR: 'eris',
+  });
+  runGate(
+    root,
+    [
+      'request',
+      '--executor',
+      'claude',
+      '--action',
+      'executing-D',
+      '--reason',
+      'r',
+    ],
+    { GUILD_ACTOR: 'eris' },
+  );
+  runGate(root, ['approve', '2026-04-18-0004', '--by', 'eris'], {
+    GUILD_ACTOR: 'eris',
+  });
+  runGate(root, ['execute', '2026-04-18-0004', '--by', 'claude'], {
+    GUILD_ACTOR: 'claude',
+  });
+  runGate(
+    root,
+    ['fast-track', '--action', 'completed-E', '--reason', 'r'],
+    { GUILD_ACTOR: 'eris' },
+  );
+}
+
+test('gate board: text output groups rows under pending/approved/executing headers', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    seedBoard(root);
+    const { stdout, status } = runGate(root, ['board']);
+    assert.equal(status, 0);
+    assert.match(stdout, /^pending \(2\):/m);
+    assert.match(stdout, /^approved \(1\):/m);
+    assert.match(stdout, /^executing \(1\):/m);
+    // Content rows appear under their headers.
+    assert.match(stdout, /pending-A/);
+    assert.match(stdout, /approved-C/);
+    assert.match(stdout, /executing-D/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate board: completed/failed/denied requests do NOT appear on the board', () => {
+  // The fast-tracked completed-E must not leak in. "In flight"
+  // means "someone could still act on this"; closed records belong
+  // to gate tail / gate show / gate voices.
+  const { root, cleanup } = bootstrap();
+  try {
+    seedBoard(root);
+    const { stdout } = runGate(root, ['board']);
+    assert.equal(/completed-E/.test(stdout), false);
+    assert.equal(/completed \(/.test(stdout), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate board: empty sections still render their header (board shape is stable)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Nothing on the board at all.
+    const { stdout } = runGate(root, ['board']);
+    assert.match(stdout, /pending \(0\):/);
+    assert.match(stdout, /approved \(0\):/);
+    assert.match(stdout, /executing \(0\):/);
+    // Each empty section shows "(none)" so the reader knows there
+    // are no rows (not that rendering is broken).
+    const noneCount = (stdout.match(/\(none\)/g) ?? []).length;
+    assert.equal(noneCount, 3);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate board --for <m>: narrows each section to rows naming that actor', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    seedBoard(root);
+    const { stdout } = runGate(root, ['board', '--for', 'claude']);
+    // claude appears as executor on pending-B and executing-D; not
+    // on pending-A (no executor) nor approved-C (exec=sentinel).
+    assert.match(stdout, /pending-B/);
+    assert.match(stdout, /executing-D/);
+    assert.equal(/pending-A/.test(stdout), false);
+    assert.equal(/approved-C/.test(stdout), false);
+    // Counts reflect the filtered rows.
+    assert.match(stdout, /pending \(1\):/);
+    assert.match(stdout, /approved \(0\):/);
+    assert.match(stdout, /executing \(1\):/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate board --format json: always emits all three keys, even when empty', () => {
+  // Stable key set lets consumers rely on `payload.executing`
+  // existing as an array without guarding for undefined.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout, status } = runGate(root, ['board', '--format', 'json']);
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.ok(Array.isArray(payload.pending));
+    assert.ok(Array.isArray(payload.approved));
+    assert.ok(Array.isArray(payload.executing));
+    assert.equal(payload.pending.length, 0);
+    assert.equal(payload.approved.length, 0);
+    assert.equal(payload.executing.length, 0);
+    // Terminal-state keys MUST NOT appear.
+    assert.equal('completed' in payload, false);
+    assert.equal('failed' in payload, false);
+    assert.equal('denied' in payload, false);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up (4) from the dogfood round-3 report. Between `gate status` (counts across every state) and `gate list --state <s>` (contents of **one** state), there was no single-shot view of "what's happening right now." Users reached for three commands:

```
gate pending
gate list --state approved
gate list --state executing
```

`gate board` bundles those into one call, grouped by state.

### Example

```
$ gate board
pending (2):
  2026-04-18-0001  from=eris                    refactor inbox
  2026-04-18-0002  from=eris  exec=claude       ship the CHANGELOG

approved (1):
  2026-04-18-0003  from=eris  exec=sentinel     DB migration

executing (1):
  2026-04-18-0004  from=eris  exec=claude       bump deps
```

```
$ gate board --for claude
pending (1):
  2026-04-18-0002  from=eris  exec=claude       ship the CHANGELOG

approved (0):
  (none)

executing (1):
  2026-04-18-0004  from=eris  exec=claude       bump deps
```

### Scope decisions

- **Terminal states excluded.** completed / failed / denied are closed work; they belong to `gate tail` / `gate show` / `gate voices`. "In flight" means "someone could still act on this."
- **Issues excluded.** Different record type, different affordances; `gate issues list` is already there. Not lump-summed into the board.
- **Empty sections keep their header.** `pending (0): (none)` stays rendered, so the board shape is stable across calls — a reader scanning for "executing" always finds the line.
- **Stable JSON key set.** `{ pending: [], approved: [], executing: [] }` — consumers can rely on all three arrays existing even when empty.

### Filters

`--for <m>` narrows each section to rows naming the actor as `from` / `executor` / `auto-review`. GUILD_ACTOR is applied implicitly when `--for` is omitted, with a stderr notice for visibility — mirrors `gate list` / `gate pending`.

### Implementation

Piggybacks on existing `RequestUseCases.listByState` and the `request.ts` rendering helpers (`computeReviewMarkerWidth`, `formatReviewMarkers`). No new rendering machinery. ~110 lines of handler + schema entry + HELP entry + index dispatch.

## Test plan

- [x] `npm test` — 371 passing (+5: headers present, empty shape stable, terminal states excluded, `--for` narrows each section, JSON key set stable).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox dogfood: 2 pending / 1 approved / 1 executing / 1 completed setup. text + JSON verified. `--for claude` filter verified.

## Closes

Report item (4) from the post-a4b190f dogfood round-3 follow-up.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu