### PR TITLE
fix: STDIN sentinel for gate message/broadcast; --text flag for issues add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **`gate message --text -` and `gate broadcast --text -` now read
+  from stdin (med, silent data loss regression).** `gate issues
+  note --text -` worked. `gate request --reason -` / `deny` /
+  `fail` / `review --comment -` all worked. But `message` and
+  `broadcast` silently stored the literal `-` as the body.
+  Heredoc-piped handoff notes dropped their content with no
+  error to show for it — a direct hit on the "the record is the
+  truth" invariant. Ported the same `--text -` sentinel as
+  `issues note`.
+
+### Added
+- **`gate issues add` now accepts `--text <s>` / `--text -` (low,
+  symmetry).** Pre-fix the verb accepted text only as the
+  positional argument, while the sibling `gate issues note` had
+  all three routes. Users who built muscle memory on `note`
+  bounced off `add`. Now symmetrical: `--text <s>` inline,
+  `--text -` for stdin, positional remains as the backward-
+  compat legacy form. Missing-text error lists all three routes
+  and carries the same POSIX escape hint (`--text=<value>` / `--`
+  separator) as `issues note` when a flag value begins with `--`.
+
 ### Added
 - **`gate board` — "what's in flight" view.** New read verb that
   answers "what's happening right now" in one call, grouping

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -24,8 +24,39 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
     const severity = requireOption(args, 'severity', '--severity required');
     const area = requireOption(args, 'area', '--area required');
-    const text = args.positional.slice(1).join(' ');
-    if (!text) throw new Error('Usage: gate issues add ... <text>');
+    // Text resolution mirrors `gate issues note`:
+    //   --text <s>       inline short text
+    //   --text -         STDIN until EOF
+    //   <positional>     everything after `add` (legacy / short form)
+    // Before this, `issues add` accepted only the positional form
+    // while `issues note` had all three — asymmetry that users hit
+    // as soon as they reached for the muscle-memory they'd just built.
+    const textOpt = optionalOption(args, 'text');
+    const positional = args.positional.slice(1).join(' ');
+    let text: string;
+    if (textOpt === '-') {
+      text = (await readStdin()).trim();
+    } else if (textOpt !== undefined) {
+      text = textOpt;
+    } else {
+      text = positional;
+    }
+    if (!text.trim()) {
+      // If args.options.text landed as boolean, the user did pass
+      // --text but with a value that began with "--" and the parser
+      // refused it. Point at the POSIX escape valves, same hint shape
+      // as `gate issues note`.
+      const hint =
+        args.options['text'] === true
+          ? '\n  (Your --text value began with "--" and was not consumed. ' +
+            'Use --text=<value> or put "-- <value>" after the other flags.)'
+          : '';
+      throw new Error(
+        'Usage: gate issues add --from <m> --severity <s> --area <a> ' +
+          '[--text <s> | --text - | <text>]' +
+          hint,
+      );
+    }
     // Proxy creation: derive pre-save (id unknown), emit notice after
     // the issue is allocated. Same pattern as gate request.
     const invokedBy = deriveInvokedBy(from);

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -3,12 +3,23 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C, deriveInvokedBy, emitInvokedByNotice } from './internal.js';
+import {
+  C,
+  deriveInvokedBy,
+  emitInvokedByNotice,
+  readStdin,
+} from './internal.js';
 
 export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const to = requireOption(args, 'to', '--to required');
-  const text = requireOption(args, 'text', '--text required');
+  let text = requireOption(args, 'text', '--text required');
+  // `--text -` reads from stdin — same sentinel as `gate issues note
+  // --text -` and `gate review --comment -`. Heredoc bodies for long
+  // handoff messages landed as literal "-" until this; that was
+  // silent data loss, since the record-is-truth invariant broke
+  // without any error to show for it.
+  if (text === '-') text = (await readStdin()).trim();
   const type = optionalOption(args, 'type');
   const invokedBy = deriveInvokedBy(from);
   await c.messageUC.send({
@@ -27,7 +38,8 @@ export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
 
 export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
-  const text = requireOption(args, 'text', '--text required');
+  let text = requireOption(args, 'text', '--text required');
+  if (text === '-') text = (await readStdin()).trim();
   const type = optionalOption(args, 'type');
   const invokedBy = deriveInvokedBy(from);
   if (invokedBy !== undefined) {

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -85,7 +85,8 @@ Requests:
                   [--with <n1>[,<n2>...]]
 
 Issues:
-  gate issues add --from <m> --severity <s> --area <a> <text>
+  gate issues add --from <m> --severity <s> --area <a>
+                  [--text <s> | --text - | <text>]
   gate issues list [--state <s>]
   gate issues resolve|defer|start|reopen <id>
   gate issues note <id> --by <m> [--text <s> | --text - | <text>]
@@ -93,8 +94,8 @@ Issues:
                                       [--action <a>] [--reason <r>]
 
 Messages:
-  gate message --from <m> --to <m> --text <s>
-  gate broadcast --from <m> --text <s>
+  gate message --from <m> --to <m> [--text <s> | --text -]
+  gate broadcast --from <m> [--text <s> | --text -]
   gate inbox --for <m> [--unread]
   gate inbox mark-read [N] [--for <m>]
 

--- a/tests/interface/stdinSentinel.test.ts
+++ b/tests/interface/stdinSentinel.test.ts
@@ -1,0 +1,272 @@
+// STDIN sentinel (`--text -` / --reason - / --comment -) across the
+// CLI. Round-3 dogfood caught that `gate message` and `gate broadcast`
+// silently stored the literal `-` because their handlers never wired
+// the sentinel. `gate issues add` never read the `--text` flag at all.
+// Both were symmetry gaps with `gate issues note`, which already had
+// the three-route (`--text <s>` / `--text -` / positional) shape.
+//
+// These tests pin each surface via spawnSync-with-input so the
+// stdin path round-trips end-to-end, not just the handler logic.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import YAML from 'yaml';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-stdin-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const dir of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, dir));
+  }
+  for (const name of ['eris', 'claude']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  opts: { input?: string; env?: Record<string, string> } = {},
+): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...(opts.env ?? {}) },
+    input: opts.input,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status ?? -1,
+  };
+}
+
+// ── (1) gate message --text - ──
+
+test('gate message --text - reads the message body from stdin', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status } = runGate(
+      root,
+      ['message', '--from', 'eris', '--to', 'claude', '--text', '-'],
+      { input: 'handoff note from stdin\n', env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    const inbox = YAML.parse(
+      readFileSync(join(root, 'inbox', 'claude.yaml'), 'utf8'),
+    );
+    assert.equal(inbox.messages.length, 1);
+    assert.equal(inbox.messages[0].text, 'handoff note from stdin');
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate message --text <s> inline still works (no stdin)', () => {
+  // Regression guard: the stdin branch must not clobber the existing
+  // inline path.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status } = runGate(
+      root,
+      [
+        'message',
+        '--from',
+        'eris',
+        '--to',
+        'claude',
+        '--text',
+        'inline body',
+      ],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    const inbox = YAML.parse(
+      readFileSync(join(root, 'inbox', 'claude.yaml'), 'utf8'),
+    );
+    assert.equal(inbox.messages[0].text, 'inline body');
+  } finally {
+    cleanup();
+  }
+});
+
+// ── (1) gate broadcast --text - ──
+
+test('gate broadcast --text - reads the message body from stdin', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status } = runGate(
+      root,
+      ['broadcast', '--from', 'eris', '--text', '-'],
+      {
+        input: 'guild-wide announcement via pipe\n',
+        env: { GUILD_ACTOR: 'eris' },
+      },
+    );
+    assert.equal(status, 0);
+    const inbox = YAML.parse(
+      readFileSync(join(root, 'inbox', 'claude.yaml'), 'utf8'),
+    );
+    assert.equal(inbox.messages[0].text, 'guild-wide announcement via pipe');
+    // Broadcast type, not "message" — verifies the handler path
+    // didn't short-circuit to the wrong code branch.
+    assert.equal(inbox.messages[0].type, 'broadcast');
+  } finally {
+    cleanup();
+  }
+});
+
+// ── (2) gate issues add --text ──
+
+test('gate issues add --text <s>: inline flag accepted (new in this PR)', () => {
+  // Pre-fix: `--text <s>` threw "Usage: gate issues add ... <text>".
+  // Pin so users who reach for muscle memory from `issues note` don't
+  // bounce off the wall.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stdout } = runGate(
+      root,
+      [
+        'issues',
+        'add',
+        '--from',
+        'eris',
+        '--severity',
+        'low',
+        '--area',
+        'ux',
+        '--text',
+        'flag inline',
+      ],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    assert.match(stdout, /✓ issue:/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues add --text -: reads text from stdin', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status } = runGate(
+      root,
+      [
+        'issues',
+        'add',
+        '--from',
+        'eris',
+        '--severity',
+        'low',
+        '--area',
+        'ux',
+        '--text',
+        '-',
+      ],
+      {
+        input: 'long issue body from pipe\n',
+        env: { GUILD_ACTOR: 'eris' },
+      },
+    );
+    assert.equal(status, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues add <positional>: backward-compat legacy form still works', () => {
+  // The original (and for a while only) way to pass text. The new
+  // --text flag is additive; positional must keep working.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stdout } = runGate(
+      root,
+      [
+        'issues',
+        'add',
+        '--from',
+        'eris',
+        '--severity',
+        'low',
+        '--area',
+        'ux',
+        'legacy positional body',
+      ],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    assert.match(stdout, /✓ issue:/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues add: neither --text nor positional → informative error', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(
+      root,
+      ['issues', 'add', '--from', 'eris', '--severity', 'low', '--area', 'ux'],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.notEqual(status, 0);
+    // Usage names all three routes so the reader sees the full surface.
+    assert.match(stderr, /--text <s>/);
+    assert.match(stderr, /--text -/);
+    assert.match(stderr, /<text>/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues add --text <value-starting-with--> surfaces the POSIX escape hint', () => {
+  // Same hint shape as `issues note` + `review`: when the user
+  // passes a value that begins with "--", the parser refuses it and
+  // the handler's fallback error points at the escape valves.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stderr } = runGate(
+      root,
+      [
+        'issues',
+        'add',
+        '--from',
+        'eris',
+        '--severity',
+        'low',
+        '--area',
+        'ux',
+        '--text',
+        '--reason',
+      ],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.notEqual(status, 0);
+    assert.match(stderr, /--text=<value>/);
+    assert.match(stderr, /-- <value>/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Closes report items **(1) med** and **(2) low** from the post-a4b190f dogfood round-3 follow-up. Both are symmetry gaps with the `--text -` / `--comment -` / `--reason -` stdin sentinel that other verbs already supported.

### (1) `gate message --text -` and `gate broadcast --text -` — silent data loss (med)

**Before**:

```
$ echo "handoff note" | gate message --from X --to Y --text -
✓ message sent: X → Y

# inbox/Y.yaml
  text: "-"    # body never reached the record
```

No error, no warning — just `"-"` in the YAML. The handoff body was lost. This broke the "the record is the truth" invariant exactly where it mattered most: piped multi-line handoff notes that are the whole reason the sentinel exists on other verbs.

**After**: `message` and `broadcast` handlers port the same `if (text === '-') text = (await readStdin()).trim()` branch that `gate issues note` already had.

### (2) `gate issues add` — `--text` flag not supported (low)

**Before**: only positional `<text>` worked. Users who'd just built muscle memory on `gate issues note --text <s>` / `--text -` bounced off immediately.

```
$ gate issues add --from X --severity low --area ux --text "body"
error: Usage: gate issues add ... <text>
```

**After**: all three routes that `issues note` has — inline `--text <s>`, stdin `--text -`, positional (legacy, backward-compat). Missing-text error lists all three. POSIX escape hint (`--text=<value>` / `-- <value>`) fires when a passed value begins with `--`, matching the handler pattern added in #40.

### Meta — dogfooded through `gate` itself

The session itself was recorded in gate:

1. New content_root under `/tmp/self-host`, registered `claude` and `eris`.
2. Filed the work as `2026-04-18-0001` with `--auto-review eris`.
3. Approved + executed via gate.
4. On completion, used the just-fixed `message --text -` to notify `eris` via heredoc pipe (the exact shape that was broken). Verified the body landed in `inbox/eris.yaml`, not `"-"`.
5. Used the just-fixed `issues add --text -` to record a follow-up question ("should we migrate pre-fix records with `text: -`?") as `i-2026-04-18-0001`.
6. `eris` reviewed `[devil/ok]`; `claude` completed.

Self-verification round-trip clean. `gate show 2026-04-18-0001 --format text` shows the full trace.

## Test plan

- [x] `npm test` — 383 passing (+8 new `stdinSentinel.test.ts` spawning the binary with piped stdin to round-trip the sentinel end-to-end).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox (`/tmp/stdin-verify`): 5 happy-path variants + 2 edge cases (`--text=--...`, `-- ...`) + 1 empty-text error — all clean.
- [x] Meta-sandbox (`/tmp/self-host`): session recorded in gate via the fixed verbs themselves; final inbox/YAML verified.

## Closes

Report items (1) and (2) from the post-a4b190f round-3 follow-up.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu