### PR TITLE
fix(repo): pass config.lenses to hydrate from listByState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **Custom lenses (configured in `guild.config.yaml`) no longer break
+  `listAll`-backed read verbs.** `findById` correctly passed
+  `config.lenses` to the hydrator, but `listByState` did not — so a
+  review with a custom lens (e.g. `rational`, `emotional`) wrote
+  fine, showed fine via `gate show`, but then `gate chain` / `gate
+  voices` / `gate tail` hit hydrate failure with "Invalid lense" and
+  silently dropped the record. Surfaced by dogfooding gate in
+  solo-journal mode with a `rational / emotional / future-self /
+  skeptic` lens set. One-line fix at the call site.
 - **`gate message --text -` and `gate broadcast --text -` now read
   from stdin (med, silent data loss regression).** `gate issues
   note --text -` worked. `gate request --reason -` / `deny` /

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -65,7 +65,7 @@ export class YamlRequestRepository implements RequestRepository {
       const absSource = join(this.config.paths.requests, rel);
       const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
       if (parsed === undefined) continue;
-      const r = hydrate(parsed, state, absSource, this.config.onMalformed);
+      const r = hydrate(parsed, state, absSource, this.config.onMalformed, this.config.lenses);
       if (r) out.push(r);
     }
     return out;

--- a/tests/infrastructure/YamlRequestRepository.test.ts
+++ b/tests/infrastructure/YamlRequestRepository.test.ts
@@ -252,3 +252,61 @@ test('save() produces no top-level duplicated completion_note in writer path', a
     cleanup();
   }
 });
+
+test('listByState passes config.lenses to hydrate (custom lens YAML round-trips)', async () => {
+  // Regression: listByState used to drop config.lenses when calling
+  // hydrate, so a request whose reviews used a custom lens (declared
+  // in guild.config.yaml `lenses:`) became unreadable on any
+  // listAll-backed verb (chain / voices / tail). findById worked;
+  // listByState did not. Silent breakage — the warn-and-skip
+  // swallowed the error and callers saw an empty result.
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-repo-lens-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\nlenses:\n  - rational\n  - skeptic\n',
+    );
+    const cfg = GuildConfig.load(root, () => {});
+    const repo = new YamlRequestRepository(cfg);
+
+    const req = Request.create({
+      id: RequestId.generate(new Date('2026-04-18T00:00:00Z'), 1),
+      from: 'alice',
+      action: 'try a custom lens',
+      reason: 'r',
+    });
+    await repo.saveNew(req);
+
+    // Hand-author a review with a custom lens by writing YAML directly,
+    // bypassing Review.create (which also needs `allowedLenses`).
+    // This mirrors the wire contract on disk.
+    const path = join(root, 'requests', 'pending', `${req.id.value}.yaml`);
+    const doc = YAML.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    doc['reviews'] = [
+      {
+        by: 'alice',
+        lense: 'rational',
+        verdict: 'concern',
+        comment: 'custom lens on disk',
+        at: '2026-04-18T00:00:01Z',
+      },
+    ];
+    writeFileSync(path, YAML.stringify(doc));
+
+    // findById already works (test above, implicitly). listByState
+    // is the one that used to fail.
+    const list = await repo.listByState('pending');
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.reviews[0]!.lense, 'rational');
+
+    // Same via listAll (chain/tail/voices entry point).
+    const all = await repo.listAll();
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.reviews[0]!.lense, 'rational');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Silent data-read bug found by dogfooding gate in a solo-journal mode with custom lenses (`rational / emotional / future-self / skeptic`). Writes accepted, but the `listAll` read path silently dropped the records.

## Repro

```
$ cat guild.config.yaml
lenses:
  - rational
  - emotional
...

$ gate review 2026-04-18-0001 --by me --lense rational --verdict concern "..."
✓ review recorded: 2026-04-18-0001 [rational/concern]

$ gate show 2026-04-18-0001   # findById — fine
... (shows the review with lense: rational)

$ gate voices me
warn: .../requests/pending/2026-04-18-0001.yaml: hydrate failed (id=2026-04-18-0001),
  skipping record: Invalid lense: "rational"
  accepted: devil, layer, cognitive, user
(no utterances from me)
```

Same failure on `gate chain` and `gate tail`. Record becomes invisible on every `listAll`-backed verb.

## Cause

Two call sites of `hydrate()` in `YamlRequestRepository`:

- `findById` (line 49): passes `this.config.lenses` as the 5th arg (the allow-list the domain consults when validating review lenses).
- `listByState` (line 68): drops that arg. Hydrator falls back to the 4 canonical lenses, rejects the custom one, calls `onMalformed`, skips the record.

`listAll` flows through `listByState`, so every read verb except `findById`-based `show` silently lost records that used custom lenses.

One-line fix at the call site.

## Test plan

- [x] `npm test` — 384 passing (+1 regression). Test constructs a `GuildConfig` with custom lenses, hand-authors a review using one, calls `listByState` + `listAll`, asserts the record returns and the review lens round-trips as the custom value.
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox: before/after — same `voices` / `tail` / `chain` calls that failed with the hydrate warning now return the record correctly with the custom lens preserved.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu