### PR TITLE
docs: persist domain-fit exploration (conventions + design notes + open Qs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ the value you're getting is worth the reading.
 | 10 min | [`AGENT.md`](./AGENT.md) | you're an AI agent about to run `gate` and want the verb map |
 | 30 min | **this README** (below) | you want the design rationale, first-time setup, verb cookbook |
 | 1 hour | [`docs/verbs.md`](./docs/verbs.md) + [`examples/dogfood-session/`](./examples/dogfood-session/) | you're adopting this seriously and want to see real sessions |
+| working notes | [`docs/domain-fit/`](./docs/domain-fit/) | you're curious whether gate fits a non-standard domain (story, meeting, research, post-mortem, etc.) |
 | when needed | [`POLICY.md`](./POLICY.md) / [`SECURITY.md`](./SECURITY.md) | you're embedding guild-cli and need the stability / threat contract |
 
 If a layer is enough for what you're doing, stop there. Nothing

--- a/docs/domain-fit/README.md
+++ b/docs/domain-fit/README.md
@@ -1,0 +1,68 @@
+# Domain fit — working notes
+
+Exploration of how `guild-cli` behaves when used beyond the "agent
+request lifecycle" it was built for. Notes from hands-on dogfooding
+across six domains, plus the design intuitions the tours surfaced.
+
+Everything here is **provisional**. No design decision is locked by
+anything in this folder. The goal is to have a place where "how
+does this tool flex to X?" stays durable across sessions, instead
+of evaporating with a chat context.
+
+## What's here
+
+- [`domain-conventions.md`](./domain-conventions.md) — per-domain
+  recipes. Six sections covering story, meeting, game design,
+  research log, incident post-mortem, and solo journal. Each one
+  has a reproducible sandbox setup, what felt natural, and what
+  pushed back.
+- [`design-notes.md`](./design-notes.md) — the design intuitions
+  the tours surfaced. Central one: **gate's state machine encodes
+  a social contract between principals, not a time axis.** The
+  review-lens mechanism is the dual — principal separation in the
+  perspective dimension. Two axes; domains that hit both get the
+  most out of the tool.
+- [`open-questions.md`](./open-questions.md) — unresolved design
+  tensions. The story-mode plugin (three layers of depth), a
+  predictive taxonomy of fit, and whether state-machine aliasing
+  is worth building.
+
+## How to use / contribute
+
+If you try gate on a new domain and it teaches you something:
+
+- **Add a section** to `domain-conventions.md` following the
+  existing shape. The reproducible sandbox is the load-bearing
+  part — it lets the next reader verify (or falsify) the claim.
+- **Append to `open-questions.md`** if you hit a design tension
+  that isn't obviously a bug. Tensions that stay unresolved for
+  weeks are more interesting than ones that get patched; keep
+  them visible.
+- **Amend `design-notes.md`** if you find an angle that reframes
+  an existing claim. Don't delete the old framing — strike it
+  through or move it to "earlier framings" so the evolution
+  stays visible. These are working notes; the history is part
+  of the content.
+
+All three files are in a register that's closer to a lab notebook
+than a spec. They're trying to think out loud, not ship a
+pronouncement.
+
+## How this relates to the rest of `docs/`
+
+- [`docs/concepts-for-newcomers.md`](../concepts-for-newcomers.md)
+  — the "first 30 seconds" map. User-facing, authoritative.
+  `domain-fit/` is the opposite register: internal, exploratory.
+- [`docs/verbs.md`](../verbs.md) — the per-verb reference.
+  `domain-fit/conventions` shows the verbs in action across
+  domains; it's the "how to compose them" side of the same story.
+- [`POLICY.md`](../../POLICY.md) — versioning + invariants.
+  Anything in `domain-fit/` that graduates into a hard design
+  decision should move into `POLICY.md` or a real design doc.
+
+## History / provenance
+
+This folder started as the writeup of one session's dogfood
+exploration (2026-04-18). The commits that introduced each
+domain's convention are linked from the per-domain sections so
+the original exploration context is recoverable.

--- a/docs/domain-fit/design-notes.md
+++ b/docs/domain-fit/design-notes.md
@@ -1,0 +1,161 @@
+# Design notes
+
+Intuitions the domain tour surfaced. Not design decisions — these
+are claims the reader should be able to push back on. Where a
+claim gets rejected, strike it through and add the replacement
+rather than deleting; the evolution is part of the record.
+
+## The core claim
+
+> **Gate's state machine is not a time axis. It is a
+> social-contract protocol between principals.**
+
+The 4 non-terminal states (pending → approved → executing →
+completed) plus the 2 early terminals (denied, failed) look like
+they encode time, but a careful read says they encode something
+tighter:
+
+1. **Declare → sanction gap** (pending → approved). A different
+   principal than the author confirms the work may proceed.
+2. **Sanction → execute gap** (approved → executing). The
+   decision moment is separable from the action moment, often
+   with a third principal doing the executing.
+3. **Observable execution duration** (executing → completed).
+   Work that has beginning and end, not a one-shot event.
+
+None of these are "time" in the wall-clock sense. They're
+positions in a social protocol. If one person does all three
+roles simultaneously, the gaps collapse — which is exactly what
+`fast-track` codifies as an escape valve.
+
+## The dual: review lenses as perspective separation
+
+Where the state machine separates principals across _time_, the
+review-lens mechanism separates principals across _perspective_.
+A single request can carry multiple reviews at the same moment in
+its lifecycle, each from a different lens (devil / layer / user /
+…). Each lens is effectively a distinct voice commenting on the
+same artifact.
+
+The two separations are **orthogonal axes**:
+
+```
+                  sanction separation
+                  (state machine)
+                        ↑
+                        |   [max fit zone]
+                        |   incident post-mortem
+                        |   meeting
+                        |
+                        +───────────> perspective separation
+                                       (review lenses)
+                        |
+            [partial] fast-track       [partial]
+            all-at-once                multi-voice
+            solo journal               game design
+            research log               story critique
+```
+
+- **Top-right quadrant** (both axes active): incident
+  post-mortem, meeting. These are where gate was designed for
+  and where it feels best.
+- **Top-left** (state machine active, single perspective):
+  deployment pipelines, compliance workflows. Gate handles them
+  but the review machinery sits mostly unused.
+- **Bottom-right** (single principal in time, many voices):
+  solo journal, game-design brainstorming. Review lenses carry
+  the weight; state machine is overhead and `fast-track` is
+  always the answer.
+- **Bottom-left** (neither axis active): plain note-taking,
+  bookmarking, diary. Don't use gate — a text file does this.
+
+## Predictive taxonomy
+
+If the claim holds, we should be able to predict fit for a new
+domain just by looking at whether its native structure has each
+axis.
+
+| Domain | declare/sanction gap? | multi-perspective? | prediction | observed |
+|---|---|---|---|---|
+| Contract law | ✓ (draft → agreement) | ✓ (each party's legal view) | max | not tested |
+| Clinical procedures with consent | ✓ (diagnosis → patient consent → procedure) | ✓ (patient/MD/ethics) | max | not tested |
+| Academic peer review | ✓ (submit → editor → reviewers) | ✓ (each reviewer) | max | not tested |
+| Incident post-mortem | ✓ | ✓ | max | ✓ confirmed |
+| Meeting decisions | ✓ | ✓ | max | ✓ confirmed |
+| Recipe iteration | △ (taste ≈ sanction?) | ✓ (taste/health/cost) | partial | not tested |
+| Diary | ✗ | ✗ | skip | ✓ confirmed (would be overhead) |
+
+When you sit with an uncertain domain and ask "is there a
+sanction gap here, really?", the answer usually resolves the fit
+question cleanly. "Recipe iteration" is an example where
+reasonable people disagree — does tasting-before-serving count as
+sanction? That ambiguity IS the prediction: the domain is in the
+middle and will feel partial.
+
+## Consequences for design
+
+Some consequences that follow if the claim is right:
+
+1. **The state machine isn't "about time"; marketing and docs
+   that say so mislead.** More accurate: "gate records
+   deliberative multi-principal work." The time thing is a
+   surface feature of the social protocol underneath.
+
+2. **Fast-track is not a shortcut, it's a declaration**: "no
+   sanction gap in this particular case." Treat it as part of
+   the contract vocabulary, not an afterthought.
+
+3. **Custom lenses are already a principal-separation mechanism
+   on the perspective axis.** There's currently no analogue on
+   the time axis — no way to declare "this domain's sanction
+   protocol is not approve/execute/complete, it's submit/review/
+   publish." See `open-questions.md` for whether this matters.
+
+4. **Domain conventions = choosing which axis to activate.** The
+   6-domain tour in `domain-conventions.md` shows that every
+   domain can be modeled by choosing consciously which
+   separations matter. Story mode chose to collapse the time
+   axis (fast-track) and keep the perspective axis (narrator/
+   character/critic lenses). Incident mode used both. This is
+   the right register for domain conventions: declare the
+   separations the domain has.
+
+## What the claim doesn't explain
+
+- **Why append-only feels right across _every_ domain.** The
+  six-domain tour didn't produce a single case where append-only
+  was a problem, including story mode (where wall-clock order
+  ≠ story order, but even there, the solution was "add overlay
+  metadata," not "make it mutable"). Append-only seems to be a
+  more foundational invariant than the time/perspective axes.
+  It might be the "what" gate does; the axes might be the "when
+  it helps vs. when it's overkill."
+
+- **The role of issues and chain** across domains. Both worked
+  in every domain. Issues seem to model "open threads" at any
+  granularity; chain surfaces reference structure regardless of
+  whether the records are deliberative. These two features might
+  generalize further than the axes framework suggests.
+
+- **The emotional/affective dimension**, especially for the solo
+  journal case. The framework treats principals as interchangeable;
+  the real reason solo-journal worked was the affordance of
+  externalizing an internal voice and then seeing it in writing.
+  That's not a property of principal separation; it's a property
+  of records-as-mirrors. The framework may be under-specifying
+  this.
+
+## Earlier framings (kept for posterity)
+
+Earlier version of the central claim read:
+
+> Gate's state machine encodes time; domains whose native time
+> structure matches get the benefit.
+
+This was wrong in an important way: it made "time" the central
+abstraction, when the observed pattern was that _time_ was
+always present but the _principal separation_ was the thing that
+varied between fitting and non-fitting domains. A clock ticks in
+every domain; what varies is whether different principals control
+different parts of the record's lifecycle. The corrected version
+(above) makes principal separation central and time the surface.

--- a/docs/domain-fit/domain-conventions.md
+++ b/docs/domain-fit/domain-conventions.md
@@ -1,0 +1,441 @@
+# Domain conventions
+
+Six domains where gate was tried hands-on. Each section carries:
+
+- **Use case** — what was being recorded.
+- **Config / setup** — what went in `guild.config.yaml` and how
+  members were registered.
+- **Reproducible sandbox** — the shell commands that built the
+  example. Anyone can rerun to verify.
+- **What worked** — verbs and patterns that felt natural.
+- **What pushed back** — friction the domain created with gate's
+  defaults.
+- **Fit verdict** — one-line summary.
+
+Shared bootstrap used below (creates the sandbox dir + common
+members):
+
+```bash
+mkdir -p /tmp/gate-sandbox && cd /tmp/gate-sandbox
+cp /path/to/guild-cli/guild.config.yaml.example guild.config.yaml
+mkdir members requests issues inbox
+export GATE=/path/to/guild-cli/bin/gate.mjs
+```
+
+`GUILD_ACTOR=<name>` is exported per invocation as needed.
+
+---
+
+## 1. Storytelling — character + plot beats
+
+**Use case**: tracking plot beats, character appearances, and
+foreshadowed open threads as a long-form story develops.
+
+**Config**: default lenses. Characters are members (Mira, Kit,
+Narrator). Narrator is used as `GUILD_ACTOR` so authorial actions
+are separable from in-character actions via the `invoked_by`
+delegation mark.
+
+```bash
+node "$GATE" register --name mira --display-name "Mira"
+node "$GATE" register --name kit --display-name "Kit"
+node "$GATE" register --name narrator --display-name "Narrator"
+
+# A plot beat authored by the narrator but attributed to Mira
+GUILD_ACTOR=narrator node "$GATE" fast-track --from mira \
+  --action "灯台に一人で登る" \
+  --reason "父が最後に見た光を確かめに行く" \
+  > /dev/null
+
+# Authorial critique of the beat (structure lens)
+GUILD_ACTOR=narrator node "$GATE" review 2026-04-18-0001 \
+  --by narrator --lense devil --verdict concern \
+  "一人で登らせるのは筋が通る、情報量は不足"
+
+# An open plot question
+GUILD_ACTOR=narrator node "$GATE" issues add \
+  --from narrator --severity med --area plot \
+  -- "父の死因が曖昧。第4章までに回答必要"
+```
+
+**What worked**:
+
+- `voices <character>` returns every beat the character appeared
+  in, chronologically. It reads as a character tracker.
+- `invoked_by=narrator` on beats authored for a character lands
+  the "the author moved this character" structure without extra
+  mechanism.
+- `issues` holds foreshadowing gracefully. An issue that stays
+  open _is_ a plot thread still hanging.
+- `chain` tracks which beats reference which earlier beats —
+  useful for setup/payoff checks.
+
+**What pushed back**:
+
+- The state machine (pending → approved → executing → completed)
+  doesn't map to how a beat lives in a manuscript. Everything
+  ends up going through `fast-track` to compress the lifecycle,
+  which works but leaves fake timestamps in `status_log` for a
+  semantically single event.
+- Story time is not wall-clock time. Beat 3 of Chapter 2 might
+  be written after Chapter 7 is drafted. The append-only
+  `status_log` actively fights this; retroactive edits have no
+  first-class representation.
+- No notion of "which beat is _now_ in the story" — no marker
+  for narrative present vs. past.
+
+**Fit verdict**: partial. Review vocabulary and character-voice
+queries land beautifully; the state machine and wall-clock
+append-only-log fight the domain.
+
+Related in `open-questions.md`: the three-layer story plugin sketch.
+
+---
+
+## 2. Meetings — decisions and parking-lot items
+
+**Use case**: capturing proposals, objections, action items, and
+revised proposals from a live meeting.
+
+**Config**: default lenses. Participants are members with their
+roles in display-name (PM, eng lead, design).
+
+```bash
+node "$GATE" register --name nao --display-name "ナオ (PM)"
+node "$GATE" register --name sari --display-name "サリ (eng lead)"
+node "$GATE" register --name ren --display-name "レン (design)"
+
+# Proposal
+GUILD_ACTOR=nao node "$GATE" request --with sari,ren \
+  --action "feature X を来週月曜にローンチ" \
+  --reason "マーケ準備 OK、次の窓は2ヶ月先"
+
+# Objections as reviews
+GUILD_ACTOR=sari node "$GATE" review 2026-04-18-0001 \
+  --by sari --lense layer --verdict concern \
+  "DB migration 未完、火曜 or 翌週月曜提案"
+GUILD_ACTOR=ren node "$GATE" review 2026-04-18-0001 \
+  --by ren --lense user --verdict concern \
+  "オンボ画面 QA 1週間必要"
+
+# Formal rejection + refile with revision
+GUILD_ACTOR=nao node "$GATE" deny 2026-04-18-0001 --by nao \
+  --reason "2人 concern、翌週月曜に差し戻し、新 request で起票"
+GUILD_ACTOR=nao node "$GATE" request --with sari,ren \
+  --action "feature X を翌週月曜にローンチ (旧案 2026-04-18-0001 からの改訂)" \
+  --reason "DB migration 余裕 + QA 1週間確保"
+
+# Parking-lot item
+GUILD_ACTOR=nao node "$GATE" issues add --from nao --severity low \
+  --area meeting-backlog \
+  -- "DB migration を ship blocking にするか、次回議題"
+
+# Action item (executor named; cross-reference in reason)
+GUILD_ACTOR=sari node "$GATE" request --from sari --executor sari \
+  --action "DB migration 完了まで 3日見積もり、毎朝進捗共有" \
+  --reason "ローンチ blocker として 2026-04-18-0002 に紐づく"
+```
+
+**What worked**:
+
+- `deny` + refile reads as "proposal rejected; revised version
+  submitted." Clean vocabulary match.
+- `gate chain 2026-04-18-0002` later shows the full decision
+  graph: old proposal (denied) ← new proposal ← action item
+  depending on new proposal. This is the information that
+  traditional meeting notes lose.
+- `review` with layer / user lenses separates "technical
+  constraint" from "user-impact concern" naturally.
+- Parking lot as issues, action items as requests with executors.
+
+**What pushed back**:
+
+- Not much. This was the cleanest fit.
+
+**Fit verdict**: **Maximum gift**. The domain's native vocabulary
+(propose / object / reject / revise / act) is what gate was
+already built to model. Decision provenance gets preserved without
+extra process.
+
+---
+
+## 3. Game design brainstorming — proposal + multi-lens critique
+
+**Use case**: exploring a game mechanic, surfacing failure modes,
+variant proposals that respond to specific critiques.
+
+**Config**: default lenses (devil / layer / user map surprisingly
+well to game-design critique axes).
+
+```bash
+node "$GATE" register --name designer --display-name "Designer"
+node "$GATE" register --name devil --display-name "Devil (critique)"
+node "$GATE" register --name user --display-name "User (playability)"
+
+GUILD_ACTOR=designer node "$GATE" request \
+  --action "核: '時間を預ける' rogue-like" \
+  --reason "プレイヤーが実時間を他プレイヤーに預けると、預け先で強力アイテムが生成される"
+GUILD_ACTOR=designer node "$GATE" approve 2026-04-18-0001 --by designer
+
+# Three lenses in action
+GUILD_ACTOR=devil node "$GATE" review 2026-04-18-0001 \
+  --by devil --lense devil --verdict concern \
+  "グリーフィングが主ゲームになる。rogue-like の 'もう一回' 感が消える"
+GUILD_ACTOR=devil node "$GATE" review 2026-04-18-0001 \
+  --by devil --lense layer --verdict concern \
+  "実時間消費は同期ゲーム。rogue-like の非同期 solo run と根本的に合わない"
+GUILD_ACTOR=user node "$GATE" review 2026-04-18-0001 \
+  --by user --lense user --verdict ok \
+  "初回プレイは新鮮。ただし 3 run 目から作業"
+
+# Variant that explicitly answers a critique
+GUILD_ACTOR=designer node "$GATE" request \
+  --action "変奏: solo で時間預け、AI shadow が返しに来る" \
+  --reason "2026-04-18-0001 の devil concern (グリーフィング) を回避する案"
+
+# Open design questions
+GUILD_ACTOR=designer node "$GATE" issues add \
+  --from designer --severity med --area mechanics \
+  -- "初回 run で shadow が無い問題。チュートリアル run の扱いを決める"
+```
+
+**What worked**:
+
+- devil / layer / user lenses map to **player-behavior critique /
+  mechanical coherence / player experience** without renaming.
+  This is surprising and suggests the default lens set has a
+  generality beyond the tool's origin.
+- Variant proposals referencing the original by ID create a
+  design-decision genealogy that chain can walk.
+- Issues for open questions with severity × area = natural
+  triage.
+
+**What pushed back**:
+
+- State machine is underutilized (ideas don't really "execute"),
+  so fast-track dominates again. Same pattern as story mode.
+
+**Fit verdict**: strong. Review lenses are the load-bearing part;
+state machine is overhead. Consider `fast-track` the default
+verb in this mode.
+
+---
+
+## 4. Research log — literature review with cross-references
+
+**Use case**: tracking read papers, their critiques, follow-up
+work that responds to earlier papers, and open research questions.
+
+**Config**: default lenses. Often a single actor (the reader).
+
+```bash
+node "$GATE" register --name me
+
+# Each paper = one fast-tracked request; critique = review
+GUILD_ACTOR=me node "$GATE" fast-track \
+  --action "Paper: Attention Is All You Need (2017)" \
+  --reason "Transformer 原論文。attention のみで seq2seq"
+GUILD_ACTOR=me node "$GATE" review 2026-04-18-0001 \
+  --by me --lense layer --verdict concern \
+  "位置エンコーディングは ad-hoc、後続研究の方向性を示唆する weakness"
+
+# Follow-up paper that references the earlier critique by ID
+GUILD_ACTOR=me node "$GATE" fast-track \
+  --action "Paper: RoPE (Su 2021)" \
+  --reason "2026-04-18-0001 の位置情報 weakness への回答。外挿性あり"
+GUILD_ACTOR=me node "$GATE" fast-track \
+  --action "Paper: ALiBi (Press 2021)" \
+  --reason "同じく 2026-04-18-0001 weakness。bias として注入"
+
+# Open research question referencing both follow-ups
+GUILD_ACTOR=me node "$GATE" issues add --from me --severity med --area theory \
+  -- "RoPE と ALiBi、長文脈で支配的はどちら? 2026-04-18-0002 と 2026-04-18-0003 の extrapolation 比較探す"
+```
+
+**What worked**:
+
+- `chain 2026-04-18-0001` shows **inbound** references — every
+  follow-up paper that cited this one. The #45 bidirectional walk
+  pays off directly here; citation graphs are inherently bidirectional.
+- An open issue mentions multiple paper IDs in its text; chain
+  walks those forward refs too. The question _about_ two papers
+  gets correctly wired to both papers.
+- `voices me` reads as "the reading log with my commentary."
+
+**What pushed back**:
+
+- State machine has no meaning for "read a paper." Every entry
+  is fast-tracked.
+- Single-actor means review lenses are self-critique only — no
+  cross-principal perspective benefit.
+
+**Fit verdict**: partial. The `chain` bidirectional walk is the
+big win; it makes gate a credible lightweight reference tracker.
+Everything else is overhead the single-principal structure can't
+leverage.
+
+---
+
+## 5. Incident post-mortem — detection → mitigation timeline
+
+**Use case**: reconstructing the timeline of a production incident,
+attributing cause, process gap, and customer impact, producing
+follow-up action items.
+
+**Config**: default lenses. Principals are SRE, DB team, dev owner
+— genuinely different roles writing from different viewpoints.
+
+```bash
+node "$GATE" register --name sre --display-name "SRE on-call"
+node "$GATE" register --name db --display-name "DB team"
+node "$GATE" register --name dev --display-name "dev owner"
+
+# The incident as a request; state transitions map to detection/
+# triage/mitigation/resolution.
+GUILD_ACTOR=sre node "$GATE" request --executor sre \
+  --action "INC-2026-04-18: 503 spike (14:02-14:47)" \
+  --reason "14:02 UTC 0.1% → 47%. 14:05 pager. 14:47 rollback で復旧"
+GUILD_ACTOR=sre node "$GATE" approve 2026-04-18-0001 --by sre \
+  --note "14:05 調査開始 — db_connection_pool exhausted"
+GUILD_ACTOR=sre node "$GATE" execute 2026-04-18-0001 --by sre \
+  --note "14:23 mitigation: deployment 68af3 を rollback"
+GUILD_ACTOR=sre node "$GATE" complete 2026-04-18-0001 --by sre \
+  --note "14:47 metrics green、incident closed"
+
+# Post-mortem multi-POV review
+GUILD_ACTOR=db node "$GATE" review 2026-04-18-0001 \
+  --by db --lense layer --verdict concern \
+  "deployment 68af3 が connection leak。負荷試験の coverage gap"
+GUILD_ACTOR=dev node "$GATE" review 2026-04-18-0001 \
+  --by dev --lense cognitive --verdict concern \
+  "PR review で close 漏れ見落とし。金曜18時も要因"
+GUILD_ACTOR=sre node "$GATE" review 2026-04-18-0001 \
+  --by sre --lense user --verdict concern \
+  "顧客影響 45分、SLO 超過 5分、status page 更新 7分 gap"
+
+# Action items as new requests; process question as issue
+GUILD_ACTOR=db node "$GATE" request --from db --executor db \
+  --action "負荷試験に connection leak 検出を追加 (2026-04-18-0001 INC から)" \
+  --reason "coverage gap を埋める"
+GUILD_ACTOR=dev node "$GATE" issues add --from dev --severity high --area process \
+  -- "金曜夕方 deploy 禁止を制度化するか: 2026-04-18-0001 INC root cause"
+```
+
+**What worked**:
+
+- **state machine is almost isomorphic to incident lifecycle**:
+  pending = detected, approved = triaged, executing = mitigating,
+  completed = resolved. The `status_log` with per-transition
+  notes _is_ the incident timeline. This is the single cleanest
+  fit among the six domains.
+- Three lenses map to **technical root cause / process gap /
+  customer impact** — the classic post-mortem triad.
+- Follow-up action items with `executor` assignments, open
+  process questions as issues — both supported by existing
+  vocabulary.
+
+**What pushed back**:
+
+- Nothing significant.
+
+**Fit verdict**: **Maximum gift**. The state machine that was
+overhead everywhere else becomes a gift here because the domain's
+native time structure matches gate's.
+
+---
+
+## 6. Solo journal — multi-voice self-dialogue
+
+**Use case**: one person recording a decision while deliberately
+separating perspectives (rational self, emotional self, imagined
+future self, internal skeptic).
+
+**Config**: **custom lenses** declared in `guild.config.yaml`.
+Multiple "selves" registered as members to carry the different
+voices.
+
+```yaml
+# guild.config.yaml
+lenses:
+  - rational
+  - emotional
+  - future-self
+  - skeptic
+```
+
+```bash
+node "$GATE" register --name me --display-name "Me (current)"
+node "$GATE" register --name tomorrow --display-name "Me (tomorrow)"
+
+GUILD_ACTOR=me node "$GATE" request \
+  --action "仕事を辞めて 6ヶ月研究に専念するか" \
+  --reason "貯金1年分。合わない3割で疲労大。平行1年試して失速"
+
+# Self-review on the same decision through four separate lenses
+GUILD_ACTOR=me node "$GATE" review 2026-04-18-0001 --by me \
+  --lense rational --verdict concern \
+  "財務は合理的。6ヶ月は弱気に取るべき、9ヶ月バッファで考え直す"
+GUILD_ACTOR=me node "$GATE" review 2026-04-18-0001 --by me \
+  --lense emotional --verdict concern \
+  "疲労は本物。だが逃避と方向転換は区別すべき"
+GUILD_ACTOR=tomorrow node "$GATE" review 2026-04-18-0001 --by tomorrow \
+  --lense future-self --verdict ok \
+  "6ヶ月後は 'やってよかった' と言う。ゴール明文化が条件"
+GUILD_ACTOR=me node "$GATE" review 2026-04-18-0001 --by me \
+  --lense skeptic --verdict reject \
+  "決断しないことの不安からの決断。毎晩3時間で3週間続くか試せ"
+
+# Skeptic's critique becomes a concrete pre-commitment action
+GUILD_ACTOR=me node "$GATE" fast-track \
+  --action "3週間の毎晩3時間テスト開始 (2026-04-18-0001 の skeptic concern への応答)" \
+  --reason "決断前の検証。疲労か方向転換かを切り分け"
+```
+
+**What worked**:
+
+- **Custom lenses become domain-specific perspective framework**.
+  The four lenses read as four separable voices; gate's
+  ⚠ self-review warning fires appropriately but doesn't block,
+  matching the intended semantic (the reviewer _is_ the same
+  person, on purpose).
+- An action item that references a specific critique by verdict
+  traces "what the skeptic said → what I did about it."
+- Multiple "self" actors (me / tomorrow) let future-self
+  reasoning carry a different `by` without lying about authorship.
+
+**What pushed back**:
+
+- **Bug (found via this dogfood, fixed in PR #52)**: custom
+  lenses were accepted on write but rejected on listAll-backed
+  read verbs (`chain`, `voices`, `tail`). `findById` passed
+  `config.lenses` to hydrate; `listByState` didn't. Fixed.
+- Single-principal state machine still has no traction. Every
+  entry is fast-tracked.
+- ⚠ self-review warnings fire on every lens — semantically
+  correct but noisy when the pattern is intentional. A future
+  convention might be `--self-review-ok` to suppress when the
+  solo-dialogue use is declared.
+
+**Fit verdict**: partial. The custom-lens mechanism generalizes
+review beautifully to multi-voice self-dialogue, but the lifecycle
+machinery sits unused. Good case study of how review and state
+machine are orthogonal axes of fit.
+
+---
+
+## Summary matrix
+
+| Domain | state machine | review lenses | issues | chain | Overall fit |
+|---|---|---|---|---|---|
+| Story | ✗ (fast-track) | ✓ authorial | ✓ foreshadowing | ○ beat refs | partial |
+| Meeting | ✓ deny→refile | ✓ multi-POV | ✓ parking lot | ✓ decision graph | **max** |
+| Game design | ✗ | ✓ multi-lens | ✓ open Qs | ○ | strong |
+| Research | ✗ | ✓ self-critique | ✓ open Qs | ✓✓ citations | partial |
+| Incident | ✓✓ isomorphic | ✓ triad | ✓ follow-ups | ○ | **max** |
+| Solo journal | ✗ | ✓ custom lenses | — | — | partial |
+
+The two "max" fits have a shared property: **multiple principals
+deliberating about the same record across time**. The "partial"
+fits either collapse principals to one (research, solo journal) or
+have a domain time structure that doesn't match gate's (story,
+game design). `design-notes.md` unpacks this further.

--- a/docs/domain-fit/open-questions.md
+++ b/docs/domain-fit/open-questions.md
@@ -1,0 +1,221 @@
+# Open questions
+
+Design tensions the domain tour surfaced but didn't resolve.
+Kept visible so the conversation stays accessible across sessions.
+
+Each question has:
+
+- **The tension** — what makes it an open question rather than a
+  task.
+- **Options explored** — what paths have been considered.
+- **Current lean** — what feels right today, low confidence.
+- **What would settle it** — evidence or test that could tip the
+  decision.
+
+## Q1. Story mode as a plugin — how deep?
+
+**The tension**: Story domain partially fits gate but actively
+fights two features: (a) the append-only wall-clock `status_log`
+vs. the non-linear story time, and (b) no notion of "narrative
+present vs. past." `fast-track` plus custom lenses cover maybe 80%;
+the remaining 20% wants overlay metadata (chapter, beat-in-chapter,
+POV, tense, draft state). Question: is that 20% worth building?
+
+**Options explored** (layers, cheap to expensive):
+
+- **Layer 0 — config-only conventions**. Document the "story
+  convention for guild-cli" as a file in `examples/` showing
+  custom lens set (reader / structure / voice / continuity),
+  fast-track as the default verb, issues-as-foreshadowing. Zero
+  new code. Gets 80%.
+
+- **Layer 1 — companion CLI (`guild-cli-story` as a separate
+  package)**. A `story` binary that reads gate's `content_root`,
+  writes sidecar metadata (`story/scenes/<id>.yaml` with
+  chapter/beat/POV/tense/draft-state), and provides story-time
+  views (`story chapter 4`, `story arc mira-grief`). Doesn't
+  touch gate. ~500 lines of new code, new package.
+
+- **Layer 2 — `overlay_dir` hook in gate**. Minimal additive:
+  `gate show <id>` reads a sidecar if configured, appends its
+  fields. ~30 lines in gate. Only worth it if Layer 1 proves
+  useful enough that making overlays visible in gate's own
+  verbs matters.
+
+**Current lean**: Layer 0, publish as `examples/story-convention.md`.
+Layer 1 is genuine value but not worth building unless multiple
+story-mode users show up. Layer 2 is always a later optimization.
+
+**What would settle it**: two or three people independently trying
+gate for serialized fiction and reporting whether the Layer 0
+convention is livable or whether they hand-built the same overlay
+structure anyway.
+
+## Q2. State-machine aliasing — domain-specific vocab for transitions?
+
+**The tension**: Custom lenses let the review vocabulary be
+domain-specific (`rational / emotional / future-self / skeptic`
+instead of `devil / layer / user / cognitive`). There's no
+analogue for state-machine transition names. A meeting wants
+"proposed / approved / in-progress / completed"; an incident
+wants "detected / triaged / mitigating / resolved." The
+underlying semantic is identical, but the labels aren't.
+
+**Options explored**:
+
+- **Do nothing**. The current names (`pending / approved /
+  executing / completed`) are generic enough that domain users
+  can mentally rename without confusion. No feature cost.
+
+- **Config-driven aliases**. `guild.config.yaml` gains a
+  `state_aliases:` key: `{ pending: "detected", approved:
+  "triaged", … }`. Display-only; on disk the canonical name
+  stays. Renders via aliases in `gate show` text format.
+
+- **Full pluggable state machines**. Different state sets per
+  domain. Probably a mistake — it breaks the "gate models
+  deliberative work" thesis that makes the tool coherent.
+
+**Current lean**: do nothing, maybe add one-sentence doc note
+that the state names are conventional-but-generic. The meeting
+and incident domains both worked with the default names; the
+tour found no case where the naming was actively confusing.
+
+**What would settle it**: a domain where the default names
+positively mislead (user reads "executing" and infers "running
+code" when they meant "in session"). Hasn't happened yet in the
+six domains tried.
+
+## Q3. Self-review warning in intentional multi-voice contexts
+
+**The tension**: `gate review --by X` when the request's author
+is also X emits a `⚠ self-review` warning (intentional, see #38).
+In solo-journal mode the warning fires on every lens because the
+pattern is intentional — one person deliberately reviewing their
+own decision from four separate vantage points. The warning is
+correct at a micro level but noisy when the convention is solo-
+multi-voice.
+
+**Options explored**:
+
+- **Suppress via flag**: `gate review --by X --self-review-ok`.
+  Opt-in, explicit, per-call. Heavy for a common convention.
+
+- **Suppress via config**: `guild.config.yaml` gains
+  `allow_self_review: true`. Declarative, whole-content_root.
+  Loses the per-call visibility.
+
+- **Suppress when custom lens is active**: if the reviewer uses
+  a custom lens (not in the built-in 4), treat it as intentional
+  multi-voice and skip the warning. Implicit, potentially too
+  magical.
+
+- **Leave it**. The warning is cheap; the noise is cosmetic;
+  maintaining "self-review is always flagged" as an invariant
+  has value.
+
+**Current lean**: leave it. Two reasons: (a) the warning goes
+to stderr, so most automation filters it out anyway; (b) the
+"flagged even when intentional" stance keeps the Two-Persona
+Devil frame honest. The few users who find it noisy can pipe
+stderr away.
+
+**What would settle it**: a user explicitly asking for
+suppression in a non-cosmetic way (e.g., "the warning is
+corrupting my log output in pipeline X").
+
+## Q4. Predictive taxonomy accuracy — does the two-axes model actually predict fit?
+
+**The tension**: `design-notes.md` claims that fit can be
+predicted from two axes (principal separation in time via state
+machine, in perspective via review lenses). Six domains confirm
+the pattern for the cases tried. Is the model actually
+predictive, or did it fit _because_ the six were chosen from
+within the gravitational field of the tool's existing design?
+
+**Options explored**:
+
+- **More domain attempts**. Try domains that the model predicts
+  should fit or not fit, and see if they do. Candidates:
+  - **Predicted "max"**: contract negotiation, clinical
+    procedures, peer review — all multi-principal deliberative
+    work. Should feel like incident / meeting did.
+  - **Predicted "partial"**: recipe iteration, fitness log,
+    photography critique. Should feel like game design or
+    research log.
+  - **Predicted "skip"**: grocery list, bookmark collection.
+    Should feel like overhead; the tool should actively feel
+    wrong.
+
+- **A counter-example that breaks the model**. The more
+  interesting outcome. If _any_ domain predicted to fit turns
+  out not to, or any "skip" turns out to fit surprisingly, the
+  framework is incomplete.
+
+**Current lean**: the model is probably right at the coarse
+level but under-specified. Specifically, `design-notes.md`
+explicitly calls out that issues and chain worked in every
+domain, including ones where the axes predicted partial or no
+fit. Those two features might run on a third axis (reference
+structure) that the two-axes model doesn't capture.
+
+**What would settle it**: at least three more domain tours
+before drawing a confidence interval. Ideally by someone other
+than the tool's author, since the author has taste bias.
+
+## Q5. Records-as-mirrors effect — what is it, and should gate lean into it?
+
+**The tension**: In solo-journal mode the _value_ wasn't from
+principal separation or state machinery; it was that
+externalizing an internal voice and seeing it in writing changed
+how the voice felt. This is a property of records, not of gate
+specifically. But the affordances gate provides — append-only,
+timestamped, cross-referenceable, lens-tagged — might amplify
+the effect vs. a plain text file.
+
+**Options explored**:
+
+- **Don't design for it**. The mirror effect emerges from the
+  fundamentals; adding features for it would be over-reaching.
+
+- **Design for it explicitly**. Build a "reflection mode" that
+  surfaces one's own historical reviews with a delay (e.g.,
+  `gate reflect --since 7d` shows a week-old utterance prefixed
+  with "a week ago you said:"). Low confidence this is useful.
+
+- **Write about it**. Document the mirror effect as something
+  users may notice, without building for it. Lets the observation
+  stay visible without committing to a feature path.
+
+**Current lean**: write about it (probably in
+`concepts-for-newcomers.md` if it ever makes sense there, or
+here in design-notes). Don't build for it until someone reports
+that the effect is what kept them using the tool.
+
+**What would settle it**: evidence that some users stay
+specifically because of the mirror effect, not because of the
+deliberative-work features. Would reframe gate as a reflection
+tool that happens to also model deliberation.
+
+---
+
+## Adding a new question
+
+If you hit something that doesn't resolve in one session,
+append a `Q{N}` section here. The template:
+
+```
+## Q{N}. <short title>
+
+**The tension**: <what makes it open>
+
+**Options explored**:
+- ...
+
+**Current lean**: <what feels right today, low confidence>
+
+**What would settle it**: <evidence that would tip>
+```
+
+Questions can stay open indefinitely. Resolved questions move to
+`design-notes.md` with a note pointing back to the question.


### PR DESCRIPTION
## Summary

Persist today's session exploration as working notes in `docs/domain-fit/`. The session ran gate across six non-origin domains (story, meeting, game design, research log, incident post-mortem, solo journal), surfaced a bug (fixed in #52), and produced a design intuition that felt worth keeping:

> **Gate's state machine is not a time axis. It's a social-contract protocol between principals. Review lenses are the dual, on the perspective axis.**

The observation reframes the tool's fit/overhead patterns across domains into a two-axis predictive model. Rather than let it evaporate with this session's context, persist it in a form that makes it possible to keep thinking with.

## Structure

```
docs/domain-fit/
  README.md              — intro, how to use, how to contribute
  domain-conventions.md  — six per-domain recipes with reproducible sandbox commands
  design-notes.md        — the social-contract claim + two-axes framing + predictive taxonomy
  open-questions.md      — five unresolved design tensions with "current lean / what would settle it" template
```

Register is lab-notebook, not spec:
- Claims are marked provisional;
- Each open question has a "current lean / what would settle it" frame;
- An "earlier framings (kept for posterity)" section on the main claim preserves the shift from "time axis" to "principal separation" rather than overwriting it;
- Adding new domains / questions has an explicit template.

None of this is a design decision. It's a place to think from.

## README wiring

Added one line to README.md's doc-depth table:

| working notes | `docs/domain-fit/` | you're curious whether gate fits a non-standard domain (story, meeting, research, post-mortem, etc.) |

So readers who encounter the new folder via the README land in the right register (exploratory, not authoritative).

## Non-goals

- Not shipping a story plugin (sketched in `open-questions.md` but not built).
- Not renaming state-machine transitions per domain (sketched as Q2, current lean: do nothing).
- Not suppressing the self-review warning in multi-voice contexts (sketched as Q3, current lean: leave it).

Those are all "come back when someone else independently needs them."

## Test plan

- [x] Manual: files render as Markdown, cross-links resolve, the README entry points at the right folder.
- [x] No code changes; `npm test` unaffected (but kept green from prior PRs).
- [x] The sandbox commands in `domain-conventions.md` were all run during the original session; they're the same ones that produced the session's observations.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu