### PR TITLE
feat(promote): structured promoted_from field so chain survives override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate issues promote` writes a structured `promoted_from` field
+  on the created request.** The default `--action` / `--reason`
+  templates mention the source issue id textually, and chain picks
+  that up via its text-scan. But both flags can be overridden — in
+  that narrow case the textual link disappears and chain would lose
+  the connection. The new `promoted_from: <issue-id>` field on the
+  request carries the tool-generated link independent of text
+  content, so chain walks it as a separate-from-text reference path
+  regardless of overrides. The field is omitted on non-promoted
+  requests so existing YAML stays byte-identical; `gate show
+  --format text` renders it on a dedicated line; `chain` dedupes
+  against text-mention hits so default-promote output doesn't
+  surface the same issue twice. Added as the first example of a
+  tool-generated structured relationship (alongside `executor`,
+  `auto_review`, `with`) — user-authored references still use the
+  general text-mention channel. (#47 neighborhood.)
+
 ### Fixed
 - **Custom lenses (configured in `guild.config.yaml`) no longer break
   `listAll`-backed read verbs.** `findById` correctly passed

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -46,6 +46,10 @@ export class RequestUseCases {
     autoReview?: string;
     with?: readonly string[];
     invokedBy?: string;
+    /** Issue id this request was promoted from (via `gate issues
+     *  promote`). Tool-generated structured link surviving any
+     *  --action / --reason overrides. */
+    promotedFrom?: string;
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -83,6 +87,8 @@ export class RequestUseCases {
     if (input.with !== undefined && input.with.length > 0)
       createArgs.with = input.with;
     if (input.invokedBy !== undefined) createArgs.invokedBy = input.invokedBy;
+    if (input.promotedFrom !== undefined)
+      createArgs.promotedFrom = input.promotedFrom;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -48,6 +48,16 @@ export interface RequestProps {
    * are deferred until the need surfaces in actual use.
    */
   with?: MemberName[];
+  /**
+   * Tool-generated structured link to the issue this request was
+   * promoted from (via `gate issues promote`). Populated by the
+   * promote orchestration; undefined for plain `gate request`.
+   * Distinct from text mentions in action/reason: chain uses this
+   * as a separate-from-text-scan reference path so the link
+   * survives full overrides of --action AND --reason. Same shape as
+   * other tool-generated relationship fields (executor, autoReview).
+   */
+  promotedFrom?: string;
   state: RequestState;
   createdAt: string;
   reviews: Review[];
@@ -86,6 +96,9 @@ export class Request {
      * byte-identical to pre-invariant YAML.
      */
     invokedBy?: string;
+    /** See RequestProps.promotedFrom — issue id this request was
+     *  promoted from. Populated by `gate issues promote` only. */
+    promotedFrom?: string;
   }): Request {
     const from = MemberName.of(input.from);
     const action = sanitizeText(input.action, 'action');
@@ -138,6 +151,9 @@ export class Request {
       }
       if (list.length > 0) props.with = list;
     }
+    if (input.promotedFrom !== undefined) {
+      props.promotedFrom = input.promotedFrom;
+    }
     // New requests have no on-disk predecessor; loadedVersion=0 marks
     // "never seen" for the optimistic-lock check in save().
     return new Request(props, 0);
@@ -168,6 +184,9 @@ export class Request {
   }
   get autoReview(): MemberName | undefined {
     return this.props.autoReview;
+  }
+  get promotedFrom(): string | undefined {
+    return this.props.promotedFrom;
   }
   get with(): readonly MemberName[] {
     return this.props.with ?? [];
@@ -279,6 +298,8 @@ export class Request {
     if (this.props.target !== undefined) out['target'] = this.props.target;
     if (this.props.with && this.props.with.length > 0)
       out['with'] = this.props.with.map((m) => m.value);
+    if (this.props.promotedFrom !== undefined)
+      out['promoted_from'] = this.props.promotedFrom;
     // Derive legacy closure keys from the last status_log entry so
     // external consumers (chain / voices / show --format text) keep
     // working unchanged. Single source of truth: status_log[-1].note.

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -344,6 +344,9 @@ function hydrate(
       }
       if (partners.length > 0) props.with = partners;
     }
+    if (typeof obj['promoted_from'] === 'string') {
+      props.promotedFrom = obj['promoted_from'] as string;
+    }
     // Legacy top-level closure keys (completion_note / deny_reason /
     // failure_reason) are no longer written separately — status_log[-1].note
     // is the single source of truth. Handle the three migration cases

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -146,6 +146,13 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
     from,
     action,
     reason,
+    // Structured link to the source issue. The default action/reason
+    // already mention the issue id textually, but --action and
+    // --reason can both be overridden — in which case the textual
+    // link disappears and chain would lose the connection. This
+    // field carries the tool-generated link independent of text
+    // content, so chain can walk it regardless of overrides.
+    promotedFrom: id,
   };
   if (executor !== undefined) input.executor = executor;
   if (autoReview !== undefined) input.autoReview = autoReview;

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -246,6 +246,27 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   const linkedRequestIds = refs.requestIds.filter((id) => id !== rootId);
   const linkedIssueIds = refs.issueIds.filter((id) => id !== rootId);
 
+  // Structured forward link: a request root that was promoted from
+  // an issue carries `promoted_from: <issue-id>` independent of its
+  // action/reason text. Add that issue to the forward-referenced
+  // list so chain surfaces the link even when --action and --reason
+  // were both overridden at promote time (the narrow case where the
+  // text-mention scan can't reach). Dedup against linkedIssueIds so
+  // the default case (text mentions i-X + structured field = i-X)
+  // doesn't render the same issue twice.
+  if (!isIssueId) {
+    const rootReq = requestById.get(rootId);
+    const rootRj = rootReq?.toJSON() as unknown as RequestJSON | undefined;
+    const structuredIssue = rootRj?.promoted_from;
+    if (
+      structuredIssue !== undefined &&
+      structuredIssue !== rootId &&
+      !linkedIssueIds.includes(structuredIssue)
+    ) {
+      linkedIssueIds.push(structuredIssue);
+    }
+  }
+
   // Inbound references: scan every other record's text for rootId so
   // an issue that was promoted to a request can `gate chain` the
   // resolving request, not just the other way around. Without this
@@ -271,10 +292,18 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
         : {}),
     });
     const inboundRefs = extractReferences(text);
-    if (
+    const textMentions =
       inboundRefs.requestIds.includes(rootId) ||
-      inboundRefs.issueIds.includes(rootId)
-    ) {
+      inboundRefs.issueIds.includes(rootId);
+    // Structured inbound: a request whose `promoted_from` equals the
+    // current issue root is linked via the tool-generated field even
+    // if its overridden text doesn't mention the issue id. Issue
+    // roots are the only ones that can catch this kind of link;
+    // request roots have their own forward promoted_from handled
+    // above.
+    const structuredInbound =
+      isIssueId && rj.promoted_from === rootId;
+    if (textMentions || structuredInbound) {
       inboundRequestRecords.push(r);
     }
   }

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -169,6 +169,9 @@ function formatRequestText(r: Request): string {
   if (Array.isArray(j['with']) && j['with'].length > 0) {
     lines.push(`  with:     ${(j['with'] as string[]).join(', ')}`);
   }
+  if (j['promoted_from']) {
+    lines.push(`  promoted_from: ${j['promoted_from']}`);
+  }
   lines.push(`  created:  ${j['created_at']}`);
   lines.push('');
   pushMultilineField(lines, '  action:   ', String(j['action']));

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -44,6 +44,10 @@ export type RequestJSON = {
   readonly with?: ReadonlyArray<string>;
   readonly reviews?: ReadonlyArray<ReviewJSON>;
   readonly status_log?: ReadonlyArray<StatusLogEntryJSON>;
+  // Tool-generated structured link to the source issue when this
+  // request came from `gate issues promote`. Used by chain as a
+  // text-independent forward/inbound ref path.
+  readonly promoted_from?: string;
 };
 
 export type ReviewJSON = {

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -420,3 +420,48 @@ test('Request.create without invokedBy leaves initial entry clean', () => {
   const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
   assert.equal('invoked_by' in log[0]!, false);
 });
+
+// ── promoted_from: structured link to source issue ──
+
+test('Request.create with promotedFrom stores the id on the aggregate', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'whatever',
+    reason: 'whatever',
+    promotedFrom: 'i-2026-04-14-0001',
+  });
+  assert.equal(r.promotedFrom, 'i-2026-04-14-0001');
+  assert.equal(r.toJSON()['promoted_from'], 'i-2026-04-14-0001');
+});
+
+test('Request.toJSON omits promoted_from when not set (pre-promote requests byte-identical)', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+  });
+  assert.equal('promoted_from' in r.toJSON(), false);
+});
+
+test('Request.restore preserves promotedFrom on round-trip', () => {
+  // Simulates the repo rehydrating a request that was promoted.
+  // The field must survive load → toJSON without needing domain
+  // logic to re-infer it from text.
+  const r = Request.restore({
+    id: RequestId.generate(d, 1),
+    from: MemberName.of('alice'),
+    action: 'custom title (no id mention)',
+    reason: 'custom reason (no id mention)',
+    state: 'pending',
+    createdAt: '2026-04-14T00:00:00.000Z',
+    statusLog: [
+      { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+    ],
+    reviews: [],
+    promotedFrom: 'i-2026-04-14-0007',
+  });
+  assert.equal(r.promotedFrom, 'i-2026-04-14-0007');
+  assert.equal(r.toJSON()['promoted_from'], 'i-2026-04-14-0007');
+});


### PR DESCRIPTION
## Summary

Closes the narrow but real case where `gate issues promote` + both `--action` and `--reason` overridden loses the chain link back to the source issue. The default templates mention the issue id textually, and #45's bidirectional chain scan picks that up — but the override case leaves no text mention and chain can't follow.

## Approach

Add a tool-generated structured field `promoted_from: <issue-id>` on the created request. `chain` walks it as an additional reference path, independent of the text-scan.

**Not** the alternative ("auto-append the issue id to the user's custom action text"): that would violate gate's invariant that written text is returned as written (modulo control-char sanitization). Good intention, wrong mechanism.

**Asymmetry is honest**: text-mention stays as the channel for user-authored references ("see i-X" in a note). Tool-generated relationships get their own first-class field (alongside `executor`, `auto_review`, `with`, which were already structured).

## Example

```
$ gate issues promote i-2026-04-18-0001 \
    --action "全然違うタイトル" --reason "全然違う理由"
✓ promoted i-2026-04-18-0001 → 2026-04-18-0001 (issue resolved)

$ cat requests/pending/2026-04-18-0001.yaml | tail -4
reviews: []
promoted_from: i-2026-04-18-0001          # ← the new field

$ gate chain 2026-04-18-0001
2026-04-18-0001  [pending]  from=eris  全然違うタイトル
└── referenced issues
    └── i-2026-04-18-0001  [low/test]  resolved  source issue

$ gate chain i-2026-04-18-0001
i-2026-04-18-0001  [low/test]  resolved  source issue
└── referenced by requests
    └── 2026-04-18-0001  [pending]  from=eris  全然違うタイトル

$ gate show 2026-04-18-0001 --format text
2026-04-18-0001  [pending]
  from:     eris
  promoted_from: i-2026-04-18-0001         # ← rendered
  ...
```

Default (no-override) case: text and structured link both point at the same issue; chain dedupes so the "referenced issues" section shows the issue once, not twice.

Non-promoted requests (plain `gate request`): field is omitted, YAML byte-identical to pre-fix. No migration.

## Layer touches

| Layer | Change |
|---|---|
| Domain (`Request`) | `promotedFrom?` on props, `create` input, `toJSON` emits, getter, restore round-trip |
| Repo | `YamlRequestRepository` hydrates `promoted_from` alongside existing structured fields |
| Use case | `RequestUseCases.create` forwards `promotedFrom` |
| Handler | `issuesPromote` passes `promotedFrom: id` unconditionally |
| Chain | forward ref for request roots with the field; inbound ref for issue roots via request.`promoted_from === rootId`; both dedup against text-scan hits |
| `show --format text` | renders `promoted_from: i-...` as a dedicated field line |
| `RequestJSON` type (voices.ts) | `promoted_from?` declared so chain can read it |

## Test plan

- [x] `npm test` — 387 passing (+3 domain: `create` carries field, `toJSON` omits when unset, `restore` round-trip).
- [x] `npx tsc --noEmit` clean.
- [x] Sandbox e2e:
  - Override both flags → structured field landed; chain works both directions; show renders the line.
  - Default promote → chain shows issue once (no duplication between text-scan and structured-field paths).
  - Plain `gate request` (non-promoted) → no `promoted_from` key in YAML; byte-identical.

## Non-goals

- Auto-injecting the issue id into overridden text (rejected: breaks the "text is returned as written" invariant).
- Adding structured fields for other relationships (`blocked_by`, `supersedes`, etc.) — those remain as text mentions for now; the general-vs-tool-generated asymmetry stays until a concrete use case forces the question.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu