### PR TITLE
fix: three review-mode follow-ups (temporal concerns / positional - / chain dedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **`unresponded_concerns` no longer counts pre-dating mentions as
+  follow-ups.** `UnrespondedConcernsQuery.hasFollowUp` was checking
+  "does any authored record mention this id?" without a temporal
+  guard. Concrete failure: v1 denied with reason mentioning v2.id
+  ("refile as v2"), then v2 reviewed with a concern — the earlier
+  v1 deny's mention of v2.id falsely counted as a follow-up, so the
+  concern was hidden from resume. With the guard, a referring record
+  is only counted as a follow-up if its `created_at` post-dates the
+  latest concern on the request. Surfaced by a review-mode dogfood
+  where concerns were legitimately open but invisible.
+- **Positional `-` now triggers the stdin sentinel on `gate review`,
+  `gate issues note`, and `gate issues add`.** Previously `--comment -`
+  / `--text -` read stdin but writing the sentinel as a trailing
+  positional (`gate review ... --verdict X - <<EOF`) stored the
+  literal `"-"` as the body — a natural shape that silently dropped
+  the heredoc. Positional `-` now reads stdin the same way as the
+  explicit flag forms.
+- **`gate chain` dedupes bidirectional mentions and marks them with
+  `↔`.** Two records that mention each other in their text used to
+  appear in BOTH "referenced" and "referenced by" sections — the
+  same record rendered twice. Now bidirectional refs appear once,
+  in the forward section, prefixed with `↔` to signal mutual
+  reference. One-way refs stay as before.
+
 ### Added
 - **`gate issues promote` writes a structured `promoted_from` field
   on the created request.** The default `--action` / `--reason`

--- a/src/application/concern/UnrespondedConcernsQuery.ts
+++ b/src/application/concern/UnrespondedConcernsQuery.ts
@@ -108,7 +108,30 @@ export function computeUnrespondedConcerns(
     }
     if (concerns.length === 0) continue;
 
-    if (hasFollowUp(r.id.value, authorshipSet, allRequests, allIssues)) {
+    // Follow-up detection is temporal: a record mentioning R.id that
+    // was created BEFORE the latest concern can't be a response to
+    // it (the concern didn't exist yet when the referrer was written).
+    // Without this guard, iteration flows like v1-denied-mentioning-v2
+    // followed by a concern on v2 would falsely mark the concern as
+    // "responded" because the v1 deny happens to mention v2.id —
+    // even though the deny pre-dates the concern by seconds. The
+    // latest concern's `at` is the correct cutoff: a follow-up must
+    // know about ALL concerns on the request to credibly respond to
+    // the set (the all-or-nothing semantic documented above).
+    const latestConcernAtMs = concerns.reduce((max, c) => {
+      const t = Date.parse(c.at);
+      return Number.isFinite(t) && t > max ? t : max;
+    }, 0);
+
+    if (
+      hasFollowUp(
+        r.id.value,
+        authorshipSet,
+        allRequests,
+        allIssues,
+        latestConcernAtMs,
+      )
+    ) {
       continue;
     }
 
@@ -153,27 +176,39 @@ function latestAt(entry: UnrespondedConcernsEntry): number {
 
 /**
  * Return true if any request or issue other than `targetId`, authored
- * by someone in `authorshipSet`, mentions `targetId` in its free text.
- * This is the "follow-up exists" check. Does NOT try to detect whether
- * the follow-up actually addresses the concerns — that is the reader's
- * judgment, documented as a deliberate limitation.
+ * by someone in `authorshipSet`, mentions `targetId` in its free text
+ * AND was created after `afterMs`. This is the "follow-up exists"
+ * check. Does NOT try to detect whether the follow-up actually
+ * addresses the concerns — that is the reader's judgment, documented
+ * as a deliberate limitation. The temporal guard (`afterMs`) prevents
+ * referrers that pre-date the concern from being falsely counted.
  */
 function hasFollowUp(
   targetId: string,
   authorshipSet: ReadonlySet<string>,
   allRequests: ReadonlyArray<Request>,
   allIssues: ReadonlyArray<Issue>,
+  afterMs: number,
 ): boolean {
   for (const r of allRequests) {
     if (r.id.value === targetId) continue;
     if (!authorshipSet.has(r.from.value)) continue;
+    if (!isAfter(r.statusLog[0]?.at, afterMs)) continue;
     if (proseMentionsId(gatherRequestProse(r), targetId)) return true;
   }
   for (const i of allIssues) {
     if (!authorshipSet.has(i.from.value)) continue;
+    const iJson = i.toJSON() as Record<string, unknown>;
+    if (!isAfter(iJson['created_at'], afterMs)) continue;
     if (proseMentionsId(i.text, targetId)) return true;
   }
   return false;
+}
+
+function isAfter(at: unknown, afterMs: number): boolean {
+  if (typeof at !== 'string') return false;
+  const t = Date.parse(at);
+  return Number.isFinite(t) && t > afterMs;
 }
 
 function gatherRequestProse(r: Request): string {

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -38,6 +38,11 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
       text = (await readStdin()).trim();
     } else if (textOpt !== undefined) {
       text = textOpt;
+    } else if (positional === '-') {
+      // Symmetry with `--text -`. `gate issues add ... -` with a
+      // heredoc attached reads the body from stdin, same as the
+      // explicit flag form.
+      text = (await readStdin()).trim();
     } else {
       text = positional;
     }
@@ -213,6 +218,10 @@ async function issuesNote(c: C, args: ParsedArgs): Promise<number> {
     text = (await readStdin()).trim();
   } else if (textOpt !== undefined) {
     text = textOpt;
+  } else if (positional === '-') {
+    // Symmetry with `--text -`. A lone `-` as positional argument
+    // means "read the note body from stdin," same as in review.
+    text = (await readStdin()).trim();
   } else {
     text = positional;
   }

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -329,15 +329,51 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
     }
   }
 
-  type Resolved<T> = { id: string; record: T | undefined };
+  // Bidirectional dedup: when record X appears on both sides (root
+  // mentions X AND X mentions root), render it once in the forward
+  // section with a `↔` marker rather than twice (once under
+  // "referenced X" and again under "referenced by X"). The
+  // bidirectional mark is NOT the same information as the pair of
+  // one-way marks; it's tighter — "they know about each other" —
+  // and that's usually what the reader cares about.
+  const inboundRequestIdSet = new Set(
+    inboundRequestRecords.map((r) => r.id.value),
+  );
+  const inboundIssueIdSet = new Set(
+    inboundIssueRecords.map((i) => i.id.value),
+  );
+  const bidirRequestIds = new Set(
+    linkedRequestIds.filter((id) => inboundRequestIdSet.has(id)),
+  );
+  const bidirIssueIds = new Set(
+    linkedIssueIds.filter((id) => inboundIssueIdSet.has(id)),
+  );
+
+  type Resolved<T> = {
+    id: string;
+    record: T | undefined;
+    bidirectional: boolean;
+  };
   const linkedRequests: Array<Resolved<ReturnType<typeof requestById.get>>> =
-    linkedRequestIds.map((id) => ({ id, record: requestById.get(id) }));
+    linkedRequestIds.map((id) => ({
+      id,
+      record: requestById.get(id),
+      bidirectional: bidirRequestIds.has(id),
+    }));
   const linkedIssues: Array<Resolved<ReturnType<typeof issueById.get>>> =
-    linkedIssueIds.map((id) => ({ id, record: issueById.get(id) }));
+    linkedIssueIds.map((id) => ({
+      id,
+      record: issueById.get(id),
+      bidirectional: bidirIssueIds.has(id),
+    }));
   const inboundRequests: Array<Resolved<ReturnType<typeof requestById.get>>> =
-    inboundRequestRecords.map((r) => ({ id: r.id.value, record: r }));
+    inboundRequestRecords
+      .filter((r) => !bidirRequestIds.has(r.id.value))
+      .map((r) => ({ id: r.id.value, record: r, bidirectional: false }));
   const inboundIssues: Array<Resolved<ReturnType<typeof issueById.get>>> =
-    inboundIssueRecords.map((i) => ({ id: i.id.value, record: i }));
+    inboundIssueRecords
+      .filter((i) => !bidirIssueIds.has(i.id.value))
+      .map((i) => ({ id: i.id.value, record: i, bidirectional: false }));
 
   process.stdout.write(`${rootHeader}\n`);
 
@@ -385,18 +421,23 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
       const item = sorted[i]!;
       const last = i === sorted.length - 1;
       const glyph = last ? '└──' : '├──';
+      // `↔` prefix signals "root and this record reference each
+      // other"; no prefix means "one-way in this direction only."
+      // The marker is short on purpose — readers scan a tree, not a
+      // paragraph.
+      const bidirMark = item.bidirectional ? '↔ ' : '';
       if (item.record) {
         const j = item.record.toJSON();
         const summary =
           section.kind === 'issue'
-            ? `${item.id}  [${j['severity']}/${j['area']}]  ${j['state']}` +
+            ? `${bidirMark}${item.id}  [${j['severity']}/${j['area']}]  ${j['state']}` +
               `  ${truncateCodePoints(String(j['text'] ?? ''), 70)}`
-            : `${item.id}  [${j['state']}]  from=${j['from']}` +
+            : `${bidirMark}${item.id}  [${j['state']}]  from=${j['from']}` +
               `  ${truncateCodePoints(String(j['action'] ?? ''), 70)}`;
         process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
       } else {
         process.stdout.write(
-          `${childPrefix}${glyph} ${item.id}  (referenced but not found)\n`,
+          `${childPrefix}${glyph} ${bidirMark}${item.id}  (referenced but not found)\n`,
         );
       }
     }

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -33,6 +33,12 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     comment = await readStdin();
   } else if (commentOpt !== undefined) {
     comment = commentOpt;
+  } else if (positional === '-') {
+    // Positional `-` gets the same stdin-sentinel treatment as
+    // `--comment -`. Symmetry: users reach for `gate review <id> ...
+    // - <<EOF` naturally (same shape as `--comment -`); the literal
+    // "-" as a comment body is almost never what anyone means.
+    comment = await readStdin();
   } else if (positional) {
     comment = positional;
   } else if (process.stdin.isTTY) {

--- a/tests/application/UnrespondedConcernsQuery.test.ts
+++ b/tests/application/UnrespondedConcernsQuery.test.ts
@@ -332,3 +332,80 @@ test('self-review on own request still counts as a concern to track', () => {
   const out = computeUnrespondedConcerns([target], [], 'claude', BASE_DATE.getTime(), 30);
   assert.equal(out.length, 1);
 });
+
+// ── temporal guard: a record that PRE-dates the concern can't be a follow-up ──
+
+test('follow-up that pre-dates the concern is NOT counted (temporal guard)', () => {
+  // The failure mode this pins: v1 was denied with a deny_reason that
+  // happens to mention v2's id (because the deny already announced
+  // "I'll refile as <id>"). Then v2 is created, reviewed, concerned.
+  // Without the temporal guard, v1's earlier mention of v2.id would
+  // falsely count as "follow-up exists" and the concern on v2 would
+  // be hidden. With the guard, the earlier mention is ignored and
+  // the concern surfaces.
+  //
+  // Timeline:
+  //   T0: v1 denied, deny_reason mentions v2.id
+  //   T1: v2 created
+  //   T2: concern on v2 (later than T0)
+  // A legitimate follow-up would need to be created AFTER T2.
+  const v2 = makeRequest({
+    seq: 2,
+    from: 'mia',
+    action: 'v2',
+    createdAt: daysAgo(2),
+    reviews: [
+      // concern is 1 day after v2 creation (2 days ago)
+      { by: 'rev', lense: 'devil', verdict: 'concern', at: daysAgo(1) },
+    ],
+  });
+  const v1 = makeRequest({
+    seq: 1,
+    from: 'mia',
+    action: 'v1',
+    reason: `refiled as ${v2.id.value}`,
+    createdAt: daysAgo(3), // v1 pre-dates v2 AND its concern
+  });
+  const out = computeUnrespondedConcerns(
+    [v1, v2],
+    [],
+    'mia',
+    BASE_DATE.getTime(),
+    30,
+  );
+  // The concern on v2 must surface: v1 is too old to count as a
+  // follow-up to it.
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.request_id, v2.id.value);
+});
+
+test('follow-up that post-dates the concern IS counted (baseline still works)', () => {
+  // Sanity: the temporal guard shouldn't break the happy path where
+  // a legitimate later follow-up exists.
+  const earlier = makeRequest({
+    seq: 1,
+    from: 'mia',
+    action: 'earlier',
+    createdAt: daysAgo(3),
+    reviews: [
+      { by: 'rev', lense: 'devil', verdict: 'concern', at: daysAgo(3) },
+    ],
+  });
+  const later = makeRequest({
+    seq: 2,
+    from: 'mia',
+    action: 'response referencing earlier',
+    reason: `addresses ${earlier.id.value}`,
+    createdAt: daysAgo(1), // created AFTER the concern on `earlier`
+  });
+  const out = computeUnrespondedConcerns(
+    [earlier, later],
+    [],
+    'mia',
+    BASE_DATE.getTime(),
+    30,
+  );
+  // The earlier request's concern was followed up by the later one,
+  // so it should NOT surface.
+  assert.equal(out.length, 0);
+});

--- a/tests/interface/chain.test.ts
+++ b/tests/interface/chain.test.ts
@@ -186,3 +186,99 @@ test('gatherIssueText: empty notes array is same as no notes', () => {
   const result = gatherIssueText({ text: 'x', notes: [] });
   assert.equal(result, 'x');
 });
+
+// ── bidirectional mention dedup ──
+// End-to-end: when two requests reference each other, chain renders
+// the other one once (under "referenced") with a ↔ marker, not twice
+// (once under "referenced" and once under "referenced by").
+
+import { spawnSync as _spawnSync } from 'node:child_process';
+import {
+  mkdtempSync as _mkdtempSync,
+  writeFileSync as _writeFileSync,
+  rmSync as _rmSync,
+  mkdirSync as _mkdirSync,
+} from 'node:fs';
+import { tmpdir as _tmpdir } from 'node:os';
+import { join as _join, resolve as _resolve, dirname as _dirname } from 'node:path';
+import { fileURLToPath as _fileURLToPath } from 'node:url';
+
+const _here = _dirname(_fileURLToPath(import.meta.url));
+const _GATE = _resolve(_here, '../../../bin/gate.mjs');
+
+function _bootstrap(): { root: string; cleanup: () => void } {
+  const root = _mkdtempSync(_join(_tmpdir(), 'guild-chain-bidir-'));
+  _writeFileSync(
+    _join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    _mkdirSync(_join(root, d));
+  }
+  _writeFileSync(
+    _join(root, 'members', 'mia.yaml'),
+    'name: mia\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => _rmSync(root, { recursive: true, force: true }) };
+}
+
+function _runGate(cwd: string, args: string[]): { stdout: string; status: number } {
+  const r = _spawnSync(process.execPath, [_GATE, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'mia' },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout, status: r.status ?? -1 };
+}
+
+test('chain: bidirectional text-mention renders once with ↔ marker, not twice', () => {
+  const { root, cleanup } = _bootstrap();
+  try {
+    // r1 and r2 mention each other in their text.
+    _runGate(root, ['request', '--from', 'mia', '--action', 'v1', '--reason', 'r']);
+    _runGate(root, ['deny', '2026-04-18-0001', '--by', 'mia',
+      '--reason', 'refiled as 2026-04-18-0002']);
+    _runGate(root, ['request', '--from', 'mia', '--action',
+      'v2 from 2026-04-18-0001', '--reason', 'response to critique']);
+    const { stdout } = _runGate(root, ['chain', '2026-04-18-0002']);
+    // Count only tree-entry lines (those starting with tree glyphs);
+    // the root header ALSO mentions v1 in its action text (because
+    // v2's action was "v2 from 2026-04-18-0001"), and that's not a
+    // dedup concern.
+    const entryLines = stdout
+      .split('\n')
+      .filter((l) => /^[│├└ ]/.test(l) && /2026-04-18-0001/.test(l));
+    assert.equal(
+      entryLines.length,
+      1,
+      `expected 1 tree entry for v1, got ${entryLines.length}:\n${stdout}`,
+    );
+    assert.match(entryLines[0]!, /↔ 2026-04-18-0001/);
+    // "referenced by requests" section should NOT appear (dedupped
+    // into the forward section).
+    assert.equal(/referenced by requests/.test(stdout), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('chain: one-way reference shows no ↔ marker', () => {
+  const { root, cleanup } = _bootstrap();
+  try {
+    _runGate(root, ['request', '--from', 'mia', '--action', 'target', '--reason', 'r']);
+    // Only r2 mentions r1 (not vice versa).
+    _runGate(root, ['request', '--from', 'mia', '--action',
+      'refers to 2026-04-18-0001', '--reason', 'one-way']);
+    const { stdout: forwardOut } = _runGate(root, ['chain', '2026-04-18-0002']);
+    // r2's chain: r1 is referenced (not bidirectional).
+    assert.match(forwardOut, /referenced requests/);
+    assert.equal(/↔/.test(forwardOut), false);
+
+    const { stdout: inboundOut } = _runGate(root, ['chain', '2026-04-18-0001']);
+    // r1's chain: r2 mentions it (inbound, not bidirectional).
+    assert.match(inboundOut, /referenced by requests/);
+    assert.equal(/↔/.test(inboundOut), false);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/interface/stdinSentinel.test.ts
+++ b/tests/interface/stdinSentinel.test.ts
@@ -270,3 +270,78 @@ test('gate issues add --text <value-starting-with--> surfaces the POSIX escape h
     cleanup();
   }
 });
+
+// ── positional `-` as stdin sentinel (symmetry with --comment -/--text -) ──
+
+test('gate review <id> ... - reads stdin (positional sentinel)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Pre-create a target request for review.
+    runGate(
+      root,
+      ['request', '--from', 'eris', '--action', 'x', '--reason', 'r'],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    const { status } = runGate(
+      root,
+      [
+        'review',
+        '2026-04-18-0001',
+        '--by',
+        'claude',
+        '--lense',
+        'devil',
+        '--verdict',
+        'ok',
+        '-',
+      ],
+      { input: 'stdin review body\n', env: { GUILD_ACTOR: 'claude' } },
+    );
+    assert.equal(status, 0);
+    // Assert via gate show that the comment landed (not literal "-").
+    const { stdout } = runGate(root, ['show', '2026-04-18-0001', '--format', 'text']);
+    assert.match(stdout, /stdin review body/);
+    assert.equal(/\[devil\/ok\] by claude.*\n\s+-\n/.test(stdout), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues note <id> ... - reads stdin (positional sentinel)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['issues', 'add', '--from', 'eris', '--severity', 'low', '--area', 'x',
+       '--text', 'seed'],
+      { env: { GUILD_ACTOR: 'eris' } },
+    );
+    const { status } = runGate(
+      root,
+      ['issues', 'note', 'i-2026-04-18-0001', '--by', 'eris', '-'],
+      { input: 'stdin note body\n', env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    const { stdout } = runGate(root, ['issues', 'list']);
+    assert.match(stdout, /stdin note body/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate issues add ... - reads stdin (positional sentinel, symmetric to note)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status } = runGate(
+      root,
+      ['issues', 'add', '--from', 'eris', '--severity', 'low', '--area', 'x',
+       '-'],
+      { input: 'stdin issue body\n', env: { GUILD_ACTOR: 'eris' } },
+    );
+    assert.equal(status, 0);
+    const { stdout } = runGate(root, ['issues', 'list']);
+    assert.match(stdout, /stdin issue body/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Three small fixes, all found in one session by running gate "all-in on review" (4 reviewers × 4 lenses × multi-round revision on an essay). Bundled because the theme is coherent — gaps that only show up in heavy review workflows.

### (1) `UnrespondedConcernsQuery` temporal guard (med)

**Symptom**: a concern on v2 was hidden from the author's `gate resume` because v1's deny_reason (written *before* v2 even existed) happened to mention v2.id. The "follow-up detection" had no timestamp check.

**Fix**: `hasFollowUp` now requires the referring record's `created_at` to post-date the latest concern on the target. Legitimate follow-ups still count; accidental earlier mentions (typically "I'll refile as `<id>`" written in a deny reason before the new request exists) no longer falsely close the loop.

### (2) Positional `-` as stdin sentinel for `review` / `issues note` / `issues add` (low)

**Symptom**: `gate review <id> ... --verdict X - <<EOF ... EOF` stored `"-"` as the literal comment body. Only the explicit `--comment -` form triggered stdin read; the natural positional form silently dropped the heredoc.

**Fix**: positional `-` triggers the same stdin read as the flag form. Applied across the three verbs where `--text -` / `--comment -` already worked, restoring symmetry.

### (3) Chain bidirectional dedup + `↔` marker (low)

**Symptom**: two records that mention each other in their text (common after refile: v1 deny mentions v2, v2 reason mentions v1) rendered the other under BOTH `referenced` and `referenced by` sections. Same record twice.

**Fix**: bidirectional refs render once, in the forward section, prefixed with `↔`. The marker is tighter information than "two one-way marks" — it says "they know about each other," which is usually what the reader cares about. One-way refs keep the old behavior.

```
# Before (v1 ↔ v2 mutual mention)
2026-04-18-0002
├── referenced requests
│   └── 2026-04-18-0001  [denied]  v1
└── referenced by requests
    └── 2026-04-18-0001  [denied]  v1   ← duplicate

# After
2026-04-18-0002
└── referenced requests
    └── ↔ 2026-04-18-0001  [denied]  v1
```

## Test plan

- [x] `npm test` — 394 passing (+7 new)
  - Temporal guard: pre-dating mention dropped; post-dating mention counted
  - Positional `-` stdin: review / issues note / issues add
  - Chain dedup: bidirectional → 1 entry with `↔`; one-way → no marker
- [x] `npx tsc --noEmit` clean
- [x] Sandbox e2e reproducing the original review-mode scenario: author's concern surfaces in resume after refile; chain shows mutual ref once; heredoc review body lands in YAML.

## Non-goals

- Per-concern follow-up tracking (the current all-or-nothing semantic is deliberate; documented in the query docstring).
- Two-way ← marker variants; just `↔` for mutual, no prefix for one-way.

https://claude.ai/code/session_01UsCGmDvqWhJ2AkPBzLAoPu