### PR TITLE
docs(readme): signal that README.ja.md is peer, not translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ live — on disk, in YAML, across sessions, across models. No daemon,
 no DB, no network. The `content_root` you work in is the whole world.
 
 > 日本語の概要は [`README.ja.md`](./README.ja.md) を参照してください。
+> (英語版の翻訳ではなく、日本語話者の AI エージェントに向けて独立に書かれています。
+> 設計と開発は日英の往復で進んでいます。)
 >
 > **New to the concepts?** Read
 > [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md)


### PR DESCRIPTION
## What

Adds two lines under the existing `README.ja.md` pointer in `README.md`:

```
> 日本語の概要は [`README.ja.md`](./README.ja.md) を参照してください。
> (英語版の翻訳ではなく、日本語話者の AI エージェントに向けて独立に書かれています。
> 設計と開発は日英の往復で進んでいます。)
```

## Why

`README.ja.md` is written as a **peer** document: shorter, focused on Japanese-speaking AI agents, carrying a different shape than the English README rather than translating it line-by-line. The single-line pointer understated that — read as "see the JA file" without signaling what kind of document it is or that the project is bilingual by practice.

The earlier (pre-split) inline Japanese blockquote in `README.md` carried a social signal beyond its content: a reader scrolling the English text saw Japanese and understood "this project is built bilingually." Splitting the JA blockquote out to `README.ja.md` was right for size, but that signal got thinner. Two prose lines restore it at minimum maintenance cost — they describe the *practice* (bilingual development) and the file's *register* (peer, not translation), and neither needs to stay in sync with the full JA document.

## Scope

Docs-only. No change to `README.ja.md`, the CLI, tests, or build.

## Alternatives considered

- **Language-switcher header** (`[English](./README.md) · [日本語](./README.ja.md)`) — standard OSS pattern, but flag/emoji UI felt tonally off for this repo's quieter register. Rejected.
- **Pointer only (current)** — lowest cost, but the signal that the project is bilingually developed is absent. The two added lines are the minimum to restore it.
- **Restoring the inline JA blockquote** — would rebuild the signal directly but at the maintenance cost the split was meant to avoid. Rejected.

## Test plan

- [x] Manual render: lines appear under the pointer, before the "New to the concepts" hint.

https://claude.ai/code/session_01AEP2rdAuiJAPf9PG8tG5E2