### PR TITLE
polish: drop redundant &quot;(invoked_by recorded as X)&quot; suffix on delegation notice

### DIFF
--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -74,9 +74,13 @@ export function emitInvokedByNotice(
   verb: string,
   target: string,
 ): void {
+  // The prefix "invoked by X on behalf of Y" already names both the
+  // real hand (X) and the on-record attribution (Y); the earlier
+  // "(invoked_by recorded as X)" suffix only restated X. Dropped to
+  // keep the line tight — the fact that invoked_by is persisted is
+  // part of the contract, not something to re-announce on every call.
   process.stderr.write(
-    `# ${verb} ${target}: invoked by ${invokedBy} on behalf of ${by} ` +
-      `(invoked_by recorded as ${invokedBy})\n`,
+    `# ${verb} ${target}: invoked by ${invokedBy} on behalf of ${by}\n`,
   );
 }
 


### PR DESCRIPTION
## What

The delegation stderr notice emitted on proxy-mode writes used to read:

```
# fast-track 2026-04-18-0001: invoked by claude on behalf of eris-proxy (invoked_by recorded as claude)
```

The parenthetical restated the name already on the line (`invoked by claude`) and named an implementation detail (the persisted `invoked_by` field) that is the very thing the notice exists to signal. Dropped the suffix. Post:

```
# fast-track 2026-04-18-0001: invoked by claude on behalf of eris-proxy
```

## Why

Noticed while dogfooding proxy mode. Every proxy-mode verb emitted a line with a redundant tail that added no information — the signal was clean before the parenthetical and the parenthetical was noise. Back to tight.

## Safety

- No tests asserted the exact stderr string. The `invoked_by` invariant tests read the YAML field, not the notice text.
- Docs (`gate --help`, AGENT.md troubleshooting, CHANGELOG) describe the notice by purpose, not by wording, and the trimmed form still conveys that purpose.
- `npm run build` + `npm test` (394/394) green.

## Scope

One file, one site: `emitInvokedByNotice` in `src/interface/gate/handlers/internal.ts`.

https://claude.ai/code/session_01AEP2rdAuiJAPf9PG8tG5E2