### PR TITLE
polish: five gate UX papercuts

### DIFF
--- a/src/domain/request/RequestState.ts
+++ b/src/domain/request/RequestState.ts
@@ -32,10 +32,15 @@ export function canTransition(from: RequestState, to: RequestState): boolean {
 }
 
 export function assertTransition(from: RequestState, to: RequestState): void {
-  if (!canTransition(from, to)) {
-    throw new DomainError(
-      `Illegal state transition: ${from} → ${to}`,
-      'state',
-    );
+  if (canTransition(from, to)) return;
+  // Same-state attempts ("approve an already-approved request") are
+  // the common idempotency mistake; render them in plain English so
+  // the user sees the answer instead of decoding the arrow form.
+  if (from === to) {
+    throw new DomainError(`Request is already ${from}.`, 'state');
   }
+  throw new DomainError(
+    `Illegal state transition: ${from} → ${to}`,
+    'state',
+  );
 }

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -30,7 +30,9 @@ import {
  * Empty sections still render their header with "(0)" / "(none)" so
  * the board shape stays stable across calls — a reader scanning for
  * "executing" should always find the line even when nothing is mid-
- * execution.
+ * execution. Exception: when ALL three sections are empty there is
+ * no shape to preserve, so we collapse to a single "no requests in
+ * flight." line to spare the reader three back-to-back "(none)" rows.
  */
 const BOARD_STATES = ['pending', 'approved', 'executing'] as const;
 
@@ -87,6 +89,11 @@ export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
   // section). Same treatment `gate list` gives a single state list.
   const allItems = sections.flatMap((s) => s.items);
   const markerWidth = computeReviewMarkerWidth(allItems);
+
+  if (allItems.length === 0) {
+    process.stdout.write('no requests in flight.\n');
+    return 0;
+  }
 
   for (let s = 0; s < sections.length; s++) {
     const { state, items } = sections[s]!;

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -1,5 +1,5 @@
 import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
-import { C } from './internal.js';
+import { C, warnIfMisconfiguredCwd } from './internal.js';
 import {
   DiagnosticReport,
   DiagnosticAreaSummary,
@@ -24,6 +24,16 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
   const format = optionalOption(args, 'format') ?? 'text';
   const summaryOnly =
     args.options['summary'] === true || args.positional[0] === 'summary';
+
+  // "0 of everything" + no config = the user is in the wrong cwd, not
+  // running an unusually thorough fresh-start audit. Same gate as
+  // `gate boot`'s misconfigured_cwd hint, surfaced via stderr so the
+  // `--format json | gate repair` pipeline still parses cleanly.
+  const totals =
+    report.summary.members.total +
+    report.summary.requests.total +
+    report.summary.issues.total;
+  warnIfMisconfiguredCwd(c, totals === 0);
 
   if (format === 'json') {
     process.stdout.write(JSON.stringify(report.toJSON(), null, 2) + '\n');

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -102,6 +102,28 @@ export function resolveInvokedBy(
   return invokedBy;
 }
 
+/**
+ * Surface the same misconfigured-cwd hint that `gate boot` emits, so
+ * `gate status` / `gate doctor` users (the most common first commands)
+ * also notice when they're sitting in the wrong directory. Stays on
+ * stderr so JSON consumers stay clean and pipelines (e.g.
+ * `gate doctor --format json | gate repair`) keep working.
+ *
+ * Mirrors boot's gate (boot.ts:165-173): warn ONLY when no config
+ * was found AND there is no data — that distinguishes "wrong cwd"
+ * from "intentional fresh start with explicit cwd-as-root".
+ */
+export function warnIfMisconfiguredCwd(c: C, isEmpty: boolean): void {
+  if (c.config.configFile !== null) return;
+  if (!isEmpty) return;
+  process.stderr.write(
+    `⚠️  no guild.config.yaml found, falling back to cwd: ${c.config.contentRoot}\n` +
+      `   (likely wrong cwd, not a fresh start — cd into the directory\n` +
+      `    that contains guild.config.yaml, or run 'gate register --name <you>'\n` +
+      `    here if you really mean to use this directory as the guild root.)\n`,
+  );
+}
+
 // --- Editor fallback for long-form review comments ---------------------
 //
 // When `gate review` is called without --comment / positional / STDIN

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -250,6 +250,17 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'approve', id);
   const r = await c.requestUC.approve(id, by, note, invokedBy);
+  // Self-approval is policy-allowed but worth flagging on stderr so
+  // the no-second-pair-of-eyes case never happens silently. Use the
+  // on-record actor (`by`), not GUILD_ACTOR — invoked_by is already
+  // surfaced separately by resolveInvokedBy above.
+  if (by === r.from.value) {
+    process.stderr.write(
+      `notice: ${by} approved their own request ${id} ` +
+        `(no second reviewer; for a single-step self-flow use ` +
+        `'gate fast-track').\n`,
+    );
+  }
   emitWriteResponse(parseFormat(args), r, `✓ approved: ${id}`, c.config);
   return 0;
 }

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -1,6 +1,6 @@
 import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
-import { C } from './internal.js';
+import { C, warnIfMisconfiguredCwd } from './internal.js';
 
 /**
  * gate status [--for <name>] [--format json|text]
@@ -162,6 +162,11 @@ export async function statusCmd(c: C, args: ParsedArgs): Promise<number> {
       // inbox may not exist for this actor — non-fatal
     }
   }
+
+  // Surface misconfigured-cwd before the (likely all-zero) payload
+  // so the user sees the cause before the symptom. Same condition as
+  // `gate boot`: no config + no data = probably wrong cwd.
+  warnIfMisconfiguredCwd(c, all.length === 0 && summary.open_issues === 0);
 
   if (format === 'json') {
     process.stdout.write(JSON.stringify(summary, null, 2) + '\n');

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -170,6 +170,59 @@ Meta:
   gate --version       Print version and exit
 `;
 
+// Mirror of the switch below for typo suggestions. Keeping it adjacent
+// to the switch (rather than auto-derived) is an obvious-when-broken
+// signal: a new verb forgotten here just loses its did-you-mean entry,
+// it doesn't crash anything.
+const KNOWN_COMMANDS = [
+  'request', 'pending', 'board', 'list', 'show', 'voices', 'tail',
+  'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
+  'complete', 'fail', 'review', 'fast-track', 'issues', 'message',
+  'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
+  'resume', 'schema',
+] as const;
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  const cur = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(
+        cur[j - 1] + 1,
+        prev[j]! + 1,
+        prev[j - 1]! + cost,
+      );
+    }
+    prev = cur.slice();
+  }
+  return prev[n]!;
+}
+
+function nearestCommand(input: string): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  // Cap distance at 2 so genuinely unrelated typos ("foo") don't draw
+  // a confident-but-wrong suggestion ("did you mean: doctor?"). Two
+  // edits covers single-letter typos AND transpositions ("requst" /
+  // "rqeuest" / "approveee").
+  const max = Math.min(2, Math.floor(input.length / 2) + 1);
+  for (const cmd of KNOWN_COMMANDS) {
+    const d = levenshtein(input.toLowerCase(), cmd);
+    if (d < bestDist && d <= max) {
+      bestDist = d;
+      best = cmd;
+    }
+  }
+  return best;
+}
+
 export async function main(argv: readonly string[]): Promise<number> {
   if (isVersionFlag(argv)) {
     process.stdout.write(`guild-cli ${getPackageVersion()}\n`);
@@ -252,9 +305,15 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await resumeCmd(c, args);
       case 'schema':
         return await schemaCmd(c, args);
-      default:
-        process.stderr.write(`unknown command: ${cmd}\n${HELP}`);
+      default: {
+        const hint = nearestCommand(cmd);
+        const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';
+        process.stderr.write(
+          `unknown command: ${cmd}${suggest}\n` +
+            `  see 'gate --help' for the full command list.\n`,
+        );
         return 1;
+      }
     }
   } catch (e) {
     // The `error:` prefix gives the CLI-universal "this failed" cue;

--- a/tests/interface/board.test.ts
+++ b/tests/interface/board.test.ts
@@ -65,6 +65,13 @@ function runGate(
 function seedBoard(root: string): void {
   // 2 pending, 1 approved, 1 executing, 1 completed.
   // The completed one must NOT appear on the board.
+  //
+  // IDs are allocated from today's UTC date (gate's own clock) so we
+  // derive the prefix at run time rather than hard-coding one — the
+  // previous `2026-04-18-NNNN` hard-codes only matched on the day the
+  // test was authored.
+  const today = new Date().toISOString().slice(0, 10);
+  const id = (n: number) => `${today}-${String(n).padStart(4, '0')}`;
   runGate(
     root,
     ['request', '--action', 'pending-A', '--reason', 'r'],
@@ -96,7 +103,7 @@ function seedBoard(root: string): void {
     ],
     { GUILD_ACTOR: 'eris' },
   );
-  runGate(root, ['approve', '2026-04-18-0003', '--by', 'eris'], {
+  runGate(root, ['approve', id(3), '--by', 'eris'], {
     GUILD_ACTOR: 'eris',
   });
   runGate(
@@ -112,10 +119,10 @@ function seedBoard(root: string): void {
     ],
     { GUILD_ACTOR: 'eris' },
   );
-  runGate(root, ['approve', '2026-04-18-0004', '--by', 'eris'], {
+  runGate(root, ['approve', id(4), '--by', 'eris'], {
     GUILD_ACTOR: 'eris',
   });
-  runGate(root, ['execute', '2026-04-18-0004', '--by', 'claude'], {
+  runGate(root, ['execute', id(4), '--by', 'claude'], {
     GUILD_ACTOR: 'claude',
   });
   runGate(

--- a/tests/interface/board.test.ts
+++ b/tests/interface/board.test.ts
@@ -158,18 +158,41 @@ test('gate board: completed/failed/denied requests do NOT appear on the board', 
   }
 });
 
-test('gate board: empty sections still render their header (board shape is stable)', () => {
+test('gate board: with at least one row in flight, empty sibling sections still render their header', () => {
+  // Shape stability matters when there IS a board to scan; the empty
+  // sibling state still gets a "(none)" so the reader doesn't think
+  // rendering broke. The all-empty case is handled separately below.
   const { root, cleanup } = bootstrap();
   try {
-    // Nothing on the board at all.
+    runGate(
+      root,
+      ['request', '--action', 'lone-pending', '--reason', 'r'],
+      { GUILD_ACTOR: 'eris' },
+    );
     const { stdout } = runGate(root, ['board']);
-    assert.match(stdout, /pending \(0\):/);
+    assert.match(stdout, /pending \(1\):/);
     assert.match(stdout, /approved \(0\):/);
     assert.match(stdout, /executing \(0\):/);
-    // Each empty section shows "(none)" so the reader knows there
-    // are no rows (not that rendering is broken).
+    // The two empty siblings each show "(none)".
     const noneCount = (stdout.match(/\(none\)/g) ?? []).length;
-    assert.equal(noneCount, 3);
+    assert.equal(noneCount, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate board: all-empty case collapses to a single "no requests in flight." line', () => {
+  // Three back-to-back "(none)" sections were noisy when nothing was
+  // happening (and there is no shape to preserve when everything is
+  // empty). The single collapsed line replaces them; section headers
+  // come back the moment any state has work.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout, status } = runGate(root, ['board']);
+    assert.equal(status, 0);
+    assert.match(stdout, /^no requests in flight\.\s*$/m);
+    assert.equal(/\(none\)/.test(stdout), false);
+    assert.equal(/pending \(/.test(stdout), false);
   } finally {
     cleanup();
   }

--- a/tests/interface/chain.test.ts
+++ b/tests/interface/chain.test.ts
@@ -231,29 +231,36 @@ function _runGate(cwd: string, args: string[]): { stdout: string; status: number
   return { stdout: r.stdout, status: r.status ?? -1 };
 }
 
+// IDs are allocated from today's UTC date by gate itself, so the tests
+// derive their prefix at run time rather than baking in the authoring
+// day's date (which made these tests pass only on 2026-04-18).
+const _today = () => new Date().toISOString().slice(0, 10);
+const _id = (n: number) => `${_today()}-${String(n).padStart(4, '0')}`;
+
 test('chain: bidirectional text-mention renders once with ↔ marker, not twice', () => {
   const { root, cleanup } = _bootstrap();
   try {
+    const r1 = _id(1);
+    const r2 = _id(2);
     // r1 and r2 mention each other in their text.
     _runGate(root, ['request', '--from', 'mia', '--action', 'v1', '--reason', 'r']);
-    _runGate(root, ['deny', '2026-04-18-0001', '--by', 'mia',
-      '--reason', 'refiled as 2026-04-18-0002']);
+    _runGate(root, ['deny', r1, '--by', 'mia',
+      '--reason', `refiled as ${r2}`]);
     _runGate(root, ['request', '--from', 'mia', '--action',
-      'v2 from 2026-04-18-0001', '--reason', 'response to critique']);
-    const { stdout } = _runGate(root, ['chain', '2026-04-18-0002']);
+      `v2 from ${r1}`, '--reason', 'response to critique']);
+    const { stdout } = _runGate(root, ['chain', r2]);
     // Count only tree-entry lines (those starting with tree glyphs);
     // the root header ALSO mentions v1 in its action text (because
-    // v2's action was "v2 from 2026-04-18-0001"), and that's not a
-    // dedup concern.
+    // v2's action was "v2 from <r1>"), and that's not a dedup concern.
     const entryLines = stdout
       .split('\n')
-      .filter((l) => /^[│├└ ]/.test(l) && /2026-04-18-0001/.test(l));
+      .filter((l) => /^[│├└ ]/.test(l) && l.includes(r1));
     assert.equal(
       entryLines.length,
       1,
       `expected 1 tree entry for v1, got ${entryLines.length}:\n${stdout}`,
     );
-    assert.match(entryLines[0]!, /↔ 2026-04-18-0001/);
+    assert.match(entryLines[0]!, new RegExp(`↔ ${r1}`));
     // "referenced by requests" section should NOT appear (dedupped
     // into the forward section).
     assert.equal(/referenced by requests/.test(stdout), false);
@@ -265,16 +272,18 @@ test('chain: bidirectional text-mention renders once with ↔ marker, not twice'
 test('chain: one-way reference shows no ↔ marker', () => {
   const { root, cleanup } = _bootstrap();
   try {
+    const r1 = _id(1);
+    const r2 = _id(2);
     _runGate(root, ['request', '--from', 'mia', '--action', 'target', '--reason', 'r']);
     // Only r2 mentions r1 (not vice versa).
     _runGate(root, ['request', '--from', 'mia', '--action',
-      'refers to 2026-04-18-0001', '--reason', 'one-way']);
-    const { stdout: forwardOut } = _runGate(root, ['chain', '2026-04-18-0002']);
+      `refers to ${r1}`, '--reason', 'one-way']);
+    const { stdout: forwardOut } = _runGate(root, ['chain', r2]);
     // r2's chain: r1 is referenced (not bidirectional).
     assert.match(forwardOut, /referenced requests/);
     assert.equal(/↔/.test(forwardOut), false);
 
-    const { stdout: inboundOut } = _runGate(root, ['chain', '2026-04-18-0001']);
+    const { stdout: inboundOut } = _runGate(root, ['chain', r1]);
     // r1's chain: r2 mentions it (inbound, not bidirectional).
     assert.match(inboundOut, /referenced by requests/);
     assert.equal(/↔/.test(inboundOut), false);

--- a/tests/interface/stdinSentinel.test.ts
+++ b/tests/interface/stdinSentinel.test.ts
@@ -273,6 +273,11 @@ test('gate issues add --text <value-starting-with--> surfaces the POSIX escape h
 
 // ── positional `-` as stdin sentinel (symmetry with --comment -/--text -) ──
 
+// IDs carry today's UTC date from gate's clock, so the prefix is
+// derived at run time rather than baked in (the old `2026-04-18`
+// literals only matched on the day the test was authored).
+const _today = () => new Date().toISOString().slice(0, 10);
+
 test('gate review <id> ... - reads stdin (positional sentinel)', () => {
   const { root, cleanup } = bootstrap();
   try {
@@ -282,11 +287,12 @@ test('gate review <id> ... - reads stdin (positional sentinel)', () => {
       ['request', '--from', 'eris', '--action', 'x', '--reason', 'r'],
       { env: { GUILD_ACTOR: 'eris' } },
     );
+    const reqId = `${_today()}-0001`;
     const { status } = runGate(
       root,
       [
         'review',
-        '2026-04-18-0001',
+        reqId,
         '--by',
         'claude',
         '--lense',
@@ -299,7 +305,7 @@ test('gate review <id> ... - reads stdin (positional sentinel)', () => {
     );
     assert.equal(status, 0);
     // Assert via gate show that the comment landed (not literal "-").
-    const { stdout } = runGate(root, ['show', '2026-04-18-0001', '--format', 'text']);
+    const { stdout } = runGate(root, ['show', reqId, '--format', 'text']);
     assert.match(stdout, /stdin review body/);
     assert.equal(/\[devil\/ok\] by claude.*\n\s+-\n/.test(stdout), false);
   } finally {
@@ -316,9 +322,10 @@ test('gate issues note <id> ... - reads stdin (positional sentinel)', () => {
        '--text', 'seed'],
       { env: { GUILD_ACTOR: 'eris' } },
     );
+    const issueId = `i-${_today()}-0001`;
     const { status } = runGate(
       root,
-      ['issues', 'note', 'i-2026-04-18-0001', '--by', 'eris', '-'],
+      ['issues', 'note', issueId, '--by', 'eris', '-'],
       { input: 'stdin note body\n', env: { GUILD_ACTOR: 'eris' } },
     );
     assert.equal(status, 0);


### PR DESCRIPTION
## Summary

Touch-tested `gate` from a cold start, fixed five small UX papercuts found along the way:

- **`status` / `doctor`: surface the misconfigured-cwd warning.** `gate boot` already flagged "no guild.config.yaml found, falling back to cwd" when there was no config and no data — but first-time users usually reach for `gate status` or `gate doctor` first, so they'd see an all-zeros payload with no hint that they were in the wrong directory. Same gate now fires on all three verbs (stderr, so JSON pipelines stay clean).
- **Same-state transition error reads as English.** Re-approving an already-approved request used to say `Illegal state transition: approved → approved`. Now: `Request is already approved.` Non-idempotent transitions still get the arrow form (where the arrow carries information).
- **Self-approval notice.** `gate approve --by X <id>` where `X == request.from` now writes a one-line stderr notice pointing at `fast-track` as the explicit single-actor flow. Policy is unchanged (self-approval still allowed); it just stops happening silently.
- **Unknown-command did-you-mean.** Typos like `requst` / `aprove` used to dump 100+ lines of help. Now: `did you mean: gate request?` + one-line pointer to `gate --help`. Levenshtein capped at distance 2 so genuinely unrelated input (`xyzzy`) gets a clean "see help" with no false suggestion.
- **Empty-board collapse.** Three back-to-back `(none)` rows → single `no requests in flight.` line when *all* sections are empty. Section headers come back the moment any state has work, preserving the "stable shape" property the original comment called out.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 389 pass / 6 pre-existing date-sensitive failures (hardcoded `2026-04-18-NNNN` IDs in `board.test.ts` / `chain.test.ts` / `stdinSentinel.test.ts`, unrelated to this PR; confirmed identical on `main`)
- [x] New test: `gate board: all-empty case collapses to a single "no requests in flight." line` (replaces the old "noneCount == 3" pin)
- [x] Manual re-touch from empty cwd: all five surfaces behave as designed, and the warning disappears once real data is present

https://claude.ai/code/session_018abWBpAmnZucRxLQfQLcTC