### PR TITLE
feat(ax): five agent-experience affordances

### DIFF
--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -137,11 +137,12 @@ export class RequestUseCases {
     by: string,
     note?: string,
     invokedBy?: string,
+    opts?: { dryRun?: boolean },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
     req.approve(actor, note, invokedBy);
-    await this.deps.requests.save(req);
+    if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }
 
@@ -150,11 +151,12 @@ export class RequestUseCases {
     by: string,
     reason: string,
     invokedBy?: string,
+    opts?: { dryRun?: boolean },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
     req.deny(actor, reason, invokedBy);
-    await this.deps.requests.save(req);
+    if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }
 
@@ -163,11 +165,12 @@ export class RequestUseCases {
     by: string,
     note?: string,
     invokedBy?: string,
+    opts?: { dryRun?: boolean },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
     req.execute(actor, note, invokedBy);
-    await this.deps.requests.save(req);
+    if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }
 
@@ -176,11 +179,12 @@ export class RequestUseCases {
     by: string,
     note?: string,
     invokedBy?: string,
+    opts?: { dryRun?: boolean },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
     req.complete(actor, note, invokedBy);
-    await this.deps.requests.save(req);
+    if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }
 
@@ -189,11 +193,12 @@ export class RequestUseCases {
     by: string,
     reason: string,
     invokedBy?: string,
+    opts?: { dryRun?: boolean },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
     req.fail(actor, reason, invokedBy);
-    await this.deps.requests.save(req);
+    if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }
 
@@ -204,6 +209,7 @@ export class RequestUseCases {
     verdict: string;
     comment: string;
     invokedBy?: string;
+    dryRun?: boolean;
   }): Promise<Request> {
     const req = await this.loadOrThrow(input.id);
     await assertActor(input.by, '--by', this.deps.members);
@@ -217,7 +223,7 @@ export class RequestUseCases {
       ...(this.deps.allowedLenses ? { allowedLenses: this.deps.allowedLenses } : {}),
     });
     req.addReview(review);
-    await this.deps.requests.save(req);
+    if (!input.dryRun) await this.deps.requests.save(req);
     return req;
   }
 

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -76,9 +76,22 @@ export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
     // Plain object keyed by state name in lifecycle order. Stable
     // key set (pending/approved/executing) across calls; consumers
     // can rely on all three being present even when empty.
+    //
+    // `_meta.filter` echoes any scoping that was applied so a JSON
+    // consumer sees what the stderr notice shows to humans. Without
+    // it, an agent piping stdout has no way to tell "empty because
+    // filtered" from "empty because nothing in flight".
     const payload: Record<string, unknown> = {};
     for (const { state, items } of sections) {
       payload[state] = items.map((r) => r.toJSON());
+    }
+    if (forFilter !== undefined) {
+      payload['_meta'] = {
+        filter: {
+          actor: forFilter,
+          source: explicitFor !== undefined ? '--for' : 'GUILD_ACTOR',
+        },
+      };
     }
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
     return 0;

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -2,6 +2,7 @@ import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
 import { C, loadAllRequestsAsJson, parseOptionalIntOption } from './internal.js';
 import { collectStatus, StatusSummary } from './status.js';
 import { collectUtterances } from '../voices.js';
+import { Request } from '../../../domain/request/Request.js';
 
 /**
  * Next-step hint embedded in boot. Mirrors the SuggestedNext shape
@@ -212,7 +213,12 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     // Diagnostic errored — skip health, keep boot usable.
   }
 
-  const suggestedNext = deriveBootSuggestedNext(actor, role, members);
+  const suggestedNext = deriveBootSuggestedNext(
+    actor,
+    role,
+    members,
+    allRequests,
+  );
 
   const payload: BootPayload = {
     actor,
@@ -257,6 +263,7 @@ function deriveBootSuggestedNext(
   actor: string | null,
   role: BootPayload['role'],
   members: ReadonlyArray<{ name: { value: string } }>,
+  allRequests: ReadonlyArray<Request>,
 ): BootSuggestedNext | null {
   if (actor === null) {
     if (members.length === 0) {
@@ -289,6 +296,85 @@ function deriveBootSuggestedNext(
         `Run gate register --name ${actor} to create the member file.`,
     };
   }
+  // Known actor: pick the most actionable open loop. Priority reflects
+  // "which one would surprise the agent most if missed":
+  //   1. Executing-by-me  → mid-flight work; resume/close it first
+  //   2. Unreviewed mine  → others are blocked on our verdict
+  //   3. Approved for me  → warm queue, ready to start
+  // Stops at the first match so the agent gets ONE verb to call next.
+  // The other loops remain visible via status counts.
+  const actorLower = actor.toLowerCase();
+
+  const executingMine = allRequests.find(
+    (r) =>
+      r.state === 'executing' &&
+      (r.executor?.value === actorLower || r.from.value === actorLower),
+  );
+  if (executingMine) {
+    return {
+      verb: 'complete',
+      args: { id: executingMine.id.value, by: actor },
+      reason:
+        `you are executing ${executingMine.id.value} — ` +
+        `complete it (or 'gate fail <id> --reason <s>' if it can't land).`,
+    };
+  }
+
+  const unreviewedMine = allRequests.find(
+    (r) =>
+      r.state === 'completed' &&
+      r.autoReview?.value === actorLower &&
+      r.reviews.length === 0,
+  );
+  if (unreviewedMine) {
+    return {
+      verb: 'review',
+      args: {
+        id: unreviewedMine.id.value,
+        by: actor,
+        lense: 'devil',
+      },
+      reason:
+        `${unreviewedMine.id.value} completed with auto-review assigned to ` +
+        `you; pick --verdict <ok|concern|reject> and --comment after reading ` +
+        `the work.`,
+    };
+  }
+
+  const approvedForMe = allRequests.find(
+    (r) => r.state === 'approved' && r.executor?.value === actorLower,
+  );
+  if (approvedForMe) {
+    return {
+      verb: 'execute',
+      args: { id: approvedForMe.id.value, by: actor },
+      reason:
+        `${approvedForMe.id.value} is approved and names you as executor — ` +
+        `start the work (gate execute), then complete/fail when done.`,
+    };
+  }
+
+  // Pending-as-executor: someone queued work for me but it still needs
+  // approval. Any registered actor can approve (author-approval gets
+  // the self-approval notice; third-party approval is the clean case).
+  // Suggest it so the agent sees the bottleneck instead of sitting.
+  const pendingAsExecutor = allRequests.find(
+    (r) =>
+      r.state === 'pending' &&
+      r.executor?.value === actorLower &&
+      r.from.value !== actorLower,
+  );
+  if (pendingAsExecutor) {
+    return {
+      verb: 'approve',
+      args: { id: pendingAsExecutor.id.value, by: actor },
+      reason:
+        `${pendingAsExecutor.id.value} is pending and names you as executor ` +
+        `(authored by ${pendingAsExecutor.from.value}); approve it to unblock, ` +
+        `or deny with --reason if it shouldn't proceed.`,
+    };
+  }
+
   return null;
 }
 

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -103,6 +103,64 @@ export function resolveInvokedBy(
 }
 
 /**
+ * Shared --dry-run detector for write verbs. Accepted as `--dry-run`
+ * or `--dry-run=true`. Anything else (missing, or explicit `=false`)
+ * returns false.
+ *
+ * The agent use case: "what would this command do?" before committing.
+ * Humans can try-undo; agents lack that affordance and benefit from a
+ * safe preview. Repair already has --apply vs --dry-run; this extends
+ * the same contract to the state-transition verbs.
+ */
+export function isDryRun(args: ParsedArgs): boolean {
+  const v = args.options['dry-run'];
+  if (v === true) return true;
+  if (typeof v === 'string' && v.toLowerCase() === 'true') return true;
+  return false;
+}
+
+/**
+ * Emit a dry-run preview envelope on stdout (JSON only — text callers
+ * already have `gate show` for inspection, and the preview is mostly
+ * an agent-facing affordance).
+ *
+ * Shape:
+ *   {
+ *     "dry_run": true,
+ *     "verb": "approve",
+ *     "id": "...",
+ *     "by": "...",
+ *     "would_transition": {"from": "pending", "to": "approved"},
+ *     "preview": { full request JSON post-mutation, NOT persisted }
+ *   }
+ *
+ * `would_transition` is omitted when the verb doesn't cross states
+ * (review). `preview` always reflects the unsaved in-memory object
+ * so the caller sees exactly what would land if they dropped
+ * `--dry-run`.
+ */
+export function emitDryRunPreview(p: {
+  verb: string;
+  id: string;
+  by: string;
+  fromState?: string;
+  toState?: string;
+  after: { toJSON(): Record<string, unknown> };
+}): void {
+  const envelope: Record<string, unknown> = {
+    dry_run: true,
+    verb: p.verb,
+    id: p.id,
+    by: p.by,
+  };
+  if (p.fromState !== undefined && p.toState !== undefined) {
+    envelope['would_transition'] = { from: p.fromState, to: p.toState };
+  }
+  envelope['preview'] = p.after.toJSON();
+  process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
+}
+
+/**
  * Surface the same misconfigured-cwd hint that `gate boot` emits, so
  * `gate status` / `gate doctor` users (the most common first commands)
  * also notice when they're sitting in the wrong directory. Stays on

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -11,6 +11,8 @@ import {
   deriveInvokedBy,
   emitInvokedByNotice,
   resolveInvokedBy,
+  isDryRun,
+  emitDryRunPreview,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
@@ -140,7 +142,10 @@ function describeFilters(filters: Record<string, string | undefined>): string {
 
 export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  if (!id) throw new Error('Usage: gate show <id> [--format json|text]');
+  if (!id)
+    throw new Error(
+      'Usage: gate show <id> [--format json|text] [--fields k1,k2,...]',
+    );
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
@@ -151,7 +156,25 @@ export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
     return 1;
   }
   if (format === 'json') {
-    process.stdout.write(JSON.stringify(r.toJSON(), null, 2) + '\n');
+    // `--fields state,executor` trims the payload to what the caller
+    // actually needs. A full `show` JSON runs ~400-800 bytes; for an
+    // agent checking just `state` in a tight loop, that's a lot of
+    // tokens for one boolean-ish answer. Only available in JSON mode
+    // (text already has its own compact summary).
+    const fields = optionalOption(args, 'fields');
+    let payload: Record<string, unknown> = r.toJSON();
+    if (fields !== undefined) {
+      const keep = fields
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      const picked: Record<string, unknown> = {};
+      for (const k of keep) {
+        if (k in payload) picked[k] = payload[k];
+      }
+      payload = picked;
+    }
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
   } else {
     process.stdout.write(formatRequestText(r) + '\n');
   }
@@ -245,10 +268,18 @@ function formatRequestText(r: Request): string {
 
 export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  if (!id) throw new Error('Usage: gate approve <id> --by <m>');
+  if (!id) throw new Error('Usage: gate approve <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'approve', id);
+  if (isDryRun(args)) {
+    const prior = await c.requestUC.show(id);
+    if (!prior) throw new Error(`Request not found: ${id}`);
+    const fromState = prior.state;
+    const r = await c.requestUC.approve(id, by, note, invokedBy, { dryRun: true });
+    emitDryRunPreview({ verb: 'approve', id, by, fromState, toState: r.state, after: r });
+    return 0;
+  }
   const r = await c.requestUC.approve(id, by, note, invokedBy);
   // Self-approval is policy-allowed but worth flagging on stderr so
   // the no-second-pair-of-eyes case never happens silently. Use the
@@ -270,12 +301,20 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const reason = await resolveReason(args, 'deny');
   if (!id || !reason) {
     throw new Error(
-      'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]' +
+      'Usage: gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]' +
         dashedValueHint(args, ['reason', 'note']),
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const invokedBy = resolveInvokedBy(by, 'deny', id);
+  if (isDryRun(args)) {
+    const prior = await c.requestUC.show(id);
+    if (!prior) throw new Error(`Request not found: ${id}`);
+    const fromState = prior.state;
+    const r = await c.requestUC.deny(id, by, reason, invokedBy, { dryRun: true });
+    emitDryRunPreview({ verb: 'deny', id, by, fromState, toState: r.state, after: r });
+    return 0;
+  }
   const r = await c.requestUC.deny(id, by, reason, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ denied: ${id}`, c.config);
   return 0;
@@ -283,10 +322,18 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  if (!id) throw new Error('Usage: gate execute <id> --by <m>');
+  if (!id) throw new Error('Usage: gate execute <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'execute', id);
+  if (isDryRun(args)) {
+    const prior = await c.requestUC.show(id);
+    if (!prior) throw new Error(`Request not found: ${id}`);
+    const fromState = prior.state;
+    const r = await c.requestUC.execute(id, by, note, invokedBy, { dryRun: true });
+    emitDryRunPreview({ verb: 'execute', id, by, fromState, toState: r.state, after: r });
+    return 0;
+  }
   const r = await c.requestUC.execute(id, by, note, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ executing: ${id}`, c.config);
   return 0;
@@ -294,10 +341,18 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
 
 export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
-  if (!id) throw new Error('Usage: gate complete <id> --by <m>');
+  if (!id) throw new Error('Usage: gate complete <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'complete', id);
+  if (isDryRun(args)) {
+    const prior = await c.requestUC.show(id);
+    if (!prior) throw new Error(`Request not found: ${id}`);
+    const fromState = prior.state;
+    const r = await c.requestUC.complete(id, by, note, invokedBy, { dryRun: true });
+    emitDryRunPreview({ verb: 'complete', id, by, fromState, toState: r.state, after: r });
+    return 0;
+  }
   const r = await c.requestUC.complete(id, by, note, invokedBy);
   const extraLines: string[] = [];
   if (r.autoReview) {
@@ -317,12 +372,20 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   const reason = await resolveReason(args, 'fail');
   if (!id || !reason) {
     throw new Error(
-      'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]' +
+      'Usage: gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]' +
         dashedValueHint(args, ['reason', 'note']),
     );
   }
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
   const invokedBy = resolveInvokedBy(by, 'fail', id);
+  if (isDryRun(args)) {
+    const prior = await c.requestUC.show(id);
+    if (!prior) throw new Error(`Request not found: ${id}`);
+    const fromState = prior.state;
+    const r = await c.requestUC.fail(id, by, reason, invokedBy, { dryRun: true });
+    emitDryRunPreview({ verb: 'fail', id, by, fromState, toState: r.state, after: r });
+    return 0;
+  }
   const r = await c.requestUC.fail(id, by, reason, invokedBy);
   emitWriteResponse(parseFormat(args), r, `✓ failed: ${id}`, c.config);
   return 0;

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -3,7 +3,14 @@ import {
   requireOption,
   optionalOption,
 } from '../../shared/parseArgs.js';
-import { C, readStdin, readCommentViaEditor, resolveInvokedBy } from './internal.js';
+import {
+  C,
+  readStdin,
+  readCommentViaEditor,
+  resolveInvokedBy,
+  isDryRun,
+  emitDryRunPreview,
+} from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
@@ -60,6 +67,21 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   }
 
   const invokedBy = resolveInvokedBy(by, 'review', id);
+  if (isDryRun(args)) {
+    const updated = await c.requestUC.review({
+      id,
+      by,
+      lense,
+      verdict,
+      comment,
+      ...(invokedBy !== undefined ? { invokedBy } : {}),
+      dryRun: true,
+    });
+    // Review doesn't transition state — omit would_transition, let
+    // the preview payload carry the new review entry in `reviews`.
+    emitDryRunPreview({ verb: 'review', id, by, after: updated });
+    return 0;
+  }
   const updated = await c.requestUC.review({
     id,
     by,

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -66,20 +66,27 @@ Requests:
                        executing, grouped by state.
   gate list --state <state> [--for <m>] [--from <m>]
                             [--executor <m>] [--auto-review <m>]
-  gate show <id> [--format json|text]          (default: json)
+  gate show <id> [--format json|text] [--fields k1,k2,...]
+                       --fields trims the JSON payload to just the
+                       requested keys (agent-facing; JSON only).
   gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]
                      [--format json|text]          (default: json)
   gate tail [N]                                   (default 20)
   gate whoami                                     (needs GUILD_ACTOR)
   gate chain <id>                                 (request or issue;
                                                    forward refs + inbound)
-  gate approve <id> --by <m> [--note <s>]
-  gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>]
-  gate execute <id> --by <m> [--note <s>]
-  gate complete <id> --by <m> [--note <s>]
-  gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>]
+  gate approve <id> --by <m> [--note <s>] [--dry-run]
+  gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]
+  gate execute <id> --by <m> [--note <s>] [--dry-run]
+  gate complete <id> --by <m> [--note <s>] [--dry-run]
+  gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]
   gate review <id> --by <m> --lense <l> --verdict <v>
-                   [--comment <s> | --comment - | <comment>]
+                   [--comment <s> | --comment - | <comment>] [--dry-run]
+                       --dry-run on any write verb above emits a
+                       preview JSON envelope (dry_run/verb/would_
+                       transition/preview) without persisting. Use
+                       --dry-run=true if followed by a non-dash
+                       positional (see "Values beginning with '--'").
   gate fast-track --from <m> --action <a> --reason <r>
                   [--executor <m>] [--auto-review <m>] [--note <s>]
                   [--with <n1>[,<n2>...]]
@@ -326,6 +333,24 @@ export async function main(argv: readonly string[]): Promise<number> {
       : e instanceof Error
         ? e.message
         : String(e);
+    // When the caller asked for JSON output, mirror the error on
+    // stderr as a JSON envelope so a tool layer doesn't have to run
+    // two parsers (one on stdout JSON, one on stderr text). The
+    // human-readable `error: …` line still goes out too — pipelines
+    // that ignore stderr keep working, and humans reading the
+    // terminal still get a scannable message at the top.
+    if (args.options['format'] === 'json') {
+      const payload: Record<string, unknown> = {
+        ok: false,
+        error: {
+          message:
+            e instanceof DomainError ? e.message : msg,
+        },
+      };
+      const errObj = payload['error'] as Record<string, unknown>;
+      if (e instanceof DomainError && e.field) errObj['field'] = e.field;
+      process.stderr.write(JSON.stringify(payload) + '\n');
+    }
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -1,0 +1,338 @@
+// AX — AI-experience affordances.
+//
+// These tests pin agent-facing behaviors that a tool layer depends on:
+//   - boot.suggested_next reaches beyond onboarding into the live
+//     workflow (executing-by-me / unreviewed-mine / approved-for-me /
+//     pending-as-executor) so an agent's orientation call returns
+//     a single next verb to dispatch.
+//   - --format json errors arrive on stderr as a parseable envelope
+//     alongside the human-readable `error: …` line.
+//   - board --format json echoes any implicit scoping so a JSON
+//     consumer can tell "empty because filtered" from "empty because
+//     nothing in flight".
+//   - show --fields trims the payload for hot-loop callers.
+//   - --dry-run previews state transitions without persisting.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-ax-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+  input?: string,
+): { stdout: string; stderr: string; status: number } {
+  const opts: Parameters<typeof spawnSync>[2] = {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  };
+  if (input !== undefined) opts.input = input;
+  const r = spawnSync(process.execPath, [GATE, ...args], opts);
+  return {
+    stdout: typeof r.stdout === 'string' ? r.stdout : '',
+    stderr: typeof r.stderr === 'string' ? r.stderr : '',
+    status: r.status ?? -1,
+  };
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+const rid = (n: number) => `${today()}-${String(n).padStart(4, '0')}`;
+
+// ── boot.suggested_next: workflow-stage routing ───────────────────
+
+test('boot.suggested_next: pending-as-executor → approve', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'approve');
+    assert.equal(payload.suggested_next?.args?.id, rid(1));
+    assert.equal(payload.suggested_next?.args?.by, 'bob');
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.suggested_next: approved-for-me → execute', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(1), '--by', 'alice']);
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'execute');
+    assert.equal(payload.suggested_next?.args?.id, rid(1));
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.suggested_next: executing-by-me → complete (takes priority)', () => {
+  // If I'm mid-flight on request A and also have approved-for-me B
+  // waiting, orient me back to A first — "finish what's in your hand".
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'A', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(1), '--by', 'alice']);
+    runGate(root, ['execute', rid(1), '--by', 'bob']);
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'B', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(2), '--by', 'alice']);
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'complete');
+    assert.equal(payload.suggested_next?.args?.id, rid(1));
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.suggested_next: unreviewed-mine → review', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--auto-review', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'review');
+    assert.equal(payload.suggested_next?.args?.id, rid(1));
+    assert.equal(payload.suggested_next?.args?.lense, 'devil');
+  } finally {
+    cleanup();
+  }
+});
+
+// ── --format json: structured error envelope ─────────────────────
+
+test('--format json: errors emit a JSON envelope on stderr', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Complete an id that doesn't exist → DomainError.
+    const { stdout, stderr, status } = runGate(
+      root,
+      ['approve', '9999-99-99-0001', '--by', 'alice', '--format', 'json'],
+    );
+    assert.equal(status, 1);
+    assert.equal(stdout, '');
+    // First line of stderr is the JSON envelope; the second is the
+    // human-readable `error: …` line kept for terminal readers.
+    const firstLine = stderr.split('\n').find((l) => l.trim().startsWith('{'));
+    assert.ok(firstLine, 'expected a JSON envelope line on stderr');
+    const payload = JSON.parse(firstLine!);
+    assert.equal(payload.ok, false);
+    assert.equal(typeof payload.error?.message, 'string');
+    assert.match(payload.error.message, /Request not found/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('--format json not set: errors stay text-only (no JSON leak)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stderr, status } = runGate(
+      root,
+      ['approve', '9999-99-99-0001', '--by', 'alice'],
+    );
+    assert.equal(status, 1);
+    // stderr has the `error:` line and nothing else — no JSON envelope
+    // should leak into non-json mode.
+    assert.equal(/\{\s*"ok"/.test(stderr), false);
+    assert.match(stderr, /^error: /);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── board --format json: filter meta ─────────────────────────────
+
+test('board --format json: _meta.filter echoes GUILD_ACTOR scoping', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['board', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(payload._meta?.filter, { actor: 'alice', source: 'GUILD_ACTOR' });
+  } finally {
+    cleanup();
+  }
+});
+
+test('board --format json: _meta.filter echoes --for source when explicit', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['board', '--format', 'json', '--for', 'alice']);
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(payload._meta?.filter, { actor: 'alice', source: '--for' });
+  } finally {
+    cleanup();
+  }
+});
+
+test('board --format json: no _meta when unfiltered (global view)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['board', '--format', 'json']);
+    const payload = JSON.parse(stdout);
+    assert.equal('_meta' in payload, false);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── gate show --fields ───────────────────────────────────────────
+
+test('show --fields: trims JSON to requested keys', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['show', rid(1), '--fields', 'state,executor']);
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(Object.keys(payload).sort(), ['executor', 'state']);
+    assert.equal(payload.state, 'pending');
+    assert.equal(payload.executor, 'bob');
+  } finally {
+    cleanup();
+  }
+});
+
+test('show --fields: unknown keys silently dropped (not errored)', () => {
+  // "Silently dropped" is an intentional agent affordance: tool layers
+  // may enumerate an optimistic field set; we don't want speculative
+  // keys to take down the whole call.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['show', rid(1), '--fields', 'state,not_a_field']);
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(Object.keys(payload), ['state']);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── --dry-run on state-transition verbs ──────────────────────────
+
+test('approve --dry-run: emits preview envelope, does NOT persist', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout, status } = runGate(
+      root,
+      ['approve', rid(1), '--by', 'alice', '--dry-run'],
+    );
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.dry_run, true);
+    assert.equal(payload.verb, 'approve');
+    assert.deepEqual(payload.would_transition, { from: 'pending', to: 'approved' });
+    assert.equal(payload.preview.state, 'approved');
+    // After dry-run, the real record is still pending.
+    const after = JSON.parse(
+      runGate(root, ['show', rid(1), '--fields', 'state']).stdout,
+    );
+    assert.equal(after.state, 'pending');
+  } finally {
+    cleanup();
+  }
+});
+
+test('review --dry-run: preview includes new review without persisting', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    // Note: `--dry-run=true` rather than bare `--dry-run`, because the
+    // comment `looks good` that follows would otherwise be consumed as
+    // the flag's value by the generic parser. Explicit-value form is
+    // the documented escape valve (see parseArgs.ts).
+    const { stdout, status } = runGate(
+      root,
+      [
+        'review', rid(1),
+        '--by', 'bob',
+        '--lense', 'devil',
+        '--verdict', 'ok',
+        '--dry-run=true',
+        'looks good',
+      ],
+    );
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.dry_run, true);
+    assert.equal(payload.verb, 'review');
+    // No state transition for review — envelope omits the field.
+    assert.equal('would_transition' in payload, false);
+    assert.equal(payload.preview.reviews.length, 1);
+    // After dry-run, real reviews list is still empty.
+    const after = JSON.parse(runGate(root, ['show', rid(1)]).stdout);
+    assert.equal(after.reviews.length, 0);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Five agent-experience (AX) affordances. Common thread: each surfaces information that the CLI was already giving humans (stderr text, multi-stream awareness, "try it and see") but that a tool-layer consumer piping stdout had no way to reach.

- **`boot.suggested_next` reaches beyond onboarding.** Previously: only the no-actor / unknown-actor cases got a `{verb, args, reason}` triple; registered members with work waiting got `null`. Now: known actors are routed to the most actionable open loop — `executing-by-me → complete` (finish what's in your hand first), `unreviewed-mine → review` (others are blocked), `approved-for-me → execute`, `pending-as-executor → approve`. The agent's orientation call returns one verb to dispatch.
- **`--format json` errors emit a JSON envelope on stderr.** A tool layer asking for JSON no longer needs two parsers (stdout JSON for success, stderr text for failure). Both land on stderr — the envelope (`{"ok": false, "error": {"message", "field"}}`) on the first line, the human-readable `error: …` line on the second. Non-JSON callers are unchanged.
- **`board --format json` echoes `_meta.filter`.** Implicit GUILD_ACTOR scoping (or explicit `--for`) is invisible to a stdout-only consumer unless the JSON itself names it. Added `_meta.filter = {actor, source}` when filtered; absent when unfiltered.
- **`gate show --fields k1,k2,...`.** Trims the JSON payload to the requested keys. A full show is ~400-800 bytes; `--fields state` returns ~25. Unknown keys silently dropped so speculative enumeration doesn't break the call. Text mode unchanged.
- **`--dry-run` on approve/deny/execute/complete/fail/review.** Emits a preview envelope (`{dry_run, verb, would_transition, preview}`) without persisting. Humans can try-undo; agents can't, and this is the symmetric half of repair's existing `--apply` / `--dry-run` contract. Implemented as `opts.dryRun` on the RequestUseCases methods (skips the `save` call, returns the in-memory post-mutation object).

## Test plan

- [x] `npm test` — 408 pass / 0 fail (395 existing + 13 new in `tests/interface/ax.test.ts` covering each affordance)
- [x] Manual probe from a fresh cwd: each new behavior traces end-to-end (`boot → approve → execute → complete` chain via `suggested_next`; JSON error envelope on `--format json`; `_meta.filter` toggling on GUILD_ACTOR vs `--for` vs unfiltered; `show --fields` byte count; `approve --dry-run` leaves state unchanged in `show --fields state`)
- [x] HELP text updated to document `--dry-run` and `--fields`

https://claude.ai/code/session_018abWBpAmnZucRxLQfQLcTC