### PR TITLE
feat(ax): error code + known-boolean flags

### DIFF
--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -349,9 +349,35 @@ export async function main(argv: readonly string[]): Promise<number> {
       };
       const errObj = payload['error'] as Record<string, unknown>;
       if (e instanceof DomainError && e.field) errObj['field'] = e.field;
+      const code = deriveErrorCode(e);
+      if (code) errObj['code'] = code;
       process.stderr.write(JSON.stringify(payload) + '\n');
     }
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }
+}
+
+/**
+ * Macro-level error classification for the JSON envelope. Patterns
+ * match the current set of `DomainError` messages so a tool layer
+ * can branch on `code` instead of regex-matching the prose.
+ *
+ * The codes are intentionally coarse (a 4-way fork covers most retry
+ * / escalate decisions): fine-grained differentiation stays in the
+ * `message` + `field` pair.
+ *
+ * Message-pattern derivation rather than a per-throw `code` argument
+ * keeps the change surgical — adding a code later at the throw site
+ * remains compatible; a call that doesn't yet name one still produces
+ * the right classification here.
+ */
+function deriveErrorCode(e: unknown): string | null {
+  if (!(e instanceof Error)) return null;
+  const m = e.message;
+  if (/\bnot found\b/i.test(m)) return 'not_found';
+  if (/\bis already \w+\.?/i.test(m)) return 'already_in_state';
+  if (/illegal state transition/i.test(m)) return 'illegal_transition';
+  if (e instanceof DomainError) return 'validation_error';
+  return null;
 }

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -14,11 +14,35 @@
  * stays boolean-true because the parser can't tell a value-that-
  * happens-to-start-with-dashes apart from a genuine next flag. This
  * is the standard POSIX resolution to that ambiguity.
+ *
+ * Known-boolean flags (KNOWN_BOOLEAN_FLAGS) are NEVER consumed-with-
+ * value: they land as `true` even when followed by a non-dash token.
+ * This closes the footgun where `gate review <id> --dry-run "LGTM"`
+ * quietly read "LGTM" as the dry-run value and silently skipped the
+ * intended boolean. Callers of these flags use `=== true` on the
+ * value anyway, so the old misbehaviour was latent: true intent
+ * dropped on the floor, positional swallowed.
  */
 export interface ParsedArgs {
   readonly options: Readonly<Record<string, string | boolean>>;
   readonly positional: readonly string[];
 }
+
+/**
+ * Flags that are definitionally boolean — they never take a value.
+ * Listed here so the parser doesn't speculatively consume the next
+ * token as their "value" (see docblock above).
+ *
+ * Adding to this list is the right move when a new `--flag` is
+ * documented as boolean-only; forgetting to add it just preserves
+ * the old `--dry-run=true` escape-valve behaviour, not a crash.
+ */
+export const KNOWN_BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
+  'apply',      // gate repair --apply
+  'dry-run',    // write verbs' preview mode
+  'summary',    // gate doctor --summary
+  'unread',     // gate inbox --unread
+]);
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const options: Record<string, string | boolean> = {};
@@ -44,7 +68,11 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       } else {
         const key = token.slice(2);
         const next = argv[i + 1];
-        if (next !== undefined && !next.startsWith('--')) {
+        if (
+          !KNOWN_BOOLEAN_FLAGS.has(key) &&
+          next !== undefined &&
+          !next.startsWith('--')
+        ) {
           options[key] = next;
           i++;
         } else {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -307,10 +307,10 @@ test('review --dry-run: preview includes new review without persisting', () => {
       ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
       { GUILD_ACTOR: 'alice' },
     );
-    // Note: `--dry-run=true` rather than bare `--dry-run`, because the
-    // comment `looks good` that follows would otherwise be consumed as
-    // the flag's value by the generic parser. Explicit-value form is
-    // the documented escape valve (see parseArgs.ts).
+    // Bare `--dry-run` followed by the positional comment `looks good`
+    // works because `dry-run` is listed in KNOWN_BOOLEAN_FLAGS — the
+    // parser won't speculatively consume the next token as the flag's
+    // value. Before that fix this line needed `--dry-run=true`.
     const { stdout, status } = runGate(
       root,
       [
@@ -318,7 +318,7 @@ test('review --dry-run: preview includes new review without persisting', () => {
         '--by', 'bob',
         '--lense', 'devil',
         '--verdict', 'ok',
-        '--dry-run=true',
+        '--dry-run',
         'looks good',
       ],
     );

--- a/tests/interface/parseArgs.test.ts
+++ b/tests/interface/parseArgs.test.ts
@@ -155,3 +155,31 @@ test('requireOption: plain missing flag does NOT emit the -- hint (stays terse)'
     assert.equal(/begin/.test(e.message), false);
   }
 });
+
+// ── KNOWN_BOOLEAN_FLAGS: `--dry-run <positional>` doesn't swallow ──
+
+test('parseArgs: known-boolean flag stays boolean even with non-dash next token', () => {
+  // The historical footgun: `gate review ... --dry-run "LGTM"` read
+  // "LGTM" as --dry-run's value, silently dropping the boolean intent
+  // and losing the positional. Boolean-only flags in the registry
+  // short-circuit the speculative-consume rule.
+  const args = parseArgs(['--dry-run', 'LGTM']);
+  assert.equal(args.options['dry-run'], true);
+  assert.deepEqual(args.positional, ['LGTM']);
+});
+
+test('parseArgs: explicit --dry-run=false still parses as the literal string', () => {
+  // We didn't coerce the =value form — callers still see the raw
+  // string. Existing call sites check `=== true`, so `--dry-run=false`
+  // reads as falsy (correct) without the parser doing magic.
+  const args = parseArgs(['--dry-run=false']);
+  assert.equal(args.options['dry-run'], 'false');
+});
+
+test('parseArgs: non-boolean flag preserves the value-consuming behaviour', () => {
+  // Regression guard: only the known list short-circuits. Unknown
+  // flags keep the "next non-dash token is my value" convention.
+  const args = parseArgs(['--from', 'eris', 'extra']);
+  assert.equal(args.options['from'], 'eris');
+  assert.deepEqual(args.positional, ['extra']);
+});


### PR DESCRIPTION
## Summary

Two smaller AX papercuts surfaced by actually running the first-batch changes in an agent-style loop. Implemented, tried, felt the difference, adopted.

- **`code` field on `--format json` error envelopes.** Derives a four-way classification (`not_found` / `already_in_state` / `illegal_transition` / `validation_error`) from the DomainError message pattern. A tool layer can now branch on `code` instead of regex-matching prose; `message` + `field` stay available for finer-grained cases. Derivation at the envelope site rather than per-throw argument keeps the change surgical — retrofitting explicit codes at throw sites later is compatible.
- **`KNOWN_BOOLEAN_FLAGS` registry in parseArgs.** Boolean-only flags (`apply`, `dry-run`, `summary`, `unread`) never speculatively consume the next token as their value. Closes the footgun where `gate review <id> --dry-run "LGTM"` read "LGTM" as --dry-run's value and silently dropped both the boolean intent and the positional comment. The `--dry-run=true` workaround is no longer needed; the bare form reads the way intent flows.

Drive-by: the ax.test.ts review-dry-run case now uses the natural bare `--dry-run` form, which doubles as a canary for the parseArgs change.

## Test plan

- [x] `npm test` — 411 pass / 0 fail (408 prior + 3 new parseArgs tests pinning the known-boolean behaviour)
- [x] Agent-loop probe: chained `boot → dispatch suggested_next → boot` four times with `jq .error.code` branching on failures and `--dry-run "comment"` in natural form; both reads flow without workaround.
- [x] Regression check on the other three boolean flags (`--apply`, `--summary`, `--unread`) — all unchanged.

https://claude.ai/code/session_018abWBpAmnZucRxLQfQLcTC