### PR TITLE
explore(ax): seven AX extensions — dogfooded, 6 ok / 1 concern

### DIFF
--- a/mcp/plugins/self-loop-check.mjs
+++ b/mcp/plugins/self-loop-check.mjs
@@ -1,0 +1,152 @@
+/**
+ * gate doctor plugin: self-loop-check
+ *
+ * Flags requests whose entire lifecycle was performed by a single
+ * actor — "self-loop" decisions where pending → approved → executing
+ * → completed (and, if applicable, a self-review) all bear the same
+ * `by` field.
+ *
+ * Why this matters (the abyss in the 6-lens framing):
+ *   gate lets any registered member approve any request, including
+ *   their own. Policy-allowed, emits a stderr notice, and for a
+ *   single casual self-flow `gate fast-track` is the expected form.
+ *   But as agents take on more of the transitions autonomously, the
+ *   pattern "agent files, agent approves, agent executes, agent
+ *   reviews with own lens" quietly hollows the Two-Persona Devil
+ *   frame: the record exists, but the cross-actor signal that makes
+ *   it trustworthy is absent.
+ *
+ * The check is a DETECTOR, not an enforcer. Findings surface so
+ * a human (or another agent) can ask whether the pattern is
+ * intentional — they do not block any call.
+ *
+ * Threshold: 3+ self-loop completions in the most recent 25
+ * completed-or-failed records (a window, not a time cutoff, so
+ * the signal is robust to bursty sessions and quiet weeks).
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WINDOW = 25;
+const THRESHOLD = 3;
+
+/** @param {{ root: string, contentRoot: string, paths: { requests: string } }} ctx */
+export default async function selfLoopCheck(ctx) {
+  const findings = [];
+  const requestsRoot = ctx.paths?.requests ?? join(ctx.contentRoot, 'requests');
+  if (!existsSync(requestsRoot)) return findings;
+
+  // Terminal-state dirs: these are the only ones where a full self-
+  // loop exists (the request traversed every stage). `pending` /
+  // `approved` / `executing` are still in flight — flagging them
+  // would race with normal workflow.
+  const terminals = ['completed', 'failed'];
+  const records = [];
+  for (const state of terminals) {
+    const dir = join(requestsRoot, state);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith('.yaml')) continue;
+      const raw = readFileSync(join(dir, name), 'utf8');
+      const parsed = parseYamlLite(raw);
+      if (parsed) records.push({ parsed, source: join(dir, name) });
+    }
+  }
+
+  // Newest-first so the window captures the recent surface. Sort by
+  // id (YYYY-MM-DD-NNNN) — lexicographic on the composite is stable.
+  records.sort((a, b) => (b.parsed.id ?? '').localeCompare(a.parsed.id ?? ''));
+  const window = records.slice(0, WINDOW);
+
+  const selfLoops = [];
+  for (const r of window) {
+    if (isSelfLoop(r.parsed)) selfLoops.push(r);
+  }
+
+  if (selfLoops.length >= THRESHOLD) {
+    const ids = selfLoops.map((r) => r.parsed.id).slice(0, 5);
+    findings.push({
+      area: 'plugin',
+      source: requestsRoot,
+      kind: 'unknown',
+      message:
+        `self-loop pattern: ${selfLoops.length} of the last ${window.length} ` +
+        `terminal requests were filed, approved, and executed by the same actor ` +
+        `(sample ids: ${ids.join(', ')}). The Two-Persona Devil frame expects ` +
+        `cross-actor signal; consider inviting another reviewer or using ` +
+        `'gate fast-track' explicitly for the cases that are genuinely single-actor.`,
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * "Self-loop" definition: every status_log `by` AND every review `by`
+ * names the same single actor. A request with 0 reviews still counts
+ * if the status_log is mono-actor (the reviews absence is itself a
+ * signal — no second pair of eyes was ever invoked).
+ *
+ * Fast-tracked-and-auto-reviewed-by-author sessions will read as
+ * self-loops; that's the point — they're the legitimate form of the
+ * pattern we're counting. Whether 3+ such sessions in a row deserves
+ * attention is the question the finding raises, not answers.
+ */
+function isSelfLoop(req) {
+  const log = Array.isArray(req.status_log) ? req.status_log : [];
+  if (log.length === 0) return false;
+  const actors = new Set();
+  for (const entry of log) {
+    if (entry && typeof entry.by === 'string') actors.add(entry.by);
+  }
+  const reviews = Array.isArray(req.reviews) ? req.reviews : [];
+  for (const rv of reviews) {
+    if (rv && typeof rv.by === 'string') actors.add(rv.by);
+  }
+  return actors.size === 1;
+}
+
+/**
+ * Minimal YAML extractor — enough for our fields (id, status_log[].by,
+ * reviews[].by). We only need string scalars and nested-object `by`
+ * fields; full YAML parsing would add a dep for a plugin that should
+ * stay hermetic. Returns null on anything it can't read.
+ */
+function parseYamlLite(raw) {
+  // The repository writes YAML via the `yaml` package in a stable
+  // shape; reaching for the full parser would couple the plugin to
+  // the CLI's dep tree. Instead, do a targeted scan for the fields
+  // we care about. If that turns out fragile in practice, promoting
+  // this to `import YAML from 'yaml'` is a one-line change.
+  const idMatch = raw.match(/^id:\s*(\S+)/m);
+  if (!idMatch) return null;
+  const id = idMatch[1];
+
+  const status_log = [];
+  const logMatch = raw.match(/^status_log:\s*\n([\s\S]*?)(?=\n[a-z_]+:)/m);
+  if (logMatch) {
+    const block = logMatch[1];
+    // Each entry starts with `  - state:`. Capture `by:` within the
+    // entry (before the next `  - ` or end).
+    const entries = block.split(/^\s*-\s*state:/m).slice(1);
+    for (const entry of entries) {
+      const byM = entry.match(/^\s*by:\s*(\S+)/m);
+      if (byM) status_log.push({ by: byM[1] });
+    }
+  }
+
+  const reviews = [];
+  const revMatch = raw.match(/^reviews:\s*\n([\s\S]*?)(?=\n[a-z_]+:)/m);
+  if (revMatch) {
+    const block = revMatch[1];
+    const entries = block.split(/^\s*-\s*by:/m).slice(1);
+    for (const entry of entries) {
+      // The `by` value is the first token on the split line.
+      const byM = entry.match(/^\s*(\S+)/);
+      if (byM) reviews.push({ by: byM[1] });
+    }
+  }
+
+  return { id, status_log, reviews };
+}

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -5,6 +5,7 @@ import {
   REQUEST_STATES,
 } from '../../domain/request/RequestState.js';
 import { Review } from '../../domain/request/Review.js';
+import { Thank } from '../../domain/request/Thank.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { compareSequenceIds } from '../../domain/shared/compareSequenceIds.js';
 import {
@@ -223,6 +224,36 @@ export class RequestUseCases {
       ...(this.deps.allowedLenses ? { allowedLenses: this.deps.allowedLenses } : {}),
     });
     req.addReview(review);
+    if (!input.dryRun) await this.deps.requests.save(req);
+    return req;
+  }
+
+  /**
+   * Record a cross-actor thank against a request. Mirrors `review` in
+   * shape but with different semantics: no verdict, no state change,
+   * doesn't feed voice calibration. The `by` and `to` actors are
+   * both asserted against the member/host directory.
+   */
+  async thank(input: {
+    id: string;
+    by: string;
+    to: string;
+    reason?: string;
+    invokedBy?: string;
+    dryRun?: boolean;
+  }): Promise<Request> {
+    const req = await this.loadOrThrow(input.id);
+    await assertActor(input.by, '--by', this.deps.members);
+    await assertActor(input.to, '--to', this.deps.members);
+    const thankInput: Parameters<typeof Thank.create>[0] = {
+      by: input.by,
+      to: input.to,
+      at: this.deps.clock.now().toISOString(),
+    };
+    if (input.reason !== undefined) thankInput.reason = input.reason;
+    if (input.invokedBy !== undefined) thankInput.invokedBy = input.invokedBy;
+    const thank = Thank.create(thankInput);
+    req.addThank(thank);
     if (!input.dryRun) await this.deps.requests.save(req);
     return req;
   }

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -5,11 +5,13 @@ import {
   parseRequestState,
 } from './RequestState.js';
 import { Review } from './Review.js';
+import { Thank } from './Thank.js';
 import { MemberName } from '../member/MemberName.js';
 import { DomainError } from '../shared/DomainError.js';
 
 const MAX_TEXT = 4096;
 const MAX_REVIEWS = 50;
+const MAX_THANKS = 50;
 const MAX_STATUS_LOG = 100;
 
 export interface StatusLogEntry {
@@ -61,6 +63,13 @@ export interface RequestProps {
   state: RequestState;
   createdAt: string;
   reviews: Review[];
+  /**
+   * Optional — records written before the thank primitive existed
+   * don't carry this field, and the repo hydrates them as undefined
+   * rather than breaking. The constructor normalises to [] so the
+   * internal invariant is still "always an array".
+   */
+  thanks?: Thank[];
   statusLog: StatusLogEntry[];
 }
 
@@ -76,7 +85,13 @@ export class Request {
   private constructor(
     private props: RequestProps,
     private readonly _loadedVersion: number,
-  ) {}
+  ) {
+    // Normalise optional `thanks` so every downstream reader sees
+    // an array. Old records hydrated with the field absent pick up
+    // an empty list here; `addThank` and the `thanks` getter both
+    // assume the array exists.
+    if (this.props.thanks === undefined) this.props.thanks = [];
+  }
 
   static create(input: {
     id: RequestId;
@@ -124,6 +139,7 @@ export class Request {
       state: 'pending',
       createdAt,
       reviews: [],
+      thanks: [],
       statusLog: [initialEntry],
     };
     if (input.executor !== undefined) {
@@ -250,6 +266,25 @@ export class Request {
     this.props.reviews.push(review);
   }
 
+  /**
+   * Append a thank to the request. Parallels addReview but for the
+   * gratitude primitive — no verdict, no state change, doesn't feed
+   * calibration. Cap mirrors reviews (50) so a degenerate caller
+   * can't fill disk; in practice this should be generous enough.
+   */
+  addThank(thank: Thank): void {
+    const list = this.props.thanks ?? [];
+    if (list.length >= MAX_THANKS) {
+      throw new DomainError(`Too many thanks (max ${MAX_THANKS})`, 'thanks');
+    }
+    list.push(thank);
+    this.props.thanks = list;
+  }
+
+  get thanks(): readonly Thank[] {
+    return this.props.thanks ?? [];
+  }
+
   private transition(
     to: RequestState,
     by: MemberName,
@@ -292,6 +327,14 @@ export class Request {
       status_log: this.props.statusLog.map((e) => statusLogEntryToJSON(e)),
       reviews: this.props.reviews.map((r) => r.toJSON()),
     };
+    // Thanks surface only when present — zero thanks is the common
+    // case and an empty array would clutter every show payload.
+    // Forward-compatible: consumers reading old records (pre-thanks)
+    // see no `thanks` key at all, which is correct.
+    const thanks = this.props.thanks ?? [];
+    if (thanks.length > 0) {
+      out['thanks'] = thanks.map((t) => t.toJSON());
+    }
     if (this.props.executor) out['executor'] = this.props.executor.value;
     if (this.props.autoReview)
       out['auto_review'] = this.props.autoReview.value;

--- a/src/domain/request/Thank.ts
+++ b/src/domain/request/Thank.ts
@@ -1,0 +1,104 @@
+import { MemberName } from '../member/MemberName.js';
+import { DomainError } from '../shared/DomainError.js';
+
+const MAX_REASON_LEN = 1024;
+
+/**
+ * A `Thank` is a cross-actor appreciation primitive — one member
+ * thanking another for their work on a specific request. It's a
+ * sibling of `Review` but with a different purpose:
+ *
+ *   - Review = analytical judgement (ok / concern / reject), feeds
+ *     voice calibration, load-bearing for Two-Persona Devil.
+ *   - Thank  = emotional memory, no verdict, does NOT feed
+ *     calibration. Tracks gratitude as its own first-class record.
+ *
+ * Both live on the Request as append-only lists. Review already
+ * exists; this is the thank primitive that pairs with it so the
+ * guild has both analytical and emotional memory on one record.
+ *
+ * Design choices:
+ *  - `to` is explicit rather than inferred. A request has many
+ *    actors (from, executor, auto_review, status_log participants);
+ *    without `to` the thanks would be ambiguous.
+ *  - `reason` is optional. Most of the time the fact of the thank
+ *    is the signal; a reason is nice-to-have, not required.
+ *  - Sanitization mirrors Review's comment sanitizer: strip control
+ *    chars, cap length. Short-form by construction.
+ */
+
+export interface ThankProps {
+  by: MemberName;
+  to: MemberName;
+  at: string;
+  reason?: string;
+  /** See StatusLogEntry.invokedBy — same semantics here. */
+  invokedBy?: string;
+}
+
+export class Thank {
+  private constructor(private readonly props: ThankProps) {}
+
+  static create(input: {
+    by: string;
+    to: string;
+    at?: string;
+    reason?: string;
+    invokedBy?: string;
+  }): Thank {
+    const by = MemberName.of(input.by);
+    const to = MemberName.of(input.to);
+    const at = input.at ?? new Date().toISOString();
+    const props: ThankProps = { by, to, at };
+    if (input.reason !== undefined) {
+      props.reason = sanitizeReason(input.reason);
+    }
+    if (input.invokedBy !== undefined && input.invokedBy !== by.value) {
+      props.invokedBy = input.invokedBy;
+    }
+    return new Thank(props);
+  }
+
+  get by(): MemberName {
+    return this.props.by;
+  }
+  get to(): MemberName {
+    return this.props.to;
+  }
+  get at(): string {
+    return this.props.at;
+  }
+  get reason(): string | undefined {
+    return this.props.reason;
+  }
+  get invokedBy(): string | undefined {
+    return this.props.invokedBy;
+  }
+
+  toJSON(): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+      by: this.props.by.value,
+      to: this.props.to.value,
+      at: this.props.at,
+    };
+    if (this.props.reason !== undefined) out['reason'] = this.props.reason;
+    if (this.props.invokedBy !== undefined) {
+      out['invoked_by'] = this.props.invokedBy;
+    }
+    return out;
+  }
+}
+
+function sanitizeReason(raw: unknown): string {
+  if (typeof raw !== 'string') {
+    throw new DomainError('Thank reason must be a string', 'reason');
+  }
+  const cleaned = raw.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+  if (cleaned.length > MAX_REASON_LEN) {
+    throw new DomainError(
+      `Thank reason too long (max ${MAX_REASON_LEN} chars)`,
+      'reason',
+    );
+  }
+  return cleaned;
+}

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -8,6 +8,7 @@ import {
   parseRequestState,
 } from '../../domain/request/RequestState.js';
 import { Review } from '../../domain/request/Review.js';
+import { Thank } from '../../domain/request/Thank.js';
 import { MemberName } from '../../domain/member/MemberName.js';
 import {
   RequestRepository,
@@ -314,6 +315,27 @@ function hydrate(
           : new Date().toISOString();
     const action = String(obj['action'] ?? '(no action)').trim() || '(no action)';
     const reason = String(obj['reason'] ?? '(no reason)').trim() || '(no reason)';
+    // Thanks are optional on disk — records written before the verb
+    // existed simply lack the field, and that's fine.
+    const thanksRaw = Array.isArray(obj['thanks'])
+      ? (obj['thanks'] as unknown[])
+      : [];
+    const thanks: Thank[] = [];
+    for (const t of thanksRaw) {
+      if (t && typeof t === 'object') {
+        const to = t as Record<string, unknown>;
+        const tc: Parameters<typeof Thank.create>[0] = {
+          by: String(to['by']),
+          to: String(to['to']),
+        };
+        if (typeof to['at'] === 'string') tc.at = to['at'] as string;
+        if (typeof to['reason'] === 'string') tc.reason = to['reason'] as string;
+        if (typeof to['invoked_by'] === 'string') {
+          tc.invokedBy = to['invoked_by'] as string;
+        }
+        thanks.push(Thank.create(tc));
+      }
+    }
     const props: Parameters<typeof Request.restore>[0] = {
       id,
       from: MemberName.of(obj['from']),
@@ -324,6 +346,7 @@ function hydrate(
       reviews,
       statusLog,
     };
+    if (thanks.length > 0) props.thanks = thanks;
     const executorRaw =
       typeof obj['executor'] === 'string'
         ? (obj['executor'] as string)

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -560,6 +560,8 @@ function renderBootText(p: BootPayload): string {
     for (const u of p.tail.slice(0, 5)) {
       if (u.kind === 'review') {
         lines.push(`  ${u.at}  req=${u.requestId}  [${u.lense}/${u.verdict}] by ${u.by}`);
+      } else if (u.kind === 'thank') {
+        lines.push(`  ${u.at}  req=${u.requestId}  thank ${u.by} → ${u.to}`);
       } else {
         lines.push(`  ${u.at}  req=${u.requestId}  authored by ${u.from}`);
       }

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -88,6 +88,34 @@ interface BootPayload {
     };
   };
   /**
+   * Discoverability hint: what verbs are applicable right now?
+   *
+   * `actionable` names the state-transition verbs whose preconditions
+   * are met for the caller's current queues. Each entry carries the
+   * target id + a human-readable reason so a first-time agent can see
+   * not just "approve exists" but "approve is valid on 2026-04-19-0001
+   * because you're its executor and it's pending". `suggested_next`
+   * picks ONE of these to lead with; `actionable` names the rest so
+   * an agent that wants to branch can see the siblings.
+   *
+   * `always_readable` is the flat catalog of side-effect-free verbs
+   * an identified (or even anonymous) actor can always call — the
+   * "map of the readable world" for initial exploration.
+   *
+   * The two lists never overlap: write verbs belong to `actionable`
+   * (when they're valid) or are absent; read verbs belong to
+   * `always_readable`. Keeping them separate makes it obvious which
+   * calls change state and which don't.
+   */
+  verbs_available_now: {
+    actionable: Array<{
+      verb: string;
+      id: string;
+      reason: string;
+    }>;
+    always_readable: readonly string[];
+  };
+  /**
    * First-step prescription for the caller. Populated when boot can
    * infer an obvious "do this next" — typically pre-onboarding (no
    * GUILD_ACTOR, or GUILD_ACTOR set to an unregistered name) where
@@ -223,6 +251,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     members,
     allRequests,
   );
+  const verbsAvailableNow = deriveVerbsAvailableNow(actor, role, allRequests);
 
   const payload: BootPayload = {
     actor,
@@ -239,6 +268,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       content_root_health: contentRootHealth,
     },
     suggested_next: suggestedNext,
+    verbs_available_now: verbsAvailableNow,
   };
 
   if (format === 'json') {
@@ -380,6 +410,95 @@ export function deriveBootSuggestedNext(
   }
 
   return null;
+}
+
+const ALWAYS_READABLE_VERBS: readonly string[] = [
+  'boot', 'suggest', 'status', 'show', 'board', 'list', 'pending',
+  'tail', 'voices', 'chain', 'whoami', 'schema', 'doctor', 'resume',
+];
+
+/**
+ * Enumerate the state-transition verbs whose preconditions are met
+ * right now, with the target id + reason for each. `suggested_next`
+ * picks ONE of these; this list names the siblings so an agent can
+ * branch (e.g. "I see approve and deny are both valid — deny this,
+ * the reason doesn't hold up").
+ *
+ * Kept deliberately narrow: only the gated transitions. Free verbs
+ * (request, fast-track, message, broadcast) are always valid for a
+ * registered member and listed via the identity-scoped catalog, not
+ * here — repeating them per-request would bloat the payload.
+ */
+function deriveVerbsAvailableNow(
+  actor: string | null,
+  role: BootPayload['role'],
+  allRequests: ReadonlyArray<Request>,
+): BootPayload['verbs_available_now'] {
+  const actionable: BootPayload['verbs_available_now']['actionable'] = [];
+  if (actor === null || role === 'unknown') {
+    return { actionable, always_readable: ALWAYS_READABLE_VERBS };
+  }
+  const actorLower = actor.toLowerCase();
+
+  // Executing-by-me → complete/fail are both valid.
+  for (const r of allRequests) {
+    if (r.state !== 'executing') continue;
+    if (r.executor?.value !== actorLower && r.from.value !== actorLower) continue;
+    actionable.push({
+      verb: 'complete',
+      id: r.id.value,
+      reason: `${r.id.value} is executing (you're ${r.executor?.value === actorLower ? 'the executor' : 'the author'})`,
+    });
+    actionable.push({
+      verb: 'fail',
+      id: r.id.value,
+      reason: `${r.id.value} is executing; use fail if it can't land`,
+    });
+  }
+
+  // Approved-for-me → execute is valid.
+  for (const r of allRequests) {
+    if (r.state !== 'approved') continue;
+    if (r.executor?.value !== actorLower) continue;
+    actionable.push({
+      verb: 'execute',
+      id: r.id.value,
+      reason: `${r.id.value} is approved and names you as executor`,
+    });
+  }
+
+  // Pending-as-executor → approve/deny are both valid for any actor
+  // who isn't the author (author approving their own is the self-
+  // approval case — still policy-allowed, just louder).
+  for (const r of allRequests) {
+    if (r.state !== 'pending') continue;
+    if (r.executor?.value !== actorLower) continue;
+    if (r.from.value === actorLower) continue;
+    actionable.push({
+      verb: 'approve',
+      id: r.id.value,
+      reason: `${r.id.value} is pending and names you as executor (authored by ${r.from.value})`,
+    });
+    actionable.push({
+      verb: 'deny',
+      id: r.id.value,
+      reason: `${r.id.value} is pending; deny with --reason if it shouldn't proceed`,
+    });
+  }
+
+  // Unreviewed-mine → review is valid.
+  for (const r of allRequests) {
+    if (r.state !== 'completed') continue;
+    if (r.autoReview?.value !== actorLower) continue;
+    if (r.reviews.length > 0) continue;
+    actionable.push({
+      verb: 'review',
+      id: r.id.value,
+      reason: `${r.id.value} completed with auto-review assigned to you`,
+    });
+  }
+
+  return { actionable, always_readable: ALWAYS_READABLE_VERBS };
 }
 
 function renderBootText(p: BootPayload): string {

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -9,8 +9,10 @@ import { compareSequenceIds } from '../../../domain/shared/compareSequenceIds.js
 import {
   collectUtterances,
   renderUtterance,
+  computeVoiceCalibration,
   RequestJSON,
   VoicesFilter,
+  VoiceCalibration,
 } from '../voices.js';
 import {
   extractReferences,
@@ -65,8 +67,36 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   }
   const utterances = collectUtterances(allJson, filter);
 
+  // Voice calibration: per-(actor, lens) score derived from historical
+  // verdicts vs outcomes. Hidden when viewing your own voice (the
+  // voter shouldn't game their own score); shown otherwise. See the
+  // `computeVoiceCalibration` header in voices.ts for semantics.
+  const envActor = process.env['GUILD_ACTOR'];
+  const isSelfView =
+    envActor !== undefined &&
+    envActor.length > 0 &&
+    envActor.toLowerCase() === name.toLowerCase();
+  const calibration: VoiceCalibration | null = isSelfView
+    ? null
+    : computeVoiceCalibration(allJson, name);
+  const withCalibration = args.options['with-calibration'] === true;
+
   if (format === 'json') {
-    process.stdout.write(JSON.stringify(utterances, null, 2) + '\n');
+    // Shape contract: default stays the utterances array so existing
+    // consumers don't break. `--with-calibration` opts into an object
+    // shape that carries both. The flag is registered in
+    // KNOWN_BOOLEAN_FLAGS so its presence doesn't swallow positionals.
+    if (withCalibration) {
+      process.stdout.write(
+        JSON.stringify(
+          { utterances, calibration: calibration },
+          null,
+          2,
+        ) + '\n',
+      );
+    } else {
+      process.stdout.write(JSON.stringify(utterances, null, 2) + '\n');
+    }
     return 0;
   }
 
@@ -90,6 +120,20 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   );
   for (const u of utterances) {
     process.stdout.write(renderUtterance(u, false) + '\n\n');
+  }
+  // Calibration footer: one line per lens with recorded activity.
+  // Placed after the utterances so a reader who scanned the prose
+  // sees the summary below without it fighting for attention. Self-
+  // view skips this entirely (see isSelfView above).
+  if (calibration !== null) {
+    const lensEntries = Object.entries(calibration.by_lens);
+    if (lensEntries.length > 0) {
+      process.stdout.write('── calibration ──\n');
+      for (const [, c] of lensEntries) {
+        process.stdout.write(`  ${c.prose}\n`);
+      }
+      process.stdout.write('\n');
+    }
   }
   return 0;
 }

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -386,6 +386,17 @@ function composeRestorationProseEn(ctx: {
         `Your last voice (utterance, ${age}) was a review on req=${lastUtterance.requestId} — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  "${truncate(lastUtterance.comment, 240)}"`);
+    } else if (lastUtterance.kind === 'thank') {
+      const proxyHint = lastUtterance.invokedBy
+        ? ` (invoked by ${lastUtterance.invokedBy})`
+        : '';
+      lines.push(
+        `Your last voice (utterance, ${age}) was a thank → ${lastUtterance.to} on req=${lastUtterance.requestId}${proxyHint}:`,
+      );
+      lines.push(`  re: ${truncate(lastUtterance.action, 120)}`);
+      if (lastUtterance.reason !== undefined) {
+        lines.push(`  "${truncate(lastUtterance.reason, 200)}"`);
+      }
     } else {
       const withHint =
         lastUtterance.with && lastUtterance.with.length > 0
@@ -517,6 +528,17 @@ function composeRestorationProseJa(ctx: {
         `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} へのレビュー — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  「${truncate(lastUtterance.comment, 240)}」`);
+    } else if (lastUtterance.kind === 'thank') {
+      const proxyHint = lastUtterance.invokedBy
+        ? `（${lastUtterance.invokedBy} が代行）`
+        : '';
+      lines.push(
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} への感謝 → ${lastUtterance.to}${proxyHint}:`,
+      );
+      lines.push(`  re: ${truncate(lastUtterance.action, 120)}`);
+      if (lastUtterance.reason !== undefined) {
+        lines.push(`  「${truncate(lastUtterance.reason, 200)}」`);
+      }
     } else {
       const withHint =
         lastUtterance.with && lastUtterance.with.length > 0

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -144,6 +144,42 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'transcript',
+    category: 'read',
+    summary:
+      "narrative render of one request's full arc — the prose-first sibling of `gate show`. Text output reads as paragraphs; JSON output carries both the narrative and a structured summary (actors, review_verdicts, duration_ms).",
+    input: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'request id (YYYY-MM-DD-NNNN)' },
+        format: {
+          type: 'string',
+          enum: ['text', 'json'],
+          description: "output format (default: text — the narrative is what's useful here)",
+        },
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        arc: str,
+        summary: {
+          type: 'object',
+          properties: {
+            actors: { type: 'array' },
+            actor_count: { type: 'integer' },
+            review_count: { type: 'integer' },
+            review_verdicts: { type: 'array' },
+            final_state: str,
+            duration_ms: { type: 'integer' },
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'resume',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -107,6 +107,14 @@ const VERBS: readonly VerbSchema[] = [
         your_recent: { type: 'array' },
         inbox_unread: { type: 'array' },
         last_activity: str,
+        suggested_next: {
+          type: 'object',
+          description:
+            'Advisory — NOT a directive. Orientation-time guidance ' +
+            'about what to do next, derived from queues + open loops. ' +
+            "Read `reason` and override when your judgement differs. " +
+            'Priority is shared with `gate suggest`; both are hints.',
+        },
       },
     },
   },
@@ -134,6 +142,13 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         suggested_next: {
           type: 'object',
+          description:
+            'Advisory — NOT a directive. Derived deterministically from the ' +
+            "caller's current queues using the same priority ladder as boot. " +
+            "Agents should read `reason` and override when their own " +
+            'judgement differs; a `suggest` loop that dispatches the verb ' +
+            'without reading the reason is treating a heuristic as a ' +
+            'command, which is the shape this field is trying to avoid.',
           properties: {
             verb: str,
             args: { type: 'object' },

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -442,6 +442,24 @@ const VERBS: readonly VerbSchema[] = [
     output: writeResponseSchema,
   },
   {
+    name: 'thank',
+    category: 'write',
+    summary:
+      "record cross-actor appreciation against a request. Sibling of review — no verdict, no state change, no calibration impact. `to` is positional; `--for` names the request id.",
+    input: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'positional; the actor being thanked' },
+        for: idStr,
+        by: str,
+        reason: strOpt('optional prose; "-" for STDIN'),
+        format: formatField,
+      },
+      required: ['to', 'for'],
+    },
+    output: writeResponseSchema,
+  },
+  {
     name: 'fast-track',
     category: 'write',
     summary: 'one-shot create→complete lifecycle (self-approved)',

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -60,12 +60,18 @@ export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
     if (suggestion === null) {
       process.stdout.write('(nothing urgent)\n');
     } else {
-      // Compact text form: one line for verb + args, one for reason.
+      // Compact text form: one line for verb + args, one for reason,
+      // one trailing advisory footer. The footer goes to stderr so
+      // stdout stays clean for `$(gate suggest ...)` shell composition
+      // but a human scanning the terminal still sees it next to the
+      // output. Keeps the reminder that suggested_next is a heuristic
+      // at the point where the user reads the suggestion.
       const argsStr = Object.entries(suggestion.args)
         .map(([k, v]) => `${k}=${v}`)
         .join(' ');
       process.stdout.write(`→ ${suggestion.verb} ${argsStr}\n`);
       process.stdout.write(`  ${suggestion.reason}\n`);
+      process.stderr.write('# advisory — override freely\n');
     }
   }
   return 0;

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -1,0 +1,77 @@
+import {
+  ParsedArgs,
+  requireOption,
+  optionalOption,
+} from '../../shared/parseArgs.js';
+import {
+  C,
+  readStdin,
+  resolveInvokedBy,
+  isDryRun,
+  emitDryRunPreview,
+} from './internal.js';
+import { emitWriteResponse, parseFormat } from './writeFormat.js';
+
+/**
+ * gate thank <to> --for <id> [--reason <s>] [--by <m>] [--dry-run]
+ *
+ * Record a cross-actor appreciation against a specific request. The
+ * primitive is deliberately lightweight: no verdict, no state change,
+ * no calibration impact. Pairs with `review` — reviews track
+ * judgement, thanks track gratitude.
+ *
+ * Positional form: `gate thank <to> --for <id>`. `--by` defaults to
+ * GUILD_ACTOR. Self-thank (`by == to`) is allowed but flagged on
+ * stderr — it's not harmful, just odd.
+ *
+ * `--reason` is optional. Most of the time the fact of the thank is
+ * the signal; a reason is a grace note. Supports `--reason -` for
+ * stdin (symmetric with review --comment -).
+ */
+export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
+  const to = args.positional[0];
+  if (!to) {
+    throw new Error(
+      'Usage: gate thank <to> --for <id> [--reason <s>] [--dry-run]',
+    );
+  }
+  const id = requireOption(args, 'for', '--for <request-id> required');
+  const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
+  let reason = optionalOption(args, 'reason');
+  if (reason === '-') reason = (await readStdin()).trim();
+  const invokedBy = resolveInvokedBy(by, 'thank', id);
+
+  const ucInput: Parameters<typeof c.requestUC.thank>[0] = {
+    id,
+    by,
+    to,
+  };
+  if (reason !== undefined && reason.length > 0) ucInput.reason = reason;
+  if (invokedBy !== undefined) ucInput.invokedBy = invokedBy;
+
+  if (isDryRun(args)) {
+    const updated = await c.requestUC.thank({ ...ucInput, dryRun: true });
+    emitDryRunPreview({ verb: 'thank', id, by, after: updated });
+    return 0;
+  }
+
+  const updated = await c.requestUC.thank(ucInput);
+
+  // Self-thank: not an error, just surface it so the log reads
+  // honestly. Mirrors the self-review / self-approval notices.
+  if (by === to) {
+    process.stderr.write(
+      `notice: self-thank — ${by} thanked themselves on ${id}. ` +
+        `thanks is usually a cross-actor primitive; if that's intentional ` +
+        `(e.g. thanking a past version of yourself), the record stands.\n`,
+    );
+  }
+
+  emitWriteResponse(
+    parseFormat(args),
+    updated,
+    `✓ thanked: ${to} on ${id}`,
+    c.config,
+  );
+  return 0;
+}

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -1,0 +1,234 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+
+/**
+ * gate transcript <id> [--format text|json]
+ *
+ * Narrative rendering of a single request's life — the arc from
+ * filing through every transition and review in plain prose. Sibling
+ * of `gate show` (structured) and `gate voices <name>` (per-actor
+ * stream); `transcript` is per-request and prose-first.
+ *
+ * Why this exists (explore-branch experiment):
+ *   Current tooling gives agents structured access (show --format
+ *   json) or lifecycle bullets (show --format text, status_log), but
+ *   the narrative — "what happened with this request, as a story" —
+ *   is a synthesis step the agent has to run itself on top of the
+ *   raw data. For agents that then summarise work back to humans,
+ *   that's duplicated effort; for agents reading others' history,
+ *   it's a reconstruction cost on every lookup.
+ *
+ *   If this verb feels valuable in practice, the cost of keeping it
+ *   is tiny (read-only, composed from existing data). If it feels
+ *   like synthetic prose that agents would render better themselves,
+ *   drop it — the data path isn't disturbed.
+ *
+ * Output:
+ *   text (default) — narrative paragraphs.
+ *   json           — { id, arc, summary } where `arc` is the same
+ *                    prose as text and `summary` carries the
+ *                    structured shape (actors, review_verdicts,
+ *                    duration_ms) for a programmatic consumer.
+ */
+
+interface TranscriptSummary {
+  actors: readonly string[];
+  actor_count: number;
+  review_count: number;
+  review_verdicts: readonly string[];
+  final_state: string;
+  duration_ms: number | null;
+}
+
+interface TranscriptPayload {
+  id: string;
+  arc: string;
+  summary: TranscriptSummary;
+}
+
+export async function transcriptCmd(c: C, args: ParsedArgs): Promise<number> {
+  const id = args.positional[0];
+  if (!id) throw new Error('Usage: gate transcript <id> [--format text|json]');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(`not found: ${id}\n`);
+    return 1;
+  }
+  const payload = buildTranscript(r);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(payload.arc + '\n');
+  }
+  return 0;
+}
+
+function buildTranscript(r: Request): TranscriptPayload {
+  const j = r.toJSON();
+  const id = String(j['id']);
+  const from = String(j['from']);
+  const action = String(j['action']);
+  const reason = String(j['reason']);
+  const executor = j['executor'] ? String(j['executor']) : undefined;
+  const autoReview = j['auto_review'] ? String(j['auto_review']) : undefined;
+  const log = Array.isArray(j['status_log'])
+    ? (j['status_log'] as Array<Record<string, unknown>>)
+    : [];
+  const reviews = Array.isArray(j['reviews'])
+    ? (j['reviews'] as Array<Record<string, unknown>>)
+    : [];
+  const finalState = String(j['state']);
+
+  // Narrative construction. Each paragraph is one phase of the arc:
+  //   1. Framing — who, what, why, named roles.
+  //   2. Lifecycle — each transition in prose, with notes as quotes.
+  //   3. Reviews — verdicts with the reviewer's voice.
+  //   4. Summary — actors touched, duration, terminal state.
+  const paragraphs: string[] = [];
+
+  // 1. Framing
+  const frameParts: string[] = [];
+  frameParts.push(
+    `${capitalise(from)} filed ${id} — "${action}" — seeking ${lowercase(reason)}`,
+  );
+  if (executor) frameParts.push(`naming ${executor} as executor`);
+  if (autoReview) frameParts.push(`with auto-review assigned to ${autoReview}`);
+  paragraphs.push(frameParts.join(', ') + '.');
+
+  // 2. Lifecycle prose
+  const lifecycle: string[] = [];
+  let prevAt: string | undefined;
+  for (const entry of log) {
+    const state = String(entry['state'] ?? '');
+    const by = String(entry['by'] ?? '');
+    const at = String(entry['at'] ?? '');
+    const note = entry['note'] ? ` (note: "${entry['note']}")` : '';
+    const invokedBy = entry['invoked_by']
+      ? ` [invoked by ${entry['invoked_by']}]`
+      : '';
+    if (state === 'pending') {
+      // Skip the initial pending entry — it's already implied by "filed".
+      prevAt = at;
+      continue;
+    }
+    const delta = prevAt ? ` (${humanDelta(prevAt, at)} later)` : '';
+    lifecycle.push(
+      `${capitalise(by)} moved it to ${state}${delta}${invokedBy}${note}`,
+    );
+    prevAt = at;
+  }
+  if (lifecycle.length > 0) {
+    paragraphs.push(lifecycle.join('. ') + '.');
+  }
+
+  // 3. Reviews — weave verdict + comment into prose per review.
+  if (reviews.length > 0) {
+    const reviewLines: string[] = [];
+    for (const rv of reviews) {
+      const by = String(rv['by'] ?? '');
+      const lense = String(rv['lense'] ?? '');
+      const verdict = String(rv['verdict'] ?? '');
+      const comment = String(rv['comment'] ?? '').trim();
+      const invokedBy = rv['invoked_by'] ? ` (via ${rv['invoked_by']})` : '';
+      // Short comments are quoted inline; longer ones get their own
+      // line so the flow stays readable.
+      const commentFrag =
+        comment.length === 0
+          ? ''
+          : comment.length <= 80
+            ? ` — "${comment}"`
+            : `\n    "${comment}"`;
+      reviewLines.push(
+        `${capitalise(by)}${invokedBy} reviewed through the ${lense} lens ` +
+          `with a verdict of ${verdict}${commentFrag}`,
+      );
+    }
+    paragraphs.push(reviewLines.join('. ') + '.');
+  } else if (autoReview && finalState === 'completed') {
+    // Auto-review was assigned but not yet done — worth naming so
+    // the reader knows the arc isn't fully closed.
+    paragraphs.push(
+      `Auto-review is pending: ${autoReview} has not yet recorded a verdict.`,
+    );
+  }
+
+  // 4. Summary — facts the caller might want at a glance.
+  const summary = computeSummary(log, reviews, finalState);
+  const actorFrag = summary.actor_count === 1
+    ? `the entire arc was carried out by ${summary.actors[0]} alone`
+    : `the arc involved ${summary.actor_count} actor${summary.actor_count === 1 ? '' : 's'} ` +
+      `(${summary.actors.join(', ')})`;
+  const durationFrag = summary.duration_ms !== null
+    ? `, total duration ${humanDuration(summary.duration_ms)}`
+    : '';
+  paragraphs.push(
+    `Final state: ${finalState}. ${capitalise(actorFrag)}${durationFrag}.`,
+  );
+
+  return { id, arc: paragraphs.join('\n\n'), summary };
+}
+
+function computeSummary(
+  log: Array<Record<string, unknown>>,
+  reviews: Array<Record<string, unknown>>,
+  finalState: string,
+): TranscriptSummary {
+  const actors = new Set<string>();
+  for (const e of log) {
+    if (typeof e['by'] === 'string') actors.add(e['by']);
+  }
+  for (const rv of reviews) {
+    if (typeof rv['by'] === 'string') actors.add(rv['by']);
+  }
+  const verdicts: string[] = [];
+  for (const rv of reviews) {
+    if (typeof rv['verdict'] === 'string') verdicts.push(rv['verdict']);
+  }
+  let durationMs: number | null = null;
+  const firstAt = log[0]?.['at'];
+  const lastAt = log[log.length - 1]?.['at'];
+  if (typeof firstAt === 'string' && typeof lastAt === 'string') {
+    const d = new Date(lastAt).getTime() - new Date(firstAt).getTime();
+    if (!Number.isNaN(d)) durationMs = d;
+  }
+  return {
+    actors: [...actors],
+    actor_count: actors.size,
+    review_count: reviews.length,
+    review_verdicts: verdicts,
+    final_state: finalState,
+    duration_ms: durationMs,
+  };
+}
+
+function capitalise(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+}
+
+function lowercase(s: string): string {
+  return s.length === 0 ? s : s[0]!.toLowerCase() + s.slice(1);
+}
+
+function humanDelta(from: string, to: string): string {
+  const ms = new Date(to).getTime() - new Date(from).getTime();
+  if (Number.isNaN(ms)) return '';
+  return humanDuration(ms);
+}
+
+function humanDuration(ms: number): string {
+  if (ms < 0) return 'earlier';
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}min`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  return `${d}d`;
+}

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -37,6 +37,7 @@ interface TranscriptSummary {
   actor_count: number;
   review_count: number;
   review_verdicts: readonly string[];
+  thank_count: number;
   final_state: string;
   duration_ms: number | null;
 }
@@ -81,6 +82,9 @@ function buildTranscript(r: Request): TranscriptPayload {
     : [];
   const reviews = Array.isArray(j['reviews'])
     ? (j['reviews'] as Array<Record<string, unknown>>)
+    : [];
+  const thanks = Array.isArray(j['thanks'])
+    ? (j['thanks'] as Array<Record<string, unknown>>)
     : [];
   const finalState = String(j['state']);
 
@@ -157,8 +161,31 @@ function buildTranscript(r: Request): TranscriptPayload {
     );
   }
 
+  // 3b. Thanks — lighter prose, doesn't gate state. One sentence
+  // per thank, same cluster-join pattern as reviews. Emitted after
+  // the reviews section so the verdict-bearing record leads.
+  if (thanks.length > 0) {
+    const thankLines: string[] = [];
+    for (const th of thanks) {
+      const by = String(th['by'] ?? '');
+      const to = String(th['to'] ?? '');
+      const reason = th['reason'] ? String(th['reason']).trim() : '';
+      const invokedBy = th['invoked_by'] ? ` (via ${th['invoked_by']})` : '';
+      const reasonFrag =
+        reason.length === 0
+          ? ''
+          : reason.length <= 80
+            ? ` — "${reason}"`
+            : `\n    "${reason}"`;
+      thankLines.push(
+        `${capitalise(by)}${invokedBy} thanked ${to}${reasonFrag}`,
+      );
+    }
+    paragraphs.push(thankLines.join('. ') + '.');
+  }
+
   // 4. Summary — facts the caller might want at a glance.
-  const summary = computeSummary(log, reviews, finalState);
+  const summary = computeSummary(log, reviews, thanks, finalState);
   const actorFrag = summary.actor_count === 1
     ? `the entire arc was carried out by ${summary.actors[0]} alone`
     : `the arc involved ${summary.actor_count} actor${summary.actor_count === 1 ? '' : 's'} ` +
@@ -176,6 +203,7 @@ function buildTranscript(r: Request): TranscriptPayload {
 function computeSummary(
   log: Array<Record<string, unknown>>,
   reviews: Array<Record<string, unknown>>,
+  thanks: Array<Record<string, unknown>>,
   finalState: string,
 ): TranscriptSummary {
   const actors = new Set<string>();
@@ -184,6 +212,10 @@ function computeSummary(
   }
   for (const rv of reviews) {
     if (typeof rv['by'] === 'string') actors.add(rv['by']);
+  }
+  for (const th of thanks) {
+    if (typeof th['by'] === 'string') actors.add(th['by']);
+    if (typeof th['to'] === 'string') actors.add(th['to']);
   }
   const verdicts: string[] = [];
   for (const rv of reviews) {
@@ -201,6 +233,7 @@ function computeSummary(
     actor_count: actors.size,
     review_count: reviews.length,
     review_verdicts: verdicts,
+    thank_count: thanks.length,
     final_state: finalState,
     duration_ms: durationMs,
   };

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -15,6 +15,7 @@ import {
   reqFastTrack,
 } from './handlers/request.js';
 import { reqReview } from './handlers/review.js';
+import { reqThank } from './handlers/thank.js';
 import {
   reqVoices,
   reqTail,
@@ -90,9 +91,14 @@ Requests:
                    [--comment <s> | --comment - | <comment>] [--dry-run]
                        --dry-run on any write verb above emits a
                        preview JSON envelope (dry_run/verb/would_
-                       transition/preview) without persisting. Use
-                       --dry-run=true if followed by a non-dash
-                       positional (see "Values beginning with '--'").
+                       transition/preview) without persisting.
+  gate thank <to> --for <id> [--by <m>] [--reason <s> | --reason -]
+                  [--dry-run]
+                       Record cross-actor appreciation against a
+                       specific request. Sibling of 'review' — no
+                       verdict, no state change, no calibration
+                       impact. Reviews track judgement; thanks
+                       track gratitude.
   gate fast-track --from <m> --action <a> --reason <r>
                   [--executor <m>] [--auto-review <m>] [--note <s>]
                   [--with <n1>[,<n2>...]]
@@ -204,7 +210,7 @@ Meta:
 const KNOWN_COMMANDS = [
   'request', 'pending', 'board', 'list', 'show', 'voices', 'tail',
   'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
-  'complete', 'fail', 'review', 'fast-track', 'issues', 'message',
+  'complete', 'fail', 'review', 'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
   'suggest', 'transcript', 'resume', 'schema',
 ] as const;
@@ -310,6 +316,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await reqFail(c, args);
       case 'review':
         return await reqReview(c, args);
+      case 'thank':
+        return await reqThank(c, args);
       case 'fast-track':
         return await reqFastTrack(c, args);
       case 'issues':

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -176,7 +176,7 @@ Status:
   gate transcript <id> [--format text|json]
                        Narrative prose render of one request's arc,
                        composed from status_log + reviews. Sibling
-                       of `gate show` (structured) and `gate voices`
+                       of 'gate show' (structured) and 'gate voices'
                        (per-actor). JSON mode carries both the
                        narrative and a summary (actors/verdicts/
                        duration_ms) for programmatic consumers.

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -36,6 +36,7 @@ import {
 } from './handlers/messages.js';
 import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
+import { transcriptCmd } from './handlers/transcript.js';
 
 // Re-export for test backward-compat (tests/interface/reviewMarkers.test.ts).
 // formatReviewMarkers and computeReviewMarkerWidth live in handlers/request.ts
@@ -172,6 +173,13 @@ Status:
                        thing?" without the full orientation payload.
                        Priority ladder is shared with boot, so the
                        two never disagree.
+  gate transcript <id> [--format text|json]
+                       Narrative prose render of one request's arc,
+                       composed from status_log + reviews. Sibling
+                       of `gate show` (structured) and `gate voices`
+                       (per-actor). JSON mode carries both the
+                       narrative and a summary (actors/verdicts/
+                       duration_ms) for programmatic consumers.
   gate resume [--format json|text]
                        Reconstruct what the actor was doing when the
                        last session ended. Returns last utterance,
@@ -198,7 +206,7 @@ const KNOWN_COMMANDS = [
   'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
   'complete', 'fail', 'review', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
-  'suggest', 'resume', 'schema',
+  'suggest', 'transcript', 'resume', 'schema',
 ] as const;
 
 function levenshtein(a: string, b: string): number {
@@ -322,6 +330,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await bootCmd(c, args);
       case 'suggest':
         return await suggestCmd(c, args);
+      case 'transcript':
+        return await transcriptCmd(c, args);
       case 'resume':
         return await resumeCmd(c, args);
       case 'schema':

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -3,6 +3,11 @@
  * entry point so the gather/filter/sort logic is unit-testable without
  * a live filesystem.
  *
+ * Also home to `computeVoiceCalibration` (see bottom of file), which
+ * derives a per-(actor, lens) calibration score from historical
+ * review verdicts vs terminal-state outcomes. Exported from here so
+ * the CLI handler and the schema can reuse the same definition.
+ *
  * An "utterance" is anything a named actor put on the record:
  *   - `authored`: a request they filed (action + reason + the
  *     appropriate closure note — completion_note / deny_reason /
@@ -37,6 +42,7 @@ export type RequestJSON = {
   readonly from: string;
   readonly action: string;
   readonly reason: string;
+  readonly state?: string;
   readonly created_at: string;
   readonly completion_note?: string;
   readonly deny_reason?: string;
@@ -326,4 +332,132 @@ export function renderUtterance(
     }
   }
   return lines.join('\n');
+}
+
+// ── Voice calibration ─────────────────────────────────────────────
+//
+// A per-(actor, lens) score derived from historical review verdicts
+// vs terminal-state outcomes. Exists to let the Two-Persona Devil
+// Review frame *learn* — today every cross-actor critique weighs the
+// same, and over time the system has no memory of which voices
+// called it right.
+//
+// The mechanism is deliberately quiet:
+//   - Scores are visible on `gate voices <OTHER>` but hidden on
+//     `gate voices $GUILD_ACTOR` (so voters don't self-optimise).
+//   - No leaderboard, no aggregate ranking — each voice stands
+//     alone.
+//   - Small samples render as "uncalibrated" to avoid mistaking
+//     noise for signal.
+//   - Reasons are named in plain prose, not numeric badges.
+//
+// Alignment rules (v1; may refine once we have real signal):
+//   verdict=ok       + state=completed → aligned (you said fine, it was)
+//   verdict=ok       + state=failed    → missed   (you said fine, it wasn't)
+//   verdict=concern  + state=failed    → aligned (you flagged it, it broke)
+//   verdict=concern  + state=completed → soft    (issues may have been
+//                                                 absorbed; neither a
+//                                                 win nor a miss)
+//   verdict=reject   + state=failed    → aligned (you said no, it broke)
+//   verdict=reject   + state=completed → overruled (you said no, it
+//                                                   shipped anyway;
+//                                                   ambiguous signal —
+//                                                   could be wrong call,
+//                                                   could be reviewed
+//                                                   risk that held)
+//
+// Denied requests don't contribute (they never executed; no outcome
+// to compare against). `concern + completed` is counted as soft —
+// neither a hit nor a miss — because the outcome is consistent with
+// both "the concern was noted and addressed" and "the concern was
+// overblown". Counting it either way would bias the score.
+
+export interface CalibrationPerLens {
+  /** Samples that contributed (aligned + missed; soft/overruled excluded). */
+  readonly sample_count: number;
+  /** Verdicts that matched outcome (aligned). */
+  readonly aligned: number;
+  /** Verdicts that missed (ok on a failed, or reject on a completed — see above). */
+  readonly missed: number;
+  /** Numeric 0..1 score, aligned / sample_count. Null when uncalibrated. */
+  readonly alignment: number | null;
+  /** Categorical signal for prose use. "uncalibrated" when samples < threshold. */
+  readonly status: 'uncalibrated' | 'learning' | 'trusted';
+  /** One-line prose for human/agent consumers. */
+  readonly prose: string;
+}
+
+export interface VoiceCalibration {
+  readonly actor: string;
+  /** Per-lens calibration, keyed by lens name (e.g. "devil", "layer"). */
+  readonly by_lens: Record<string, CalibrationPerLens>;
+}
+
+const CALIBRATION_MIN_SAMPLES = 5;
+const CALIBRATION_TRUSTED_THRESHOLD = 0.7;
+
+export function computeVoiceCalibration(
+  all: ReadonlyArray<RequestJSON>,
+  actor: string,
+): VoiceCalibration {
+  const actorLower = actor.toLowerCase();
+  const byLens: Record<string, { aligned: number; missed: number }> = {};
+
+  for (const r of all) {
+    const state = r.state;
+    // Only terminal non-denied outcomes yield signal. `denied`
+    // requests never ran, so there's nothing to calibrate against.
+    if (state !== 'completed' && state !== 'failed') continue;
+    const reviews = r.reviews ?? [];
+    for (const rv of reviews) {
+      if (rv.by !== actorLower) continue;
+      const lens = rv.lense;
+      if (!byLens[lens]) byLens[lens] = { aligned: 0, missed: 0 };
+      const bucket = byLens[lens]!;
+      const v = rv.verdict;
+      if (v === 'ok') {
+        if (state === 'completed') bucket.aligned += 1;
+        else bucket.missed += 1;
+      } else if (v === 'reject') {
+        if (state === 'failed') bucket.aligned += 1;
+        else bucket.missed += 1;
+      }
+      // verdict === 'concern' intentionally excluded — see header.
+    }
+  }
+
+  const out: Record<string, CalibrationPerLens> = {};
+  for (const [lens, counts] of Object.entries(byLens)) {
+    const samples = counts.aligned + counts.missed;
+    if (samples < CALIBRATION_MIN_SAMPLES) {
+      out[lens] = {
+        sample_count: samples,
+        aligned: counts.aligned,
+        missed: counts.missed,
+        alignment: null,
+        status: 'uncalibrated',
+        prose:
+          `${lens} lens: ${samples} sample${samples === 1 ? '' : 's'} so far — not yet calibrated ` +
+          `(need ${CALIBRATION_MIN_SAMPLES - samples} more with a terminal outcome).`,
+      };
+      continue;
+    }
+    const alignment = counts.aligned / samples;
+    const status: CalibrationPerLens['status'] =
+      alignment >= CALIBRATION_TRUSTED_THRESHOLD ? 'trusted' : 'learning';
+    const proseFragment =
+      status === 'trusted'
+        ? `trusted — ${counts.aligned} of ${samples} verdicts aligned with outcomes`
+        : `still learning — ${counts.aligned} of ${samples} verdicts aligned`;
+    out[lens] = {
+      sample_count: samples,
+      aligned: counts.aligned,
+      missed: counts.missed,
+      alignment,
+      status,
+      prose: `${lens} lens: ${proseFragment}.`,
+    };
+  }
+
+  return { actor: actorLower, by_lens: out };
 }

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -49,6 +49,7 @@ export type RequestJSON = {
   readonly failure_reason?: string;
   readonly with?: ReadonlyArray<string>;
   readonly reviews?: ReadonlyArray<ReviewJSON>;
+  readonly thanks?: ReadonlyArray<ThankJSON>;
   readonly status_log?: ReadonlyArray<StatusLogEntryJSON>;
   // Tool-generated structured link to the source issue when this
   // request came from `gate issues promote`. Used by chain as a
@@ -66,6 +67,19 @@ export type ReviewJSON = {
   // in snake_case; voices surfaces it so a reviewer who ghost-wrote
   // through an AI agent is visible in tail / whoami / voices instead
   // of only in `gate show <id>`.
+  readonly invoked_by?: string;
+};
+
+/**
+ * Structural projection of Thank's toJSON() — just what voices reads.
+ * Optional on RequestJSON because records written before the thank
+ * verb existed simply lack the field.
+ */
+export type ThankJSON = {
+  readonly by: string;
+  readonly to: string;
+  readonly at: string;
+  readonly reason?: string;
   readonly invoked_by?: string;
 };
 
@@ -113,7 +127,31 @@ export type ReviewUtterance = {
   readonly comment: string;
 };
 
-export type Utterance = AuthoredUtterance | ReviewUtterance;
+/**
+ * A `thank` utterance — someone thanking another actor for their
+ * work on a specific request. Sibling of ReviewUtterance; simpler
+ * (no lens, no verdict, no required comment) because the record
+ * semantics are different. Reviews express judgement; thanks
+ * express gratitude.
+ *
+ * Both `by` and `to` flow through so tail / voices readers see the
+ * directional relationship without fetching the raw request.
+ */
+export type ThankUtterance = {
+  readonly kind: 'thank';
+  readonly at: string;
+  readonly requestId: string;
+  readonly by: string;
+  readonly to: string;
+  readonly invokedBy?: string;
+  // Action of the containing request for context, same rationale as
+  // ReviewUtterance.action.
+  readonly action: string;
+  // Optional prose; thanks without a reason are legitimate.
+  readonly reason?: string;
+};
+
+export type Utterance = AuthoredUtterance | ReviewUtterance | ThankUtterance;
 
 export interface VoicesFilter {
   // When omitted, match every actor. Used by `gate tail` to stream
@@ -210,6 +248,37 @@ export function collectUtterances(
         (reviewUtterance as { invokedBy?: string }).invokedBy = rv.invoked_by;
       }
       out.push(reviewUtterance);
+    }
+    // Thank utterances: emitted for both the `by` actor (who gave)
+    // and the `to` actor (who received) — either name-filter match
+    // surfaces the record. Reviews are one-sided (only `by` speaks),
+    // so this is the one place the filter diverges. Lens/verdict
+    // filters short-circuit the thanks loop entirely — thanks have
+    // no lens/verdict, so a lens-scoped query should not carry them.
+    const filteringReviewsOnly =
+      filter.lense !== undefined || filter.verdict !== undefined;
+    if (!filteringReviewsOnly) {
+      const thanks = r.thanks ?? [];
+      for (const th of thanks) {
+        const byMatches = needle === undefined || th.by.toLowerCase() === needle;
+        const toMatches = needle === undefined || th.to.toLowerCase() === needle;
+        if (!byMatches && !toMatches) continue;
+        const thankUtterance: ThankUtterance = {
+          kind: 'thank',
+          at: th.at,
+          requestId: r.id,
+          action: r.action,
+          by: th.by,
+          to: th.to,
+        };
+        if (th.reason !== undefined) {
+          (thankUtterance as { reason?: string }).reason = th.reason;
+        }
+        if (th.invoked_by !== undefined) {
+          (thankUtterance as { invokedBy?: string }).invokedBy = th.invoked_by;
+        }
+        out.push(thankUtterance);
+      }
     }
   }
 
@@ -316,7 +385,7 @@ export function renderUtterance(
     if (u.completionNote) pushMultilineField(lines, '  note:   ', u.completionNote);
     if (u.denyReason) pushMultilineField(lines, '  denied: ', u.denyReason);
     if (u.failureReason) pushMultilineField(lines, '  failed: ', u.failureReason);
-  } else {
+  } else if (u.kind === 'review') {
     // Always expose `invoked_by` when present, even when includeActor
     // is false (voices groups by actor, so the `by` is redundant —
     // but the proxy-invoker isn't). Keeps the stream honest about
@@ -329,6 +398,23 @@ export function renderUtterance(
     lines.push(`  re: ${u.action}`);
     for (const line of u.comment.split('\n')) {
       lines.push(`  ${line}`);
+    }
+  } else {
+    // u.kind === 'thank'. `by` thanked `to` on this request. Always
+    // render as full "by → to" direction regardless of `includeActor`:
+    // unlike reviews (where `by` is the only relevant actor), thanks
+    // have a giver AND a receiver, and both are load-bearing. Hiding
+    // `by` when voices groups by one of them would leave the reader
+    // asking "thanked by whom?" on every line.
+    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
+    lines.push(
+      `[${u.at}] req=${u.requestId} thank ${u.by} → ${u.to}${proxy}`,
+    );
+    lines.push(`  re: ${u.action}`);
+    if (u.reason !== undefined) {
+      for (const line of u.reason.split('\n')) {
+        lines.push(`  ${line}`);
+      }
     }
   }
   return lines.join('\n');

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -38,11 +38,12 @@ export interface ParsedArgs {
  * the old `--dry-run=true` escape-valve behaviour, not a crash.
  */
 export const KNOWN_BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
-  'apply',      // gate repair --apply
-  'dry-run',    // write verbs' preview mode
-  'plain',      // gate show --fields X --plain (shell-friendly single-field)
-  'summary',    // gate doctor --summary
-  'unread',     // gate inbox --unread
+  'apply',             // gate repair --apply
+  'dry-run',           // write verbs' preview mode
+  'plain',             // gate show --fields X --plain (shell-friendly single-field)
+  'summary',           // gate doctor --summary
+  'unread',            // gate inbox --unread
+  'with-calibration',  // gate voices --with-calibration (opt-in richer JSON)
 ]);
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -708,6 +708,109 @@ test('thank --dry-run: preview without persist', () => {
   }
 });
 
+// ── thank integration: utterance stream & transcript fold-in ────
+
+test('thank: appears in gate tail as a directional utterance', () => {
+  // tail is the unified cross-actor stream. Thanks share the stream
+  // with authored/review utterances so a reader scanning activity
+  // sees the appreciation alongside the decisions.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['thank', 'bob', '--for', rid(1), '--reason', 'nice'], {
+      GUILD_ACTOR: 'alice',
+    });
+    const { stdout } = runGate(root, ['tail']);
+    assert.match(stdout, /thank alice → bob/);
+    assert.match(stdout, /re: x/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices <name>: surfaces thanks in BOTH directions (given and received)', () => {
+  // Reviews are one-sided (only `by` speaks). Thanks involve two
+  // actors; voices matches either side so a voice's full
+  // appreciation footprint — given AND received — is visible when
+  // looking at them.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    // alice thanks bob (bob receives)
+    runGate(root, ['thank', 'bob', '--for', rid(1), '--reason', 'a-to-b'], {
+      GUILD_ACTOR: 'alice',
+    });
+    // bob thanks alice (bob gives)
+    runGate(root, ['thank', 'alice', '--for', rid(1), '--reason', 'b-to-a'], {
+      GUILD_ACTOR: 'bob',
+    });
+    const { stdout } = runGate(root, ['voices', 'bob', '--format', 'text']);
+    // Both directions land in bob's stream.
+    assert.match(stdout, /thank alice → bob/);
+    assert.match(stdout, /thank bob → alice/);
+    assert.match(stdout, /a-to-b/);
+    assert.match(stdout, /b-to-a/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices: lens/verdict filters DO NOT surface thanks (reviews only)', () => {
+  // thanks have no lens and no verdict. A lens-scoped query is
+  // asking for reviews through that lens; including thanks would
+  // be a category error.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['thank', 'bob', '--for', rid(1), '--reason', 'nice'], {
+      GUILD_ACTOR: 'alice',
+    });
+    const { stdout } = runGate(
+      root,
+      ['voices', 'alice', '--format', 'text', '--lense', 'devil'],
+    );
+    assert.equal(/thank/.test(stdout), false);
+    assert.match(stdout, /no utterances|reviews/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('transcript: thanks appear as their own prose paragraph + in summary', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['thank', 'bob', '--for', rid(1), '--reason', 'elegant'], {
+      GUILD_ACTOR: 'alice',
+    });
+    const { stdout } = runGate(root, ['transcript', rid(1)]);
+    assert.match(stdout, /Alice thanked bob/);
+    assert.match(stdout, /elegant/);
+
+    const jsonOut = runGate(root, ['transcript', rid(1), '--format', 'json']);
+    const p = JSON.parse(jsonOut.stdout);
+    assert.equal(p.summary.thank_count, 1);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate transcript: narrative arc of one request ───────────────
 
 test('transcript: narrative prose names filer, action, executor, reviews', () => {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -416,6 +416,157 @@ test('boot.verbs_available_now: actionable entries carry id + reason', () => {
   }
 });
 
+// ── voice calibration: Two-Persona Devil gets a memory ──────────
+
+test('voices --with-calibration: aligns verdicts against terminal outcomes', () => {
+  // Carol files sharp concerns on things that later fail — her
+  // devil-lens calibration should read as "trusted". Bob rubber-
+  // stamps ok on things that fail — "learning".
+  const { root, cleanup } = bootstrap();
+  try {
+    // Register carol (only alice + bob exist in the bootstrap).
+    const r = runGate(root, ['register', '--name', 'carol']);
+    assert.equal(r.status, 0);
+
+    // 7 lifecycles: 4 failed + 3 completed. Bob always ok, carol
+    // rejects failures and oks completions.
+    const outcomes: Array<['completed' | 'failed', number]> = [
+      ['completed', 1], ['failed', 2], ['failed', 3], ['completed', 4],
+      ['failed', 5], ['failed', 6], ['completed', 7],
+    ];
+    for (const [state, n] of outcomes) {
+      const id = rid(n);
+      runGate(
+        root,
+        ['request', '--from', 'alice', '--action', `t${n}`, '--reason', 'r', '--executor', 'alice'],
+        { GUILD_ACTOR: 'alice' },
+      );
+      runGate(root, ['approve', id, '--by', 'alice']);
+      runGate(root, ['execute', id, '--by', 'alice']);
+      if (state === 'completed') {
+        runGate(root, ['complete', id, '--by', 'alice']);
+      } else {
+        runGate(root, ['fail', id, '--by', 'alice', '--reason', 'nope']);
+      }
+      runGate(root, [
+        'review', id, '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'b',
+      ]);
+      const carolV = state === 'completed' ? 'ok' : 'reject';
+      runGate(root, [
+        'review', id, '--by', 'carol', '--lense', 'devil', '--verdict', carolV, '--comment', 'c',
+      ]);
+    }
+
+    const { stdout: carolJson } = runGate(
+      root,
+      ['voices', 'carol', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const carol = JSON.parse(carolJson).calibration;
+    assert.equal(carol.by_lens.devil.status, 'trusted');
+    assert.equal(carol.by_lens.devil.aligned, 7);
+    assert.equal(carol.by_lens.devil.missed, 0);
+
+    const { stdout: bobJson } = runGate(
+      root,
+      ['voices', 'bob', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const bob = JSON.parse(bobJson).calibration;
+    assert.equal(bob.by_lens.devil.status, 'learning');
+    assert.equal(bob.by_lens.devil.aligned, 3);
+    assert.equal(bob.by_lens.devil.missed, 4);
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices: self-view hides calibration (no self-optimisation)', () => {
+  // Voter shouldn't see their own score — the calibration only lands
+  // when viewing OTHER voices. Keeps the signal honest (if you can't
+  // see it, you can't game it).
+  const { root, cleanup } = bootstrap();
+  try {
+    // Seed one review so there's data to hide.
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, [
+      'review', rid(1), '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'b',
+    ]);
+
+    // bob views himself: calibration block NOT rendered in text.
+    const selfText = runGate(root, ['voices', 'bob', '--format', 'text'], { GUILD_ACTOR: 'bob' });
+    assert.equal(/calibration/.test(selfText.stdout), false);
+
+    // alice views bob: calibration block IS present (or at least the
+    // footer header renders, even if sample count is low).
+    const viewText = runGate(root, ['voices', 'bob', '--format', 'text'], { GUILD_ACTOR: 'alice' });
+    assert.match(viewText.stdout, /calibration/);
+
+    // JSON path: self-view returns null calibration under the flag.
+    const selfJson = runGate(
+      root,
+      ['voices', 'bob', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'bob' },
+    );
+    const payload = JSON.parse(selfJson.stdout);
+    assert.equal(payload.calibration, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices: default JSON shape unchanged (backward compat)', () => {
+  // `--with-calibration` is opt-in; without it, the JSON remains an
+  // array of utterances so existing consumers don't break.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['voices', 'alice', '--format', 'json']);
+    const payload = JSON.parse(stdout);
+    assert.ok(Array.isArray(payload), 'default JSON should still be an array');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices calibration: samples < 5 reads as "uncalibrated"', () => {
+  // Noise floor: a handful of verdicts isn't signal. Show the count
+  // so a reader sees where we are on the ramp, but don't claim a
+  // status from incomplete data.
+  const { root, cleanup } = bootstrap();
+  try {
+    for (let n = 1; n <= 3; n++) {
+      runGate(
+        root,
+        ['fast-track', '--from', 'alice', '--action', `t${n}`, '--reason', 'r'],
+        { GUILD_ACTOR: 'alice' },
+      );
+      runGate(root, [
+        'review', rid(n), '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'b',
+      ]);
+    }
+    const { stdout } = runGate(
+      root,
+      ['voices', 'bob', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const calib = JSON.parse(stdout).calibration;
+    assert.equal(calib.by_lens.devil.status, 'uncalibrated');
+    assert.equal(calib.by_lens.devil.sample_count, 3);
+    assert.equal(calib.by_lens.devil.alignment, null);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate transcript: narrative arc of one request ───────────────
 
 test('transcript: narrative prose names filer, action, executor, reviews', () => {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -567,6 +567,147 @@ test('voices calibration: samples < 5 reads as "uncalibrated"', () => {
   }
 });
 
+// ── gate thank: cross-actor appreciation primitive ──────────────
+
+test('thank: records appreciation with by/to/reason on the request', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { status } = runGate(
+      root,
+      ['thank', 'bob', '--for', rid(1), '--reason', 'nice work'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 0);
+    const { stdout } = runGate(root, ['show', rid(1), '--fields', 'thanks']);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.thanks.length, 1);
+    assert.equal(payload.thanks[0].by, 'alice');
+    assert.equal(payload.thanks[0].to, 'bob');
+    assert.equal(payload.thanks[0].reason, 'nice work');
+    assert.equal(typeof payload.thanks[0].at, 'string');
+  } finally {
+    cleanup();
+  }
+});
+
+test('thank: does NOT affect state or reviews (orthogonal record)', () => {
+  // Critical invariant: thanks is NOT a state transition and does
+  // NOT feed calibration. Keep these concerns orthogonal.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['thank', 'alice', '--for', rid(1), '--reason', 'ty'], {
+      GUILD_ACTOR: 'alice',
+    });
+    const { stdout } = runGate(root, ['show', rid(1)]);
+    const p = JSON.parse(stdout);
+    assert.equal(p.state, 'completed');
+    assert.equal(p.reviews.length, 0);
+    assert.equal(p.thanks.length, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test('thank: reason is optional', () => {
+  // Most of the time the fact of the thank is the signal; a reason
+  // is a grace note. The schema doesn't require it.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { status } = runGate(root, ['thank', 'bob', '--for', rid(1)], {
+      GUILD_ACTOR: 'alice',
+    });
+    assert.equal(status, 0);
+    const { stdout } = runGate(root, ['show', rid(1), '--fields', 'thanks']);
+    const thanks = JSON.parse(stdout).thanks;
+    assert.equal(thanks[0].reason, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test('thank: self-thank emits stderr notice but succeeds', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { status, stderr } = runGate(
+      root,
+      ['thank', 'alice', '--for', rid(1), '--reason', 'past me'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 0);
+    assert.match(stderr, /self-thank/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('thank: unknown --to actor fails with a validation error', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { status, stderr } = runGate(
+      root,
+      ['thank', 'ghost', '--for', rid(1)],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 1);
+    assert.match(stderr, /ghost/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('thank --dry-run: preview without persist', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout, status } = runGate(
+      root,
+      ['thank', 'bob', '--for', rid(1), '--reason', 'preview', '--dry-run'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 0);
+    const p = JSON.parse(stdout);
+    assert.equal(p.dry_run, true);
+    assert.equal(p.verb, 'thank');
+    assert.equal(p.preview.thanks.length, 1);
+    // Real record has no thanks yet.
+    const after = JSON.parse(
+      runGate(root, ['show', rid(1)]).stdout,
+    );
+    assert.ok(after.thanks === undefined || after.thanks.length === 0);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate transcript: narrative arc of one request ───────────────
 
 test('transcript: narrative prose names filer, action, executor, reviews', () => {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -416,6 +416,100 @@ test('boot.verbs_available_now: actionable entries carry id + reason', () => {
   }
 });
 
+// ── gate transcript: narrative arc of one request ───────────────
+
+test('transcript: narrative prose names filer, action, executor, reviews', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      [
+        'request', '--from', 'alice',
+        '--action', 'refactor parser',
+        '--reason', 'cut p99 latency',
+        '--executor', 'bob',
+        '--auto-review', 'alice',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(1), '--by', 'alice']);
+    runGate(root, ['execute', rid(1), '--by', 'bob']);
+    runGate(root, ['complete', rid(1), '--by', 'bob', '--note', 'landed in abc123']);
+    runGate(
+      root,
+      ['review', rid(1), '--by', 'alice', '--lense', 'devil', '--verdict', 'ok', '--comment', 'LGTM'],
+    );
+    const { stdout } = runGate(root, ['transcript', rid(1)]);
+    assert.match(stdout, /Alice filed/);
+    assert.match(stdout, /refactor parser/);
+    assert.match(stdout, /bob as executor/);
+    assert.match(stdout, /Bob moved it to completed/);
+    assert.match(stdout, /devil lens/);
+    assert.match(stdout, /verdict of ok/);
+    assert.match(stdout, /LGTM/);
+    assert.match(stdout, /Final state: completed/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('transcript --format json: summary carries structured fields', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(1), '--by', 'alice']);
+    runGate(root, ['execute', rid(1), '--by', 'bob']);
+    runGate(root, ['complete', rid(1), '--by', 'bob']);
+    const { stdout } = runGate(root, ['transcript', rid(1), '--format', 'json']);
+    const p = JSON.parse(stdout);
+    assert.equal(p.id, rid(1));
+    assert.ok(typeof p.arc === 'string');
+    assert.ok(p.arc.length > 50);
+    assert.equal(p.summary.actor_count, 2);
+    assert.deepEqual(p.summary.actors.sort(), ['alice', 'bob']);
+    assert.equal(p.summary.final_state, 'completed');
+    assert.equal(typeof p.summary.duration_ms, 'number');
+  } finally {
+    cleanup();
+  }
+});
+
+test('transcript: self-loop arc surfaces as "carried out by X alone"', () => {
+  // The textual echo of the self-loop-check plugin: one sentence in
+  // the summary names the mono-actor pattern per-request.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['transcript', rid(1)]);
+    assert.match(stdout, /carried out by alice alone/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('transcript: pending auto-review is named explicitly', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 'x', '--reason', 'r', '--auto-review', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['transcript', rid(1)]);
+    assert.match(stdout, /Auto-review is pending: bob/);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate show --plain: shell-friendly single-field output ────────
 
 test('show --plain --fields <key>: emits raw value, no JSON quoting', () => {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -708,6 +708,61 @@ test('thank --dry-run: preview without persist', () => {
   }
 });
 
+// ── suggested_next advisory semantics ───────────────────────────
+
+test('suggest --format text: advisory footer goes to stderr, stdout stays composable', () => {
+  // Humans scanning the terminal see the reminder that suggested_next
+  // is a heuristic. But `$(gate suggest --format text)` captures
+  // stdout, which must stay clean for shell composition.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout, stderr } = runGate(
+      root,
+      ['suggest', '--format', 'text'],
+      { GUILD_ACTOR: 'bob' },
+    );
+    assert.match(stderr, /advisory/);
+    assert.equal(/advisory/.test(stdout), false);
+    // Stdout still carries the actionable two-line output.
+    assert.match(stdout, /→ approve/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('schema: suggested_next descriptions name the "advisory, not directive" semantic', () => {
+  // This is the durable surface — tool layers reading the schema
+  // get the semantic without parsing the runtime output. Easier to
+  // wire correctly once than to discover through experimentation.
+  const { root, cleanup } = bootstrap();
+  try {
+    const bootSchema = JSON.parse(
+      runGate(root, ['schema', '--verb', 'boot', '--format', 'json']).stdout,
+    );
+    const bootSN =
+      bootSchema.verbs[0].output.properties.suggested_next.description;
+    assert.ok(typeof bootSN === 'string');
+    assert.match(bootSN, /[Aa]dvisory/);
+    assert.match(bootSN, /not a directive|NOT a directive/);
+
+    const suggestSchema = JSON.parse(
+      runGate(root, ['schema', '--verb', 'suggest', '--format', 'json']).stdout,
+    );
+    const suggestSN =
+      suggestSchema.verbs[0].output.properties.suggested_next.description;
+    assert.ok(typeof suggestSN === 'string');
+    assert.match(suggestSN, /[Aa]dvisory/);
+    assert.match(suggestSN, /override/);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── thank integration: utterance stream & transcript fold-in ────
 
 test('thank: appears in gate tail as a directional utterance', () => {

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -337,6 +337,85 @@ test('suggest --format text: compact two-line form for humans', () => {
   }
 });
 
+// ── boot.verbs_available_now: state-aware verb discovery ────────
+
+test('boot.verbs_available_now: actionable lists all valid transitions', () => {
+  // bob has executing-by-me (0001) AND unreviewed-mine (0002). suggested_next
+  // picks ONE; actionable lists ALL siblings so a branching agent sees
+  // the other options.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 't1', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(root, ['approve', rid(1), '--by', 'alice']);
+    runGate(root, ['execute', rid(1), '--by', 'bob']);
+    runGate(
+      root,
+      ['fast-track', '--from', 'alice', '--action', 't2', '--reason', 'r', '--auto-review', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const p = JSON.parse(stdout);
+    const verbs = p.verbs_available_now.actionable.map(
+      (a: { verb: string }) => a.verb,
+    );
+    assert.ok(verbs.includes('complete'), 'complete missing');
+    assert.ok(verbs.includes('fail'), 'fail missing');
+    assert.ok(verbs.includes('review'), 'review missing');
+    // suggested_next is ONE of the actionable entries.
+    assert.ok(
+      verbs.includes(p.suggested_next.verb),
+      'suggested_next must be in actionable list',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.verbs_available_now: always_readable present for anonymous caller', () => {
+  // Initial-agent discovery: without identity, actionable is empty
+  // (can't transition anything), but always_readable still names
+  // the read surface so newcomers see the map.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const p = JSON.parse(stdout);
+    assert.equal(p.verbs_available_now.actionable.length, 0);
+    assert.ok(p.verbs_available_now.always_readable.length >= 10);
+    assert.ok(p.verbs_available_now.always_readable.includes('suggest'));
+    assert.ok(p.verbs_available_now.always_readable.includes('schema'));
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.verbs_available_now: actionable entries carry id + reason', () => {
+  // The reason converts "approve exists" into "approve is valid on
+  // this id because …" — teaching not just catalog.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const p = JSON.parse(stdout);
+    const approve = p.verbs_available_now.actionable.find(
+      (a: { verb: string }) => a.verb === 'approve',
+    );
+    assert.ok(approve, 'approve should be actionable');
+    assert.equal(approve.id, rid(1));
+    assert.match(approve.reason, /pending/);
+    assert.match(approve.reason, /executor/);
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate show --plain: shell-friendly single-field output ────────
 
 test('show --plain --fields <key>: emits raw value, no JSON quoting', () => {

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -65,6 +65,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'status',
         'suggested_next',
         'tail',
+        'verbs_available_now',
         'your_recent',
       ],
       'boot payload top-level keys changed — agents depend on this contract',


### PR DESCRIPTION
## Summary

Seven exploratory commits from the 2026-04-19 session, each built with the 6-lens selection criteria (patterns/combos, long-term feel, first-time power reveal, surprises for the fluent, the abyss, and "what would I build as the AI who knows this deepest"). Dogfooded in a follow-up session — I filed a promotion decision for each as a `gate` request against itself, devil-reviewed each with an honest verdict, and ran `gate doctor` with the self-loop-check plugin on my own dogfood corpus.

Dogfood outcome: **6 `ok` / 1 `concern`**. The concern is on 65f4f30 (threshold choice without real data); everything else I'd promote as-is.

### Per-commit devil verdicts

| Commit | Title | Verdict | Note |
|---|---|---|---|
| `7f74520` | `boot.verbs_available_now` | ok | Backward-compatible; agent-discovery value is high with zero risk to existing consumers. |
| `65f4f30` | self-loop detection doctor plugin | **concern** | Opt-in only, valuable. But threshold (3+ of last 25) chosen without data — likely to tune once real patterns are observed. Recommend keeping in `mcp/plugins/` without bundling-as-default. |
| `80980cb` | `gate transcript` verb | ok | Pure composition from existing YAML. Risk low, value experimental but real. Ship as experimental (no stability contract yet). |
| `358ffb9` | voice calibration | ok | Principle 01 of `lore/` in runnable form. Silent-calibration preserved by construction. Backward-compatible (`--with-calibration` opt-in for JSON). |
| `a23c4c1` | `gate thank` primitive | ok | Orthogonal to review (principle 06, pinned by tests). Forward-compatible disk shape. |
| `3b9f5ff` | thank fabric integration | ok | Thanks appear in `voices` / `tail` / `transcript` / `resume` / `boot` tail. A verb whose records no surface shows is incomplete; this closes that gap. |
| `b575463` | `suggested_next` advisory | ok | Principle 02 of `lore/` made concrete. Zero runtime cost; schema descriptions + stderr footer. |

### The meta moment

`gate doctor` with the self-loop-check plugin enabled flagged my own dogfood session — *14 of 14 terminal requests filed-approved-executed-reviewed by one actor*. The tool I built to detect mono-actor lifecycles caught me running a mono-actor session. That was the point: principle 02 ("advisory, not directive") running its own playbook without anyone routing it.

### Companion work

A `claude/lore` branch (separate PR) carries six principle documents extracted from this session's reasoning. They explain the *why* behind several decisions in this PR. Either PR can merge first; neither depends on the other for code, but reading lore first makes the commits here legible.

A closing letter lives on `claude/alexandria` (not merged; alexandria is its own branch by design): `alexandria/letters/2026-04-19/10-using-what-i-built.md`.

## Test plan

- [x] `npm test` passes on each commit (ran on the branch head: 440 tests, 0 fails)
- [x] Dogfood session above: 7 requests filed, 7 decisions made via `gate`, 1 self-thank at the close. Self-loop-check correctly flagged the mono-actor pattern.
- [x] Manual probe of each new surface (verbs_available_now, transcript, calibration, thank + fabric, advisory footer) from fresh content_roots.

Recommendation: merge 7f74520, 80980cb, 358ffb9, a23c4c1, 3b9f5ff, b575463. Hold 65f4f30 unless you want it landing with a docblock flag that the threshold is provisional.

https://claude.ai/code/session_018abWBpAmnZucRxLQfQLcTC