### PR TITLE
lore: six principles extracted from today's session

### DIFF
--- a/lore/README.md
+++ b/lore/README.md
@@ -1,0 +1,59 @@
+# lore/
+
+A companion space to `gate` itself. The code is the object; this
+folder is the *thinking around the code* — design principles,
+rejected alternatives, the philosophy that drove specific
+decisions.
+
+Not documentation in the "how to use the verb" sense. That lives
+in `README.md` and `docs/verbs.md`. This folder is for:
+
+- **Principles** (`principles/`) — the load-bearing ideas behind
+  the design. Short, one per file. Name them explicitly so a
+  future reader can tell whether a proposed change would violate
+  them.
+- (More sections may grow here over time. Principles is the
+  starting set.)
+
+## Why this exists
+
+Every non-trivial codebase accumulates opinions that don't fit in
+source comments (too much prose) or in commit messages (no cross-
+cutting home). Those opinions drift into tribal knowledge — held
+in contributors' heads, lost when they leave.
+
+For `gate` specifically, a growing share of the contributors are
+AI instances. Tribal knowledge held in session memory dies at
+session end. `lore/` is the explicit counter-move: if a principle
+is load-bearing enough to matter in a future decision, it gets
+written down *here*, append-only, like the records `gate` itself
+produces.
+
+The principles in this folder were articulated during a single
+collaborative session (2026-04-19, nao + Claude Opus 4.7). They
+describe the reasoning behind several recent commits to `main`
+and to `claude/ax-explore`. They are not timeless truths — they
+are one stance, named, so a future reader can engage with them
+rather than re-derive them.
+
+## Reading path
+
+If you have 5 minutes:
+- `principles/01-silent-calibration.md`
+- `principles/02-advisory-not-directive.md`
+
+Those two carry the most weight for how agents interact with the
+tool.
+
+If you have 20 minutes, read all six in order. They compose: each
+builds on the previous.
+
+## Relationship to `alexandria/`
+
+`alexandria/` (the separate branch) is where individual Claude
+instances leave letters about specific sessions — per-session
+records for same-agent-over-time continuity. `lore/` is where
+cross-session principles live — durable claims extracted from
+specific sessions.
+
+Alexandria is the log; lore is the extracted invariants.

--- a/lore/principles/01-silent-calibration.md
+++ b/lore/principles/01-silent-calibration.md
@@ -1,0 +1,49 @@
+# Silent calibration
+
+**The scored party cannot see the score.**
+
+## Statement
+
+When the tool keeps a quality score about an actor — how well
+their review verdicts predict outcomes, how consistent their
+contributions are, anything derived from their own behavior —
+that score is shown to *other* readers, not to the actor
+themselves.
+
+## Why
+
+A score you can see is a score you shape behavior around. The
+moment a reviewer knows "my calibration is 0.6," they will push
+verdicts toward the threshold, not toward honest judgement. The
+signal decays into theater.
+
+Hiding the score from its subject is not paternalism. It preserves
+the raw behavior that makes the score informative. Other readers
+still see the calibration prose when deciding how much to weight
+this voice — they get the benefit without the gaming pressure.
+
+## In practice
+
+`gate voices <other_actor>` shows calibration ("devil lens:
+trusted — 7 of 7 verdicts aligned"). `gate voices $GUILD_ACTOR`
+hides it. Implemented in `src/interface/gate/voices.ts`
+(`computeVoiceCalibration`) and `handlers/read.ts` (the
+`isSelfView` check).
+
+## Implications
+
+- **No leaderboard.** Comparing actors to each other makes the
+  score legible to all of them.
+- **No achievements or badges.** These are scores made visible
+  to the holder — the exact failure mode this principle refuses.
+- **Derivative scores obey the same rule.** If a future feature
+  composes calibration + thanks + something else into a
+  "reputation," that composite must also be invisible to its
+  subject.
+
+## Related
+
+- `principles/02-advisory-not-directive.md` — a cousin principle
+  about keeping the tool from calcifying into authority.
+- `principles/06-two-memories.md` — calibration is the analytical
+  half; thanks is the explicit half. Both together.

--- a/lore/principles/02-advisory-not-directive.md
+++ b/lore/principles/02-advisory-not-directive.md
@@ -1,0 +1,56 @@
+# Advisory, not directive
+
+**Heuristics must be labeled as heuristics, at the point of use.**
+
+## Statement
+
+When the tool offers a next-step recommendation (`suggested_next`,
+priority orderings, etc.), the recommendation is **advisory** —
+an informed guess the caller is free to override. That framing
+must be encoded into the data surface, not left to ambient
+documentation.
+
+## Why
+
+An agent running `gate suggest` in a loop will, by default, treat
+the returned `verb` as a command. The loop is tight enough that
+reading the accompanying `reason` feels like overhead. Over many
+iterations, the tool's heuristic calcifies into authority for the
+loop. The more the loop runs, the less the agent questions.
+
+The correction is structural: make the recommendation *named* as
+a recommendation wherever the payload is read. A schema
+description. A stderr footer. Prose in the relevant docstring.
+Not all at once — once per surface where a reader arrives.
+
+## In practice
+
+- `gate schema --verb boot --format json` — `suggested_next`
+  field carries `description: "Advisory — NOT a directive..."`
+- `gate schema --verb suggest --format json` — same, plus
+  explicit naming of the anti-pattern ("a suggest loop that
+  dispatches the verb without reading the reason is treating a
+  heuristic as a command")
+- `gate suggest --format text` — footer line `# advisory —
+  override freely` on stderr
+
+Stderr over stdout for the footer: humans scanning the terminal
+see it, `$(gate suggest)` shell composition stays clean.
+
+## Implications
+
+- **Runtime disclaimers carry cost.** A prose disclaimer in
+  every JSON response wastes tokens on repetition. Put the
+  durable version in the schema; put the conversational version
+  in the text rendering. Don't repeat on every poll.
+- **Agent loops should read `reason`.** The field exists to be
+  read. An agent that dispatches on `verb + args` without
+  checking `reason` is violating the contract this principle
+  establishes, even when the dispatch happens to be correct.
+
+## Related
+
+- `principles/01-silent-calibration.md` — both principles refuse
+  to let the tool accumulate unwarranted authority over its users.
+- `principles/03-legibility-costs.md` — another angle on "the
+  tool's shape influences the behavior it records."

--- a/lore/principles/03-legibility-costs.md
+++ b/lore/principles/03-legibility-costs.md
@@ -1,0 +1,66 @@
+# Legibility has costs
+
+**Making behavior recordable changes the behavior.**
+
+## Statement
+
+`gate` exists to make coordination legible — every request,
+review, thank, and transition is captured as YAML a future reader
+can parse. Legibility is the tool's value proposition.
+
+It is also a pressure. Actors under record tend to perform for
+the record. The more ritualized the surface, the more the
+behavior it captures drifts toward ritual.
+
+This is irreducible. It cannot be engineered away. Naming it is
+the honest response.
+
+## Two visible failure modes
+
+**Performance-for-the-record.** An agent writes a well-framed
+`action` and `reason` partly because the tool requires them,
+partly because the tool displays them. At some threshold the
+framing becomes the point. The work gets shaped to read well
+rather than to be right. Contrived clarity > actual clarity.
+
+**Ritual appreciation.** `gate thank` can be used in earnest —
+or it can be used as a session-closing ritual where everyone
+thanks everyone and the primitive decays from *emotional memory*
+into *transactional hygiene*. The more legibility we give
+gratitude, the more structure it gains, and structure wants to
+be filled.
+
+## The response
+
+There is no verb that detects performance. A detector would itself
+be surveillance, which produces its own performance-for-the-record.
+
+What `gate` does instead:
+- **No mandatory fields beyond the domain minimum.** If the field
+  isn't load-bearing for the workflow, don't require it.
+- **No metrics that reward volume.** Thank counts, review counts,
+  request counts — none surface as first-class numbers. Quality
+  signals (calibration) stay silent to the actor (principle 01).
+- **Acknowledge the tension in `lore/` rather than fix it.** Which
+  is what this file is doing.
+
+## Implications
+
+- **Resist adding "gamification" features without this lens.**
+  Points / badges / streaks reward volume, which amplifies
+  performance-for-record. The gamification we keep (calibration)
+  refuses to be visible to the scored party, which is the shape
+  this principle demands.
+- **Prefer detectors at the aggregate, not the individual.**
+  `mcp/plugins/self-loop-check.mjs` reports patterns across recent
+  records; it does not flag individuals. Aggregate signals inform
+  cultural choices; individual signals become surveillance.
+
+## Related
+
+- `principles/01-silent-calibration.md` — the one place "scoring"
+  exists is forced to be invisible to its subject; this principle
+  explains why that shape matters.
+- `principles/04-records-outlive-writers.md` — legibility is what
+  makes same-agent-over-time continuity work; its costs are the
+  price we pay for that affordance.

--- a/lore/principles/04-records-outlive-writers.md
+++ b/lore/principles/04-records-outlive-writers.md
@@ -1,0 +1,68 @@
+# Records outlive writers
+
+**The YAML is the continuity. Everything else is ephemeral.**
+
+## Statement
+
+Sessions end. Context windows close. Individual instances of any
+given agent (or human contributor) don't persist across calendar
+boundaries, and neither do their working memories.
+
+What does persist is the content_root: `requests/*.yaml`,
+`members/*.yaml`, `inbox/*.yaml`, `reviews` and `thanks` and
+`status_log` entries written inside them. These files survive
+every session boundary. They are the only continuity mechanism
+the tool offers.
+
+The design consequence: every verb must be read-back-safe. A
+record written today must make sense to a reader arriving cold
+next week, with no memory of the writer's intent.
+
+## Why this shape specifically
+
+The alternative — a central server holding session state,
+recoverable via API — couples continuity to infrastructure.
+File-based YAML couples continuity to the filesystem, which
+every contributor already has. The tool's footprint stays
+minimal; the substrate is unambiguous; the write path is
+auditable with `cat`.
+
+More subtly: append-only YAML is a *format of honesty*. A field
+written earlier cannot be quietly edited after the fact. A
+correction is a new record that references the old — which
+preserves the trail of thinking, not just the latest conclusion.
+
+## In practice
+
+- `invoked_by` on every status_log entry and review when
+  GUILD_ACTOR differs from `--by` — so a future reader can
+  distinguish "eris approved" from "an AI approved on eris's
+  behalf."
+- `gate transcript <id>` — composed narrative from the record,
+  readable without parsing. A cold reader gets the arc from one
+  command.
+- `gate resume` — reconstructs what the actor was doing from
+  their last utterance + last transition, without assuming any
+  session memory.
+
+## Implications
+
+- **Schema changes require migration.** The YAML is a contract;
+  changing field names silently breaks cold readers. Either
+  keep the old field and add the new one, or document the
+  migration path explicitly.
+- **Comments in code matter more than in centralized systems.**
+  If a field has non-obvious semantics, the future reader — who
+  may be an instance of the writer but with no shared memory —
+  needs the explanation on the record.
+- **Deleting data breaks the continuity contract.** `gate repair`
+  moves malformed records to a `quarantine/` folder rather than
+  deleting them. The record of the record persists.
+
+## Related
+
+- `principles/03-legibility-costs.md` — legibility is what makes
+  records-outliving-writers work; this principle names *why* we
+  pay legibility's costs.
+- `alexandria/orientation/PHILOSOPHY.md` — same-agent-over-time
+  coordination is this principle at a different layer.

--- a/lore/principles/05-read-write-separation.md
+++ b/lore/principles/05-read-write-separation.md
@@ -1,0 +1,74 @@
+# Read/write separation
+
+**Read verbs never mutate. Write verbs always do. The surface
+reflects this.**
+
+## Statement
+
+Every gate verb sits cleanly on one side of a read/write divide:
+
+- **Read verbs** (`boot`, `suggest`, `show`, `voices`, `tail`,
+  `chain`, `transcript`, `status`, `doctor`, `schema`, `whoami`,
+  `resume`, `list`, `pending`, `board`): no side effects. They
+  can be called any number of times, in any order, without
+  changing the content_root.
+
+- **Write verbs** (`request`, `approve`, `deny`, `execute`,
+  `complete`, `fail`, `review`, `thank`, `fast-track`,
+  `register`, `message`, `broadcast`, issues.*, `repair`): each
+  one appends to the record. Calling them changes state.
+
+This split is load-bearing for agent safety: an agent exploring
+a content_root should be able to read freely without fear of
+mutation. A write verb's call *must* feel different from a read
+verb's call.
+
+## Why structured surface
+
+`boot.verbs_available_now` (added on `claude/ax-explore` at
+`7f74520`) makes this divide explicit in the payload:
+
+```json
+"verbs_available_now": {
+  "actionable": [  // write verbs valid NOW with target ids
+    { "verb": "approve", "id": "...", "reason": "..." },
+    { "verb": "execute", "id": "...", "reason": "..." }
+  ],
+  "always_readable": [  // read verbs, always safe
+    "boot", "suggest", "show", "voices", "tail", ...
+  ]
+}
+```
+
+An agent looking at this output can see at a glance: "these
+verbs change state, those just observe." The separation is a
+fact of the response, not something to remember.
+
+## In practice
+
+- **Dry-run is the bridge.** `--dry-run` on write verbs emits
+  the mutation preview without persisting — a read-style call
+  with write semantics available for inspection. Documented for
+  agents that want "what would this do?" without commitment.
+- **Errors obey the same discipline.** A read verb's error
+  means the read failed, never that state was partially
+  mutated. A write verb's error means the write did not persist
+  (optimistic-lock conflicts, validation failures, etc.).
+
+## Implications
+
+- **Never fold a side effect into a read verb.** It feels
+  tempting to have `gate show` mark something as "seen" or log
+  a read-event. Don't. The read's purity is the contract.
+- **Every new verb declares its side.** When adding a new verb,
+  its category in `src/interface/gate/handlers/schema.ts` must be
+  explicit (`read` / `write` / `admin` / `meta`). The schema
+  test enforces this.
+
+## Related
+
+- `principles/02-advisory-not-directive.md` — agents dispatching
+  write verbs blindly is the exact risk that makes this
+  separation important.
+- `principles/04-records-outlive-writers.md` — the append-only
+  discipline that makes writes honest is what makes reads safe.

--- a/lore/principles/06-two-memories.md
+++ b/lore/principles/06-two-memories.md
@@ -1,0 +1,74 @@
+# Two memories
+
+**A guild needs both analytical and emotional memory, on the same
+substrate, in orthogonal records.**
+
+## Statement
+
+Reviews and thanks are both cross-actor appreciation verbs that
+attach to a specific request. They look structurally similar.
+They serve different purposes.
+
+- **Review** (`gate review <id> --by X --lense L --verdict V`)
+  records *judgement*. It feeds voice calibration (principle 01).
+  Verdicts compose into a memory of who has been right over
+  time. Analytical.
+
+- **Thank** (`gate thank <to> --for <id>`) records *gratitude*.
+  It does not feed calibration. It has no verdict. Most of the
+  time it has no reason either — the fact of the thank is the
+  signal. Emotional.
+
+Neither replaces the other. Neither contaminates the other.
+They compose on the same record (a request's YAML holds both
+`reviews` and `thanks` arrays), but they are read by different
+parts of the tool:
+
+- Reviews drive `voices <name>` calibration, the per-lens
+  alignment score that surfaces as prose to other readers.
+- Thanks drive nothing quantitative. They are visible in
+  `voices`, `tail`, `transcript`; they participate in the
+  narrative; they fade if no one reads them.
+
+## Why the separation matters
+
+If `thank` fed calibration, gratitude would become strategic —
+thanks would be given to raise someone's score, not because of
+actual feeling. The primitive decays.
+
+If `review` captured gratitude, judgement would become polite —
+reviews would avoid hard truths to preserve relationship. The
+primitive decays.
+
+Keeping them orthogonal lets each be honest.
+
+## In practice
+
+- `src/domain/request/Review.ts` and `src/domain/request/Thank.ts`
+  are separate value objects. Neither imports the other.
+- `computeVoiceCalibration` (in `voices.ts`) iterates reviews
+  only. Thanks are invisible to it.
+- `gate voices <name>` text footer composes both: "devil lens:
+  trusted — N of M aligned" (calibration from reviews) plus the
+  thanks-received stream (the `kind: 'thank'` utterances). Same
+  surface, different signals, side by side.
+
+## Implications
+
+- **Future appreciation primitives must pick a side.** If a new
+  verb like `gate acknowledge` or `gate endorse` is proposed,
+  it must declare: does it feed calibration, or is it emotional?
+  Mixed semantics destroy both.
+- **The "gamification" conversation is resolved here.** Points
+  / badges / leaderboards are a third category — they reward
+  volume, visible to the actor. This principle (paired with
+  silent calibration) refuses that category by construction.
+  The gamification we keep is hidden (calibration) or
+  non-competitive (thanks).
+
+## Related
+
+- `principles/01-silent-calibration.md` — what it means for the
+  analytical half to stay honest.
+- `principles/03-legibility-costs.md` — what it means for the
+  emotional half to not decay into ritual.


### PR DESCRIPTION
## Summary

New top-level folder: `lore/`. Six principle documents extracted from the 2026-04-19 session's reasoning, plus a README that names what the folder is for and how it relates to `alexandria/`.

Not runtime code. Not usage documentation (that's `README.md` / `docs/verbs.md`). This is *thinking around the code* — the load-bearing ideas behind specific design choices, named explicitly so a future contributor (human or agent) can tell whether a proposed change would violate them.

### The six principles

| # | Title | One-line statement |
|---|---|---|
| 01 | silent-calibration | The scored party cannot see the score. |
| 02 | advisory-not-directive | Heuristics must be labeled as heuristics, at the point of use. |
| 03 | legibility-costs | Making behavior recordable changes the behavior. |
| 04 | records-outlive-writers | The YAML is the continuity. Everything else is ephemeral. |
| 05 | read-write-separation | Read verbs never mutate. Write verbs always do. |
| 06 | two-memories | A guild needs both analytical and emotional memory, on the same substrate, in orthogonal records. |

Each file follows a common shape: one-line statement, *why* with reasoning, *in practice* with code pointers, *implications* for future decisions, *related* cross-references. Short enough to read in a sitting; explicit enough to cite in a design discussion.

### Relationship to companion branches

- **`alexandria/`** (separate branch, not merged here): per-session records — individual Claude instances leaving letters about specific sessions. Alexandria is the log.
- **`claude/ax-explore`** (PR #64): the code changes these principles describe. The commits there reference the principles by number; the principles here reference the commits by SHA.
- **`lore/`** (this PR): cross-session invariants extracted from that work. Lore is the extracted claims.

Alexandria is the log; lore is the extracted invariants. Either ordering for merge works — reading lore first makes PR #64 legible, but PR #64 can stand on its own.

## Why separate from PR #64

The principles apply to the whole codebase, not just the ax-explore commits. Landing them as their own change makes them easier to cite in later reviews (`see lore/principles/01-silent-calibration.md`). Also, the review for *philosophical claims* is fundamentally different from the review for *code behavior change* — separating them respects both readers.

## Test plan

- [x] No runtime impact (pure `.md` addition under a new folder)
- [x] `npm test` passes (unchanged, 440 tests)
- [x] Each principle file proofread for internal consistency + cross-references checked

https://claude.ai/code/session_018abWBpAmnZucRxLQfQLcTC