### PR TITLE
fix: spurious VersionConflict on legacy stateless status_log rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **`save()` no longer throws spurious `RequestVersionConflict` on
+  records carrying legacy stateless `status_log` entries.** `hydrate`
+  skips status_log rows whose `state` field is missing (an older
+  format wrote review notes that way), but `readVersion` was counting
+  those rows from the raw YAML — so `loadedVersion` (from the hydrated
+  aggregate) lagged `maxOnDisk` (from the raw count) by exactly the
+  number of skipped entries. Every save() on such a record then threw
+  `RequestVersionConflict` even when no concurrent writer existed.
+  Surfaced by `gate thank` against any reviews ≥ 1 request whose
+  status_log carried a legacy review-note row — the verb only touches
+  `thanks[]`, so the version drift wasn't masked by a real
+  status_log/reviews delta. Same shape as the earlier
+  "`Custom lenses no longer break listAll-backed read verbs`" fix
+  (read-path skip rule out of sync with raw count). One-line behavior
+  fix; regression test injects the legacy shape and runs `addThank` →
+  `save()` round-trip.
 - **`unresponded_concerns` no longer counts pre-dating mentions as
   follow-ups.** `UnrespondedConcernsQuery.hasFollowUp` was checking
   "does any authored record mention this id?" without a temporal

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -190,7 +190,22 @@ export class YamlRequestRepository implements RequestRepository {
 function readVersion(parsed: unknown): number {
   if (!parsed || typeof parsed !== 'object') return 0;
   const obj = parsed as Record<string, unknown>;
-  const log = Array.isArray(obj['status_log']) ? obj['status_log'].length : 0;
+  // Match hydrate()'s skip rule: legacy status_log entries that
+  // omit `state` (e.g., review notes from older formats) are dropped
+  // during hydration. If we count them here, loadedVersion (from the
+  // hydrated aggregate) lags maxOnDisk (from raw YAML) by exactly
+  // the number of such entries — making every save() throw
+  // RequestVersionConflict on a record that nobody else is touching.
+  // Surfaced when adding `gate thank` to a request whose status_log
+  // carries a legacy review-note entry.
+  const log = Array.isArray(obj['status_log'])
+    ? (obj['status_log'] as unknown[]).filter(
+        (e) =>
+          e !== null &&
+          typeof e === 'object' &&
+          typeof (e as Record<string, unknown>)['state'] === 'string',
+      ).length
+    : 0;
   const reviews = Array.isArray(obj['reviews']) ? obj['reviews'].length : 0;
   return computeVersion(log, reviews);
 }

--- a/tests/infrastructure/YamlRequestRepository.test.ts
+++ b/tests/infrastructure/YamlRequestRepository.test.ts
@@ -310,3 +310,71 @@ test('listByState passes config.lenses to hydrate (custom lens YAML round-trips)
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('save() does not throw spurious VersionConflict on records with legacy stateless status_log entries', async () => {
+  // Regression guard: hydrate() skips status_log entries whose
+  // `state` field is missing (e.g., a review-note row written by an
+  // older format). readVersion() used to count those entries from
+  // the raw YAML, so loadedVersion (from the hydrated aggregate)
+  // and maxOnDisk (from raw count) drifted by exactly the number
+  // of skipped entries — every save() on such a record then threw
+  // RequestVersionConflict even though no concurrent writer existed.
+  // Surfaced by `gate thank` against any reviews>=1 request whose
+  // status_log carried a legacy review-note entry.
+  const { root, cfg, repo, cleanup } = makeRoot();
+  try {
+    const req = await createSaved(repo, 1);
+    const path = join(
+      root,
+      'requests',
+      'pending',
+      `${req.id.value}.yaml`,
+    );
+    const doc = YAML.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    // Inject the legacy shape: a review row in status_log without
+    // a `state` field (review-note flavor).
+    (doc['status_log'] as unknown[]).push({
+      by: 'human',
+      at: '2026-04-16T00:00:01Z',
+      note: 'review (concern, lense: devil): legacy review-note row',
+    });
+    // Plus a real review entry so reviews.length=1.
+    doc['reviews'] = [
+      {
+        by: 'human',
+        lense: 'devil',
+        verdict: 'concern',
+        comment: 'legacy companion review',
+        at: '2026-04-16T00:00:01Z',
+      },
+    ];
+    writeFileSync(path, YAML.stringify(doc));
+
+    const reloaded = await repo.findById(RequestId.of(req.id.value));
+    assert.ok(reloaded);
+    // Hydrated aggregate drops the stateless row → statusLog.length=1,
+    // reviews.length=1, loadedVersion=2.
+    assert.equal(reloaded!.statusLog.length, 1);
+    assert.equal(reloaded!.reviews.length, 1);
+    assert.equal(reloaded!.loadedVersion, 2);
+
+    // Touch a non-status_log/reviews field path: addThank.
+    // Pre-fix, this threw RequestVersionConflict (expected 2, found 3).
+    const thank = (await import(
+      '../../src/domain/request/Thank.js'
+    )).Thank.create({
+      by: 'alice',
+      to: 'human',
+      at: '2026-04-16T00:00:02Z',
+      reason: 'legacy-version regression',
+    });
+    reloaded!.addThank(thank);
+    await repo.save(reloaded!); // must not throw
+    cfg; // keep makeRoot's cfg referenced
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

`hydrate()` drops `status_log` entries whose `state` field is
missing (an older format wrote review notes that way), but
`readVersion()` was counting those rows from the raw YAML — so
`loadedVersion` (from the hydrated aggregate) lagged `maxOnDisk`
(from the raw count) by exactly the number of skipped entries.

Every `save()` on such a record then threw `RequestVersionConflict`
even when no concurrent writer existed. The drift was masked on
verbs that touch `status_log` or `reviews` (+1 from the legitimate
mutation cancelled the −1 skip), but `gate thank` only appends to
`thanks[]` so it surfaced cleanly:

```
$ gate thank miki --for 2026-04-14-004 --by eris --reason "..."
error: Request 2026-04-14-004 changed on disk
       (expected version 5, found 6); reload and retry
```

— against a record nobody else was touching.

## Fix

Apply the same skip rule in `readVersion()` that `hydrate()` uses:
status_log rows without a string `state` field are excluded from the
count. Single contained behavior change in
`src/infrastructure/persistence/YamlRequestRepository.ts`.

Same shape as the earlier "Custom lenses no longer break
listAll-backed read verbs" fix (read-path skip rule out of sync with
raw count) — flagging in case a broader audit of read-path skip
rules vs raw counts is worth doing.

## Test

New regression test in `tests/infrastructure/YamlRequestRepository.test.ts`
injects the legacy shape (status_log row without `state`, plus a
real review) and runs `addThank` → `save()` round-trip:

- pre-fix: throws `RequestVersionConflict(expected=2, actual=3)`
- post-fix: saves cleanly

Full suite: 441 tests pass (440 + 1 new).

## CHANGELOG

Entry added under `[Unreleased]` / `Fixed`.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 441/441 pass
- [x] manual repro: `gate thank` against reviews≥1 record with
      legacy stateless status_log row succeeds
- [x] manual non-regression: `gate thank` against reviews=0 record
      still works (self-thank notice unchanged)
- [x] manual non-regression: existing concurrent-write
      `RequestVersionConflict` test path still triggers (the real
      race detector is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)