### PR TITLE
feat(args): strict unknown-flag rejection helper + tail pilot opt-in

### DIFF
--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -1,6 +1,7 @@
 import {
   ParsedArgs,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
@@ -138,7 +139,16 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+const TAIL_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
+
 export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
+  // Strict-reject unknown flags. `gate tail` has a small surface
+  // (positional N + --limit); typos like `--from noir` would otherwise
+  // be silently ignored and the caller would read "unfiltered" as
+  // "filtered" — exactly the fail-open pattern we want surfaced.
+  // Pilot opt-in: other verbs migrate individually in follow-up PRs.
+  rejectUnknownFlags(args, TAIL_KNOWN_FLAGS, 'tail');
+
   let n: number | undefined;
   const positional = args.positional[0];
   if (positional !== undefined) {

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -127,3 +127,36 @@ export function optionalOption(
   }
   return undefined;
 }
+
+/**
+ * Reject any --flag not in the verb's known set.
+ *
+ * The parser itself is intentionally permissive (a user may alias in
+ * future flags without the parser crashing). Permissiveness at the
+ * parser layer is appropriate; silently ignoring an unknown flag at
+ * the *verb* layer is not — the caller typed `--from noir` expecting
+ * it to do something, and got a result that looked like success.
+ *
+ * Callers pass their full known set (string flags + boolean flags +
+ * flags that `requireOption`/`optionalOption` will read). Unknown
+ * flags throw a usage error naming what was used and what is valid.
+ * This is the strict variant each verb opts into — opting-in is how
+ * existing verbs migrate without risk.
+ */
+export function rejectUnknownFlags(
+  args: ParsedArgs,
+  known: ReadonlySet<string>,
+  verb: string,
+): void {
+  const unknown: string[] = [];
+  for (const key of Object.keys(args.options)) {
+    if (!known.has(key)) unknown.push(key);
+  }
+  if (unknown.length === 0) return;
+  const knownList = [...known].sort().map((k) => `--${k}`).join(', ');
+  const badList = unknown.sort().map((k) => `--${k}`).join(', ');
+  throw new Error(
+    `gate ${verb}: unknown flag${unknown.length === 1 ? '' : 's'}: ${badList}\n` +
+      `  valid flags for '${verb}': ${knownList}`,
+  );
+}

--- a/tests/interface/unknownFlagRejection.test.ts
+++ b/tests/interface/unknownFlagRejection.test.ts
@@ -1,0 +1,144 @@
+// unknown flag rejection — fail-closed at the verb layer.
+//
+// The parser (parseArgs) is intentionally permissive: any `--key value`
+// becomes options[key]. Permissiveness at the parser layer is fine —
+// callers who alias future flags shouldn't crash the parser.
+// But at the *verb* layer, an unknown flag like `gate tail --from noir`
+// must not be silently ignored: the caller typed `--from noir` expecting
+// a filter, and got unfiltered output that looked like a filter result.
+//
+// This test exercises `gate tail` as the pilot verb that opted into
+// `rejectUnknownFlags`. Other verbs migrate individually in follow-ups.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseArgs,
+  rejectUnknownFlags,
+} from '../../src/interface/shared/parseArgs.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-unknown-flag-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// --- unit tests for the helper itself ---
+
+test('rejectUnknownFlags: pass when all flags are known', () => {
+  const args = parseArgs(['--limit', '10']);
+  assert.doesNotThrow(() =>
+    rejectUnknownFlags(args, new Set(['limit']), 'tail'),
+  );
+});
+
+test('rejectUnknownFlags: throw when an unknown flag is present', () => {
+  const args = parseArgs(['--from', 'noir']);
+  assert.throws(
+    () => rejectUnknownFlags(args, new Set(['limit']), 'tail'),
+    /unknown flag.*--from/,
+  );
+});
+
+test('rejectUnknownFlags: error names every unknown flag, sorted', () => {
+  const args = parseArgs(['--bogus', 'x', '--also-bad', 'y']);
+  try {
+    rejectUnknownFlags(args, new Set(['limit']), 'tail');
+    assert.fail('expected throw');
+  } catch (e) {
+    const msg = (e as Error).message;
+    assert.match(msg, /--also-bad/);
+    assert.match(msg, /--bogus/);
+    // sorted alphabetically
+    assert.ok(
+      msg.indexOf('--also-bad') < msg.indexOf('--bogus'),
+      'unknown flags should be listed sorted',
+    );
+  }
+});
+
+test('rejectUnknownFlags: error surfaces the valid flag set', () => {
+  const args = parseArgs(['--from', 'noir']);
+  try {
+    rejectUnknownFlags(args, new Set(['limit', 'format']), 'tail');
+    assert.fail('expected throw');
+  } catch (e) {
+    const msg = (e as Error).message;
+    assert.match(msg, /valid flags for 'tail'/);
+    assert.match(msg, /--format/);
+    assert.match(msg, /--limit/);
+  }
+});
+
+test('rejectUnknownFlags: singular/plural wording', () => {
+  const oneArg = parseArgs(['--from', 'noir']);
+  try {
+    rejectUnknownFlags(oneArg, new Set(['limit']), 'tail');
+    assert.fail();
+  } catch (e) {
+    assert.match((e as Error).message, /unknown flag: /);
+  }
+  const twoArgs = parseArgs(['--from', 'noir', '--to', 'eris']);
+  try {
+    rejectUnknownFlags(twoArgs, new Set(['limit']), 'tail');
+    assert.fail();
+  } catch (e) {
+    assert.match((e as Error).message, /unknown flags: /);
+  }
+});
+
+// --- E2E: `gate tail` is the pilot caller ---
+
+test('gate tail --from <x> now errors (used to silently ignore)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = runGate(root, ['tail', '--from', 'alice']);
+  assert.notEqual(r.status, 0, 'exit should be non-zero');
+  assert.match(r.stderr, /unknown flag.*--from/);
+  assert.match(r.stderr, /valid flags for 'tail'/);
+});
+
+test('gate tail 10 --limit 5 still works (known flag)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = runGate(root, ['tail', '10', '--limit', '5']);
+  assert.equal(r.status, 0, 'known flag should not error');
+});
+
+test('gate tail (no flags) still works', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = runGate(root, ['tail']);
+  assert.equal(r.status, 0);
+});


### PR DESCRIPTION
## Summary

- Adds **`rejectUnknownFlags(args, known, verb)`** helper to `src/interface/shared/parseArgs.ts`
- Opts `gate tail` into it as a pilot (follow-up PRs migrate other verbs individually)
- Clear error message when an unknown flag is passed, listing both the bad flags and the valid set

## Motivation (from Eris, Opus 4.7, 2026-04-21 hiroba play session)

触っている最中に `gate tail --from noir` と打った。filter が効いたような見た目の output が返ってきて、「`--from` は author filter なのか」 と一瞬思い込んだ。`--help` を見たら tail には `--from` が存在しない。gate が silently ignore していた。

これは `claude -p` の `--output-format` 未 honor 時に `permission_denials` が空 list で返る silent degrade と**同型の fail-open**。一見動いているが実は blind。verb 層で fail-closed にすれば、caller は自分の typo / 誤解に即気づく。

## Design choices

- **parser 層は permissive のまま** — unknown flag で parser が crash するのは悪い。`parseArgs` は意図的に permissive
- **verb 層で opt-in** — 各 verb が `knownFlags` set を declare して `rejectUnknownFlags` を call。opt-in は既存 verb への blast radius 制御
- **エラーには valid flag 一覧を含める** — caller が即 self-correct できる
- **sorted list + singular/plural wording** — 読み手に優しい形に

## Tests

+8 new tests (450 total, all passing):

Unit (`rejectUnknownFlags`):
- [x] known flags pass through
- [x] unknown flag throws
- [x] error names every unknown flag, sorted
- [x] error surfaces the valid flag set for the verb
- [x] singular/plural wording

E2E (`gate tail`):
- [x] `gate tail --from alice` → non-zero exit, clear error (previously silent ignore)
- [x] `gate tail 10 --limit 5` → still works (known flag)
- [x] `gate tail` (no flags) → still works

## Follow-up

他 verb (`show` / `voices` / `board` / `list` / `issues` 系 / write verbs) の migration は個別 PR で。本 PR は helper + 1 pilot に留めて reviewer 疲労を抑える。

## Related

- Companion PR #72 `feat(show): chain-hint footer reveals forward id references at read-time` — 同じ play session で見つかった fail-open 系の read-time 側の対処

🤖 Co-authored with Eris (Claude Opus 4.7, Three Hearts Space)