### PR TITLE
fix: review follow-ups — version tracking, inbox safety, docs gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -722,6 +722,57 @@ team coordination.
 - No state-transition lock; `saveNew` is race-safe (O_EXCL) but `save` has last-writer-wins semantics.
 - Sequence ceiling 999 per UTC day (ID format `YYYY-MM-DD-NNN`).
 
+## [0.2.0] — 2026-04-15
+
+Stabilization pass: diagnostic/repair verbs, cross-platform fixes, and
+the infrastructure to make 0.3.0's agent-first features possible.
+
+### Added
+- **`gate doctor` verb** — read-only diagnostic scan of the content_root.
+  Reports malformed YAML (parse failures, hydration errors, top-level
+  non-mapping), duplicate ids, and per-area totals. Text and JSON output
+  formats. Closes `i-2026-04-14-0015`. (#14)
+- **`gate repair` verb** — intervention layer paired with `gate doctor`.
+  Consumes `gate doctor --format json` output and quarantines malformed
+  records to `<content_root>/quarantine/<ISO-timestamp>/<area>/`. `--dry-run`
+  (default) previews the plan; `--apply` executes. Idempotent — already-moved
+  sources are skipped. Path safety via `realpathSync` canonicalization.
+  Closes `i-2026-04-15-0025`, `i-2026-04-15-0026`. (#15)
+- **`guild --version` / `gate --version`** (alias `-v`) — print
+  `guild-cli <version>` and exit 0. (#9)
+- `CHANGELOG.md` and `POLICY.md` — versioning promise and change history. (#8)
+- `.github/workflows/ci.yml` — typecheck + test on Node 20 / 22. (#7)
+
+### Changed
+- **Sequence ceiling**: Request and Issue ids now use 4-digit sequences
+  (`YYYY-MM-DD-NNNN` / `i-YYYY-MM-DD-NNNN`), raising the per-UTC-day
+  ceiling from 999 to 9999. Loader accepts both 3- and 4-digit forms;
+  generation always produces 4 digits. (#12)
+- **`OnMalformed` callback**: `GuildConfig` now carries
+  `onMalformed: (msg: string) => void`, defaulting to stderr. Every
+  hydrate path routes skipped records through it. (#11)
+
+### Changed (internal)
+- **Refactor**: `src/interface/gate/index.ts` split into
+  `handlers/{request,review,read,issues,messages}.ts` plus
+  `handlers/internal.ts`. `index.ts` is now 158 lines (was 1206).
+  Behavior unchanged. (#10)
+
+### Fixed
+- **Cross-platform**: Windows path separators, `EDITOR` fallback to
+  `notepad` on win32, richer error messages with hints. (#21)
+- **Diagnostic**: YAML parse errors now surface via `onMalformed`
+  instead of silently skipping. (#17)
+- **Sort**: Numeric-aware id ordering for mixed 3/4-digit sequences. (#13)
+
+### Documentation
+- README extracted verb deep-dives to `docs/verbs.md` (803→458 lines). (#16)
+- README reflects 0.2.0 status and test surface. (#19)
+- POLICY.md: MemberName ASCII-only rationale + diagnostic/repair
+  partial stability. (#20)
+- README: tighten redundancy, clarify scope and requirements. (#22)
+- CI lockfile sync, version drift guard. (#23)
+
 [Unreleased]: https://github.com/eris-ths/guild-cli/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/eris-ths/guild-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/eris-ths/guild-cli/compare/v0.1.0...v0.2.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,21 @@ write access to `content_root`".
 - **YAML safety** — parsing goes through `yaml` lib's default schema
   which refuses custom tags.
 
+## Trust assumptions (v0.3.0)
+
+- **Editor invocation.** `gate review` spawns the user's editor via
+  `$GIT_EDITOR` / `$VISUAL` / `$EDITOR` environment variables. The
+  editor command is **not validated** — the tool trusts the local
+  environment. In multi-user or container environments, restrict
+  environment variable mutation or avoid interactive review.
+- **Doctor plugins.** Plugins listed in `guild.config.yaml`
+  `doctor.plugins` are ES modules executed **in the main process**
+  with full Node.js capabilities. Only load plugins from trusted
+  sources. There is no sandboxing.
+- **MCP server (gate_mcp.py).** Spawns `gate` as a subprocess via
+  `asyncio.create_subprocess_exec` (array form, no shell expansion).
+  Project name validation blocks path traversal (`/`, `\`, `.`, `..`).
+
 ## Known hardening items (not yet addressed)
 
 - **Error messages may leak absolute paths.** Errors from `safeFs`
@@ -41,7 +56,9 @@ write access to `content_root`".
   does not independently guard against prototype keys.
 - **Concurrent writes.** There is no lock file. Two simultaneous
   `gate approve` calls on the same request have a last-writer-wins
-  race. Serialize at the caller.
+  race. Optimistic-lock detection (`RequestVersionConflict`) catches
+  most concurrent mutations, but is not a full serialization barrier.
+  Serialize at the caller for critical operations.
 
 ## Reporting
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -737,6 +737,134 @@ vs intervention. You can always run `gate doctor` without fear of
 side effects. This mirrors the `silent_fail_taxonomy` principle:
 separate the "what's wrong" from the "what to do about it."
 
+### Board: what's in flight
+
+`gate board` shows the non-terminal subset of the request corpus
+in a single view — pending, approved, and executing, stacked in
+lifecycle order:
+
+```
+$ gate board
+── pending (2) ──────────────────────────
+  2026-04-19-0003  [alice] implement caching layer
+  2026-04-19-0004  [bob]   update API docs
+
+── approved (1) ─────────────────────────
+  2026-04-19-0002  [alice] refactor auth module   executor=bob
+
+── executing (1) ────────────────────────
+  2026-04-19-0001  [bob]   add rate limiting      executor=bob ✓devil
+```
+
+`--for <m>` scopes to the actor's requests. When `GUILD_ACTOR`
+is set, filtering is implicit (with a stderr notice). JSON
+output via `--format json`.
+
+**Design note.** Board excludes terminal states and issues.
+"In flight" means "someone could still act on this." Closed
+records belong to `tail` / `voices` / `show`.
+
+### Register: onboarding in one command
+
+Before `register`, a first-time agent had to hand-author YAML.
+Now:
+
+```
+$ gate register --name claude --category professional
+✓ registered: claude (professional)
+```
+
+- `--category` defaults to `professional` (aliases: `pro`, `prof`,
+  `member`).
+- Re-registering the same name is a no-op error, not a silent
+  overwrite.
+- `--dry-run` previews the YAML without writing.
+- `--category host` is rejected — hosts go in `guild.config.yaml`.
+
+**Design note.** Registration must be frictionless so an agent's
+first interaction with a content_root doesn't stall on schema
+discovery. The verb exists because the alternative ("figure out
+the member YAML format from examples") is the wrong first
+impression for agent-first tooling.
+
+### Suggest: the hot-loop sibling of boot
+
+`gate suggest` returns the ONE next thing, right now, using the
+same priority ladder as `boot.suggested_next`:
+
+```
+$ gate suggest --format text
+→ complete id=2026-04-19-0001 by=bob
+  you are executing 2026-04-19-0001 — complete it
+# advisory — override freely
+```
+
+The `# advisory` footer goes to stderr (principle 02). JSON
+output returns `{ suggested_next: { verb, args, reason } | null }`.
+
+**Design note.** `boot` is the orientation call (comprehensive
+snapshot, once per session). `suggest` is the hot-loop call
+(minimal payload, repeated). They share `deriveBootSuggestedNext`
+so the two can never diverge. An agent that dispatches
+`suggest.verb` without reading `suggest.reason` is treating a
+heuristic as a command — the anti-pattern principle 02 names.
+
+### Thank: the gratitude primitive
+
+```
+$ gate thank noir --for 2026-04-19-0001 --by eris
+✓ thanked: noir on 2026-04-19-0001
+```
+
+Thanks are orthogonal to reviews (principle 06, Two memories):
+
+- **Reviews** record judgement → feed voice calibration.
+- **Thanks** record gratitude → feed nothing quantitative.
+
+`--reason` is optional. Most of the time the fact of the thank
+is the signal. Self-thank is allowed but flagged on stderr.
+`--reason -` reads stdin (symmetric with `review --comment -`).
+
+**Design note.** If thanks fed calibration, gratitude would
+become strategic. If reviews captured gratitude, judgement would
+become polite. Keeping them orthogonal lets each be honest.
+See `lore/principles/06-two-memories.md`.
+
+### Transcript: the narrative arc of a request
+
+```
+$ gate transcript 2026-04-19-0001
+# 2026-04-19-0001 — add rate limiting
+
+Filed by bob on 2026-04-19T10:00:00Z.
+  action: add rate limiting to the API gateway
+  reason: protect upstream services from burst traffic
+
+Approved by eris (+3m). Execution started by bob (+5m).
+Completed by bob (+2h15m): "implemented with token bucket; ...".
+
+Reviewed by noir [devil/ok] (+4h):
+  "clean implementation, considered failure modes."
+
+noir thanked bob.
+
+── summary ──
+actors: bob, eris, noir (3)
+reviews: 1 (devil/ok)
+thanks: 1
+duration: 4h
+```
+
+JSON output (`--format json`) returns `{ id, arc, summary }`
+where `arc` is the prose and `summary` carries structured data
+(actors, review_verdicts, duration_ms).
+
+**Design note.** `show` gives structured access. `voices` gives
+per-actor history. `transcript` gives per-request prose — the
+narrative a cold reader needs to understand what happened without
+parsing YAML. If agents render this better themselves, the verb
+can be dropped — the data path isn't disturbed (read-only).
+
 **Plugins.** `gate doctor` supports plugins via `guild.config.yaml`:
 
 ```yaml

--- a/examples/agent-first-session/README.md
+++ b/examples/agent-first-session/README.md
@@ -1,0 +1,30 @@
+# agent-first-session
+
+A minimal content_root showing the agent-first workflow: three
+members (`claude` author, `devil` critic, `layer` critic), three
+completed requests with reviews, no issues, no inbox.
+
+Use this to verify that `gate boot`, `gate show`, and `gate voices`
+produce sensible output on a small, clean dataset — or as a
+template for bootstrapping a new content_root.
+
+```bash
+cd examples/agent-first-session
+export GUILD_ACTOR=claude
+gate boot                            # orientation snapshot
+gate show 2026-04-16-0001 --format text   # a single request arc
+gate voices devil --format text      # the devil critic's history
+```
+
+## Structure
+
+- `guild.config.yaml` — default config, no hosts.
+- `members/` — `claude`, `devil`, `layer`.
+- `requests/completed/` — 3 requests (`2026-04-16-0001` through `-0003`),
+  each with status_log and reviews.
+
+## What this is not
+
+- Not a multi-day session (see `dogfood-session/` for that).
+- Not an example of issues, inbox, or pair-mode (`--with`).
+  See `agent-voices/` for richer patterns.

--- a/src/domain/member/Member.ts
+++ b/src/domain/member/Member.ts
@@ -22,7 +22,10 @@ export class Member {
   }): Member {
     const name = MemberName.of(input.name);
     const category = parseMemberCategory(input.category);
-    const displayName = input.displayName?.trim();
+    const rawDisplay = input.displayName?.trim();
+    const displayName = rawDisplay !== undefined && rawDisplay.length === 0
+      ? undefined
+      : rawDisplay;
     if (displayName !== undefined && displayName.length > MAX_DISPLAY_NAME_LEN) {
       throw new DomainError(
         `displayName too long (max ${MAX_DISPLAY_NAME_LEN})`,

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -183,7 +183,7 @@ export class Request {
     // silently lose one review on last-writer-wins. See
     // `computeVersion` below for the single place that defines the
     // invariant.
-    return new Request({ ...props }, computeVersion(props.statusLog.length, props.reviews.length));
+    return new Request({ ...props }, computeVersion(props.statusLog.length, props.reviews.length, (props.thanks ?? []).length));
   }
 
   get id(): RequestId {
@@ -222,10 +222,11 @@ export class Request {
   /**
    * Total mutation count observed when this aggregate was loaded from
    * disk (0 for freshly-created instances). Defined as
-   * `status_log.length + reviews.length` — both arrays are append-only,
-   * so their combined length is a monotonic version. The repository
-   * uses it as an optimistic-lock token: if the on-disk total has
-   * grown since, another writer won the race and our save is rejected.
+   * `status_log.length + reviews.length + thanks.length` — all three
+   * arrays are append-only, so their combined length is a monotonic
+   * version. The repository uses it as an optimistic-lock token: if
+   * the on-disk total has grown since, another writer won the race
+   * and our save is rejected.
    */
   get loadedVersion(): number {
     return this._loadedVersion;
@@ -236,7 +237,7 @@ export class Request {
    * repository will write with, so `loadedVersion` + delta = `currentVersion`.
    */
   get currentVersion(): number {
-    return computeVersion(this.props.statusLog.length, this.props.reviews.length);
+    return computeVersion(this.props.statusLog.length, this.props.reviews.length, (this.props.thanks ?? []).length);
   }
 
   approve(by: MemberName, note?: string, invokedBy?: string): void {
@@ -372,13 +373,17 @@ function statusLogEntryToJSON(e: StatusLogEntry): Record<string, unknown> {
 }
 
 /**
- * Total mutation count: status_log entries + reviews. Both arrays are
- * append-only so the sum is monotonic across any legal transition.
+ * Total mutation count: status_log entries + reviews + thanks. All
+ * three arrays are append-only so the sum is monotonic across any
+ * legal mutation. Thanks are included despite being orthogonal to the
+ * analytical memory (principle 06): they are still records that
+ * outlive writers (principle 04), and a concurrent addThank that
+ * silently loses to last-writer-wins would violate append-only.
  * Kept as a module-private helper so the invariant is defined in one
  * place and the repository can reuse it when reading raw YAML.
  */
-export function computeVersion(statusLogLen: number, reviewsLen: number): number {
-  return statusLogLen + reviewsLen;
+export function computeVersion(statusLogLen: number, reviewsLen: number, thanksLen: number = 0): number {
+  return statusLogLen + reviewsLen + thanksLen;
 }
 
 function sanitizeText(raw: unknown, field: string): string {

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -12,7 +12,9 @@ import {
   readTextSafe,
   writeTextSafe,
 } from './safeFs.js';
+import { join } from 'node:path';
 import { GuildConfig } from '../config/GuildConfig.js';
+import { parseYamlSafe } from './parseYamlSafe.js';
 
 const MAX_INBOX_SIZE = 500;
 
@@ -29,11 +31,15 @@ export class FsInboxNotification implements NotificationPort {
 
   async post(n: Notification): Promise<void> {
     const rel = `${n.to.value}.yaml`;
-    const file: InboxFile = existsSafe(this.config.paths.inbox, rel)
-      ? (YAML.parse(readTextSafe(this.config.paths.inbox, rel)) ?? {
-          messages: [],
-        })
-      : { messages: [] };
+    let file: InboxFile;
+    if (existsSafe(this.config.paths.inbox, rel)) {
+      const raw = readTextSafe(this.config.paths.inbox, rel);
+      const absSource = join(this.config.paths.inbox, rel);
+      const data = parseYamlSafe(raw, absSource, this.config.onMalformed);
+      file = (data as InboxFile | undefined) ?? { messages: [] };
+    } else {
+      file = { messages: [] };
+    }
     if (!Array.isArray(file.messages)) file.messages = [];
     const entry: Record<string, unknown> = {
       from: n.from,
@@ -55,9 +61,10 @@ export class FsInboxNotification implements NotificationPort {
   async listFor(member: MemberName): Promise<InboxMessage[]> {
     const rel = `${member.value}.yaml`;
     if (!existsSafe(this.config.paths.inbox, rel)) return [];
-    const parsed = YAML.parse(readTextSafe(this.config.paths.inbox, rel)) as
-      | InboxFile
-      | null;
+    const raw = readTextSafe(this.config.paths.inbox, rel);
+    const absSource = join(this.config.paths.inbox, rel);
+    const data = parseYamlSafe(raw, absSource, this.config.onMalformed);
+    const parsed = data as InboxFile | undefined;
     if (!parsed || !Array.isArray(parsed.messages)) return [];
     return parsed.messages.map((m) => normalizeMessage(m));
   }
@@ -72,9 +79,10 @@ export class FsInboxNotification implements NotificationPort {
     if (!existsSafe(this.config.paths.inbox, rel)) {
       return { marked: 0, alreadyRead: 0, total: 0 };
     }
-    const parsed = YAML.parse(readTextSafe(this.config.paths.inbox, rel)) as
-      | InboxFile
-      | null;
+    const rawText = readTextSafe(this.config.paths.inbox, rel);
+    const absSource = join(this.config.paths.inbox, rel);
+    const data = parseYamlSafe(rawText, absSource, this.config.onMalformed);
+    const parsed = data as InboxFile | undefined;
     const raw =
       parsed && Array.isArray(parsed.messages) ? parsed.messages : [];
     const total = raw.length;

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -3,7 +3,6 @@ import { Member } from '../../domain/member/Member.js';
 import { MemberName } from '../../domain/member/MemberName.js';
 import { MemberRepository } from '../../application/ports/MemberRepository.js';
 import {
-  assertUnder,
   existsSafe,
   listDirSafe,
   readTextSafe,
@@ -106,6 +105,3 @@ function hydrate(
     return null;
   }
 }
-
-// Silence unused import warning
-void assertUnder;

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -210,7 +210,10 @@ function readVersion(parsed: unknown): number {
   const reviews = Array.isArray(obj['reviews'])
     ? (obj['reviews'] as unknown[]).filter(isObjectEntry).length
     : 0;
-  return computeVersion(log, reviews);
+  const thanks = Array.isArray(obj['thanks'])
+    ? (obj['thanks'] as unknown[]).filter(isObjectEntry).length
+    : 0;
+  return computeVersion(log, reviews, thanks);
 }
 
 /**


### PR DESCRIPTION
## Summary

v0.3.0 レビューで発見した指摘事項の修正。lore/principles を踏まえた上での判断。

### Code fixes
- **`computeVersion` に thanks を追加** — thanks は analytical memory と直交（原則06）だが、record として outlive writers（原則04）。concurrent addThank の last-writer-wins による消失は append-only 違反。`readVersion` も対称的に更新。
- **`FsInboxNotification` → `parseYamlSafe`** — 他の全 Repository と統一。malformed inbox で read verb がクラッシュする問題を修正。
- **`Member.create()` の空 displayName 正規化** — whitespace-only を `undefined` に正規化。
- **`YamlMemberRepository` の未使用 `assertUnder` import 削除**

### Documentation
- **CHANGELOG v0.2.0 セクション追記** — doctor, repair, sequence ceiling, cross-platform fix, CI 等の記録が欠落していた。
- **docs/verbs.md に 5 verb 追加** — board, register, suggest, thank, transcript の design-note セクション。AGENT.md にはあったが verb cookbook に欠落。
- **SECURITY.md に信頼前提セクション追加** — editor invocation, doctor plugins, MCP server。
- **examples/agent-first-session/README.md 追加** — 他の example dir と整合。

## Test plan

- [x] `npm run build` — tsc strict pass
- [x] `npm test` — 454 tests, 0 fail
- [ ] `computeVersion` 変更が既存の version conflict テストを壊していないこと確認
- [ ] FsInboxNotification の malformed inbox ファイルで graceful degradation 確認
- [ ] docs/verbs.md の新セクションが既存の flow と矛盾しないこと目視確認

https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh