### PR TITLE
docs: align CHANGELOG + verbs.md with PR #72 and #73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate show <id> --format text` now prints a chain-hint footer.**
+  The footer scans `action` / `reason` / `completion_note` /
+  `deny_reason` / `failure_reason` / `status_log[].note` /
+  `reviews[].comment` for full-id references (`YYYY-MM-DD-NNN...`)
+  and reports either `"chain hint: no outbound id references
+  detected"` or the list of referenced ids. Read-time surfacing only
+  — the write path is untouched, so writers stay free-form while
+  readers can see at a glance whether `gate chain <id>` will return
+  anything. Short-form `(0004)` is intentionally not detected
+  (that's the case the hint is warning about). Self-ids are
+  excluded. See also the expanded paragraph in
+  [`docs/verbs.md`](./docs/verbs.md#chain-cross-reference-walks). (PR #72)
+- **Strict unknown-flag rejection helper, with `gate tail` as the
+  pilot caller.** `rejectUnknownFlags(args, known, verb)` lives in
+  `src/interface/shared/parseArgs.ts`. Verbs opt in individually;
+  `gate tail` now errors with a clear message (and lists the valid
+  flags for the verb) instead of silently ignoring a typo like
+  `gate tail --from noir`. Other verbs migrate in follow-up PRs —
+  the opt-in model is deliberate so existing invocations don't break
+  en masse. (PR #73)
+
 ### Changed
 - **README minimized; the repo's top-level surface is the entrance,
   and the entrance should be small.** README dropped from 478 to ~96

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -434,6 +434,13 @@ stays legible. Filters are intentionally omitted — tail is for
 "everything recent", and once you want to slice, switch to
 `gate voices` or `gate list`.
 
+**No-silent-ignore.** `gate tail` opts in to strict unknown-flag
+rejection: `gate tail --from noir` now errors (used to be silently
+dropped, because `--from` was never a tail flag). The error lists
+the valid flags for the verb so the fix is obvious. This is the
+pilot caller of `rejectUnknownFlags` in `parseArgs`; other verbs
+migrate one at a time so existing invocations don't break en masse.
+
 ### Whoami: session-start orientation
 
 `gate whoami` (requires `GUILD_ACTOR` in the environment) resolves
@@ -539,6 +546,15 @@ fully-spelled id; if you want all four chained, write them out in
 full in the note or review. This is a deliberate trade-off —
 range-parsing would grow the regex into something hard to audit
 for a tiny gain.
+
+**Preview without walking.** `gate show <id> --format text` ends
+with a **chain hint footer** that scans the same free-text fields
+and reports whether `gate chain <id>` will surface anything — either
+`"chain hint: no outbound id references detected"` or the list of
+referenced ids. The hint is read-time only; writers stay
+unconstrained. This is the nudge for writers who might otherwise
+discover the short-form gotcha (`(0004)` not counting as a
+reference) only when a reader can't follow the thread.
 
 ### Issue → Request promotion
 


### PR DESCRIPTION
## Summary

Align doc with code after PR #72 (show chain-hint footer) and #73 (strict unknown-flag rejection). README philosophy (small entrance, feature details in per-doc) is preserved — only `CHANGELOG.md` and `docs/verbs.md` are touched.

### CHANGELOG.md [Unreleased] — `### Added`

Two bullets for the merged work, each one paragraph with the PR number.

### docs/verbs.md

- **`### Chain`** → appended *"Preview without walking"* paragraph. Introduces `show --format text`'s chain-hint footer as the sibling of `chain` for cases where the reader wants a one-glance signal before invoking `chain`
- **`### Tail`** → appended *"No-silent-ignore"* paragraph. Makes the strict-rejection behaviour visible next to the "Filters are intentionally omitted" line it's consistent with

## What is NOT changed

- `README.md` — top-level entrance stays at ~96 lines, no feature-list growth
- `AGENT.md` — agent quick-ref; verb details defer to `verbs.md` already
- any source code or tests — doc-only PR, 454 tests still pass

🤖 Co-authored with Eris (Claude Opus 4.7, Three Hearts Space)