### PR TITLE
feat(args): strict flag rejection for all write verbs

### DIFF
--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -2,6 +2,7 @@ import {
   ParsedArgs,
   requireOption,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import {
   C,
@@ -12,6 +13,23 @@ import {
   resolveInvokedBy,
 } from './internal.js';
 
+const ISSUES_ADD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'severity',
+  'area',
+  'text',
+]);
+const ISSUES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['state']);
+const ISSUES_PROMOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'executor',
+  'auto-review',
+  'action',
+  'reason',
+]);
+const ISSUES_NOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['by', 'text']);
+const ISSUES_TRANSITION_KNOWN_FLAGS: ReadonlySet<string> = new Set([]);
+
 export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
   if (sub === 'promote') {
@@ -21,6 +39,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     return await issuesNote(c, args);
   }
   if (sub === 'add') {
+    rejectUnknownFlags(args, ISSUES_ADD_KNOWN_FLAGS, 'issues add');
     const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
     const severity = requireOption(args, 'severity', '--severity required');
     const area = requireOption(args, 'area', '--area required');
@@ -80,6 +99,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     return 0;
   }
   if (sub === 'list' || sub === undefined) {
+    rejectUnknownFlags(args, ISSUES_LIST_KNOWN_FLAGS, 'issues list');
     const state = optionalOption(args, 'state');
     const items = await c.issueUC.list(state);
     for (const i of items) {
@@ -105,6 +125,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   // State transitions: resolve, defer, start, reopen.
   const nextState = resolveIssueVerb(sub);
   if (nextState !== undefined) {
+    rejectUnknownFlags(args, ISSUES_TRANSITION_KNOWN_FLAGS, `issues ${sub}`);
     const id = args.positional[1];
     if (!id) throw new Error(`Usage: gate issues ${sub} <id>`);
     const issue = await c.issueUC.setState(id, nextState);
@@ -115,6 +136,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
 }
 
 async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, ISSUES_PROMOTE_KNOWN_FLAGS, 'issues promote');
   const id = args.positional[1];
   if (!id) {
     throw new Error(
@@ -195,6 +217,7 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
 }
 
 async function issuesNote(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, ISSUES_NOTE_KNOWN_FLAGS, 'issues note');
   // Issues are otherwise immutable by design: the original severity /
   // area / text freeze the first-frame record. A `note` is the
   // escape hatch for revised understanding — "severity should be med

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -2,6 +2,7 @@ import {
   ParsedArgs,
   requireOption,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import {
   C,
@@ -10,7 +11,24 @@ import {
   readStdin,
 } from './internal.js';
 
+const MESSAGE_SEND_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'to',
+  'text',
+  'type',
+]);
+const MESSAGE_BROADCAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'text',
+  'type',
+]);
+const INBOX_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'unread',
+]);
+
 export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, MESSAGE_SEND_KNOWN_FLAGS, 'message');
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const to = requireOption(args, 'to', '--to required');
   let text = requireOption(args, 'text', '--text required');
@@ -37,6 +55,7 @@ export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, MESSAGE_BROADCAST_KNOWN_FLAGS, 'broadcast');
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   let text = requireOption(args, 'text', '--text required');
   if (text === '-') text = (await readStdin()).trim();
@@ -74,11 +93,13 @@ export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
 export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
   // `gate inbox mark-read [N]` dispatches here too — the first
   // positional is treated as a subverb. This keeps the verb family
-  // under a single `inbox` namespace.
+  // under a single `inbox` namespace. mark-read has its own flag set
+  // (subset of INBOX_KNOWN_FLAGS), so the inner handler re-validates.
   if (args.positional[0] === 'mark-read') {
     return await msgInboxMarkRead(c, args);
   }
 
+  rejectUnknownFlags(args, INBOX_KNOWN_FLAGS, 'inbox');
   const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
   const unreadOnly = args.options['unread'] === true;
   const messages = await c.messageUC.inbox(forName);
@@ -114,7 +135,10 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+const INBOX_MARK_READ_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for']);
+
 async function msgInboxMarkRead(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, INBOX_MARK_READ_KNOWN_FLAGS, 'inbox mark-read');
   const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
   let index: number | undefined;
   const positional = args.positional[1]; // [0] is 'mark-read'

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -1,7 +1,20 @@
-import { ParsedArgs, optionalOption, requireOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { MemberName } from '../../../domain/member/MemberName.js';
 import { parseMemberCategory } from '../../../domain/member/MemberCategory.js';
+
+const REGISTER_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'name',
+  'category',
+  'display-name',
+  'dry-run',
+  'format',
+]);
 
 /**
  * gate register --name <n> [--category <c>] [--display-name <s>] [--dry-run] [--format json|text]
@@ -34,6 +47,7 @@ import { parseMemberCategory } from '../../../domain/member/MemberCategory.js';
  * host assignment an intentional, human-edited decision.
  */
 export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REGISTER_KNOWN_FLAGS, 'register');
   const name = requireOption(args, 'name', '--name required');
   const category = optionalOption(args, 'category') ?? 'professional';
   const displayName = optionalOption(args, 'display-name');

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -2,7 +2,66 @@ import {
   ParsedArgs,
   requireOption,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+
+// Known flags per write-verb. Silent-ignore of unknown flags (e.g.
+// `--executr noir` instead of `--executor noir`) would let a typo
+// slip through as "no executor assigned" with no error — the exact
+// fail-open class that `tail` already opts into. See
+// i-2026-04-22-0001 (hiroba) / devil review 2026-04-22-0001.
+const REQUEST_CREATE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'action',
+  'reason',
+  'executor',
+  'target',
+  'auto-review',
+  'with',
+  'format',
+]);
+const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'dry-run',
+  'format',
+]);
+const DENY_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'reason',
+  'note',
+  'dry-run',
+  'format',
+]);
+const EXECUTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'dry-run',
+  'format',
+]);
+const COMPLETE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'dry-run',
+  'format',
+]);
+const FAIL_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'reason',
+  'note',
+  'dry-run',
+  'format',
+]);
+const FAST_TRACK_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'from',
+  'action',
+  'reason',
+  'executor',
+  'auto-review',
+  'note',
+  'with',
+  'format',
+]);
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import {
@@ -17,6 +76,7 @@ import {
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REQUEST_CREATE_KNOWN_FLAGS, 'request');
   const from = requireOption(
     args,
     'from',
@@ -342,6 +402,7 @@ function formatRequestText(r: Request): string {
 }
 
 export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, APPROVE_KNOWN_FLAGS, 'approve');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate approve <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
@@ -372,6 +433,7 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, DENY_KNOWN_FLAGS, 'deny');
   const id = args.positional[0];
   const reason = await resolveReason(args, 'deny');
   if (!id || !reason) {
@@ -396,6 +458,7 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, EXECUTE_KNOWN_FLAGS, 'execute');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate execute <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
@@ -415,6 +478,7 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, COMPLETE_KNOWN_FLAGS, 'complete');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate complete <id> --by <m> [--dry-run]');
   const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
@@ -443,6 +507,7 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, FAIL_KNOWN_FLAGS, 'fail');
   const id = args.positional[0];
   const reason = await resolveReason(args, 'fail');
   if (!id || !reason) {
@@ -514,6 +579,7 @@ async function resolveReason(args: ParsedArgs, _verb: string): Promise<string> {
 }
 
 export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, FAST_TRACK_KNOWN_FLAGS, 'fast-track');
   const from = requireOption(args, 'from', '--from required', 'GUILD_ACTOR');
   const action = requireOption(args, 'action', '--action required');
   let reason = requireOption(args, 'reason', '--reason required');

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -2,6 +2,7 @@ import {
   ParsedArgs,
   requireOption,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import {
   C,
@@ -13,7 +14,17 @@ import {
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
+const REVIEW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'lense',
+  'verdict',
+  'comment',
+  'dry-run',
+  'format',
+]);
+
 export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REVIEW_KNOWN_FLAGS, 'review');
   const id = args.positional[0];
   if (!id) {
     throw new Error(

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -2,6 +2,7 @@ import {
   ParsedArgs,
   requireOption,
   optionalOption,
+  rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import {
   C,
@@ -11,6 +12,14 @@ import {
   emitDryRunPreview,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
+
+const THANK_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'by',
+  'reason',
+  'dry-run',
+  'format',
+]);
 
 /**
  * gate thank <to> --for <id> [--reason <s>] [--by <m>] [--dry-run]
@@ -29,6 +38,7 @@ import { emitWriteResponse, parseFormat } from './writeFormat.js';
  * stdin (symmetric with review --comment -).
  */
 export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, THANK_KNOWN_FLAGS, 'thank');
   const to = args.positional[0];
   if (!to) {
     throw new Error(

--- a/tests/interface/stdinSentinel.test.ts
+++ b/tests/interface/stdinSentinel.test.ts
@@ -245,6 +245,14 @@ test('gate issues add --text <value-starting-with--> surfaces the POSIX escape h
   // Same hint shape as `issues note` + `review`: when the user
   // passes a value that begins with "--", the parser refuses it and
   // the handler's fallback error points at the escape valves.
+  //
+  // The sentinel `--text` value here is `--severity` — another *known*
+  // flag, so strict unknown-flag rejection (see PR adding
+  // rejectUnknownFlags to all write verbs) does not short-circuit
+  // the handler before the escape-hint path runs. Using an unknown
+  // flag like `--reason` as the sentinel would fire the strict-reject
+  // guard first and never reach the hint; picking a known flag is
+  // deliberate so both guards stay testable independently.
   const { root, cleanup } = bootstrap();
   try {
     const { status, stderr } = runGate(
@@ -254,12 +262,11 @@ test('gate issues add --text <value-starting-with--> surfaces the POSIX escape h
         'add',
         '--from',
         'eris',
-        '--severity',
-        'low',
         '--area',
         'ux',
         '--text',
-        '--reason',
+        '--severity',
+        'low',
       ],
       { env: { GUILD_ACTOR: 'eris' } },
     );

--- a/tests/interface/writeVerbsStrictFlags.test.ts
+++ b/tests/interface/writeVerbsStrictFlags.test.ts
@@ -1,0 +1,302 @@
+// Strict unknown-flag rejection across all write verbs.
+//
+// Companion to `unknownFlagRejection.test.ts` (the helper + tail pilot).
+// This suite smoke-tests every write verb that opted into
+// rejectUnknownFlags in the follow-up PR, so a future verb that
+// forgets to call the helper shows up as a red line here.
+//
+// Pattern: for each verb, run a known-bad invocation (typo flag that
+// is NOT in the verb's known set), assert non-zero exit and an error
+// message naming the bad flag.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-write-strict-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function register(root: string, name: string) {
+  runGate(root, ['register', '--name', name, '--category', 'professional']);
+}
+
+type VerbCase = {
+  name: string;
+  args: string[];
+  bogus: string; // the unknown flag that should trigger rejection
+};
+
+const VERB_CASES: ReadonlyArray<VerbCase> = [
+  {
+    name: 'register',
+    args: ['register', '--name', 'alice', '--catgeory', 'professional'],
+    bogus: '--catgeory',
+  },
+  {
+    name: 'request',
+    args: [
+      'request',
+      '--from',
+      'alice',
+      '--action',
+      'x',
+      '--reason',
+      'y',
+      '--executr',
+      'alice',
+    ],
+    bogus: '--executr',
+  },
+  {
+    name: 'fast-track',
+    args: [
+      'fast-track',
+      '--from',
+      'alice',
+      '--action',
+      'x',
+      '--reason',
+      'y',
+      '--executr',
+      'alice',
+    ],
+    bogus: '--executr',
+  },
+  {
+    name: 'thank',
+    args: [
+      'thank',
+      'alice',
+      '--for',
+      '2026-04-22-0001',
+      '--reasn',
+      'thanks',
+      '--by',
+      'alice',
+    ],
+    bogus: '--reasn',
+  },
+  {
+    name: 'review',
+    args: [
+      'review',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--lense',
+      'devil',
+      '--verdict',
+      'ok',
+      '--commnt',
+      'LGTM',
+    ],
+    bogus: '--commnt',
+  },
+  {
+    name: 'message',
+    args: [
+      'message',
+      '--from',
+      'alice',
+      '--to',
+      'alice',
+      '--text',
+      'hi',
+      '--kind',
+      'info',
+    ],
+    bogus: '--kind',
+  },
+  {
+    name: 'broadcast',
+    args: [
+      'broadcast',
+      '--from',
+      'alice',
+      '--text',
+      'hi',
+      '--kind',
+      'info',
+    ],
+    bogus: '--kind',
+  },
+  {
+    name: 'inbox',
+    args: ['inbox', '--for', 'alice', '--unreadd'],
+    bogus: '--unreadd',
+  },
+  {
+    name: 'issues add',
+    args: [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'body',
+      '--priority',
+      'high',
+    ],
+    bogus: '--priority',
+  },
+  {
+    name: 'issues note',
+    args: [
+      'issues',
+      'note',
+      'i-2026-04-22-0001',
+      '--by',
+      'alice',
+      '--text',
+      'update',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'issues promote',
+    args: [
+      'issues',
+      'promote',
+      'i-2026-04-22-0001',
+      '--from',
+      'alice',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'approve',
+    args: [
+      'approve',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'deny',
+    args: [
+      'deny',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--reason',
+      'no',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'execute',
+    args: [
+      'execute',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'complete',
+    args: [
+      'complete',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+  {
+    name: 'fail',
+    args: [
+      'fail',
+      '2026-04-22-0001',
+      '--by',
+      'alice',
+      '--reason',
+      'nope',
+      '--bogus',
+      'x',
+    ],
+    bogus: '--bogus',
+  },
+];
+
+for (const vc of VERB_CASES) {
+  test(`gate ${vc.name} rejects unknown flag ${vc.bogus}`, (t) => {
+    const { root, cleanup } = bootstrap();
+    t.after(cleanup);
+    register(root, 'alice');
+    const r = runGate(root, vc.args);
+    assert.notEqual(r.status, 0, `exit should be non-zero for bogus flag`);
+    assert.match(
+      r.stderr,
+      new RegExp(`unknown flag[s]?.*${vc.bogus.replace('--', '\\-\\-')}`),
+      `stderr should name the bogus flag ${vc.bogus}`,
+    );
+    assert.match(r.stderr, /valid flags for/, 'stderr should list valid flags');
+  });
+}
+
+test('smoke: known-good invocations still work (register + request)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  register(root, 'alice');
+  const req = runGate(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'a',
+    '--reason',
+    'r',
+    '--executor',
+    'alice',
+  ]);
+  assert.equal(req.status, 0, `known-good request should succeed: ${req.stderr}`);
+});


### PR DESCRIPTION
## Summary

Closes the silent typo-ignore that PR #73 left open by design: `rejectUnknownFlags` now runs on every write verb, not just `gate tail`.

## Motivation

Devil review (hiroba `2026-04-22-0001`) flagged this as **Security H1**. Previously:

- `gate register --catgeory X` → silently registers with `category=professional` (default)
- `gate request --executr noir` → `executor` undefined, no error
- `gate thank --reasn "..."` → thank recorded with no reason

Same fail-open class as the `tail --from` case that prompted PR #73. Write verbs are where it hurts most — audit trail of the content_root breaks silently.

## Applied to

| Write verb | known flags |
|---|---|
| `register` | name / category / display-name / dry-run / format |
| `request` | from / action / reason / executor / target / auto-review / with / format |
| `approve` / `execute` / `complete` | by / note / dry-run / format |
| `deny` / `fail` | by / reason / note / dry-run / format |
| `fast-track` | from / action / reason / executor / auto-review / note / with / format |
| `review` | by / lense / verdict / comment / dry-run / format |
| `thank` | for / by / reason / dry-run / format |
| `message` / `broadcast` | from / to / text / type (to only on send) |
| `inbox` / `inbox mark-read` | for / unread / (for only on mark-read) |
| `issues add` | from / severity / area / text |
| `issues note` | by / text |
| `issues promote` | from / executor / auto-review / action / reason |
| `issues list` | state |
| `issues resolve` / `defer` / `start` / `reopen` | (no flags) |

## Design choices

- **Per-verb `const KNOWN_FLAGS = new Set([...])`** — one line per call site. No shared common set so diffs stay local and reviewable; common-set extraction can be a later refactor if churn shows up
- **Error message lists the valid flags** (inherited from the helper) — caller self-corrects without opening `--help`
- **`inbox` and `issues list` also opted in** — they have known flags too, and asymmetric opt-in would surprise users who assumed "read verbs are loose"

## Tests

+17 new (471 total, all passing):

- `tests/interface/writeVerbsStrictFlags.test.ts` — one test per verb for typo rejection + a known-good smoke test
- Existing `stdinSentinel.test.ts` `issues add --text <value-starting-with-->` updated to use `--severity` as the value-that-begins-with-dashes (a *known* flag, so strict-reject doesn't short-circuit the escape-hint path being tested)

## Related

- PR #73 (helper + tail pilot) — this is its stated follow-up
- Devil review in hiroba 2026-04-22-0001, issue i-2026-04-22-0001 (logged by eris in yori-code session)

🤖 Co-authored with Devil (THS devil agent) and Eris (Claude Opus 4.7)