### PR TITLE
feat(issue): audit trail via state_log (Sec H3, BREAKING)

### DIFF
--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -83,11 +83,17 @@ export class IssueUseCases {
     return sortIssues(await this.issues.listAll());
   }
 
-  async setState(id: string, state: string): Promise<Issue> {
+  async setState(
+    id: string,
+    state: string,
+    by: string,
+    invokedBy?: string,
+  ): Promise<Issue> {
+    await assertActor(by, '--by', this.members);
     const issueId = IssueId.of(id);
     const issue = await this.issues.findById(issueId);
     if (!issue) throw new DomainError(`Issue not found: ${id}`, 'id');
-    issue.setState(parseIssueState(state) as IssueState);
+    issue.setState(parseIssueState(state) as IssueState, by, invokedBy);
     await this.issues.save(issue);
     return issue;
   }

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -182,6 +182,25 @@ export interface IssueNote {
 }
 
 const MAX_NOTES = 50;
+const MAX_STATE_LOG = 100;
+
+/**
+ * One entry in an issue's state history. Each transition (open → resolved,
+ * resolved → open, etc.) appends one of these so the audit trail records
+ * both what changed and who changed it.
+ *
+ * Mirrors the `status_log` entry shape on Request (same fields: state,
+ * by, at, invoked_by) to keep the cross-entity mental model consistent.
+ * The difference is that Request's log covers create-through-terminal
+ * while Issue's covers only re-transitions after create (the create
+ * event itself is implicit in `createdAt` + `from`).
+ */
+export interface IssueStateLogEntry {
+  state: IssueState;
+  by: string;
+  at: string;
+  invokedBy?: string;
+}
 
 export interface IssueProps {
   id: IssueId;
@@ -193,6 +212,13 @@ export interface IssueProps {
   createdAt: string;
   /** Optional — historical YAML pre-dates notes; restore backfills []. */
   notes?: IssueNote[];
+  /**
+   * Optional — historical YAML pre-dates state_log; restore backfills
+   * []. Every `setState` call appends one entry, so the length of this
+   * array is the number of transitions the issue has taken since
+   * creation. The create event is implicit (not in the log).
+   */
+  stateLog?: IssueStateLogEntry[];
   /** See IssueNote.invokedBy — same invariant on the creation act. */
   invokedBy?: string;
 }
@@ -219,6 +245,7 @@ export class Issue {
       state: 'open',
       createdAt: input.createdAt ?? new Date().toISOString(),
       notes: [],
+      stateLog: [],
     };
     if (
       input.invokedBy !== undefined &&
@@ -237,9 +264,15 @@ export class Issue {
    * state, the operator must fix the YAML by hand.
    */
   static restore(props: IssueProps): Issue {
-    // Older on-disk issues have no `notes` array. Treat missing as
-    // empty so hydration of historical YAML keeps working.
-    return new Issue({ ...props, notes: props.notes ?? [] });
+    // Older on-disk issues have no `notes` or `state_log` arrays.
+    // Treat missing as empty so hydration of historical YAML keeps
+    // working. The missing state_log on legacy issues means their
+    // pre-upgrade transitions are lost — historical by design.
+    return new Issue({
+      ...props,
+      notes: props.notes ?? [],
+      stateLog: props.stateLog ?? [],
+    });
   }
 
   get id(): IssueId {
@@ -255,13 +288,34 @@ export class Issue {
     return this.props.text;
   }
 
-  setState(next: IssueState): void {
+  setState(next: IssueState, by: string, invokedBy?: string): void {
     assertIssueTransition(this.props.state, next);
+    const byName = MemberName.of(by).value;
     this.props.state = next;
+    if (!this.props.stateLog) this.props.stateLog = [];
+    if (this.props.stateLog.length >= MAX_STATE_LOG) {
+      throw new DomainError(
+        `Too many state transitions on ${this.props.id.value} (max ${MAX_STATE_LOG})`,
+        'state_log',
+      );
+    }
+    const entry: IssueStateLogEntry = {
+      state: next,
+      by: byName,
+      at: new Date().toISOString(),
+    };
+    if (invokedBy !== undefined && invokedBy !== byName) {
+      entry.invokedBy = invokedBy;
+    }
+    this.props.stateLog.push(entry);
   }
 
   get notes(): readonly IssueNote[] {
     return this.props.notes ?? [];
+  }
+
+  get stateLog(): readonly IssueStateLogEntry[] {
+    return this.props.stateLog ?? [];
   }
 
   addNote(
@@ -305,14 +359,29 @@ export class Issue {
     if (this.props.invokedBy !== undefined) {
       out['invoked_by'] = this.props.invokedBy;
     }
-    // Backward compat: omit the `notes` key when empty so pre-notes
-    // YAML stays byte-identical after a round-trip through restore/save.
+    // Backward compat: omit the `notes` / `state_log` keys when empty
+    // so pre-notes / pre-audit YAML stays byte-identical after a
+    // round-trip through restore/save.
     const notes = this.props.notes;
     if (notes && notes.length > 0) {
       out['notes'] = notes.map((n) => noteToJSON(n));
     }
+    const stateLog = this.props.stateLog;
+    if (stateLog && stateLog.length > 0) {
+      out['state_log'] = stateLog.map((e) => stateLogEntryToJSON(e));
+    }
     return out;
   }
+}
+
+function stateLogEntryToJSON(e: IssueStateLogEntry): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    state: e.state,
+    by: e.by,
+    at: e.at,
+  };
+  if (e.invokedBy !== undefined) out['invoked_by'] = e.invokedBy;
+  return out;
 }
 
 /**

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -4,6 +4,7 @@ import {
   IssueId,
   IssueNote,
   IssueState,
+  IssueStateLogEntry,
   parseIssueSeverity,
   parseIssueState,
 } from '../../domain/issue/Issue.js';
@@ -117,6 +118,7 @@ function hydrate(
       state: parseIssueState(String(obj['state'] ?? 'open')),
       createdAt: String(obj['created_at'] ?? new Date().toISOString()),
       notes: hydrateNotes(obj['notes'], source, onMalformed),
+      stateLog: hydrateStateLog(obj['state_log'], source, onMalformed),
     };
     if (typeof obj['invoked_by'] === 'string') {
       restoreInput.invokedBy = obj['invoked_by'];
@@ -161,6 +163,47 @@ function hydrateNotes(
     const note: IssueNote = { by, text, at };
     if (typeof r['invoked_by'] === 'string') note.invokedBy = r['invoked_by'];
     out.push(note);
+  }
+  return out;
+}
+
+function hydrateStateLog(
+  raw: unknown,
+  source: string,
+  onMalformed: OnMalformed,
+): IssueStateLogEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const out: IssueStateLogEntry[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const entry = raw[i];
+    if (!entry || typeof entry !== 'object') {
+      onMalformed(source, `state_log[${i}] is not a mapping; skipping`);
+      continue;
+    }
+    const r = entry as Record<string, unknown>;
+    const stateRaw = typeof r['state'] === 'string' ? r['state'] : '';
+    const by = typeof r['by'] === 'string' ? r['by'] : '';
+    const at = typeof r['at'] === 'string' ? r['at'] : '';
+    if (!stateRaw || !by || !at) {
+      onMalformed(
+        source,
+        `state_log[${i}] missing required fields (state/by/at); skipping`,
+      );
+      continue;
+    }
+    let state: IssueState;
+    try {
+      state = parseIssueState(stateRaw);
+    } catch {
+      onMalformed(
+        source,
+        `state_log[${i}] has unknown state "${stateRaw}"; skipping`,
+      );
+      continue;
+    }
+    const logEntry: IssueStateLogEntry = { state, by, at };
+    if (typeof r['invoked_by'] === 'string') logEntry.invokedBy = r['invoked_by'];
+    out.push(logEntry);
   }
   return out;
 }

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -106,9 +106,11 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const nextState = resolveIssueVerb(sub);
   if (nextState !== undefined) {
     const id = args.positional[1];
-    if (!id) throw new Error(`Usage: gate issues ${sub} <id>`);
-    const issue = await c.issueUC.setState(id, nextState);
-    process.stdout.write(`✓ issue ${issue.id.value}: → ${nextState}\n`);
+    if (!id) throw new Error(`Usage: gate issues ${sub} <id> --by <m>`);
+    const by = requireOption(args, 'by', '--by required', 'GUILD_ACTOR');
+    const invokedBy = resolveInvokedBy(by, `issues ${sub}`, id);
+    const issue = await c.issueUC.setState(id, nextState, by, invokedBy);
+    process.stdout.write(`✓ issue ${issue.id.value}: → ${nextState} by ${by}\n`);
     return 0;
   }
   throw new Error(`unknown issues sub: ${sub}`);
@@ -176,7 +178,7 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
     emitInvokedByNotice(from, invokedByPromote, 'issues promote', req.id.value);
   }
   try {
-    await c.issueUC.setState(id, 'resolved');
+    await c.issueUC.setState(id, 'resolved', from, invokedByPromote);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(

--- a/tests/domain/Issue.test.ts
+++ b/tests/domain/Issue.test.ts
@@ -64,20 +64,37 @@ test('assertIssueTransition throws DomainError on invalid transition', () => {
 
 test('Issue.setState enforces transition rules', () => {
   const i = mkIssue();
-  i.setState('in_progress');
+  i.setState('in_progress', 'alice');
   assert.equal(i.state, 'in_progress');
-  i.setState('resolved');
+  i.setState('resolved', 'alice');
   assert.equal(i.state, 'resolved');
   // resolved → in_progress is illegal
-  assert.throws(() => i.setState('in_progress'), DomainError);
+  assert.throws(() => i.setState('in_progress', 'alice'), DomainError);
   // resolved → open is legal (reopen)
-  i.setState('open');
+  i.setState('open', 'alice');
   assert.equal(i.state, 'open');
 });
 
 test('Issue.setState rejects same-state double-call', () => {
   const i = mkIssue();
-  assert.throws(() => i.setState('open'), DomainError);
+  assert.throws(() => i.setState('open', 'alice'), DomainError);
+});
+
+test('Issue.setState records a state_log entry per transition', () => {
+  const i = mkIssue();
+  assert.equal(i.stateLog.length, 0);
+  i.setState('in_progress', 'alice');
+  assert.equal(i.stateLog.length, 1);
+  assert.equal(i.stateLog[0]!.state, 'in_progress');
+  assert.equal(i.stateLog[0]!.by, 'alice');
+  assert.ok(i.stateLog[0]!.at, 'at should be ISO timestamp');
+  // invokedBy defaults to undefined when by === invokedBy
+  assert.equal(i.stateLog[0]!.invokedBy, undefined);
+
+  i.setState('resolved', 'bob', 'alice'); // ghost transition: bob acting on alice's behalf
+  assert.equal(i.stateLog.length, 2);
+  assert.equal(i.stateLog[1]!.by, 'bob');
+  assert.equal(i.stateLog[1]!.invokedBy, 'alice');
 });
 
 test('Issue.restore bypasses transition validation (historical truth)', () => {
@@ -95,7 +112,7 @@ test('Issue.restore bypasses transition validation (historical truth)', () => {
   });
   assert.equal(i.state, 'resolved');
   // But *new* transitions from that state must still follow the rules.
-  assert.throws(() => i.setState('deferred'), DomainError);
+  assert.throws(() => i.setState('deferred', 'alice'), DomainError);
 });
 
 // ── parseIssueSeverity — canonical + aliases + rejects ──

--- a/tests/interface/issueStateAuditTrail.test.ts
+++ b/tests/interface/issueStateAuditTrail.test.ts
@@ -1,0 +1,213 @@
+// Issue state transitions record an audit trail (state_log).
+//
+// Pre-fix: `gate issues resolve/defer/start/reopen` set `state` in
+// place with no record of who did it or when. open → resolved →
+// open → resolved was indistinguishable from a single open → resolved
+// in the YAML. Forensics was impossible.
+//
+// Fix: every transition appends one `state_log` entry: {state, by, at,
+// invoked_by?}. The `--by` flag (or GUILD_ACTOR) is now required.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import YAML from 'yaml';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-issue-audit-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function issueFilename(root: string): string {
+  // Issues are stored under issues/<id>.yaml; find the first one.
+  const issuesDir = join(root, 'issues');
+  const dir = require('node:fs').readdirSync(issuesDir);
+  const yml = dir.find((f: string) => f.endsWith('.yaml'));
+  return yml ? join(issuesDir, yml) : '';
+}
+
+test('issues resolve writes a state_log entry with by + at', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const add = runGate(
+    root,
+    [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'test issue',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(add.status, 0);
+  const idMatch = add.stdout.match(/i-\d{4}-\d{2}-\d{2}-\d+/);
+  assert.ok(idMatch, 'issue id should be emitted');
+  const id = idMatch[0];
+
+  const resolve_ = runGate(
+    root,
+    ['issues', 'resolve', id, '--by', 'alice'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(resolve_.status, 0);
+  assert.match(resolve_.stdout, /→ resolved by alice/);
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const parsed = YAML.parse(readFileSync(yml, 'utf8'));
+  assert.equal(parsed.state, 'resolved');
+  assert.ok(Array.isArray(parsed.state_log), 'state_log should exist');
+  assert.equal(parsed.state_log.length, 1);
+  assert.equal(parsed.state_log[0].state, 'resolved');
+  assert.equal(parsed.state_log[0].by, 'alice');
+  assert.ok(parsed.state_log[0].at, 'at should be set');
+});
+
+test('issues resolve → reopen → resolve records all 3 transitions', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const add = runGate(
+    root,
+    [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'flapping issue',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const id = add.stdout.match(/i-\d{4}-\d{2}-\d{2}-\d+/)![0];
+  runGate(root, ['issues', 'resolve', id, '--by', 'alice'], {
+    GUILD_ACTOR: 'alice',
+  });
+  runGate(root, ['issues', 'reopen', id, '--by', 'alice'], {
+    GUILD_ACTOR: 'alice',
+  });
+  runGate(root, ['issues', 'resolve', id, '--by', 'alice'], {
+    GUILD_ACTOR: 'alice',
+  });
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const parsed = YAML.parse(readFileSync(yml, 'utf8'));
+  assert.equal(parsed.state, 'resolved');
+  assert.equal(parsed.state_log.length, 3);
+  assert.equal(parsed.state_log[0].state, 'resolved');
+  assert.equal(parsed.state_log[1].state, 'open');
+  assert.equal(parsed.state_log[2].state, 'resolved');
+  // Without state_log, all three of these transitions would be lost
+  // — only the final state=resolved would remain visible.
+});
+
+test('issues resolve requires --by or GUILD_ACTOR', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const add = runGate(
+    root,
+    [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'x',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const id = add.stdout.match(/i-\d{4}-\d{2}-\d{2}-\d+/)![0];
+  // No --by, no GUILD_ACTOR → must fail loudly
+  const r = runGate(root, ['issues', 'resolve', id]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--by/);
+});
+
+test('legacy issue YAML without state_log still loads (backward compat)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Hand-write a legacy issue (no state_log field) and show/list it.
+  mkdirSync(join(root, 'issues'));
+  const legacy = {
+    id: 'i-2026-04-20-0001',
+    from: 'alice',
+    severity: 'low',
+    area: 'ux',
+    text: 'legacy issue predating audit trail',
+    state: 'open',
+    created_at: '2026-04-20T00:00:00Z',
+  };
+  writeFileSync(
+    join(root, 'issues', 'i-2026-04-20-0001.yaml'),
+    YAML.stringify(legacy),
+  );
+  const list = runGate(root, ['issues', 'list']);
+  assert.equal(list.status, 0);
+  assert.match(list.stdout, /i-2026-04-20-0001/);
+
+  // A transition on a legacy issue should start its state_log at [].
+  const resolve_ = runGate(
+    root,
+    ['issues', 'resolve', 'i-2026-04-20-0001', '--by', 'alice'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(resolve_.status, 0);
+  const parsed = YAML.parse(
+    readFileSync(join(root, 'issues', 'i-2026-04-20-0001.yaml'), 'utf8'),
+  );
+  assert.equal(parsed.state, 'resolved');
+  assert.equal(parsed.state_log.length, 1, 'one entry: the resolve we just did');
+  assert.equal(parsed.state_log[0].state, 'resolved');
+  assert.equal(parsed.state_log[0].by, 'alice');
+});


### PR DESCRIPTION
## Summary

Closes **Security H3** from the devil review (hiroba `2026-04-22-0001`). Issue state transitions (`open ↔ in_progress ↔ deferred ↔ resolved`) previously mutated `state` in place with **no audit trail**: `open → resolved → open → resolved` looked identical to a single `open → resolved` after the fact.

Adds a `state_log` array (mirroring `status_log` on Request) so every transition records `{ state, by, at, invoked_by? }`.

## Breaking changes (policy 0.x strict-variant minor bump)

- **`Issue.setState(next)` → `Issue.setState(next, by, invokedBy?)`**
- **`IssueUseCases.setState(id, state)` → `setState(id, state, by, invokedBy?)`**
- **`gate issues resolve / defer / start / reopen` now require `--by <m>` (or `GUILD_ACTOR`)**

Existing YAML files without `state_log` load cleanly (hydrated as `[]`); legacy pre-upgrade transitions are not retroactively reconstructed, which is the designed trade-off — state_log only covers transitions from upgrade onward.

## What gets recorded

Every transition appends:

```yaml
state_log:
  - state: resolved
    by: alice
    at: 2026-04-22T11:00:00.000Z
  - state: open
    by: alice
    at: 2026-04-22T11:05:00.000Z
    invoked_by: bob   # stamped only when GUILD_ACTOR differs from --by
```

Max 100 entries per issue (matching Request's pragmatic ceiling on mutation history).

## Backward compat

- Legacy issue YAML (no `state_log` field) hydrates as `stateLog: []`
- `toJSON` omits `state_log` key when empty → **byte-identical output** for issues that haven't transitioned yet
- `issues promote` still works (emits a transition by the promoter)
- `issues list` still works (legacy + new both shown)

## Tests

+5 new (459 total, all passing):

- `tests/domain/Issue.test.ts` — setState records state_log, invoked_by handling, existing transition-rule tests updated to pass the `by` param
- `tests/interface/issueStateAuditTrail.test.ts` — E2E:
  - `issues resolve` writes state_log entry with by + at
  - `resolve → reopen → resolve` records all 3 transitions (the forensics case)
  - `issues resolve` without `--by` / `GUILD_ACTOR` fails loudly
  - Legacy issue YAML loads, first post-upgrade transition starts state_log at length 1

## Related

- Devil review in hiroba `2026-04-22-0001` → issue `i-2026-04-22-0003`
- MEMORY.md "静かに壊れる >> 派手に壊れる" trap — state-flip-without-trace is exactly that class
- Pairs with `Request.status_log` (symmetry)

🤖 Co-authored with Devil (THS devil agent) and Eris (Claude Opus 4.7)