### PR TITLE
feat: Issue repo CAS (C1) + repair/doctor strict flag (C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **Issue repository now uses atomic write + optimistic-lock CAS.**
+  `YamlIssueRepository.save` writes via `writeTextSafeAtomic` and
+  rejects concurrent mutations with a new `IssueVersionConflict`
+  (parallel to `RequestVersionConflict` and `InboxVersionConflict`).
+  Closes the asymmetry where Request and Inbox were locked but Issue
+  was last-writer-wins — which had self-defeated the state_log
+  append-only invariant when two `gate issues resolve / note` calls
+  raced. Version counter = `state_log.length + notes.length`
+  (monotonic, append-only domain operations). Legacy issues still
+  hydrate cleanly; the first save after upgrade follows the new path.
+- **`gate repair` and `gate doctor` join the strict-flag rejection
+  set.** Typos like `gate repair --aply` (which used to silently
+  stay in dry-run) or `gate doctor --summry` (which used to show
+  the full report instead of the summary) now error with the valid
+  flag list. Brings these two verbs into parity with the write-verb
+  suite shipped earlier.
+
 ### BREAKING
 - **`gate issues resolve` / `defer` / `start` / `reopen` now require
   `--by <m>` (or `GUILD_ACTOR`).** Issue state transitions now append

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,8 @@ write access to `content_root`".
   Applies to: `register`, `request`, `approve`, `deny`, `execute`,
   `complete`, `fail`, `fast-track`, `review`, `thank`, `message`,
   `broadcast`, `inbox`, `inbox mark-read`, `issues add|list|note|
-  promote|resolve|defer|start|reopen`, and `tail` (read verb, pilot).
+  promote|resolve|defer|start|reopen`, `repair`, and — among
+  read-only verbs — `tail` and `doctor`.
 - **Denial-of-service caps** — directory listings (1000), reviews (50
   per request), status log (100 per request), issue state log (100
   per issue), inbox messages (500 per member).
@@ -76,15 +77,13 @@ write access to `content_root`".
   does not independently guard against prototype keys.
 - **Concurrent writes.** There is no lock file. Two simultaneous
   writes on the same record have a last-writer-wins race unless
-  optimistic-lock detection (`RequestVersionConflict` or
-  `InboxVersionConflict`) catches the second write's stale read —
-  which covers **most** concurrent mutations but is not a full
-  serialization barrier. Request and Inbox are covered; **Issue**
-  `save()` is not yet covered and has an outstanding follow-up
-  (tracked as an issue in the consumer's content_root); until then,
-  an `open → resolved → open → resolved` race could collapse one
-  `state_log` entry. Serialize at the caller for critical operations
-  on any record.
+  optimistic-lock detection catches the second write's stale read —
+  `RequestVersionConflict`, `InboxVersionConflict`, and
+  `IssueVersionConflict` each cover their own record class. This
+  catches **most** concurrent mutations but is not a full
+  serialization barrier (the CAS window between re-read and
+  atomic-rename is non-zero). Serialize at the caller for critical
+  operations on any record.
 
 ## Reporting
 

--- a/src/application/ports/IssueRepository.ts
+++ b/src/application/ports/IssueRepository.ts
@@ -26,3 +26,31 @@ export class IssueIdCollision extends Error {
     this.name = 'IssueIdCollision';
   }
 }
+
+/**
+ * Thrown when a concurrent writer advanced the on-disk version of
+ * an issue between the moment we loaded it and the moment we tried
+ * to save it back. Parallels `RequestVersionConflict` and
+ * `InboxVersionConflict` — same optimistic-lock pattern, one
+ * invariant per record class.
+ *
+ * Before this existed, two concurrent `gate issues resolve` /
+ * `gate issues note` calls could last-writer-wins, dropping the
+ * earlier state_log entry or note silently — which self-defeats
+ * the Issue audit trail invariant that state_log is append-only.
+ */
+export class IssueVersionConflict extends Error {
+  readonly code = 'ISSUE_VERSION_CONFLICT' as const;
+  constructor(
+    readonly id: string,
+    readonly expected: number,
+    readonly found: number,
+  ) {
+    super(
+      `issue ${id} was modified concurrently ` +
+        `(expected version ${expected}, found ${found}). ` +
+        `Re-run the command to retry.`,
+    );
+    this.name = 'IssueVersionConflict';
+  }
+}

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -215,7 +215,21 @@ export interface IssueProps {
 }
 
 export class Issue {
-  private constructor(private props: IssueProps) {}
+  private constructor(
+    private props: IssueProps,
+    private readonly _loadedVersion: number,
+  ) {}
+
+  /**
+   * Optimistic-lock snapshot of total mutation count at load time.
+   * New issues are `0` (no on-disk predecessor). Restore computes it
+   * from the in-file state_log + notes lengths. The repository
+   * compares this against the value recomputed from disk right before
+   * save, mirroring the Request / Inbox CAS pattern.
+   */
+  get loadedVersion(): number {
+    return this._loadedVersion;
+  }
 
   static create(input: {
     id: IssueId;
@@ -244,7 +258,8 @@ export class Issue {
     ) {
       props.invokedBy = input.invokedBy;
     }
-    return new Issue(props);
+    // Fresh issue — no predecessor on disk. version 0 is "never seen".
+    return new Issue(props, 0);
   }
 
   /**
@@ -259,11 +274,13 @@ export class Issue {
     // Treat missing as empty so hydration of historical YAML keeps
     // working. The missing state_log on legacy issues means their
     // pre-upgrade transitions are lost — historical by design.
-    return new Issue({
-      ...props,
-      notes: props.notes ?? [],
-      stateLog: props.stateLog ?? [],
-    });
+    const notes = props.notes ?? [];
+    const stateLog = props.stateLog ?? [];
+    // loadedVersion = total mutation count at load time. Same
+    // motivation as Request.computeVersion: catching two concurrent
+    // mutations that both grow the issue from the same snapshot.
+    const loadedVersion = computeIssueVersion(stateLog.length, notes.length);
+    return new Issue({ ...props, notes, stateLog }, loadedVersion);
   }
 
   get id(): IssueId {
@@ -363,6 +380,24 @@ export class Issue {
     }
     return out;
   }
+}
+
+/**
+ * Total mutation count for the optimistic-lock version on Issue.
+ * state_log grows by one per transition; notes grow by one per
+ * `addNote`. Both are append-only in the domain, so their sum is a
+ * monotonic "how many times has this issue been touched after
+ * create" — exactly what the CAS needs to detect a concurrent
+ * mutation. Create is the implicit 0-th event (not in either array).
+ *
+ * Exported so the repository can recompute the same value without
+ * hydrating a full Issue object, keeping the CAS path cheap.
+ */
+export function computeIssueVersion(
+  stateLogLen: number,
+  notesLen: number,
+): number {
+  return stateLogLen + notesLen;
 }
 
 function stateLogEntryToJSON(e: IssueStateLogEntry): Record<string, unknown> {

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -5,6 +5,7 @@ import {
   IssueNote,
   IssueState,
   IssueStateLogEntry,
+  computeIssueVersion,
   parseIssueSeverity,
   parseIssueState,
 } from '../../domain/issue/Issue.js';
@@ -12,12 +13,14 @@ import { MemberName } from '../../domain/member/MemberName.js';
 import {
   IssueRepository,
   IssueIdCollision,
+  IssueVersionConflict,
 } from '../../application/ports/IssueRepository.js';
 import {
   existsSafe,
   listDirSafe,
   readTextSafe,
   writeTextSafe,
+  writeTextSafeAtomic,
 } from './safeFs.js';
 import { join } from 'node:path';
 import { GuildConfig } from '../config/GuildConfig.js';
@@ -62,8 +65,38 @@ export class YamlIssueRepository implements IssueRepository {
 
   async save(issue: Issue): Promise<void> {
     const rel = `${issue.id.value}.yaml`;
+    // Optimistic-lock CAS: right before the atomic write, re-read the
+    // on-disk state_log + notes lengths and compare against the value
+    // we loaded. Concurrent writers detect each other this way. The
+    // window between re-read and rename is small but non-zero — same
+    // trade-off as Request / Inbox repositories.
+    //
+    // Unlike YamlRequestRepository, there is no loadedVersion===0
+    // guard here: Request uses that sentinel for "fresh vs loaded"
+    // because its mutation count (status_log.length) starts at 1 on
+    // create. Issue's starts at 0 (empty state_log AND empty notes),
+    // so 0 is a legitimate load result for a just-saved issue that
+    // has never been mutated. saveNew's EEXIST check is the actual
+    // collision gate for the create path.
+    if (existsSafe(this.config.paths.issues, rel)) {
+      const rawCheck = readTextSafe(this.config.paths.issues, rel);
+      const absCheck = join(this.config.paths.issues, rel);
+      const parsedCheck = parseYamlSafe(
+        rawCheck,
+        absCheck,
+        this.config.onMalformed,
+      );
+      const onDiskVersion = readIssueVersion(parsedCheck);
+      if (onDiskVersion !== issue.loadedVersion) {
+        throw new IssueVersionConflict(
+          issue.id.value,
+          issue.loadedVersion,
+          onDiskVersion,
+        );
+      }
+    }
     const text = YAML.stringify(issue.toJSON());
-    writeTextSafe(this.config.paths.issues, rel, text);
+    writeTextSafeAtomic(this.config.paths.issues, rel, text);
   }
 
   async saveNew(issue: Issue): Promise<void> {
@@ -206,4 +239,23 @@ function hydrateStateLog(
     out.push(logEntry);
   }
   return out;
+}
+
+/**
+ * Read the total mutation count from raw parsed YAML using the same
+ * `computeIssueVersion` invariant the domain uses. Defined here (not
+ * just on Issue) so the repository can compare on-disk state without
+ * hydrating a full Issue — a malformed or torn file returns 0, forcing
+ * the caller to reload rather than proceed on incomplete data.
+ *
+ * Mirrors `readVersion` in YamlRequestRepository.ts.
+ */
+function readIssueVersion(parsed: unknown): number {
+  if (!parsed || typeof parsed !== 'object') return 0;
+  const obj = parsed as Record<string, unknown>;
+  const stateLogLen = Array.isArray(obj['state_log'])
+    ? obj['state_log'].length
+    : 0;
+  const notesLen = Array.isArray(obj['notes']) ? obj['notes'].length : 0;
+  return computeIssueVersion(stateLogLen, notesLen);
 }

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -1,10 +1,23 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C, warnIfMisconfiguredCwd } from './internal.js';
 import {
   DiagnosticReport,
   DiagnosticAreaSummary,
   DiagnosticFinding,
 } from '../../../domain/diagnostic/DiagnosticReport.js';
+
+// `gate doctor` is read-only but still benefits from strict-reject:
+// `--summry` or `--formt json` typos would silently fall through to
+// defaults, giving the caller an unfiltered report when they asked
+// for the summary view. Consistent with tail's rationale.
+const DOCTOR_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'format',
+  'summary',
+]);
 
 // gate doctor — read-only diagnostic over the guild content root.
 //
@@ -20,6 +33,7 @@ import {
 // principle of separating observation from intervention.
 
 export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, DOCTOR_KNOWN_FLAGS, 'doctor');
   const report = await c.diagnosticUC.run();
   const format = optionalOption(args, 'format') ?? 'text';
   const summaryOnly =

--- a/src/interface/gate/handlers/repair.ts
+++ b/src/interface/gate/handlers/repair.ts
@@ -11,8 +11,22 @@
 
 import { readFileSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C, readStdin } from './internal.js';
+
+// `gate repair` is a write verb (`--apply` can move files into
+// quarantine). Strict-reject typos to prevent silent fall-through
+// to dry-run when the caller intended to apply — `--aply` without
+// rejection would look successful but do nothing.
+const REPAIR_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'apply',
+  'format',
+  'from-doctor',
+]);
 import {
   DiagnosticFinding,
   DiagnosticArea,
@@ -38,6 +52,7 @@ const VALID_KINDS: ReadonlySet<DiagnosticKind> = new Set([
 ]);
 
 export async function repairCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REPAIR_KNOWN_FLAGS, 'repair');
   const apply = args.options['apply'] === true;
   const format = optionalOption(args, 'format') ?? 'text';
   const fromPath = optionalOption(args, 'from-doctor');

--- a/tests/infrastructure/YamlIssueRepositoryConcurrency.test.ts
+++ b/tests/infrastructure/YamlIssueRepositoryConcurrency.test.ts
@@ -1,0 +1,152 @@
+// Issue concurrency: save() uses atomic write + version CAS so two
+// concurrent `gate issues resolve` or `gate issues note` calls can't
+// silently drop each other's state_log / notes entries.
+//
+// Companion to YamlRequestRepository (RequestVersionConflict) and
+// FsInboxNotification (InboxVersionConflict) — same optimistic-lock
+// pattern, one invariant per record class.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import YAML from 'yaml';
+import { YamlIssueRepository } from '../../src/infrastructure/persistence/YamlIssueRepository.js';
+import {
+  Issue,
+  IssueId,
+} from '../../src/domain/issue/Issue.js';
+import { IssueVersionConflict } from '../../src/application/ports/IssueRepository.js';
+import { GuildConfig } from '../../src/infrastructure/config/GuildConfig.js';
+
+function bootstrap(): {
+  repo: YamlIssueRepository;
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'guild-issue-concur-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'issues'));
+  const config = GuildConfig.load(root);
+  const repo = new YamlIssueRepository(config);
+  return { repo, root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const d = new Date('2026-04-22T00:00:00Z');
+
+async function seedIssue(repo: YamlIssueRepository): Promise<Issue> {
+  const id = IssueId.generate(d, 1);
+  const i = Issue.create({
+    id,
+    from: 'alice',
+    severity: 'low',
+    area: 'ux',
+    text: 'seed',
+  });
+  await repo.saveNew(i);
+  return i;
+}
+
+test('save() atomic write: uses temp+rename (no torn reads from a partial write)', async (t) => {
+  const { repo, root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const seeded = await seedIssue(repo);
+  // Load a fresh instance so loadedVersion is set from disk state.
+  const loaded = await repo.findById(seeded.id);
+  assert.ok(loaded);
+  loaded!.setState('in_progress', 'alice');
+  await repo.save(loaded!);
+  const parsed = YAML.parse(
+    readFileSync(join(root, 'issues', `${seeded.id.value}.yaml`), 'utf8'),
+  );
+  assert.equal(parsed.state, 'in_progress');
+  assert.equal(parsed.state_log.length, 1);
+});
+
+test('save() throws IssueVersionConflict when on-disk grew since load', async (t) => {
+  const { repo, root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const seeded = await seedIssue(repo);
+
+  // Two readers both load at version=0.
+  const reader1 = await repo.findById(seeded.id);
+  const reader2 = await repo.findById(seeded.id);
+  assert.ok(reader1 && reader2);
+
+  // reader1 transitions first → disk now at version=1.
+  reader1!.setState('in_progress', 'alice');
+  await repo.save(reader1!);
+
+  // reader2 still has the stale snapshot (loadedVersion=0). Its next
+  // save should detect the concurrent mutation and throw.
+  reader2!.setState('resolved', 'alice');
+  await assert.rejects(
+    () => repo.save(reader2!),
+    (e: unknown) =>
+      e instanceof IssueVersionConflict &&
+      e.expected === 0 &&
+      e.found === 1,
+  );
+});
+
+test('addNote race: two noters with stale load also conflict', async (t) => {
+  const { repo, cleanup } = bootstrap();
+  t.after(cleanup);
+  const seeded = await seedIssue(repo);
+
+  const r1 = await repo.findById(seeded.id);
+  const r2 = await repo.findById(seeded.id);
+  assert.ok(r1 && r2);
+
+  r1!.addNote('alice', 'first note');
+  await repo.save(r1!);
+
+  r2!.addNote('bob', 'concurrent note');
+  await assert.rejects(
+    () => repo.save(r2!),
+    (e: unknown) =>
+      e instanceof IssueVersionConflict &&
+      e.expected === 0 &&
+      e.found === 1,
+  );
+});
+
+test('computeIssueVersion: state_log + notes sum is monotonic', async (t) => {
+  const { repo, cleanup } = bootstrap();
+  t.after(cleanup);
+  const seeded = await seedIssue(repo);
+
+  let loaded = await repo.findById(seeded.id);
+  assert.equal(loaded!.loadedVersion, 0);
+
+  loaded!.setState('in_progress', 'alice');
+  await repo.save(loaded!);
+
+  loaded = await repo.findById(seeded.id);
+  assert.equal(loaded!.loadedVersion, 1, 'state_log bump = +1');
+
+  loaded!.addNote('alice', 'note 1');
+  await repo.save(loaded!);
+
+  loaded = await repo.findById(seeded.id);
+  assert.equal(loaded!.loadedVersion, 2, 'notes bump = +1 more');
+});
+
+test('IssueVersionConflict error shape', () => {
+  const err = new IssueVersionConflict('i-2026-04-22-0001', 1, 2);
+  assert.equal(err.code, 'ISSUE_VERSION_CONFLICT');
+  assert.equal(err.name, 'IssueVersionConflict');
+  assert.match(err.message, /expected version 1/);
+  assert.match(err.message, /found 2/);
+  assert.match(err.message, /Re-run/);
+});

--- a/tests/interface/writeVerbsStrictFlags.test.ts
+++ b/tests/interface/writeVerbsStrictFlags.test.ts
@@ -265,6 +265,20 @@ const VERB_CASES: ReadonlyArray<VerbCase> = [
     ],
     bogus: '--bogus',
   },
+  {
+    // `gate repair --apply` moves files to quarantine; typos like
+    // `--aply` used to silently fall through to default dry-run.
+    name: 'repair',
+    args: ['repair', '--aply'],
+    bogus: '--aply',
+  },
+  {
+    // `gate doctor` is read-only but strict-rejects anyway so a
+    // `--summry` typo doesn't quietly show the full view.
+    name: 'doctor',
+    args: ['doctor', '--summry'],
+    bogus: '--summry',
+  },
 ];
 
 for (const vc of VERB_CASES) {


### PR DESCRIPTION
## Summary

Closes the two concerns devil left open after PR #81 by design (hiroba `2026-04-22-0002` review): C1 (Issue last-writer-wins) and C2 (repair/doctor not in strict-flag set).

## C1 — Issue repository optimistic-lock (`i-2026-04-22-0006`)

**Problem**: Request and Inbox both use `writeTextSafeAtomic` + version CAS, but Issue's `save()` used plain `writeTextSafe` with no lock. Two concurrent `gate issues resolve` or `gate issues note` calls race to last-writer-wins, silently dropping one side's `state_log` entry — self-defeating the append-only audit trail invariant H3 shipped.

**Fix**:
- `YamlIssueRepository.save`: `writeTextSafeAtomic` + CAS on `computeIssueVersion(state_log.length, notes.length)`
- New `IssueVersionConflict` in `application/ports/IssueRepository.ts` (parallel to `RequestVersionConflict` / `InboxVersionConflict`)
- `Issue.loadedVersion` getter + `computeIssueVersion` helper so the repo can recompute on-disk version without hydrating

Design note: no `loadedVersion===0` guard on save (unlike Request). Issue's counter starts at 0 on create, so 0 is a legitimate loaded version after a fresh save. `saveNew`'s `wx` EEXIST check remains the collision gate for the create path.

## C2 — repair / doctor strict flag (`i-2026-04-22-0007`)

**Problem**: PR #76 claimed "all write verbs reject unknown flags" but `gate repair` (write via `--apply`) and `gate doctor` (read) were never added. `gate repair --aply` silently fell through to dry-run (no quarantine); `gate doctor --summry` showed the full report instead of the summary.

**Fix**: Both opt in to `rejectUnknownFlags` with their known sets (`{apply, format, from-doctor}` / `{format, summary}`).

## Tests

+7 new (**488 total**, all passing):

- `tests/infrastructure/YamlIssueRepositoryConcurrency.test.ts`:
  - atomic write
  - CAS conflict on concurrent `resolve` (state_log race)
  - CAS conflict on concurrent `addNote` (notes race)
  - version monotonicity (state_log += 1, notes += 1)
  - error shape (`code`, `message`, `name`)
- `tests/interface/writeVerbsStrictFlags.test.ts`:
  - `gate repair --aply` rejected
  - `gate doctor --summry` rejected

## Docs

- `CHANGELOG.md [Unreleased] ### Added`: Issue CAS + repair/doctor strict flag
- `SECURITY.md` Invariants:
  - "Strict CLI flag validation" list extended with `repair`, `doctor`
  - "Concurrent writes" note: Issue now covered; the "follow-up pending" caveat PR #81 had to write has been **removed** (devil's C1 closed)

## Follow-ups that intentionally stay open

- `i-2026-04-22-0008` — MEMORY trap ("merge-time known-flag合流") as low-priority insight
- C3 / C4 from devil 2026-04-22-0002 (test surface, broadcast catch) as low-priority track items

## Related

- devil review hiroba `2026-04-22-0002`
- PR #81 shipped H1-H3 + Refactor H1-H2; this is the promised follow-up
- MEMORY.md "SOT分散=必ず事故る" — the Issue asymmetry was exactly that; now symmetrical

🤖 Co-authored with Devil (THS devil agent) and Eris (Claude Opus 4.7)