### PR TITLE
feat(inbox): retry-once on InboxVersionConflict inside post/markRead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`FsInboxNotification.post` / `markRead` retry once on
+  `InboxVersionConflict`.** When a concurrent writer advances the
+  on-disk version between our read and the CAS check, the first
+  attempt throws; the retry re-reads the now-advanced file and
+  commits on top. Safe because post is append-only (order may
+  shift but side-effects don't duplicate) and markRead is
+  idempotent (already-read entries stay read). Two consecutive
+  conflicts still bubble up so a three-or-more simultaneous-writer
+  scenario surfaces to the caller instead of looping forever.
+  Closes devil's C4 on hiroba `2026-04-22-0002`. (PR #84)
+
 - **Issue repository now uses atomic write + optimistic-lock CAS.**
   `YamlIssueRepository.save` writes via `writeTextSafeAtomic` and
   rejects concurrent mutations with a new `IssueVersionConflict`

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -43,6 +43,29 @@ export class FsInboxNotification implements NotificationPort {
   constructor(private readonly config: GuildConfig) {}
 
   async post(n: Notification): Promise<void> {
+    // post is append-only: each attempt reads the latest on-disk
+    // version, appends the new entry, and CAS-writes. If a concurrent
+    // writer advanced the file between our read and the CAS check,
+    // the first attempt throws InboxVersionConflict — retry once
+    // after re-reading. A second conflict means three+ simultaneous
+    // writers; bubble up to the caller with the actionable message.
+    //
+    // Retry is safe here specifically because post is commutative
+    // (appending a new message after another append produces the
+    // same union, just with a different timestamp order, which is
+    // how `at` timestamps already handle it).
+    try {
+      await this._postOnce(n);
+    } catch (e) {
+      if (e instanceof InboxVersionConflict) {
+        await this._postOnce(n);
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private async _postOnce(n: Notification): Promise<void> {
     const rel = `${n.to.value}.yaml`;
     const { file, version: loadedVersion } = this.readWithVersion(rel);
     const entry: Record<string, unknown> = {
@@ -75,6 +98,27 @@ export class FsInboxNotification implements NotificationPort {
   }
 
   async markRead(
+    member: MemberName,
+    readAt: string,
+    readBy: string,
+    index?: number,
+  ): Promise<MarkReadResult> {
+    // Same retry rationale as post(): markRead is idempotent
+    // (already-read entries stay read), so a second attempt against
+    // a post-concurrent-write version is safe — entries the other
+    // writer added aren't flagged as read by us, the ones we already
+    // flagged stay flagged.
+    try {
+      return await this._markReadOnce(member, readAt, readBy, index);
+    } catch (e) {
+      if (e instanceof InboxVersionConflict) {
+        return await this._markReadOnce(member, readAt, readBy, index);
+      }
+      throw e;
+    }
+  }
+
+  private async _markReadOnce(
     member: MemberName,
     readAt: string,
     readBy: string,

--- a/tests/infrastructure/FsInboxNotificationConcurrency.test.ts
+++ b/tests/infrastructure/FsInboxNotificationConcurrency.test.ts
@@ -187,6 +187,138 @@ test('writeWithCas: detects when file was deleted between load and save', async 
   }
 });
 
+test('post() retries once on InboxVersionConflict and succeeds', async () => {
+  // post() catches InboxVersionConflict and re-reads + re-writes.
+  // This suite exercises the retry by forcing the first-attempt
+  // write to conflict (via a stale snapshot committed manually),
+  // then calling the public post() — which internally retries
+  // against the post-stale disk and succeeds.
+  //
+  // Why this is safe: post is append-only. A retry re-reads the
+  // now-advanced file, appends on top, writes. No duplicate side
+  // effect — just a later `at` timestamp for the retried message.
+  const { port, root, cleanup } = bootstrap();
+  try {
+    // Seed at version=1.
+    await port.post({
+      from: 'alice',
+      to: MemberName.of('bob'),
+      type: 'message',
+      text: 'seed',
+    });
+
+    // Manually drive a stale write so the next public post() sees
+    // a conflict on its first attempt and must retry.
+    type Priv = {
+      readWithVersion(rel: string): {
+        file: { version?: number; messages: Array<Record<string, unknown>> };
+        version: number;
+      };
+    };
+    const priv = port as unknown as Priv;
+
+    // Concurrent writer bumps disk to version=2 behind the scenes.
+    await port.post({
+      from: 'eve',
+      to: MemberName.of('bob'),
+      type: 'message',
+      text: 'concurrent',
+    });
+
+    // Now a public post() starts: its first _postOnce captures
+    // version=2 from disk (on-disk = 2, loadedVersion = 2), which
+    // agrees with CAS and succeeds without retry. To actually
+    // trigger the retry path we need to inject a stale read. We
+    // do that by monkey-patching readWithVersion for exactly one
+    // call.
+    const origRead = priv.readWithVersion.bind(priv);
+    let callCount = 0;
+    priv.readWithVersion = (rel: string) => {
+      callCount++;
+      if (callCount === 1) {
+        // Return a stale snapshot (pretend we read at version=1
+        // even though disk is at version=2). The _postOnce that
+        // consumes this will prep a write with loadedVersion=1,
+        // CAS will detect disk=2, throw InboxVersionConflict.
+        return { file: { version: 1, messages: [] }, version: 1 };
+      }
+      return origRead(rel);
+    };
+
+    await port.post({
+      from: 'alice',
+      to: MemberName.of('bob'),
+      type: 'message',
+      text: 'should survive the retry',
+    });
+
+    // call 1: post's initial read (stale, injected)
+    // call 2: writeWithCas CAS check (real disk = v2 → conflict)
+    // call 3: retry's post initial read (origRead, real)
+    // call 4: retry's writeWithCas CAS check (real, matches → pass)
+    assert.equal(
+      callCount,
+      4,
+      'first attempt (read+CAS) + retry (read+CAS) = 4 reads',
+    );
+    const parsed = YAML.parse(
+      readFileSync(join(root, 'inbox', 'bob.yaml'), 'utf8'),
+    );
+    // Expect: seed (1) + concurrent (2) + retried write (3) = 3 messages
+    assert.equal(parsed.messages.length, 3);
+    assert.equal(parsed.version, 3);
+    assert.equal(parsed.messages[2].text, 'should survive the retry');
+  } finally {
+    cleanup();
+  }
+});
+
+test('post() surfaces the conflict after the retry also fails (2nd cascade)', async () => {
+  // Retry is once-only. Two consecutive conflicts (the retry itself
+  // collides with a third writer) must bubble up so the caller
+  // knows to back off rather than loop forever.
+  const { port, cleanup } = bootstrap();
+  try {
+    await port.post({
+      from: 'alice',
+      to: MemberName.of('bob'),
+      type: 'message',
+      text: 'seed',
+    });
+    type Priv = {
+      readWithVersion(rel: string): {
+        file: { version?: number; messages: Array<Record<string, unknown>> };
+        version: number;
+      };
+    };
+    const priv = port as unknown as Priv;
+    const origRead = priv.readWithVersion.bind(priv);
+    let callCount = 0;
+    // Stale on odd calls (post initial reads), real on even calls
+    // (writeWithCas CAS checks) — so both the first attempt and the
+    // retry see a CAS mismatch and throw.
+    priv.readWithVersion = (rel: string) => {
+      callCount++;
+      if (callCount % 2 === 1) {
+        return { file: { version: 0, messages: [] }, version: 0 };
+      }
+      return origRead(rel);
+    };
+    await assert.rejects(
+      () =>
+        port.post({
+          from: 'alice',
+          to: MemberName.of('bob'),
+          type: 'message',
+          text: 'never lands',
+        }),
+      (e: unknown) => e instanceof InboxVersionConflict,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('post() sequentially: happy-path CAS (no race, no conflict)', async () => {
   // Regression guard for the "no false conflict" case — sequential
   // posts from the same instance must keep succeeding forever, with


### PR DESCRIPTION
## Summary

Closes **devil's C4** (hiroba `2026-04-22-0002`): `InboxVersionConflict` was thrown from the repository but no caller catches it. `broadcast`'s per-recipient `try/catch` lumps it into `failed[]` as a generic error, and `message` / `inbox` hit the error path with a raw stack trace + no retry suggestion.

## Why repository-layer retry

Repository-level is the right seam:

- **Transparent to callers** — no catch boilerplate across every handler / UseCase
- **Safe semantics** — post is append-only (retry produces the same union, just with a later `at`), markRead is idempotent (already-read entries stay read)
- **Bounded** — retry once; two consecutive conflicts surface to the caller so a 3+ simultaneous-writer scenario isn't masked by an infinite loop

## Implementation

`post()` and `markRead()` become thin wrappers:

```ts
async post(n: Notification): Promise<void> {
  try {
    await this._postOnce(n);
  } catch (e) {
    if (e instanceof InboxVersionConflict) {
      await this._postOnce(n);  // retry once
      return;
    }
    throw e;
  }
}
```

`_postOnce` / `_markReadOnce` carry the original read-modify-CAS logic. No public API change.

## Why Inbox specifically (not Request / Issue)

Both Request and Issue have strict policy reasons the retry isn't obviously safe:

- **Request** transitions are strict state-machine moves — retrying an approve after a concurrent transition could move the request through an unintended state
- **Issue** state_log / notes are append-only but "retry after concurrent transition" has ambiguous semantics (e.g., resolving an issue that was just reopened — whose intent wins?)

Inbox is the one repository where **append-only + idempotent** combine cleanly. Retries elsewhere stay caller-responsibility; SECURITY.md's "serialize at the caller for critical operations" stands for Request / Issue.

## Tests

+2 new (**492 total**, all passing):

1. **`post()` retries once and succeeds**
   - Monkey-patched `readWithVersion` returns stale on the first call, real on subsequent
   - Expected flow: 4 total reads (initial + CAS + retry-initial + retry-CAS)
   - Asserts: concurrent writer's content preserved, retried message lands, version climbs to 3
2. **Two consecutive conflicts escape**
   - `readWithVersion` alternates stale/real so both first attempt and retry CAS-fail
   - Asserts: `InboxVersionConflict` bubbles up to the caller

The `(port as unknown as Priv)` test seam is the same one PR #83 established.

## Docs

`CHANGELOG.md [Unreleased] ### Added` entry added explaining the retry semantics and the "two consecutive conflicts still bubble up" guarantee.

## Related

- devil review hiroba `2026-04-22-0002` (C4 closed here, only `i-2026-04-22-0008` MEMORY insight remains on the low-priority track)
- PR #77 shipped CAS; PR #83 added real-race tests; this PR adds retry — the full Inbox CAS story lands in 3 beats

🤖 Co-authored with Devil (THS devil agent) and Eris (Claude Opus 4.7)