### PR TITLE
fix: harden sanitization, unify version conflict API, name dir cap

### DIFF
--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -41,13 +41,14 @@ export class RequestIdCollision extends Error {
  * than blindly overwrite.
  */
 export class RequestVersionConflict extends Error {
+  readonly code = 'REQUEST_VERSION_CONFLICT' as const;
   constructor(
-    public readonly id: string,
-    public readonly expectedVersion: number,
-    public readonly actualVersion: number,
+    readonly id: string,
+    readonly expected: number,
+    readonly found: number,
   ) {
     super(
-      `Request ${id} changed on disk (expected version ${expectedVersion}, found ${actualVersion}); reload and retry`,
+      `Request ${id} changed on disk (expected version ${expected}, found ${found}); reload and retry`,
     );
     this.name = 'RequestVersionConflict';
   }

--- a/src/domain/request/Thank.ts
+++ b/src/domain/request/Thank.ts
@@ -1,5 +1,5 @@
 import { MemberName } from '../member/MemberName.js';
-import { DomainError } from '../shared/DomainError.js';
+import { sanitizeText } from '../shared/sanitizeText.js';
 
 const MAX_REASON_LEN = 1024;
 
@@ -90,15 +90,9 @@ export class Thank {
 }
 
 function sanitizeReason(raw: unknown): string {
-  if (typeof raw !== 'string') {
-    throw new DomainError('Thank reason must be a string', 'reason');
-  }
-  const cleaned = raw.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
-  if (cleaned.length > MAX_REASON_LEN) {
-    throw new DomainError(
-      `Thank reason too long (max ${MAX_REASON_LEN} chars)`,
-      'reason',
-    );
-  }
-  return cleaned;
+  return sanitizeText(raw, 'reason', {
+    maxLen: MAX_REASON_LEN,
+    requireNonEmpty: false,
+    trim: false,
+  });
 }

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -16,6 +16,7 @@ import {
   IssueVersionConflict,
 } from '../../application/ports/IssueRepository.js';
 import {
+  MAX_DIR_ENTRIES,
   existsSafe,
   listDirSafe,
   readTextSafe,
@@ -50,7 +51,7 @@ export class YamlIssueRepository implements IssueRepository {
   async listAll(): Promise<Issue[]> {
     const files = listDirSafe(this.config.paths.issues, '.')
       .filter((f) => FILE_PATTERN.test(f))
-      .slice(0, 1000);
+      .slice(0, MAX_DIR_ENTRIES);
     const out: Issue[] = [];
     for (const f of files) {
       const raw = readTextSafe(this.config.paths.issues, f);

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -3,6 +3,7 @@ import { Member } from '../../domain/member/Member.js';
 import { MemberName } from '../../domain/member/MemberName.js';
 import { MemberRepository } from '../../application/ports/MemberRepository.js';
 import {
+  MAX_DIR_ENTRIES,
   existsSafe,
   listDirSafe,
   readTextSafe,
@@ -42,7 +43,7 @@ export class YamlMemberRepository implements MemberRepository {
       /^[a-z][a-z0-9_-]{0,31}\.yaml$/.test(f),
     );
     const out: Member[] = [];
-    for (const f of files.slice(0, 1000)) {
+    for (const f of files.slice(0, MAX_DIR_ENTRIES)) {
       const raw = readTextSafe(this.config.paths.members, f);
       const name = f.replace(/\.yaml$/, '');
       const absSource = join(this.config.paths.members, f);

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -16,6 +16,7 @@ import {
   RequestVersionConflict,
 } from '../../application/ports/RequestRepository.js';
 import {
+  MAX_DIR_ENTRIES,
   existsSafe,
   listDirSafe,
   readTextSafe,
@@ -58,7 +59,7 @@ export class YamlRequestRepository implements RequestRepository {
   async listByState(state: RequestState): Promise<Request[]> {
     const files = listDirSafe(this.config.paths.requests, state)
       .filter((f) => /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/.test(f))
-      .slice(0, 1000);
+      .slice(0, MAX_DIR_ENTRIES);
     const out: Request[] = [];
     for (const f of files) {
       const rel = join(state, f);

--- a/src/infrastructure/persistence/safeFs.ts
+++ b/src/infrastructure/persistence/safeFs.ts
@@ -125,6 +125,13 @@ export function unlinkSafe(base: string, relOrAbs: string): void {
   if (existsSync(p)) unlinkSync(p);
 }
 
+/**
+ * Per-directory file cap applied by repository scans. Prevents memory
+ * exhaustion on oversized directories — a content_root should never
+ * reach this ceiling in normal use.
+ */
+export const MAX_DIR_ENTRIES = 1000;
+
 export function listDirSafe(base: string, relOrAbs: string): string[] {
   const p = assertUnder(base, relOrAbs);
   if (!existsSync(p)) return [];

--- a/tests/domain/sanitizeText.test.ts
+++ b/tests/domain/sanitizeText.test.ts
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeText } from '../../src/domain/shared/sanitizeText.js';
+
+const defaults = { maxLen: 100 };
+
+// --- type enforcement ---
+
+test('sanitizeText: rejects non-string input', () => {
+  assert.throws(() => sanitizeText(42, 'field', defaults), /must be a string/);
+  assert.throws(() => sanitizeText(null, 'field', defaults), /must be a string/);
+  assert.throws(() => sanitizeText(undefined, 'field', defaults), /must be a string/);
+});
+
+// --- control character stripping ---
+
+test('sanitizeText: strips NUL, BEL, BS, VT, FF, SO-US, DEL', () => {
+  const dirty = 'a\x00b\x07c\x08d\x0Be\x0Cf\x0Eg\x1Fh\x7Fi';
+  assert.equal(sanitizeText(dirty, 'f', defaults), 'abcdefghi');
+});
+
+test('sanitizeText: preserves tab, newline, carriage return', () => {
+  const input = 'line1\tindented\nline2\r\nline3';
+  assert.equal(sanitizeText(input, 'f', defaults), input);
+});
+
+// --- trim behavior ---
+
+test('sanitizeText: trims by default', () => {
+  assert.equal(sanitizeText('  hello  ', 'f', defaults), 'hello');
+});
+
+test('sanitizeText: trim=false preserves leading/trailing whitespace', () => {
+  assert.equal(
+    sanitizeText('  hello  ', 'f', { ...defaults, trim: false }),
+    '  hello  ',
+  );
+});
+
+// --- requireNonEmpty behavior ---
+
+test('sanitizeText: rejects empty string by default', () => {
+  assert.throws(() => sanitizeText('', 'f', defaults), /required/);
+});
+
+test('sanitizeText: rejects whitespace-only when trim=true (default)', () => {
+  assert.throws(() => sanitizeText('   ', 'f', defaults), /required/);
+});
+
+test('sanitizeText: allows empty when requireNonEmpty=false', () => {
+  assert.equal(
+    sanitizeText('', 'f', { ...defaults, requireNonEmpty: false }),
+    '',
+  );
+});
+
+test('sanitizeText: allows whitespace-only when requireNonEmpty=false + trim=false', () => {
+  assert.equal(
+    sanitizeText('   ', 'f', { ...defaults, requireNonEmpty: false, trim: false }),
+    '   ',
+  );
+});
+
+// --- length cap ---
+
+test('sanitizeText: accepts string at exactly maxLen', () => {
+  const s = 'x'.repeat(100);
+  assert.equal(sanitizeText(s, 'f', { maxLen: 100 }), s);
+});
+
+test('sanitizeText: rejects string exceeding maxLen', () => {
+  assert.throws(
+    () => sanitizeText('x'.repeat(101), 'f', { maxLen: 100 }),
+    /too long/,
+  );
+});
+
+test('sanitizeText: length checked after strip + trim', () => {
+  const s = '  ' + 'x'.repeat(100) + '\x00\x07  ';
+  assert.equal(sanitizeText(s, 'f', { maxLen: 100 }).length, 100);
+});
+
+// --- field name in error messages ---
+
+test('sanitizeText: error message includes field name', () => {
+  assert.throws(() => sanitizeText(42, 'myField', defaults), /myField/);
+  assert.throws(() => sanitizeText('', 'action', defaults), /action/);
+});

--- a/tests/infrastructure/YamlRequestRepository.test.ts
+++ b/tests/infrastructure/YamlRequestRepository.test.ts
@@ -85,8 +85,8 @@ test('save() throws RequestVersionConflict when on-disk grew since load', async 
       () => repo.save(aCopy!),
       (e) =>
         e instanceof RequestVersionConflict &&
-        e.expectedVersion === 1 &&
-        e.actualVersion === 2,
+        e.expected === 1 &&
+        e.found === 2,
       'expected A.save() to surface a version conflict with concrete version numbers',
     );
   } finally {
@@ -138,8 +138,8 @@ test('save() optimistic lock covers review races (not only transitions)', async 
       () => repo.save(reviewerA!),
       (e) =>
         e instanceof RequestVersionConflict &&
-        e.expectedVersion === 4 &&
-        e.actualVersion === 5,
+        e.expected === 4 &&
+        e.found === 5,
       'review race must trigger version conflict (the status_log-only bug we fixed)',
     );
   } finally {


### PR DESCRIPTION
## Summary

セキュリティ監査 + コード品質レビューから出た改善。

- **Thank.sanitizeReason → shared sanitizeText** — SECURITY.md が謳う「sanitization の単一ソース」の最後の例外を解消。Thank だけが独自 regex を持っていた穴を塞ぎ、今後の sanitize ポリシー変更が1箇所で済むようになった。
- **RequestVersionConflict プロパティ名統一** — `expectedVersion`/`actualVersion` を Issue/Inbox と同じ `expected`/`found` に。readonly `code` discriminant も追加し、3レコード型の CAS エラーが同じ形で扱える。
- **MAX_DIR_ENTRIES 定数** — 3リポジトリに散らばっていた magic number `1000` を safeFs の named export に集約。
- **sanitizeText 直接テスト 13件追加** — 型チェック、制御文字、trim モード、empty モード、length boundary をカバー。共有不変条件のリグレッション検出。

## Test plan

- [x] `npm run build` — tsc strict pass
- [x] `npm test` — 505 tests, 0 fail (+13 from sanitizeText)
- [x] 既存の VersionConflict テストが新プロパティ名で pass

https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh)_