### PR TITLE
docs: polish AGENT.md and SECURITY.md — close doc-code gaps

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -33,7 +33,7 @@ gate tail 10             # last 10 events across all actors
 ## Agent-first knobs
 
 - `gate boot` — single-command orientation (identity + status + tail + inbox)
-- `--format json` on every write verb (`request/approve/deny/execute/complete/fail/review/fast-track`)
+- `--format json` on every write verb (`request/approve/deny/execute/complete/fail/review/thank/fast-track`)
   returns `{ok, id, state, message, suggested_next:{verb, args, reason}}`
 - `gate schema` — JSON Schema for all verbs (LLM tool-layer input)
 
@@ -46,11 +46,14 @@ pending ─ approve ─▶ approved ─ execute ─▶ executing ─ complete �
 ```
 
 ```bash
-gate request --from <m> --action "..." --reason "..." [--executor <m>] [--auto-review <m>]
+gate request --from <m> --action "..." --reason "..." [--executor <m>] [--auto-review <m>] [--with <m>[,<m>...]]
 gate approve <id> --by <m> [--note "..."]
+gate deny <id> --by <m> --reason "..."
 gate execute <id> --by <m>
 gate complete <id> --by <m> [--note "..."]
+gate fail <id> --by <m> --reason "..."
 gate fast-track --from <m> --action "..." --reason "..."   # one-shot create→complete
+gate thank <to> --for <id> [--by <m>] [--reason <s>]       # gratitude (no verdict, no calibration)
 ```
 
 ## Review (Two-Persona Devil)
@@ -75,9 +78,12 @@ gate review <id> --by <m> --lense <l> --verdict <v> --comment "..."
 gate show <id>                          # request detail (JSON default)
 gate list --state <s> [--for <m>]       # filtered list
 gate pending [--for <m>]                # shortcut for --state pending
-gate voices <name> [--lense <l>]        # actor's full history (JSON default)
+gate board [--for <m>]                  # pending + approved + executing in one view
+gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>] [--with-calibration]
 gate tail [N]                           # recent activity stream (default 20)
 gate chain <id>                         # cross-reference walk (one hop)
+gate transcript <id>                    # narrative prose arc of a request
+gate suggest [--format json|text]       # suggested_next only (hot-loop sibling of boot)
 ```
 
 ## Issues
@@ -90,7 +96,8 @@ open ↔ in_progress ↔ deferred → resolved (reopen → open)
 gate issues add --from <m> --severity <low|med|high> --area <a> "text"
 gate issues list [--state <s>]
 gate issues resolve|defer|start|reopen <id> --by <m>   # --by required; appends state_log
-gate issues promote <id> --from <m>     # lift issue → new request
+gate issues note <id> --by <m> --text "..."          # append annotation
+gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>] [--action <s>] [--reason <s>]
 ```
 
 State transitions append to `state_log: [{state, by, at, invoked_by?}]`
@@ -100,9 +107,9 @@ the actor; falls back to `GUILD_ACTOR` when unset.
 ## Messages
 
 ```bash
-gate message --from <m> --to <m> --text "..."
-gate broadcast --from <m> --text "..."
-gate inbox --for <m>
+gate message --from <m> --to <m> --text "..." [--type <s>]
+gate broadcast --from <m> --text "..." [--type <s>]
+gate inbox --for <m> [--unread]
 gate inbox mark-read [N] --for <m>
 ```
 
@@ -120,9 +127,10 @@ Categories: `core | professional | assignee | trial | special | host`
 ## Diagnostic
 
 ```bash
-gate doctor                             # read-only health check
+gate doctor [--format json|text] [--summary]     # read-only health check
 gate doctor --format json | gate repair          # dry-run plan
 gate doctor --format json | gate repair --apply  # quarantine malformed
+gate repair [--from-doctor <path>] [--apply] [--format json|text]
 ```
 
 ## Configuration
@@ -158,6 +166,9 @@ Request IDs: `YYYY-MM-DD-NNNN`. Issue IDs: `i-YYYY-MM-DD-NNNN`.
 
 `GUILD_ACTOR=<name>` — default for `--from` / `--by` / `--for`.
 Explicit flags always win. `--executor` and `--auto-review` are never env-filled.
+
+`GUILD_LOCALE=<en|ja>` — prose language for `gate resume`
+`restoration_prose`. Defaults to `en`. Also settable via `--locale`.
 
 ## Output format
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,8 +13,11 @@ write access to `content_root`".
   `infrastructure/persistence/safeFs.ts`, which rejects any target that
   does not resolve under the configured base directory, and refuses to
   follow symbolic links anywhere on the path.
-- **No shell execution** — the package never calls `child_process`.
-  Verified by `grep -r 'child_process\|exec\b\|spawn\b' src/`.
+- **No shell execution for data processing.** The only
+  `child_process` usage is `spawnSync` in array form (no shell
+  expansion) for the interactive editor in `gate review` — see
+  Trust Assumptions below. All persistence, parsing, and state
+  mutation paths are in-process with no subprocess calls.
 - **Input validation at the boundary**:
   - `MemberName` — `^[a-z][a-z0-9_-]{0,31}$` + reserved-name blacklist
   - `RequestId` / `IssueId` — strict date-sequence regex


### PR DESCRIPTION
## Summary

- **SECURITY.md**: 「No shell execution — the package never calls child_process」は虚偽（spawnSync をエディタ起動に使用）。「No shell execution for data processing」に修正し、Trust Assumptions セクションとの矛盾を解消。
- **AGENT.md に欠落していた verb・フラグ・環境変数を追加**:
  - Verbs: `deny`, `fail`, `thank`, `board`, `transcript`, `suggest`, `issues note`
  - Flags: `--with` (request), `--with-calibration` (voices), `--verdict`/`--limit` (voices), `--type` (message/broadcast), `--unread` (inbox), `--executor`/`--auto-review`/`--action`/`--reason` (issues promote), `--summary` (doctor), full `repair` signature
  - Env: `GUILD_LOCALE=<en|ja>` for `gate resume` prose language

AGENT.md がエージェントクイックリファレンスとして全 verb のシグネチャをカバーする状態になった。

## Test plan

- [x] `npm run build` — tsc strict pass
- [x] `npm test` — 505 tests, 0 fail
- [ ] AGENT.md の各 verb signature が `gate <verb> --help` 相当の情報を持つこと目視確認

https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh)_