### PR TITLE
docs(domain-fit): link records-as-mirrors to principle 07

### DIFF
--- a/docs/domain-fit/design-notes.md
+++ b/docs/domain-fit/design-notes.md
@@ -143,7 +143,10 @@ Some consequences that follow if the claim is right:
   externalizing an internal voice and then seeing it in writing.
   That's not a property of principal separation; it's a property
   of records-as-mirrors. The framework may be under-specifying
-  this.
+  this. (See also `lore/principles/07-perception-not-judgement.md`
+  — the tool as a lens that sharpens perception without closing
+  the judgement loop. The mirror effect may be a specific instance
+  of that broader posture.)
 
 ## Earlier framings (kept for posterity)
 


### PR DESCRIPTION
## Summary

design-notes.md の「records-as-mirrors」観察（ソロジャーナルで内的な声を外在化して文字で見ることの変容効果）に、原則07 (perception, not judgement) への相互参照を追加。

mirror 効果は原則07が名前を付けた broader posture — ツールは知覚を研ぐが判断は閉じない — の specific instance。原則07がマージされたので線を繋ぐ。

## Test plan

- [x] ドキュメントのみの変更、コード変更なし

https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh)_