### PR TITLE
feat: gate summarize + gate why + plugin trusted guard

### DIFF
--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -97,11 +97,19 @@ export class GuildConfig implements GuildConfigProps {
           .map((x: string) => x.toLowerCase())
       : [...DEFAULT_LENSES];
     const doctor = raw.doctor ?? {};
-    const doctorPlugins = Array.isArray(doctor.plugins)
+    const pluginsTrusted = doctor.trusted === true;
+    const doctorPlugins = Array.isArray(doctor.plugins) && pluginsTrusted
       ? doctor.plugins
           .filter((x: unknown): x is string => typeof x === 'string')
           .map((x: string) => resolveUnder(root, x))
       : [];
+    if (Array.isArray(doctor.plugins) && doctor.plugins.length > 0 && !pluginsTrusted) {
+      onMalformed(
+        configPath,
+        'doctor.plugins present but doctor.trusted is not true — plugins will NOT be loaded. ' +
+          'Add `trusted: true` under `doctor:` in guild.config.yaml to enable.',
+      );
+    }
     return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, onMalformed, configPath);
   }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -195,6 +195,57 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'summarize',
+    category: 'read',
+    summary:
+      'compressed view of a request: current state, decision, open concerns, review/thank counts. The 30-second-read sibling of transcript.',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        format: formatField,
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        state: str,
+        decision: str,
+        open_concerns: { type: 'array', items: { type: 'object' } },
+        review_count: { type: 'integer' },
+        thank_count: { type: 'integer' },
+        actors: { type: 'array', items: str },
+      },
+    },
+  },
+  {
+    name: 'why',
+    category: 'read',
+    summary:
+      'decision-chain trace: terminal transition, reviews aligned with outcome, reviews that contested it. Perception, not judgement — shows which voices were heard, not whether the decision was correct.',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        format: formatField,
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        state: str,
+        terminal_transition: { type: 'object' },
+        aligned_reviews: { type: 'array', items: { type: 'object' } },
+        contested_reviews: { type: 'array', items: { type: 'object' } },
+        review_count: { type: 'integer' },
+      },
+    },
+  },
+  {
     name: 'resume',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/summarize.ts
+++ b/src/interface/gate/handlers/summarize.ts
@@ -1,0 +1,129 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+
+/**
+ * gate summarize <id> [--format text|json]
+ *
+ * Compressed view of a request's current state: decision, risks,
+ * and unresolved items. Where transcript tells the full story,
+ * summarize tells the conclusion. Read-only.
+ *
+ * Designed for the "I have 30 seconds" reader who needs:
+ *   - What state is this in?
+ *   - What concerns remain open?
+ *   - What was the final decision and who made it?
+ * without parsing the full status_log + reviews array.
+ */
+
+interface SummarizePayload {
+  id: string;
+  state: string;
+  decision: string;
+  open_concerns: Array<{
+    by: string;
+    lense: string;
+    verdict: string;
+    comment: string;
+  }>;
+  review_count: number;
+  thank_count: number;
+  actors: readonly string[];
+}
+
+export async function summarizeCmd(c: C, args: ParsedArgs): Promise<number> {
+  const id = args.positional[0];
+  if (!id) throw new Error('Usage: gate summarize <id> [--format text|json]');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(`not found: ${id}\n`);
+    return 1;
+  }
+  const payload = buildSummary(r);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(renderSummaryText(payload) + '\n');
+  }
+  return 0;
+}
+
+function buildSummary(r: Request): SummarizePayload {
+  const j = r.toJSON();
+  const id = String(j['id']);
+  const state = String(j['state']);
+  const log = Array.isArray(j['status_log'])
+    ? (j['status_log'] as Array<Record<string, unknown>>)
+    : [];
+  const reviews = Array.isArray(j['reviews'])
+    ? (j['reviews'] as Array<Record<string, unknown>>)
+    : [];
+  const thanks = Array.isArray(j['thanks'])
+    ? (j['thanks'] as Array<Record<string, unknown>>)
+    : [];
+
+  const lastEntry = log.length > 0 ? log[log.length - 1]! : null;
+  const decision = lastEntry
+    ? `${lastEntry['by']} → ${lastEntry['state']}` +
+      (lastEntry['note'] ? `: ${lastEntry['note']}` : '')
+    : '(no transitions)';
+
+  const openConcerns: SummarizePayload['open_concerns'] = [];
+  for (const rv of reviews) {
+    const verdict = String(rv['verdict'] ?? '');
+    if (verdict === 'concern' || verdict === 'reject') {
+      openConcerns.push({
+        by: String(rv['by'] ?? ''),
+        lense: String(rv['lense'] ?? ''),
+        verdict,
+        comment: String(rv['comment'] ?? '').trim(),
+      });
+    }
+  }
+
+  const actors = new Set<string>();
+  for (const e of log) {
+    if (typeof e['by'] === 'string') actors.add(e['by']);
+  }
+  for (const rv of reviews) {
+    if (typeof rv['by'] === 'string') actors.add(rv['by']);
+  }
+
+  return {
+    id,
+    state,
+    decision,
+    open_concerns: openConcerns,
+    review_count: reviews.length,
+    thank_count: thanks.length,
+    actors: [...actors],
+  };
+}
+
+function renderSummaryText(p: SummarizePayload): string {
+  const lines: string[] = [];
+  lines.push(`# ${p.id} — ${p.state}`);
+  lines.push('');
+  lines.push(`decision:  ${p.decision}`);
+  lines.push(`reviews:   ${p.review_count}    thanks: ${p.thank_count}`);
+  lines.push(`actors:    ${p.actors.join(', ')}`);
+
+  if (p.open_concerns.length > 0) {
+    lines.push('');
+    lines.push(`open concerns (${p.open_concerns.length}):`);
+    for (const c of p.open_concerns) {
+      const short = c.comment.length > 80
+        ? c.comment.slice(0, 77) + '...'
+        : c.comment;
+      lines.push(`  [${c.lense}/${c.verdict}] ${c.by}: ${short}`);
+    }
+  } else {
+    lines.push('');
+    lines.push('no open concerns');
+  }
+  return lines.join('\n');
+}

--- a/src/interface/gate/handlers/why.ts
+++ b/src/interface/gate/handlers/why.ts
@@ -1,0 +1,165 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+
+/**
+ * gate why <id> [--format text|json]
+ *
+ * Trace the decision chain that led to the current state. Extracts
+ * the reviews that influenced the outcome — not all reviews, just
+ * the ones whose verdicts aligned with or contested the terminal
+ * state. Read-only.
+ *
+ * The verb answers "why did this end up here?" by surfacing:
+ *   - The terminal transition (who moved it to the final state, why)
+ *   - Reviews that aligned with the outcome (predicted it)
+ *   - Reviews that contested the outcome (were overridden)
+ *
+ * This is perception, not judgement (principle 07): the tool shows
+ * which voices were heard and which weren't, but does not say
+ * whether the decision was correct.
+ */
+
+interface WhyPayload {
+  id: string;
+  state: string;
+  terminal_transition: {
+    by: string;
+    state: string;
+    at: string;
+    note: string | null;
+  } | null;
+  aligned_reviews: Array<{
+    by: string;
+    lense: string;
+    verdict: string;
+    comment: string;
+  }>;
+  contested_reviews: Array<{
+    by: string;
+    lense: string;
+    verdict: string;
+    comment: string;
+  }>;
+  review_count: number;
+}
+
+export async function whyCmd(c: C, args: ParsedArgs): Promise<number> {
+  const id = args.positional[0];
+  if (!id) throw new Error('Usage: gate why <id> [--format text|json]');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(`not found: ${id}\n`);
+    return 1;
+  }
+  const payload = buildWhy(r);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(renderWhyText(payload) + '\n');
+  }
+  return 0;
+}
+
+function buildWhy(r: Request): WhyPayload {
+  const j = r.toJSON();
+  const id = String(j['id']);
+  const state = String(j['state']);
+  const log = Array.isArray(j['status_log'])
+    ? (j['status_log'] as Array<Record<string, unknown>>)
+    : [];
+  const reviews = Array.isArray(j['reviews'])
+    ? (j['reviews'] as Array<Record<string, unknown>>)
+    : [];
+
+  const lastEntry = log.length > 0 ? log[log.length - 1]! : null;
+  const terminalTransition = lastEntry
+    ? {
+        by: String(lastEntry['by'] ?? ''),
+        state: String(lastEntry['state'] ?? ''),
+        at: String(lastEntry['at'] ?? ''),
+        note: typeof lastEntry['note'] === 'string'
+          ? (lastEntry['note'] as string)
+          : null,
+      }
+    : null;
+
+  const isPositiveOutcome = state === 'completed' || state === 'approved' || state === 'executing';
+
+  const aligned: WhyPayload['aligned_reviews'] = [];
+  const contested: WhyPayload['contested_reviews'] = [];
+
+  for (const rv of reviews) {
+    const verdict = String(rv['verdict'] ?? '');
+    const entry = {
+      by: String(rv['by'] ?? ''),
+      lense: String(rv['lense'] ?? ''),
+      verdict,
+      comment: String(rv['comment'] ?? '').trim(),
+    };
+    if (isPositiveOutcome) {
+      if (verdict === 'ok') aligned.push(entry);
+      else contested.push(entry);
+    } else {
+      if (verdict === 'concern' || verdict === 'reject') aligned.push(entry);
+      else contested.push(entry);
+    }
+  }
+
+  return {
+    id,
+    state,
+    terminal_transition: terminalTransition,
+    aligned_reviews: aligned,
+    contested_reviews: contested,
+    review_count: reviews.length,
+  };
+}
+
+function renderWhyText(p: WhyPayload): string {
+  const lines: string[] = [];
+  lines.push(`# why ${p.id} → ${p.state}`);
+  lines.push('');
+
+  if (p.terminal_transition) {
+    const t = p.terminal_transition;
+    const note = t.note ? `: "${t.note}"` : '';
+    lines.push(`terminal: ${t.by} → ${t.state} at ${t.at}${note}`);
+  } else {
+    lines.push('terminal: (no transitions recorded)');
+  }
+
+  lines.push('');
+
+  if (p.aligned_reviews.length > 0) {
+    lines.push(`aligned with outcome (${p.aligned_reviews.length}):`);
+    for (const r of p.aligned_reviews) {
+      const short = r.comment.length > 80
+        ? r.comment.slice(0, 77) + '...'
+        : r.comment;
+      lines.push(`  [${r.lense}/${r.verdict}] ${r.by}: ${short}`);
+    }
+  } else {
+    lines.push('aligned: (none)');
+  }
+
+  lines.push('');
+
+  if (p.contested_reviews.length > 0) {
+    lines.push(`contested outcome (${p.contested_reviews.length}):`);
+    for (const r of p.contested_reviews) {
+      const short = r.comment.length > 80
+        ? r.comment.slice(0, 77) + '...'
+        : r.comment;
+      lines.push(`  [${r.lense}/${r.verdict}] ${r.by}: ${short}`);
+    }
+  } else {
+    lines.push('contested: (none)');
+  }
+
+  return lines.join('\n');
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -38,6 +38,8 @@ import {
 import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
+import { summarizeCmd } from './handlers/summarize.js';
+import { whyCmd } from './handlers/why.js';
 
 // Re-export for test backward-compat (tests/interface/reviewMarkers.test.ts).
 // formatReviewMarkers and computeReviewMarkerWidth live in handlers/request.ts
@@ -179,6 +181,14 @@ Status:
                        thing?" without the full orientation payload.
                        Priority ladder is shared with boot, so the
                        two never disagree.
+  gate summarize <id> [--format text|json]
+                       Compressed view: state, decision, open
+                       concerns, review/thank counts. The "30-second
+                       read" sibling of transcript.
+  gate why <id> [--format text|json]
+                       Trace the decision chain: terminal transition,
+                       reviews that aligned with the outcome, reviews
+                       that contested it. Perception, not judgement.
   gate transcript <id> [--format text|json]
                        Narrative prose render of one request's arc,
                        composed from status_log + reviews. Sibling
@@ -212,7 +222,7 @@ const KNOWN_COMMANDS = [
   'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
   'complete', 'fail', 'review', 'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
-  'suggest', 'transcript', 'resume', 'schema',
+  'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
 ] as const;
 
 function levenshtein(a: string, b: string): number {
@@ -340,6 +350,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await suggestCmd(c, args);
       case 'transcript':
         return await transcriptCmd(c, args);
+      case 'summarize':
+        return await summarizeCmd(c, args);
+      case 'why':
+        return await whyCmd(c, args);
       case 'resume':
         return await resumeCmd(c, args);
       case 'schema':


### PR DESCRIPTION
## Summary

レビュー機能への改善提案を原則に照らして評価し、思想と合致する3件を実装。

### gate summarize `<id>` (read verb)
- 「30秒で読める」圧縮ビュー: state, decision, open concerns, review/thank counts
- transcript の結論だけ版。長い履歴を読む負担を軽減
- JSON + text 出力

### gate why `<id>` (read verb)
- 決定チェーンのトレース: terminal transition, aligned reviews, contested reviews
- 「なぜこの状態に至ったか」を、outcome に aligned した声と contested した声に分けて表示
- 原則07 (perception, not judgement): どの声が聞かれたかを見せる。決定が正しかったかは言わない
- JSON + text 出力

### Plugin trusted guard
- `doctor.plugins` は `doctor.trusted: true` が設定されていない限りスキップ
- 既存 config に plugins がある場合、trusted 未設定なら onMalformed 経由で warning
- SECURITY.md で「信頼できるプラグインのみ」と書いていたが、コードで enforce していなかった穴を塞ぐ

### 採用しなかったもの（15件中12件）
security review 強制、risk_level 必須、fast-track 禁止、review 品質チェックリスト等 — いずれもツールを enforcer に変える方向で、原則07 (perception, not judgement) と原則02 (advisory, not directive) に反するため不採用。

## Test plan

- [x] `npm run build` — tsc strict pass
- [x] `npm test` — 505 tests, 0 fail
- [x] schema.test.ts が summarize/why の VERBS エントリを検証（dispatch parity）
- [x] `gate summarize` / `gate why` を dogfood-session データで動作確認

https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLc5sGyuxAByTSvXh7B8nh)_