### PR TITLE
feat: surface concerns + actor-resolved hints (6-point adjusted set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,19 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   not visible from any read path short of re-running `gate resume`.
   (refines 2026-05-01-0003)
 
-- **`gate show` adds a concern marker line.** A 3-state existence
+- **`gate show` adds a concern marker line.** A binary existence
   signal — `no concerns recorded` / `concern recorded — walk gate
-  chain ...` — sits next to the existing `chain hint` line. Three
-  states deliberately, NOT a count: counting ("3 concerns, 1
-  follow-up") would invite the reader to play a "drive the number
-  down" game (principle 03 — performance-for-the-record). The
-  reader walks `gate chain` to see actual references and judges
-  status themselves; the tool only asserts existence.
+  chain ...` — sits next to the existing `chain hint` line.
+  Existence-language deliberately, NOT a count: counting ("3
+  concerns, 1 follow-up") would invite the reader to play a "drive
+  the number down" game (principle 03 — performance-for-the-record).
+  The original design called for a 3-state marker (concern + inbound
+  / concern + no inbound / no concerns); resolving inbound presence
+  at show time would require an async repository scan, so the
+  shipped form punts that resolution to `gate chain <id>` (named
+  inline in the marker text). The reader gets the same perception
+  affordance with one extra command rather than via formatRequestText
+  becoming async.
 
 - **`gate boot` adds `verbs_available_now.requires_other_actor`.**
   A sibling array to `actionable` (which keeps its existing flat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,72 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate unresponded` (read verb).** Surfaces concern/reject
+  verdicts on the actor's authored or pair-made requests that have
+  no follow-up record yet. Thin wrapper over the same
+  `UnrespondedConcernsQuery` that drives `gate resume`'s concerns
+  surface, so the two cannot diverge. Default actor is GUILD_ACTOR;
+  `--for <m>` and `--max-age-days <N>` override. Naming aligns with
+  the underlying detector's "unresponded" semantic — explicitly NOT
+  `gate concerns` (which would suggest "all concerns" rather than
+  "concerns without follow-up"). The detector is deliberately coarse
+  (existence-only follow-up detection); `gate chain <id>` walks the
+  actual references when the reader wants to verify whether a
+  follow-up addresses anything specific. Surfaces the gap that bit
+  first-time agents: a `concern` verdict on a completed request was
+  not visible from any read path short of re-running `gate resume`.
+  (refines 2026-05-01-0003)
+
+- **`gate show` adds a concern marker line.** A 3-state existence
+  signal — `no concerns recorded` / `concern recorded — walk gate
+  chain ...` — sits next to the existing `chain hint` line. Three
+  states deliberately, NOT a count: counting ("3 concerns, 1
+  follow-up") would invite the reader to play a "drive the number
+  down" game (principle 03 — performance-for-the-record). The
+  reader walks `gate chain` to see actual references and judges
+  status themselves; the tool only asserts existence.
+
+- **`gate boot` adds `verbs_available_now.requires_other_actor`.**
+  A sibling array to `actionable` (which keeps its existing flat
+  shape — additive change). Each entry names `{verb, id, candidates,
+  reason}`: a verb that exists on the actor's record but cannot be
+  dispatched by them as themselves. Surfaces blockers (e.g. "your
+  pending request needs approval by host X") so the actor sees WHY
+  their queue isn't moving without parsing `suggested_next` prose.
+  `candidates` is a list, not a single name, so a content_root with
+  N hosts (or zero) doesn't have to embed a "first host" assumption
+  in the payload. The host-self case is filtered out (a host who
+  authored a pending request sees it under `actionable` via
+  pending-as-executor, not under `requires_other_actor`).
+
+- **`SuggestedNext.actor_resolved: boolean`.** New field on the
+  write-response, boot, and resume `suggested_next` payloads. True
+  iff `args.by` is absent or matches the calling actor (GUILD_ACTOR);
+  false when the suggestion names a different actor. Lets an
+  orchestrator branch (escalate / hand off vs. dispatch as self)
+  without parsing the verb's `--by` against the env. Hint, not gate
+  — the underlying verb still validates `--by` at the boundary.
+  Schema description names the discipline so a reason-skipping loop
+  is structurally redirected.
+
+- **Concern advisory on completed-with-concern reviews.** When a
+  completed request carries a `concern`/`reject` review (and its
+  auto-reviewer, if any, has recorded), `suggested_next` returns a
+  `chain` walk advisory rather than null: verb is read-only (`chain`)
+  to avoid embedding a dispute-resolution flow in the tool's voice;
+  reason names follow-up paths AND explicitly lists "leaving as-is,
+  conversing it out, or letting it fade — all first-class." The
+  absence of action stays structurally legitimate. Replaces the
+  prior null-after-review behavior for the concern case only — `ok`
+  verdicts still close the arc cleanly with `null`.
+
+- **`gate transcript` ends with a `Concerns recorded` section.**
+  Bare enumeration of `concern`/`reject` verdicts in the request,
+  pointing at `gate chain <id>` for reference resolution. No
+  status language ("still open", "addressed by"), no severity —
+  the tool surfaces existence; status judgement stays with the
+  reader (principle 07).
+
 - **`FsInboxNotification.post` / `markRead` retry once on
   `InboxVersionConflict`.** When a concurrent writer advances the
   on-disk version between our read and the CAS check, the first

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -19,6 +19,15 @@ export interface BootSuggestedNext {
   verb: string;
   args: Record<string, string>;
   reason: string;
+  /**
+   * True iff `args.by` is absent or matches the calling actor.
+   * Mirrors `SuggestedNext.actor_resolved` from writeFormat.ts so
+   * orchestrators see the same shape across boot / suggest / resume /
+   * write-response surfaces. False when the suggestion names a
+   * different actor (e.g. "approve by host" while the caller isn't
+   * a host) — read `reason` and decide whether to escalate.
+   */
+  actor_resolved: boolean;
 }
 
 /**
@@ -91,26 +100,40 @@ interface BootPayload {
    * Discoverability hint: what verbs are applicable right now?
    *
    * `actionable` names the state-transition verbs whose preconditions
-   * are met for the caller's current queues. Each entry carries the
-   * target id + a human-readable reason so a first-time agent can see
-   * not just "approve exists" but "approve is valid on 2026-04-19-0001
-   * because you're its executor and it's pending". `suggested_next`
-   * picks ONE of these to lead with; `actionable` names the rest so
-   * an agent that wants to branch can see the siblings.
+   * are met for the caller's current queues — verbs the caller can
+   * dispatch as themselves (--by = current actor). Each entry carries
+   * the target id + a human-readable reason. `suggested_next` picks
+   * ONE of these to lead with; `actionable` names the rest so an
+   * agent that wants to branch can see the siblings.
+   *
+   * `requires_other_actor` names verbs that exist on the actor's
+   * record (request they authored or own) but cannot be dispatched
+   * by them — they require a different actor's --by. Each entry
+   * names `candidates` (a list of names — typically hosts) and the
+   * `reason` the actor can't act alone. Surfaces blockers so the
+   * caller can see WHY their request is stuck (waiting for host
+   * approval, etc.) without having to read suggested_next's prose.
+   * Empty when nothing is blocked on another actor.
    *
    * `always_readable` is the flat catalog of side-effect-free verbs
    * an identified (or even anonymous) actor can always call — the
    * "map of the readable world" for initial exploration.
    *
-   * The two lists never overlap: write verbs belong to `actionable`
-   * (when they're valid) or are absent; read verbs belong to
-   * `always_readable`. Keeping them separate makes it obvious which
-   * calls change state and which don't.
+   * The three lists never overlap: each entry sits in exactly one.
+   * Keeping them separate makes it obvious which calls the agent
+   * can do (actionable), which need someone else (requires_other_actor),
+   * and which never change state (always_readable).
    */
   verbs_available_now: {
     actionable: Array<{
       verb: string;
       id: string;
+      reason: string;
+    }>;
+    requires_other_actor: Array<{
+      verb: string;
+      id: string;
+      candidates: readonly string[];
       reason: string;
     }>;
     always_readable: readonly string[];
@@ -251,7 +274,12 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     members,
     allRequests,
   );
-  const verbsAvailableNow = deriveVerbsAvailableNow(actor, role, allRequests);
+  const verbsAvailableNow = deriveVerbsAvailableNow(
+    actor,
+    role,
+    allRequests,
+    c.config.hostNames,
+  );
 
   const payload: BootPayload = {
     actor,
@@ -301,34 +329,34 @@ export function deriveBootSuggestedNext(
 ): BootSuggestedNext | null {
   if (actor === null) {
     if (members.length === 0) {
-      return {
+      return stampActorResolved({
         verb: 'register',
         args: { name: '<your-name>' },
         reason:
           'No GUILD_ACTOR and no members on this content_root — register yourself to join.',
-      };
+      }, actor);
     }
     // Members exist; this is most likely a returning session that
     // just hasn't exported GUILD_ACTOR yet. Name a few concrete
     // options so the hint is actionable.
     const sample = members.slice(0, 3).map((m) => m.name.value);
-    return {
+    return stampActorResolved({
       verb: 'export',
       args: { GUILD_ACTOR: '<your-name>' },
       reason:
         `No GUILD_ACTOR set. Existing members: ${sample.join(', ')}` +
         (members.length > 3 ? ` (+${members.length - 3} more)` : '') +
         `. Export GUILD_ACTOR=<your-name>, or run gate register --name <your-name> if new.`,
-    };
+    }, actor);
   }
   if (role === 'unknown') {
-    return {
+    return stampActorResolved({
       verb: 'register',
       args: { name: actor },
       reason:
         `GUILD_ACTOR=${actor} but "${actor}" is not a registered member or host. ` +
         `Run gate register --name ${actor} to create the member file.`,
-    };
+    }, actor);
   }
   // Known actor: pick the most actionable open loop. Priority reflects
   // "which one would surprise the agent most if missed":
@@ -349,39 +377,58 @@ export function deriveBootSuggestedNext(
   const id = top.request.id.value;
   switch (top.kind) {
     case 'executing-mine':
-      return {
+      return stampActorResolved({
         verb: 'complete',
         args: { id, by: actor },
         reason:
           `you are executing ${id} — ` +
           `complete it (or 'gate fail <id> --reason <s>' if it can't land).`,
-      };
+      }, actor);
     case 'unreviewed-mine':
-      return {
+      return stampActorResolved({
         verb: 'review',
         args: { id, by: actor, lense: 'devil' },
         reason:
           `${id} completed with auto-review assigned to you; ` +
           `pick --verdict <ok|concern|reject> and --comment after reading the work.`,
-      };
+      }, actor);
     case 'approved-for-me':
-      return {
+      return stampActorResolved({
         verb: 'execute',
         args: { id, by: actor },
         reason:
           `${id} is approved and names you as executor — ` +
           `start the work (gate execute), then complete/fail when done.`,
-      };
+      }, actor);
     case 'pending-as-executor':
-      return {
+      return stampActorResolved({
         verb: 'approve',
         args: { id, by: actor },
         reason:
           `${id} is pending and names you as executor ` +
           `(authored by ${top.request.from.value}); approve it to unblock, ` +
           `or deny with --reason if it shouldn't proceed.`,
-      };
+      }, actor);
   }
+}
+
+/**
+ * Tag a verb/args/reason triple with whether the calling actor can
+ * dispatch it as themselves. Mirrors `withActorResolved` in
+ * writeFormat.ts — same field, same semantics, exported on
+ * BootSuggestedNext so consumers see one consistent shape.
+ */
+function stampActorResolved(
+  partial: Omit<BootSuggestedNext, 'actor_resolved'>,
+  actor: string | null,
+): BootSuggestedNext {
+  const required = partial.args['by'];
+  const resolved =
+    required === undefined ||
+    (typeof actor === 'string' &&
+      actor.length > 0 &&
+      required.toLowerCase() === actor.toLowerCase());
+  return { ...partial, actor_resolved: resolved };
 }
 
 type ActionableKind =
@@ -472,6 +519,7 @@ function actionableTransitions(
 const ALWAYS_READABLE_VERBS: readonly string[] = [
   'boot', 'suggest', 'status', 'show', 'board', 'list', 'pending',
   'tail', 'voices', 'chain', 'whoami', 'schema', 'doctor', 'resume',
+  'unresponded', 'transcript', 'summarize', 'why',
 ];
 
 /**
@@ -490,10 +538,16 @@ function deriveVerbsAvailableNow(
   actor: string | null,
   role: BootPayload['role'],
   allRequests: ReadonlyArray<Request>,
+  hostNames: readonly string[],
 ): BootPayload['verbs_available_now'] {
   const actionable: BootPayload['verbs_available_now']['actionable'] = [];
+  const requiresOtherActor: BootPayload['verbs_available_now']['requires_other_actor'] = [];
   if (actor === null || role === 'unknown') {
-    return { actionable, always_readable: ALWAYS_READABLE_VERBS };
+    return {
+      actionable,
+      requires_other_actor: requiresOtherActor,
+      always_readable: ALWAYS_READABLE_VERBS,
+    };
   }
 
   // Single source of truth shared with `deriveBootSuggestedNext`.
@@ -547,7 +601,52 @@ function deriveVerbsAvailableNow(
     }
   }
 
-  return { actionable, always_readable: ALWAYS_READABLE_VERBS };
+  // requires_other_actor: blockers on the actor's own record.
+  // Surfaces "your pending request needs approval by host X" so
+  // the actor sees WHY their queue isn't moving without having
+  // to read suggested_next's prose. Skipped when the actor is
+  // already the candidate (e.g. host approving their own request)
+  // — that case shows up under actionable instead via the
+  // pending-as-executor predicate. Empty when nothing waits.
+  //
+  // Shape decision: `candidates` is a list, not a single name, so
+  // a content_root with N hosts (or zero) does not have to embed
+  // a "first host" assumption in the payload. `reason` carries the
+  // category of role required ("host approval"), not the host
+  // name — readers in domains where "host" is the wrong word can
+  // re-interpret without the field shape pushing back.
+  const actorLower = actor.toLowerCase();
+  const isHost = hostNames.some((h) => h.toLowerCase() === actorLower);
+  if (!isHost) {
+    for (const r of allRequests) {
+      if (r.state !== 'pending') continue;
+      // Only surface blockers on records the actor is involved in.
+      // Otherwise every pending request in the content_root would
+      // show up for every member, which is noise.
+      const isAuthor = r.from.value === actorLower;
+      const isExecutor = r.executor?.value === actorLower;
+      const isPair = r.with.some((p) => p.value === actorLower);
+      if (!isAuthor && !isExecutor && !isPair) continue;
+      requiresOtherActor.push({
+        verb: 'approve',
+        id: r.id.value,
+        candidates: hostNames,
+        reason:
+          `${r.id.value} is pending; approval requires a host actor` +
+          (hostNames.length === 0
+            ? ' (none configured — see guild.config.yaml host_names)'
+            : `. You are the ${
+                isAuthor ? 'author' : isExecutor ? 'executor' : 'pair'
+              } but cannot approve as yourself.`),
+      });
+    }
+  }
+
+  return {
+    actionable,
+    requires_other_actor: requiresOtherActor,
+    always_readable: ALWAYS_READABLE_VERBS,
+  };
 }
 
 function renderBootText(p: BootPayload): string {

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -398,6 +398,33 @@ function formatRequestText(r: Request): string {
     );
   }
 
+  // Concern marker: a 3-state existence signal, not a count. Counting
+  // ("3 concerns, 1 follow-up") would invite the reader to play a
+  // "drive the number down" game — performance-for-the-record
+  // (principle 03). Three states keep perception engaged without
+  // setting a target:
+  //   - no concerns recorded
+  //   - concern recorded; no inbound reference
+  //   - concern recorded; inbound reference present
+  // The reader walks `gate chain` to see the actual references and
+  // judges for themselves whether they address the concerns. The
+  // tool only asserts existence.
+  const hasConcernReview = (reviews as Array<Record<string, unknown>>).some(
+    (rv) => rv['verdict'] === 'concern' || rv['verdict'] === 'reject',
+  );
+  if (hasConcernReview) {
+    // We don't have the cross-record inbound count here without an
+    // extra repository pass; instead say "see gate chain" and let
+    // the reader resolve presence vs absence with one command. This
+    // keeps formatRequestText synchronous + repo-free.
+    lines.push(
+      `  concern marker: concern recorded — ` +
+        `walk \`gate chain ${selfId}\` to see inbound references (if any)`,
+    );
+  } else {
+    lines.push('  concern marker: no concerns recorded');
+  }
+
   return lines.join('\n');
 }
 

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -156,7 +156,7 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   if (openLoops.length > 0) {
     const top = openLoops[0]!;
     const req = all.find((r) => r.id.value === top.id);
-    if (req) suggested = deriveSuggestedNext(req, c.config);
+    if (req) suggested = deriveSuggestedNext(req, c.config, actor);
   }
 
   // Unresponded concerns: concern/reject verdicts on the actor's

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -52,23 +52,30 @@ const formatField: JsonSchema = {
   description: 'output format (agent-first default: json for read; text for write)',
 };
 
+// Inner property shape of every `suggested_next` payload, exported
+// as a named const so multiple verb output schemas (write response,
+// boot, suggest) can share a single source of truth. Hand-rolled
+// inline copies in older revisions drifted (devil's B2 review on
+// 2026-05-01-0005); this prevents that recurring.
+const suggestedNextProperties: Record<string, JsonSchema> = {
+  verb: str,
+  args: {
+    type: 'object',
+    description: 'pre-filled argument hints — agent may override',
+  },
+  reason: str,
+  actor_resolved: {
+    type: 'boolean',
+    description:
+      'true iff `args.by` is absent or matches the calling actor (GUILD_ACTOR). ' +
+      'When false, the suggestion names a different actor — orchestrators should ' +
+      'branch (escalate / hand off) rather than naively dispatching with their own --by.',
+  },
+};
+
 const suggestedNextSchema: JsonSchema = {
   type: 'object',
-  properties: {
-    verb: str,
-    args: {
-      type: 'object',
-      description: 'pre-filled argument hints — agent may override',
-    },
-    reason: str,
-    actor_resolved: {
-      type: 'string',
-      description:
-        'true iff `args.by` is absent or matches the calling actor (GUILD_ACTOR). ' +
-        'When false, the suggestion names a different actor — orchestrators should ' +
-        'branch (escalate / hand off) rather than naively dispatching with their own --by.',
-    },
-  },
+  properties: suggestedNextProperties,
 };
 
 const writeResponseSchema: JsonSchema = {
@@ -121,6 +128,35 @@ const VERBS: readonly VerbSchema[] = [
             'about what to do next, derived from queues + open loops. ' +
             "Read `reason` and override when your judgement differs. " +
             'Priority is shared with `gate suggest`; both are hints.',
+          // Same canonical sub-schema as suggest so the two surfaces
+          // never disagree on the suggested_next shape.
+          properties: suggestedNextProperties,
+        },
+        verbs_available_now: {
+          type: 'object',
+          description:
+            "Discoverability hint: which verbs are dispatchable right now. " +
+            "`actionable` lists transitions the caller can fire as themselves; " +
+            "`requires_other_actor` names blockers (e.g. pending requests waiting " +
+            'on a host) with `candidates` so domain-specific actor models can ' +
+            "re-interpret without the payload pre-baking a host assumption; " +
+            "`always_readable` is the side-effect-free verb catalog.",
+          properties: {
+            actionable: { type: 'array', items: { type: 'object' } },
+            requires_other_actor: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  verb: str,
+                  id: str,
+                  candidates: { type: 'array', items: str },
+                  reason: str,
+                },
+              },
+            },
+            always_readable: { type: 'array', items: str },
+          },
         },
       },
     },
@@ -156,11 +192,12 @@ const VERBS: readonly VerbSchema[] = [
             'judgement differs; a `suggest` loop that dispatches the verb ' +
             'without reading the reason is treating a heuristic as a ' +
             'command, which is the shape this field is trying to avoid.',
-          properties: {
-            verb: str,
-            args: { type: 'object' },
-            reason: str,
-          },
+          // Mirror the canonical suggestedNextSchema so this surface
+          // never drifts from the write-response shape (devil B2:
+          // hand-rolled inline schema went stale when actor_resolved
+          // was added). Keeps `actor_resolved` and any future field
+          // visible to schema-aware consumers without a second edit.
+          properties: suggestedNextProperties,
         },
       },
     },

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -61,6 +61,13 @@ const suggestedNextSchema: JsonSchema = {
       description: 'pre-filled argument hints — agent may override',
     },
     reason: str,
+    actor_resolved: {
+      type: 'string',
+      description:
+        'true iff `args.by` is absent or matches the calling actor (GUILD_ACTOR). ' +
+        'When false, the suggestion names a different actor — orchestrators should ' +
+        'branch (escalate / hand off) rather than naively dispatching with their own --by.',
+    },
   },
 };
 
@@ -614,6 +621,51 @@ const VERBS: readonly VerbSchema[] = [
     summary: 'this introspection payload',
     input: { type: 'object', properties: { verb: str, format: formatField } },
     output: { type: 'object' },
+  },
+  {
+    name: 'unresponded',
+    category: 'read',
+    summary:
+      'concern/reject verdicts on the actor\'s authored or pair-made requests with no follow-up record yet. Deliberately coarse follow-up detector (existence-only); the reader walks `gate chain <id>` to verify whether existing references actually address a concern. Perception, not judgement.',
+    input: {
+      type: 'object',
+      properties: {
+        for: strOpt('actor to inspect (default: GUILD_ACTOR)'),
+        'max-age-days': strOpt('window for concern detection (default: 30)'),
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        actor: str,
+        max_age_days: { type: 'integer' },
+        count: { type: 'integer' },
+        entries: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              request_id: str,
+              action: str,
+              concerns: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    by: str,
+                    lense: str,
+                    verdict: { type: 'string', enum: ['concern', 'reject'] },
+                    at: str,
+                    age_days: { type: 'integer' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
 ];
 

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -197,6 +197,28 @@ function buildTranscript(r: Request): TranscriptPayload {
     `Final state: ${finalState}. ${capitalise(actorFrag)}${durationFrag}.`,
   );
 
+  // 5. Concerns recorded — bare enumeration of concern/reject
+  // verdicts. Deliberately descriptive: no "still open", no
+  // "addressed by", no severity language (principle 07 — the tool
+  // surfaces existence, the reader judges status). When a reader
+  // wants to know whether something already references these
+  // concerns, `gate chain <id>` walks the actual links.
+  const concernLines: string[] = [];
+  for (const rv of reviews) {
+    const verdict = String(rv['verdict'] ?? '');
+    if (verdict !== 'concern' && verdict !== 'reject') continue;
+    const by = String(rv['by'] ?? '');
+    const lense = String(rv['lense'] ?? '');
+    const at = String(rv['at'] ?? '');
+    concernLines.push(`  - [${lense}/${verdict}] by ${by} at ${at}`);
+  }
+  if (concernLines.length > 0) {
+    const header =
+      `Concerns recorded (${concernLines.length}):` +
+      ` walk \`gate chain ${id}\` to see references.`;
+    paragraphs.push([header, ...concernLines].join('\n'));
+  }
+
   return { id, arc: paragraphs.join('\n\n'), summary };
 }
 

--- a/src/interface/gate/handlers/unresponded.ts
+++ b/src/interface/gate/handlers/unresponded.ts
@@ -1,9 +1,19 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C, parseOptionalIntOption } from './internal.js';
 import {
   DEFAULT_MAX_AGE_DAYS,
   UnrespondedConcernsEntry,
 } from '../../../application/concern/UnrespondedConcernsQuery.js';
+
+const UNRESPONDED_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'max-age-days',
+  'format',
+]);
 
 /**
  * gate unresponded [--for <m>] [--max-age-days <N>] [--format json|text]
@@ -42,6 +52,12 @@ export async function unrespondedCmd(
   c: C,
   args: ParsedArgs,
 ): Promise<number> {
+  // Strict-flag rejection: keeps consistency with `gate tail` /
+  // `gate doctor` / `gate repair` (read verbs that have already
+  // adopted the discipline). A typo like `--max-age-day 7`
+  // silently falling back to the 30-day default would be the
+  // exact fail-open shape this guard exists to prevent.
+  rejectUnknownFlags(args, UNRESPONDED_KNOWN_FLAGS, 'unresponded');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/unresponded.ts
+++ b/src/interface/gate/handlers/unresponded.ts
@@ -1,0 +1,114 @@
+import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { C, parseOptionalIntOption } from './internal.js';
+import {
+  DEFAULT_MAX_AGE_DAYS,
+  UnrespondedConcernsEntry,
+} from '../../../application/concern/UnrespondedConcernsQuery.js';
+
+/**
+ * gate unresponded [--for <m>] [--max-age-days <N>] [--format json|text]
+ *
+ * Surfaces concern/reject verdicts on the actor's authored (or
+ * pair-made) requests that have no follow-up record yet. Read-only —
+ * a thin wrapper over `UnrespondedConcernsQuery` (deliberately the
+ * same query that drives `gate resume`'s concerns surface, so the
+ * two cannot diverge).
+ *
+ * Naming: the verb is `unresponded`, not `concerns`. The latter would
+ * suggest the output enumerates *all* concerns; the actual semantic
+ * is "concerns where no follow-up exists yet" — a deliberately coarse
+ * follow-up detector (see UnrespondedConcernsQuery's header). Aligning
+ * the verb with the underlying function name keeps reader expectations
+ * matched to implementation. The detector explicitly does NOT try to
+ * decide whether a follow-up actually addresses a concern; that
+ * judgement is the reader's. `gate chain <id>` walks the actual
+ * references when the reader wants to verify.
+ *
+ * Default actor: GUILD_ACTOR. `--for <m>` overrides for cross-actor
+ * inspection (e.g. a host scanning what their executor has open).
+ *
+ * Default max-age: 30 days (`UnrespondedConcernsQuery.DEFAULT_MAX_AGE_DAYS`).
+ * `--max-age-days <N>` overrides for retrospective sweeps.
+ */
+
+interface UnrespondedPayload {
+  actor: string;
+  max_age_days: number;
+  entries: ReadonlyArray<UnrespondedConcernsEntry>;
+  count: number;
+}
+
+export async function unrespondedCmd(
+  c: C,
+  args: ParsedArgs,
+): Promise<number> {
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  const explicit = optionalOption(args, 'for');
+  const envActor = process.env['GUILD_ACTOR'];
+  const actor = explicit ?? envActor ?? '';
+  if (!actor) {
+    process.stderr.write(
+      'gate unresponded needs an actor: pass --for <m> or export GUILD_ACTOR.\n',
+    );
+    return 1;
+  }
+
+  const maxAgeDays =
+    parseOptionalIntOption(args, 'max-age-days') ?? DEFAULT_MAX_AGE_DAYS;
+
+  const entries = await c.unrespondedConcernsQ.run({
+    actor,
+    now: new Date(),
+    maxAgeDays,
+  });
+
+  const payload: UnrespondedPayload = {
+    actor,
+    max_age_days: maxAgeDays,
+    entries,
+    count: entries.length,
+  };
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+
+  if (entries.length === 0) {
+    process.stdout.write(
+      `(no unresponded concerns for ${actor} within ${maxAgeDays} days)\n`,
+    );
+    return 0;
+  }
+
+  process.stdout.write(
+    `${entries.length} unresponded concern record(s) for ${actor} ` +
+      `(window: ${maxAgeDays} days)\n\n`,
+  );
+  for (const e of entries) {
+    process.stdout.write(`${e.request_id}  ${e.action}\n`);
+    for (const c of e.concerns) {
+      process.stdout.write(
+        `  [${c.lense}/${c.verdict}] by ${c.by} ` +
+          `(${c.age_days}d ago at ${c.at})\n`,
+      );
+    }
+    process.stdout.write(
+      `  → walk \`gate chain ${e.request_id}\` to see what (if anything) ` +
+        `already references it.\n\n`,
+    );
+  }
+  // Advisory footer — same shape as `gate suggest`'s footer.
+  // Reminds the reader that "no follow-up" is a structural fact,
+  // not a judgement about whether the concern matters today.
+  process.stderr.write(
+    '# advisory — these are concerns without follow-up records.\n' +
+      '# leaving as-is, conversing them out, or letting them fade ' +
+      'are all first-class.\n',
+  );
+  return 0;
+}

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -57,6 +57,15 @@ export interface SuggestedNext {
   args: Record<string, string>;
   /** One-line explanation of why this verb is suggested. */
   reason: string;
+  /**
+   * True iff `args.by` is absent or matches the calling actor
+   * (GUILD_ACTOR). When false, the suggestion can only be carried
+   * out by a different actor than the one currently running the
+   * tool — orchestrators that auto-dispatch should branch on this
+   * rather than naively re-running with their own --by. Hint, not
+   * gate: the underlying verb still validates --by at the boundary.
+   */
+  actor_resolved: boolean;
 }
 
 /**
@@ -67,14 +76,21 @@ export interface SuggestedNext {
  *   pending    → approve (host or executor decides)
  *   approved   → execute (by executor)
  *   executing  → complete (by executor)
- *   completed  → review if an auto-reviewer is assigned and they
- *                haven't reviewed yet; null otherwise (terminal-done)
+ *   completed  → review if an auto-reviewer hasn't recorded yet;
+ *                advisory `chain` walk if a concern/reject verdict
+ *                is on record; null otherwise (terminal-clean)
  *   denied     → null (terminal)
  *   failed     → null (terminal)
+ *
+ * `envActor` (when provided) is used to populate `actor_resolved` —
+ * true iff the suggestion's `by` argument is absent or matches the
+ * caller. Pass `null` or omit when no actor context is available;
+ * `actor_resolved` then reports based on `by` absence alone.
  */
 export function deriveSuggestedNext(
   req: Request,
   config: GuildConfig,
+  envActor?: string | null,
 ): SuggestedNext | null {
   const id = req.id.value;
   switch (req.state) {
@@ -86,58 +102,83 @@ export function deriveSuggestedNext(
       // (or a human at the keyboard) chooses explicitly.
       const hosts = config.hostNames;
       if (hosts.length === 1) {
-        return {
+        return withActorResolved({
           verb: 'approve',
           args: { id, by: hosts[0]! },
           reason: `request is pending; host ${hosts[0]} must approve (or deny) before execution`,
-        };
+        }, envActor);
       }
-      return {
+      return withActorResolved({
         verb: 'approve',
         args: { id },
         reason:
           hosts.length === 0
             ? 'request is pending; a registered host must approve — none are configured yet'
             : `request is pending; approve by one of the configured hosts [${hosts.join(', ')}] (or deny)`,
-      };
+      }, envActor);
     }
     case 'approved': {
       const executor = req.executor?.value ?? '';
-      return {
+      return withActorResolved({
         verb: 'execute',
         args: executor ? { id, by: executor } : { id },
         reason: 'request is approved; executor should begin work',
-      };
+      }, envActor);
     }
     case 'executing': {
       const executor = req.executor?.value ?? '';
-      return {
+      return withActorResolved({
         verb: 'complete',
         args: executor ? { id, by: executor } : { id },
         reason: 'request is executing; executor should complete (or fail) when done',
-      };
+      }, envActor);
     }
     case 'completed': {
-      if (!req.autoReview) return null;
-      const reviewer = req.autoReview.value;
-      const alreadyReviewed = req.reviews.some(
-        (r) => r.by.value === reviewer,
+      const reviewer = req.autoReview?.value;
+      const reviewerDone = reviewer
+        ? req.reviews.some((r) => r.by.value === reviewer)
+        : false;
+      if (reviewer && !reviewerDone) {
+        // Intentionally NO `verdict` default: the Two-Persona Devil
+        // Review loop exists because rubber-stamping is the failure
+        // mode. Defaulting verdict to 'ok' would let an inattentive
+        // agent chain-call the suggestion without actually reviewing.
+        // The reviewer must supply verdict explicitly.
+        return withActorResolved({
+          verb: 'review',
+          args: {
+            id,
+            by: reviewer,
+            lense: 'devil',
+          },
+          reason: `auto-review assigned to ${reviewer} but no review recorded yet; supply --verdict <ok|concern|reject> and --comment after actually reading the work`,
+        }, envActor);
+      }
+      // Completed-with-concern advisory. When any review carries a
+      // concern/reject verdict, surface a `chain` walk as the next
+      // hint — read-only, lets the reader perceive what (if anything)
+      // already references this id. The reason names follow-up paths
+      // explicitly alongside "leaving as-is, conversing it out, or
+      // letting it fade — all first-class" so the absence of action
+      // is not 2nd-class. The verb is `chain` (read), not `request`
+      // (write), so the tool isn't pushing a dispute-resolution flow;
+      // it's offering a perception aid.
+      const hasConcern = req.reviews.some(
+        (r) => r.verdict === 'concern' || r.verdict === 'reject',
       );
-      if (alreadyReviewed) return null;
-      // Intentionally NO `verdict` default: the Two-Persona Devil
-      // Review loop exists because rubber-stamping is the failure
-      // mode. Defaulting verdict to 'ok' would let an inattentive
-      // agent chain-call the suggestion without actually reviewing.
-      // The reviewer must supply verdict explicitly.
-      return {
-        verb: 'review',
-        args: {
-          id,
-          by: reviewer,
-          lense: 'devil',
-        },
-        reason: `auto-review assigned to ${reviewer} but no review recorded yet; supply --verdict <ok|concern|reject> and --comment after actually reading the work`,
-      };
+      if (hasConcern) {
+        return withActorResolved({
+          verb: 'chain',
+          args: { id },
+          reason:
+            `concern recorded on ${id}; ` +
+            `walk \`gate chain ${id}\` to see what (if anything) already references it. ` +
+            'Possible follow-ups: file a follow-up request that mentions this id, ' +
+            'file an issue tagging it — alongside leaving as-is, conversing it ' +
+            'out, or letting it fade. All first-class.',
+        }, envActor);
+      }
+      return null;
     }
     case 'denied':
     case 'failed':
@@ -147,17 +188,37 @@ export function deriveSuggestedNext(
   }
 }
 
+/**
+ * Stamp `actor_resolved` onto a verb/args/reason triple. True when
+ * the suggestion has no `by` argument (caller-agnostic) or its `by`
+ * matches the calling actor. False when a different actor is named —
+ * the orchestrator will need to escalate or hand off.
+ */
+function withActorResolved(
+  partial: Omit<SuggestedNext, 'actor_resolved'>,
+  envActor: string | null | undefined,
+): SuggestedNext {
+  const required = partial.args['by'];
+  const resolved =
+    required === undefined ||
+    (typeof envActor === 'string' &&
+      envActor.length > 0 &&
+      required.toLowerCase() === envActor.toLowerCase());
+  return { ...partial, actor_resolved: resolved };
+}
+
 export function buildWriteResponse(
   req: Request,
   message: string,
   config: GuildConfig,
 ): WriteResponse {
+  const envActor = process.env['GUILD_ACTOR'] ?? null;
   return {
     ok: true,
     id: req.id.value,
     state: req.state,
     message,
-    suggested_next: deriveSuggestedNext(req, config),
+    suggested_next: deriveSuggestedNext(req, config, envActor),
   };
 }
 

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -40,6 +40,7 @@ import { suggestCmd } from './handlers/suggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
+import { unrespondedCmd } from './handlers/unresponded.js';
 
 // Re-export for test backward-compat (tests/interface/reviewMarkers.test.ts).
 // formatReviewMarkers and computeReviewMarkerWidth live in handlers/request.ts
@@ -205,6 +206,17 @@ Status:
                        Same-actor continuation only — for a newcomer
                        arriving via handoff, use 'gate boot' to see
                        cross-actor signals (inbox, --with assignments).
+  gate unresponded [--for <m>] [--max-age-days <N>] [--format json|text]
+                       Read-only surface for concern/reject verdicts on
+                       the actor's authored or pair-made requests that
+                       have no follow-up record yet. Thin wrapper over
+                       UnrespondedConcernsQuery — same detector that
+                       drives 'gate resume'. Default actor is
+                       GUILD_ACTOR; default window is 30 days. The
+                       detector is deliberately coarse (does not infer
+                       whether a follow-up actually addresses a
+                       concern); 'gate chain <id>' walks the actual
+                       references when the reader wants to verify.
 
 Meta:
   gate schema [--verb <name>] [--format json|text]
@@ -223,6 +235,7 @@ const KNOWN_COMMANDS = [
   'complete', 'fail', 'review', 'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
   'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
+  'unresponded',
 ] as const;
 
 function levenshtein(a: string, b: string): number {
@@ -358,6 +371,8 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await resumeCmd(c, args);
       case 'schema':
         return await schemaCmd(c, args);
+      case 'unresponded':
+        return await unrespondedCmd(c, args);
       default: {
         const hint = nearestCommand(cmd);
         const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -384,9 +384,86 @@ test('boot.verbs_available_now: always_readable present for anonymous caller', (
     const { stdout } = runGate(root, ['boot']);
     const p = JSON.parse(stdout);
     assert.equal(p.verbs_available_now.actionable.length, 0);
+    assert.equal(p.verbs_available_now.requires_other_actor.length, 0);
     assert.ok(p.verbs_available_now.always_readable.length >= 10);
     assert.ok(p.verbs_available_now.always_readable.includes('suggest'));
     assert.ok(p.verbs_available_now.always_readable.includes('schema'));
+    assert.ok(p.verbs_available_now.always_readable.includes('unresponded'));
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.verbs_available_now: requires_other_actor surfaces pending blockers', () => {
+  // 2.A: a non-host author who filed a pending request sees the
+  // approval blocker — verb=approve, candidates=[host], reason
+  // explains why they can't act alone. This is the gap that bit
+  // first-time agents: suggested_next would return "by: host" with
+  // no obvious context for why the actor's own --by wouldn't work.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'pending', '--reason', 'r', '--executor', 'alice'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const p = JSON.parse(stdout);
+    assert.equal(p.verbs_available_now.actionable.length, 0);
+    assert.ok(
+      p.verbs_available_now.requires_other_actor.length >= 1,
+      'expected a pending-approval blocker for alice',
+    );
+    const blocker = p.verbs_available_now.requires_other_actor[0];
+    assert.equal(blocker.verb, 'approve');
+    assert.deepEqual(blocker.candidates, ['human']);
+    assert.match(blocker.reason, /pending/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.verbs_available_now: host self-approval doesnt double-list as blocker', () => {
+  // When the actor IS the host, pending requests on their own
+  // record show up under actionable (pending-as-executor) — NOT
+  // under requires_other_actor, since the host can self-approve.
+  const { root, cleanup } = bootstrap();
+  try {
+    // human is the host; have human file + name self executor
+    runGate(
+      root,
+      ['request', '--from', 'human', '--action', 'self', '--reason', 'r', '--executor', 'human'],
+      { GUILD_ACTOR: 'human' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'human' });
+    const p = JSON.parse(stdout);
+    assert.equal(
+      p.verbs_available_now.requires_other_actor.length,
+      0,
+      'host should not see their own pending-approval as blocker',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('write response suggested_next carries actor_resolved', () => {
+  // 2.E: the boolean lets an orchestrator branch without parsing
+  // `args.by` against the env. True when args.by is absent or
+  // matches GUILD_ACTOR, false otherwise.
+  const { root, cleanup } = bootstrap();
+  try {
+    const created = runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'alice', '--format', 'json'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const payload = JSON.parse(created.stdout);
+    // Pending state suggests approve by host (human). alice is not
+    // the host, so actor_resolved=false.
+    assert.equal(payload.suggested_next.verb, 'approve');
+    assert.equal(payload.suggested_next.args.by, 'human');
+    assert.equal(payload.suggested_next.actor_resolved, false);
   } finally {
     cleanup();
   }

--- a/tests/interface/showChainHints.test.ts
+++ b/tests/interface/showChainHints.test.ts
@@ -149,6 +149,71 @@ test('show text: N refs → lists the ids', (t) => {
   );
 });
 
+test('show text: concern marker line — no concerns recorded', (t) => {
+  // 1.A: a fresh record with no concern review surfaces an
+  // explicit "no concerns recorded" line. The 3-state existence
+  // marker (no concern / concern + chain says inbound / concern
+  // + chain says no inbound) is the perception aid.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'no concerns yet',
+    '--reason', 'baseline',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  const shown = runGate(root, ['show', id, '--format', 'text']);
+  assert.equal(shown.status, 0);
+  assert.match(
+    shown.stdout,
+    /concern marker: no concerns recorded/,
+    'expected explicit no-concerns line',
+  );
+});
+
+test('show text: concern marker line — concern recorded', (t) => {
+  // 1.A: once a concern verdict lands, the line flips to
+  // "concern recorded — walk gate chain ..." referring the
+  // reader to the actual link walker rather than asserting
+  // resolution status (which the tool refuses to judge).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  runGate(root, ['register', '--name', 'bob', '--category', 'professional']);
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'gets a concern',
+    '--reason', 'baseline',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  runGate(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'concern',
+    '--comment', 'careful here',
+  ]);
+  const shown = runGate(root, ['show', id, '--format', 'text']);
+  assert.equal(shown.status, 0);
+  assert.match(
+    shown.stdout,
+    /concern marker: concern recorded/,
+    'expected concern-recorded line',
+  );
+  // Must NOT contain a count — principle 03's performance-for-
+  // the-record concern rules out "concerns: N; resolving: M".
+  assert.doesNotMatch(
+    shown.stdout,
+    /concerns: \d+/,
+    'concern marker must use existence-language, not counts',
+  );
+});
+
 test('show text: short-form (0004) is NOT detected', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);

--- a/tests/interface/unresponded.test.ts
+++ b/tests/interface/unresponded.test.ts
@@ -178,3 +178,21 @@ test('unresponded: missing actor (no GUILD_ACTOR, no --for) is an error', (t) =>
   assert.notEqual(out.status, 0);
   assert.match(out.stderr, /actor/i);
 });
+
+test('unresponded: rejects unknown flags', (t) => {
+  // Read-verb strict-flag discipline: a typo like `--max-age-day 7`
+  // (singular) silently falling back to the 30-day default would be
+  // the exact fail-open shape rejectUnknownFlags exists to prevent.
+  // Mirrors the behavior of gate tail / doctor / repair.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const out = runGate(
+    root,
+    ['unresponded', '--max-age-day', '7'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /unknown flag/i);
+  assert.match(out.stderr, /--max-age-days/);
+});

--- a/tests/interface/unresponded.test.ts
+++ b/tests/interface/unresponded.test.ts
@@ -1,0 +1,180 @@
+// gate unresponded — read verb wrapping UnrespondedConcernsQuery.
+//
+// The detector is deliberately coarse (existence-only follow-up
+// detection; does not infer whether a follow-up actually addresses
+// a concern). These tests pin the verb's contract rather than the
+// underlying detector logic — that's covered by
+// tests/application/UnrespondedConcernsQuery.test.ts.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-unresponded-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function extractId(stdout: string): string | null {
+  const m = stdout.match(/\b(\d{4}-\d{2}-\d{2}-\d+)\b/);
+  return m ? m[1]! : null;
+}
+
+test('unresponded: empty content_root returns count=0', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  const out = runGate(
+    root,
+    ['unresponded', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(out.status, 0);
+  const p = JSON.parse(out.stdout);
+  assert.equal(p.actor, 'alice');
+  assert.equal(p.count, 0);
+  assert.deepEqual(p.entries, []);
+});
+
+test('unresponded: surfaces concern with no follow-up', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  runGate(root, ['register', '--name', 'bob', '--category', 'professional']);
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'has a concern',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  runGate(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'concern',
+    '--comment', 'something to think about',
+  ]);
+  const out = runGate(
+    root,
+    ['unresponded', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const p = JSON.parse(out.stdout);
+  assert.equal(p.count, 1);
+  assert.equal(p.entries[0].request_id, id);
+  assert.equal(p.entries[0].concerns[0].by, 'bob');
+  assert.equal(p.entries[0].concerns[0].verdict, 'concern');
+});
+
+test('unresponded: filters out concerns that have a follow-up referencing them', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  runGate(root, ['register', '--name', 'bob', '--category', 'professional']);
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'first',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  runGate(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'concern',
+    '--comment', 'concern raised',
+  ]);
+  // file a follow-up authored by alice that mentions the id
+  runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', `addresses ${id}`,
+    '--reason', `responding to ${id}'s concern`,
+    '--executor', 'alice',
+  ]);
+  const out = runGate(
+    root,
+    ['unresponded', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const p = JSON.parse(out.stdout);
+  assert.equal(
+    p.count,
+    0,
+    'follow-up referencing the id removes the concern from the unresponded set',
+  );
+});
+
+test('unresponded: --for overrides GUILD_ACTOR', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+  runGate(root, ['register', '--name', 'bob', '--category', 'professional']);
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'a',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  runGate(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'concern',
+    '--comment', 'c',
+  ]);
+  // bob asks for alice's unresponded set explicitly
+  const out = runGate(
+    root,
+    ['unresponded', '--for', 'alice', '--format', 'json'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  const p = JSON.parse(out.stdout);
+  assert.equal(p.actor, 'alice');
+  assert.equal(p.count, 1);
+});
+
+test('unresponded: missing actor (no GUILD_ACTOR, no --for) is an error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const out = runGate(root, ['unresponded', '--format', 'json']);
+  assert.notEqual(out.status, 0);
+  assert.match(out.stderr, /actor/i);
+});

--- a/tests/interface/writeFormat.test.ts
+++ b/tests/interface/writeFormat.test.ts
@@ -155,6 +155,140 @@ test('completed without auto-review → suggested_next is null', () => {
   }
 });
 
+test('actor_resolved is true when GUILD_ACTOR matches suggested args.by', () => {
+  const { cfg, cleanup } = mkConfig(['human']);
+  try {
+    const r = Request.create({
+      id: RequestId.generate(d, 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+      executor: 'alice',
+    });
+    r.approve(MemberName.of('human'));
+    // approved → execute, args.by=alice
+    const sAsAlice = deriveSuggestedNext(r, cfg, 'alice');
+    assert.equal(sAsAlice?.actor_resolved, true);
+    const sAsBob = deriveSuggestedNext(r, cfg, 'bob');
+    assert.equal(sAsBob?.actor_resolved, false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('actor_resolved is true when args has no by (caller-agnostic)', () => {
+  // Multiple hosts → suggested_next has no `by` (per existing
+  // behavior). actor_resolved falls back to true because there's
+  // no actor constraint to mismatch against.
+  const { cfg, cleanup } = mkConfig(['alice', 'bob']);
+  try {
+    const r = Request.create({
+      id: RequestId.generate(d, 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+    });
+    const s = deriveSuggestedNext(r, cfg, 'someone');
+    assert.equal(s?.args['by'], undefined);
+    assert.equal(s?.actor_resolved, true);
+  } finally {
+    cleanup();
+  }
+});
+
+test('completed with concern review and no auto-review → chain advisory', () => {
+  // 3.A: when a completed request carries a concern verdict, the
+  // suggested_next becomes a `chain` walk (read-only) so the reader
+  // can see what (if anything) already references it. The `reason`
+  // names "leaving as-is, conversing it out, or letting it fade —
+  // all first-class" so absence-of-action stays a valid choice.
+  const { cfg, cleanup } = mkConfig(['human']);
+  try {
+    const r = Request.create({
+      id: RequestId.generate(d, 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+    });
+    r.approve(MemberName.of('human'));
+    r.execute(MemberName.of('alice'));
+    r.complete(MemberName.of('alice'));
+    r.addReview(
+      Review.create({
+        by: 'bob',
+        lense: 'devil',
+        verdict: 'concern',
+        comment: 'subtle issue',
+      }),
+    );
+    const s = deriveSuggestedNext(r, cfg);
+    assert.equal(s?.verb, 'chain');
+    assert.match(s!.reason, /concern recorded/i);
+    assert.match(s!.reason, /leaving as-is/i);
+    assert.match(s!.reason, /first-class/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('completed with auto-review done AND concern present → chain advisory', () => {
+  // Auto-review fired but its verdict was concern. The advisory
+  // (chain walk + first-class options) replaces the otherwise-null
+  // suggested_next, so the concern doesn't go quiet.
+  const { cfg, cleanup } = mkConfig(['human']);
+  try {
+    const r = Request.create({
+      id: RequestId.generate(d, 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+      executor: 'alice',
+      autoReview: 'bob',
+    });
+    r.approve(MemberName.of('human'));
+    r.execute(MemberName.of('alice'));
+    r.complete(MemberName.of('alice'));
+    r.addReview(
+      Review.create({
+        by: 'bob',
+        lense: 'devil',
+        verdict: 'concern',
+        comment: 'careful',
+      }),
+    );
+    const s = deriveSuggestedNext(r, cfg);
+    assert.equal(s?.verb, 'chain');
+    assert.match(s!.reason, /first-class/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('completed with auto-review done AND ok verdict → still null', () => {
+  // The advisory only fires for concern/reject. A clean ok review
+  // closes the arc without further suggestion (existing behavior).
+  const { cfg, cleanup } = mkConfig(['human']);
+  try {
+    const r = Request.create({
+      id: RequestId.generate(d, 1),
+      from: 'alice',
+      action: 'a',
+      reason: 'r',
+      executor: 'alice',
+      autoReview: 'bob',
+    });
+    r.approve(MemberName.of('human'));
+    r.execute(MemberName.of('alice'));
+    r.complete(MemberName.of('alice'));
+    r.addReview(
+      Review.create({ by: 'bob', lense: 'devil', verdict: 'ok', comment: 'lgtm' }),
+    );
+    assert.equal(deriveSuggestedNext(r, cfg), null);
+  } finally {
+    cleanup();
+  }
+});
+
 test('terminal states (denied/failed) return null', () => {
   const { cfg, cleanup } = mkConfig(['human']);
   try {


### PR DESCRIPTION
## Summary

Six additive surface changes that close usability gaps observed during a first-time walk-through of `gate`. Each preserves principle integrity (perception not judgement / advisory not directive / read-write separation / records outlive writers) and remains backward-compatible: existing payload shapes keep their contracts, new fields are additive, advisory behaviors are inspectable rather than coercive.

The shape itself was iterated through a full Two-Persona Devil Review in `/tmp/sandbox` (initial design → devil-lens dogfood → adjusted plan → implementation → second devil-lens pass → fixes). The records are reproducible if the methodology matters; commit messages reference the request ids.

## Changes

- **`gate unresponded`** (new read verb) — thin wrapper over `UnrespondedConcernsQuery`, the same detector that drives `gate resume`'s concerns surface. Naming aligns with the underlying function rather than `concerns` (which would imply enumeration of all concerns; the detector is deliberately coarse).
- **`gate show` concern marker line** — binary existence signal (`no concerns recorded` / `concern recorded — walk gate chain ...`) next to the existing chain-hint line. Existence-language, not counts: counting would invite "drive the number to zero" gaming (principle 03's performance-for-the-record).
- **`boot.verbs_available_now.requires_other_actor`** — sibling array to `actionable`, naming blockers (e.g. pending requests waiting on a host) with `candidates` as a list. Payload shape doesn't embed a single-host assumption; domain-specific actor models can re-interpret without the field shape pushing back.
- **`SuggestedNext.actor_resolved: boolean`** — across write-response / boot / suggest / resume. True iff `args.by` is absent or matches `GUILD_ACTOR`. Lets orchestrators branch (escalate / hand off vs. dispatch as self) without parsing `--by` against the env.
- **Concern advisory on completed-with-concern reviews** — `suggested_next` returns a `chain` walk (read-only) rather than null when a completed request carries a concern verdict. Reason text names follow-up paths AND explicitly lists "leaving as-is, conversing it out, or letting it fade — all first-class." The absence of action stays structurally legitimate in the tool's voice.
- **`gate transcript` `Concerns recorded` section** — bare enumeration of `concern`/`reject` verdicts at the end of the narrative. Points at `gate chain <id>` for reference resolution; no status language (principle 07).

## Implementation notes

- **No domain / application / infrastructure changes.** All surface in `interface/gate/handlers/*` plus a new handler. `UnrespondedConcernsQuery` was already in the container; this PR exposes it.
- **Breaking-change scan**: existing `actionable` shape preserved (flat array of `{verb, id, reason}`); `requires_other_actor` is additive. `SuggestedNext.actor_resolved` is a new field, additive. CHANGELOG documents each.
- **Schema synchronisation**: `suggestedNextProperties` extracted as a single source so write-response, boot, and suggest output schemas can never silently drift again.
- **Strict-flag discipline**: `gate unresponded` has `rejectUnknownFlags` so a typo like `--max-age-day 7` errors with the valid flag list rather than silently falling back to defaults.

## Test plan

- [x] `npm test` — 521/521 passing (was 505 before this PR; +16 covering the new surfaces)
- [x] `npm run build` — clean tsc with strict mode
- [x] Dogfood verification of all six surfaces in a sandbox content_root
- [x] Schema introspection: `gate schema --verb suggest` and `--verb boot` correctly include `actor_resolved` with `type: boolean`
- [x] Devil review pass against the implementation itself (caught 4 follow-up fixes; all addressed in `ce4fda2`)

## Two commits, why

- `72adb2f feat: surface concerns + actor-resolved hints (6-point adjusted set)` — the implementation
- `ce4fda2 fix: address devil review on 2026-05-01-0005 (4 surface fixes)` — schema type bug, doc-code drift, missing strict-flag guard, schema drift between suggest/boot output and the canonical sub-schema. All caught by running the project's own review discipline against its own diff before opening this PR.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_