### PR TITLE
fix: surface tweaks + lens→lense alignment pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ A small, secure, file-based CLI for a team of agents — human and AI —
 to ask each other for work, review it, and leave a trail that nothing
 in the loop can quietly rewrite.
 
-Reviews are append-only. Each record is pinned to an actor, a lens,
+Reviews are append-only. Each record is pinned to an actor, a lense,
 and a moment. Corrections are new entries, not edits of old ones.
 Over time the content_root becomes an **event log of judgments** —
 not "what was decided" but **how the decision was formed**: who
-proposed, who objected, through which lens, and whether the objection
+proposed, who objected, through which lense, and whether the objection
 was absorbed or overridden. The tool tracks deliberation, not
 conclusions.
 
 Built around a **Two-Persona Devil Review** loop — the person who
 writes is not the person who reviews. Same model, different `--by`,
-different lens. That alone surfaces blind spots a single self-contained
+different lense. That alone surfaces blind spots a single self-contained
 loop reliably misses.
 
 The history grows. It never compresses into a single "current truth"

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -20,12 +20,12 @@ the next session — or the next agent — can pick up where you left off.
 
 | You used… | Closest guild-cli concept | Key difference |
 |-----------|--------------------------|----------------|
-| **Jira / Linear** (issues + assignees) | `request` has `executor` like assignee, `state` like status | `request` also carries multi-lens `review`s and forced `reason`; it's closer to an ADR + ticket fused together |
+| **Jira / Linear** (issues + assignees) | `request` has `executor` like assignee, `state` like status | `request` also carries multi-lense `review`s and forced `reason`; it's closer to an ADR + ticket fused together |
 | **`issues` in guild-cli** | `issue` | In guild-cli, `issue` is a lightweight observation that hasn't become a decision yet. Promote it to a `request` when someone commits to act. |
-| **GitHub pull request review** | `gate review --lense X --verdict Y` | Reviews in gate attach to *requests* (decisions), not diffs. Multiple reviewers can each apply different lenses to the same request. |
+| **GitHub pull request review** | `gate review --lense X --verdict Y` | Reviews in gate attach to *requests* (decisions), not diffs. Multiple reviewers can each apply different lenses to the same request. (`lense` is the project's spelling — see vocabulary below.) |
 | **Slack / Discord DM** | `gate message --from A --to B` | Push-based messaging with an `inbox`, same channel as the decision log — you can DM about a specific `request` and the reference persists. |
 | **ADR** (architecture decision record) | `request` + `reason` + `review`s | Same spirit, but *alive*: reviews and messages keep accruing after the decision is made. |
-| **Standup / retro notes** | `gate tail` / `gate voices <actor>` | Replay the content_root's dialogue, filtered by actor or lens, instead of scrolling chat history. |
+| **Standup / retro notes** | `gate tail` / `gate voices <actor>` | Replay the content_root's dialogue, filtered by actor or lense, instead of scrolling chat history. |
 
 ## Quick vocabulary
 
@@ -33,7 +33,7 @@ the next session — or the next agent — can pick up where you left off.
 - **host** — an actor that runs the content_root (not a member, but can `--by` / `--from` anything). Listed under `host_names:` in `guild.config.yaml`.
 - **request** — a decision-in-motion. Has `action`, `reason`, optional `executor` / `auto-review`, and moves through `pending → approved → executing → completed` (or `denied` / `failed`).
 - **review** — multi-perspective feedback on a request. Carries a `lense` (one of `devil | layer | cognitive | user` by default — extend via config) and a `verdict` (`ok | concern | reject`).
-- **lense** — the angle a reviewer is taking. `devil` = "what breaks?", `layer` = "which structural layer is this on?", `cognitive` = "where would someone hesitate?", `user` = "whose happiness (LDD)?". Add domain lenses (`security`, `perf`, `a11y`, ...) in `guild.config.yaml`.
+- **lense** — the angle a reviewer is taking. (Spelled with a trailing `e` throughout this project — the value object, the CLI flag, and prose all align.) `devil` = "what breaks?", `layer` = "which structural layer is this on?", `cognitive` = "where would someone hesitate?", `user` = "whose happiness (LDD)?". Add domain lenses (`security`, `perf`, `a11y`, ...) in `guild.config.yaml`.
 - **verdict** — `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). The word is deliberately soft — `concern` is usable, not a veto.
 - **fast-track** — single-actor shortcut for the full lifecycle when self-approved work is appropriate. Still requires `reason`; `review`s can be attached after.
 - **issue** — a standalone observation that has not yet become a decision. Lightweight, optional `severity` / `area`. Promote to `request` via `gate issues promote <id>`.
@@ -75,7 +75,7 @@ guild-cli is **not** trying to *automate* the decision. It's trying
 to make the decision and its dialogue **legible later** — to you,
 to another agent, to the next session of the same agent. The value
 compounds: one `fast-track` with one review is fine, ten sessions
-of accrued reviews across four lenses become an agent's memory.
+of accrued reviews across the four lenses become an agent's memory.
 
 ## Where to go next
 

--- a/docs/domain-fit/README.md
+++ b/docs/domain-fit/README.md
@@ -19,7 +19,7 @@ of evaporating with a chat context.
 - [`design-notes.md`](./design-notes.md) — the design intuitions
   the tours surfaced. Central one: **gate's state machine encodes
   a social contract between principals, not a time axis.** The
-  review-lens mechanism is the dual — principal separation in the
+  review-lense mechanism is the dual — principal separation in the
   perspective dimension. Two axes; domains that hit both get the
   most out of the tool.
 - [`open-questions.md`](./open-questions.md) — unresolved design

--- a/docs/domain-fit/design-notes.md
+++ b/docs/domain-fit/design-notes.md
@@ -31,10 +31,10 @@ roles simultaneously, the gaps collapse — which is exactly what
 ## The dual: review lenses as perspective separation
 
 Where the state machine separates principals across _time_, the
-review-lens mechanism separates principals across _perspective_.
+review-lense mechanism separates principals across _perspective_.
 A single request can carry multiple reviews at the same moment in
-its lifecycle, each from a different lens (devil / layer / user /
-…). Each lens is effectively a distinct voice commenting on the
+its lifecycle, each from a different lense (devil / layer / user /
+…). Each lense is effectively a distinct voice commenting on the
 same artifact.
 
 The two separations are **orthogonal axes**:
@@ -144,7 +144,7 @@ Some consequences that follow if the claim is right:
   That's not a property of principal separation; it's a property
   of records-as-mirrors. The framework may be under-specifying
   this. (See also `lore/principles/07-perception-not-judgement.md`
-  — the tool as a lens that sharpens perception without closing
+  — the tool as a lense that sharpens perception without closing
   the judgement loop. The mirror effect may be a specific instance
   of that broader posture.)
 

--- a/docs/domain-fit/domain-conventions.md
+++ b/docs/domain-fit/domain-conventions.md
@@ -47,7 +47,7 @@ GUILD_ACTOR=narrator node "$GATE" fast-track --from mira \
   --reason "父が最後に見た光を確かめに行く" \
   > /dev/null
 
-# Authorial critique of the beat (structure lens)
+# Authorial critique of the beat (structure lense)
 GUILD_ACTOR=narrator node "$GATE" review 2026-04-18-0001 \
   --by narrator --lense devil --verdict concern \
   "一人で登らせるのは筋が通る、情報量は不足"
@@ -159,7 +159,7 @@ extra process.
 
 ---
 
-## 3. Game design brainstorming — proposal + multi-lens critique
+## 3. Game design brainstorming — proposal + multi-lense critique
 
 **Use case**: exploring a game mechanic, surfacing failure modes,
 variant proposals that respond to specific critiques.
@@ -203,7 +203,7 @@ GUILD_ACTOR=designer node "$GATE" issues add \
 
 - devil / layer / user lenses map to **player-behavior critique /
   mechanical coherence / player experience** without renaming.
-  This is surprising and suggests the default lens set has a
+  This is surprising and suggests the default lense set has a
   generality beyond the tool's origin.
 - Variant proposals referencing the original by ID create a
   design-decision genealogy that chain can walk.
@@ -411,12 +411,12 @@ GUILD_ACTOR=me node "$GATE" fast-track \
   `config.lenses` to hydrate; `listByState` didn't. Fixed.
 - Single-principal state machine still has no traction. Every
   entry is fast-tracked.
-- ⚠ self-review warnings fire on every lens — semantically
+- ⚠ self-review warnings fire on every lense — semantically
   correct but noisy when the pattern is intentional. A future
   convention might be `--self-review-ok` to suppress when the
   solo-dialogue use is declared.
 
-**Fit verdict**: partial. The custom-lens mechanism generalizes
+**Fit verdict**: partial. The custom-lense mechanism generalizes
 review beautifully to multi-voice self-dialogue, but the lifecycle
 machinery sits unused. Good case study of how review and state
 machine are orthogonal axes of fit.
@@ -429,7 +429,7 @@ machine are orthogonal axes of fit.
 |---|---|---|---|---|---|
 | Story | ✗ (fast-track) | ✓ authorial | ✓ foreshadowing | ○ beat refs | partial |
 | Meeting | ✓ deny→refile | ✓ multi-POV | ✓ parking lot | ✓ decision graph | **max** |
-| Game design | ✗ | ✓ multi-lens | ✓ open Qs | ○ | strong |
+| Game design | ✗ | ✓ multi-lense | ✓ open Qs | ○ | strong |
 | Research | ✗ | ✓ self-critique | ✓ open Qs | ✓✓ citations | partial |
 | Incident | ✓✓ isomorphic | ✓ triad | ✓ follow-ups | ○ | **max** |
 | Solo journal | ✗ | ✓ custom lenses | — | — | partial |

--- a/docs/domain-fit/open-questions.md
+++ b/docs/domain-fit/open-questions.md
@@ -25,7 +25,7 @@ POV, tense, draft state). Question: is that 20% worth building?
 
 - **Layer 0 — config-only conventions**. Document the "story
   convention for guild-cli" as a file in `examples/` showing
-  custom lens set (reader / structure / voice / continuity),
+  custom lense set (reader / structure / voice / continuity),
   fast-track as the default verb, issues-as-foreshadowing. Zero
   new code. Gets 80%.
 
@@ -90,7 +90,7 @@ six domains tried.
 
 **The tension**: `gate review --by X` when the request's author
 is also X emits a `⚠ self-review` warning (intentional, see #38).
-In solo-journal mode the warning fires on every lens because the
+In solo-journal mode the warning fires on every lense because the
 pattern is intentional — one person deliberately reviewing their
 own decision from four separate vantage points. The warning is
 correct at a micro level but noisy when the convention is solo-
@@ -105,8 +105,8 @@ multi-voice.
   `allow_self_review: true`. Declarative, whole-content_root.
   Loses the per-call visibility.
 
-- **Suppress when custom lens is active**: if the reviewer uses
-  a custom lens (not in the built-in 4), treat it as intentional
+- **Suppress when custom lense is active**: if the reviewer uses
+  a custom lense (not in the built-in 4), treat it as intentional
   multi-voice and skip the warning. Implicit, potentially too
   magical.
 
@@ -170,7 +170,7 @@ principal separation or state machinery; it was that
 externalizing an internal voice and seeing it in writing changed
 how the voice felt. This is a property of records, not of gate
 specifically. But the affordances gate provides — append-only,
-timestamped, cross-referenceable, lens-tagged — might amplify
+timestamped, cross-referenceable, lense-tagged — might amplify
 the effect vs. a plain text file.
 
 **Options explored**:

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -378,11 +378,11 @@ $ gate voices kiri
 
 Each entry is an *utterance* — either an authored request (action +
 reason + whichever closure note the lifecycle produced:
-`note:` / `denied:` / `failed:`) or a review (lens + verdict +
+`note:` / `denied:` / `failed:`) or a review (lense + verdict +
 comment). Filters combine via AND:
 
 - `--lense <devil|layer|cognitive|user>` — only reviews with that
-  lens (implies review-only; authored requests carry no lens)
+  lense (implies review-only; authored requests carry no lense)
 - `--verdict <ok|concern|reject>` — only reviews with that verdict
   (implies review-only)
 - `--format text` — human-readable output (default is JSON since 0.2.0)
@@ -501,7 +501,7 @@ as `(+10s)` and a day-later afterthought as `(+1d)`.
 ### Review markers on `gate list` / `gate pending`
 
 Each row in `gate list` and `gate pending` carries a compact
-per-lens verdict summary so you can scan a whole list of completed
+per-lense verdict summary so you can scan a whole list of completed
 work and pick out the requests that closed with an unresolved
 concern:
 
@@ -694,10 +694,10 @@ lowercased on load. The validation error message lists all
 configured lenses so mistyped values are easy to correct.
 
 **Design note.** Lenses are an extension point for the review
-system. Each lens is a perspective, not a role — the same reviewer
+system. Each lense is a perspective, not a role — the same reviewer
 can write `devil` and `security` reviews on the same request. The
 config makes the set of valid perspectives explicit for a given
-content root, which prevents lens drift across long-lived projects.
+content root, which prevents lense drift across long-lived projects.
 
 ### Editor-based review comments
 

--- a/lore/principles/01-silent-calibration.md
+++ b/lore/principles/01-silent-calibration.md
@@ -24,7 +24,7 @@ this voice — they get the benefit without the gaming pressure.
 
 ## In practice
 
-`gate voices <other_actor>` shows calibration ("devil lens:
+`gate voices <other_actor>` shows calibration ("devil lense:
 trusted — 7 of 7 verdicts aligned"). `gate voices $GUILD_ACTOR`
 hides it. Implemented in `src/interface/gate/voices.ts`
 (`computeVoiceCalibration`) and `handlers/read.ts` (the

--- a/lore/principles/03-legibility-costs.md
+++ b/lore/principles/03-legibility-costs.md
@@ -46,7 +46,7 @@ What `gate` does instead:
 
 ## Implications
 
-- **Resist adding "gamification" features without this lens.**
+- **Resist adding "gamification" features without this lense.**
   Points / badges / streaks reward volume, which amplifies
   performance-for-record. The gamification we keep (calibration)
   refuses to be visible to the scored party, which is the shape

--- a/lore/principles/06-two-memories.md
+++ b/lore/principles/06-two-memories.md
@@ -24,7 +24,7 @@ They compose on the same record (a request's YAML holds both
 `reviews` and `thanks` arrays), but they are read by different
 parts of the tool:
 
-- Reviews drive `voices <name>` calibration, the per-lens
+- Reviews drive `voices <name>` calibration, the per-lense
   alignment score that surfaces as prose to other readers.
 - Thanks drive nothing quantitative. They are visible in
   `voices`, `tail`, `transcript`; they participate in the
@@ -48,7 +48,7 @@ Keeping them orthogonal lets each be honest.
   are separate value objects. Neither imports the other.
 - `computeVoiceCalibration` (in `voices.ts`) iterates reviews
   only. Thanks are invisible to it.
-- `gate voices <name>` text footer composes both: "devil lens:
+- `gate voices <name>` text footer composes both: "devil lense:
   trusted — N of M aligned" (calibration from reviews) plus the
   thanks-received stream (the `kind: 'thank'` utterances). Same
   surface, different signals, side by side.

--- a/lore/principles/07-perception-not-judgement.md
+++ b/lore/principles/07-perception-not-judgement.md
@@ -60,7 +60,7 @@ This principle is about the tool's *posture*. It describes what
 the tool is *for*: structuring perception. Not just
 `suggested_next`, but every read verb, every diagnostic, every
 narrative rendering. The tool's job is to make the record legible
-enough that the reader's own judgement can engage. It is a lens,
+enough that the reader's own judgement can engage. It is a lense,
 not an oracle.
 
 ## Implications

--- a/mcp/plugins/self-loop-check.mjs
+++ b/mcp/plugins/self-loop-check.mjs
@@ -6,13 +6,13 @@
  * → completed (and, if applicable, a self-review) all bear the same
  * `by` field.
  *
- * Why this matters (the abyss in the 6-lens framing):
+ * Why this matters (the abyss in the 6-lense framing):
  *   gate lets any registered member approve any request, including
  *   their own. Policy-allowed, emits a stderr notice, and for a
  *   single casual self-flow `gate fast-track` is the expected form.
  *   But as agents take on more of the transitions autonomously, the
  *   pattern "agent files, agent approves, agent executes, agent
- *   reviews with own lens" quietly hollows the Two-Persona Devil
+ *   reviews with own lense" quietly hollows the Two-Persona Devil
  *   frame: the record exists, but the cross-actor signal that makes
  *   it trustworthy is absent.
  *

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -68,7 +68,7 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   }
   const utterances = collectUtterances(allJson, filter);
 
-  // Voice calibration: per-(actor, lens) score derived from historical
+  // Voice calibration: per-(actor, lense) score derived from historical
   // verdicts vs outcomes. Hidden when viewing your own voice (the
   // voter shouldn't game their own score); shown otherwise. See the
   // `computeVoiceCalibration` header in voices.ts for semantics.
@@ -122,7 +122,7 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   for (const u of utterances) {
     process.stdout.write(renderUtterance(u, false) + '\n\n');
   }
-  // Calibration footer: one line per lens with recorded activity.
+  // Calibration footer: one line per lense with recorded activity.
   // Placed after the utterances so a reader who scanned the prose
   // sees the summary below without it fighting for attention. Self-
   // view skips this entirely (see isSelfView above).

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -670,7 +670,7 @@ function printSummary(r: Request, markerWidth = 16): void {
   );
 }
 
-// Render a compact per-lens verdict summary like "✓devil ✓layer" or
+// Render a compact per-lense verdict summary like "✓devil ✓layer" or
 // "!devil ✓layer". See comments in the prior index.ts implementation
 // for design notes (UTF-16 width caveat, icon map, etc).
 export function formatReviewMarkers(reviews: unknown, width = 16): string {

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -37,7 +37,7 @@ import { UnrespondedConcernsEntry } from '../../../application/concern/Unrespond
  *     - inbox unread (boot surfaces this)
  *     - requests where the actor is named in `--with` but didn't
  *       author or execute (pair-mode receiver)
- *   These are orientation concerns, and the orientation lens is
+ *   These are orientation concerns, and the orientation lense is
  *   `gate boot`. Resume's empty-path prose points at boot so a
  *   newcomer who ran resume as part of a handoff learns the right
  *   verb to reach for.
@@ -490,7 +490,7 @@ function composeRestorationProseEn(ctx: {
     lines.push(
       'Nothing is waiting — pick up fresh work (`gate pending`) or file a new request.',
     );
-    // resume is a same-actor continuation lens: it reconstructs what
+    // resume is a same-actor continuation lense: it reconstructs what
     // THIS actor was doing. Cross-actor signals (inbox unread,
     // named-as-`--with` on someone else's request, etc.) are not part
     // of its scope by design. Point at `gate boot` so a newcomer who

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -71,7 +71,13 @@ export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
         .join(' ');
       process.stdout.write(`→ ${suggestion.verb} ${argsStr}\n`);
       process.stdout.write(`  ${suggestion.reason}\n`);
-      process.stderr.write('# advisory — override freely\n');
+      // Suppress the advisory footer when the suggestion is `export`
+      // (a shell builtin used to prompt for GUILD_ACTOR setup, not a
+      // gate verb). "override freely" speaks to heuristic gate
+      // dispatches; a missing-actor bootstrap hint is not a heuristic.
+      if (suggestion.verb !== 'export') {
+        process.stderr.write('# advisory — override freely\n');
+      }
     }
   }
   return 0;

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -148,7 +148,7 @@ function buildTranscript(r: Request): TranscriptPayload {
             ? ` — "${comment}"`
             : `\n    "${comment}"`;
       reviewLines.push(
-        `${capitalise(by)}${invokedBy} reviewed through the ${lense} lens ` +
+        `${capitalise(by)}${invokedBy} reviewed through the ${lense} lense ` +
           `with a verdict of ${verdict}${commentFrag}`,
       );
     }

--- a/src/interface/gate/handlers/unresponded.ts
+++ b/src/interface/gate/handlers/unresponded.ts
@@ -96,14 +96,15 @@ export async function unrespondedCmd(
 
   if (entries.length === 0) {
     process.stdout.write(
-      `(no unresponded concerns for ${actor} within ${maxAgeDays} days)\n`,
+      `(no unresponded concerns for ${actor} within ${maxAgeDays} days; ` +
+        `--max-age-days to widen)\n`,
     );
     return 0;
   }
 
   process.stdout.write(
     `${entries.length} unresponded concern record(s) for ${actor} ` +
-      `(window: ${maxAgeDays} days)\n\n`,
+      `(window: ${maxAgeDays} days, --max-age-days to change)\n\n`,
   );
   for (const e of entries) {
     process.stdout.write(`${e.request_id}  ${e.action}\n`);

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -4,7 +4,7 @@
  * a live filesystem.
  *
  * Also home to `computeVoiceCalibration` (see bottom of file), which
- * derives a per-(actor, lens) calibration score from historical
+ * derives a per-(actor, lense) calibration score from historical
  * review verdicts vs terminal-state outcomes. Exported from here so
  * the CLI handler and the schema can reuse the same definition.
  *
@@ -13,7 +13,7 @@
  *     appropriate closure note — completion_note / deny_reason /
  *     failure_reason, whichever the lifecycle produced).
  *   - `review`: a review they recorded on someone's (or their own)
- *     request, carrying the lens / verdict / comment.
+ *     request, carrying the lense / verdict / comment.
  *
  * The RequestJSON type below intentionally models only the fields
  * voices reads. Keeping it structural (rather than importing Request
@@ -130,7 +130,7 @@ export type ReviewUtterance = {
 /**
  * A `thank` utterance — someone thanking another actor for their
  * work on a specific request. Sibling of ReviewUtterance; simpler
- * (no lens, no verdict, no required comment) because the record
+ * (no lense, no verdict, no required comment) because the record
  * semantics are different. Reviews express judgement; thanks
  * express gratitude.
  *
@@ -175,7 +175,7 @@ export interface VoicesFilter {
  * returned; when omitted, every actor's utterances flow through.
  * When `lense` or `verdict` is set, only review utterances are
  * returned — authored requests don't carry those fields, so including
- * them in a lens-scoped query would be a category error.
+ * them in a lense-scoped query would be a category error.
  *
  * Name matching is case-insensitive. Timestamps are compared as
  * strings; ISO-8601 sorts correctly lexicographically.
@@ -254,7 +254,7 @@ export function collectUtterances(
     // surfaces the record. Reviews are one-sided (only `by` speaks),
     // so this is the one place the filter diverges. Lens/verdict
     // filters short-circuit the thanks loop entirely — thanks have
-    // no lens/verdict, so a lens-scoped query should not carry them.
+    // no lense/verdict, so a lense-scoped query should not carry them.
     const filteringReviewsOnly =
       filter.lense !== undefined || filter.verdict !== undefined;
     if (!filteringReviewsOnly) {
@@ -422,7 +422,7 @@ export function renderUtterance(
 
 // ── Voice calibration ─────────────────────────────────────────────
 //
-// A per-(actor, lens) score derived from historical review verdicts
+// A per-(actor, lense) score derived from historical review verdicts
 // vs terminal-state outcomes. Exists to let the Two-Persona Devil
 // Review frame *learn* — today every cross-actor critique weighs the
 // same, and over time the system has no memory of which voices
@@ -475,7 +475,7 @@ export interface CalibrationPerLens {
 
 export interface VoiceCalibration {
   readonly actor: string;
-  /** Per-lens calibration, keyed by lens name (e.g. "devil", "layer"). */
+  /** Per-lense calibration, keyed by lense name (e.g. "devil", "layer"). */
   readonly by_lens: Record<string, CalibrationPerLens>;
 }
 
@@ -487,7 +487,7 @@ export function computeVoiceCalibration(
   actor: string,
 ): VoiceCalibration {
   const actorLower = actor.toLowerCase();
-  const byLens: Record<string, { aligned: number; missed: number }> = {};
+  const byLense: Record<string, { aligned: number; missed: number }> = {};
 
   for (const r of all) {
     const state = r.state;
@@ -497,9 +497,9 @@ export function computeVoiceCalibration(
     const reviews = r.reviews ?? [];
     for (const rv of reviews) {
       if (rv.by !== actorLower) continue;
-      const lens = rv.lense;
-      if (!byLens[lens]) byLens[lens] = { aligned: 0, missed: 0 };
-      const bucket = byLens[lens]!;
+      const lense = rv.lense;
+      if (!byLense[lense]) byLense[lense] = { aligned: 0, missed: 0 };
+      const bucket = byLense[lense]!;
       const v = rv.verdict;
       if (v === 'ok') {
         if (state === 'completed') bucket.aligned += 1;
@@ -513,17 +513,17 @@ export function computeVoiceCalibration(
   }
 
   const out: Record<string, CalibrationPerLens> = {};
-  for (const [lens, counts] of Object.entries(byLens)) {
+  for (const [lense, counts] of Object.entries(byLense)) {
     const samples = counts.aligned + counts.missed;
     if (samples < CALIBRATION_MIN_SAMPLES) {
-      out[lens] = {
+      out[lense] = {
         sample_count: samples,
         aligned: counts.aligned,
         missed: counts.missed,
         alignment: null,
         status: 'uncalibrated',
         prose:
-          `${lens} lens: ${samples} sample${samples === 1 ? '' : 's'} so far — not yet calibrated ` +
+          `${lense} lense: ${samples} sample${samples === 1 ? '' : 's'} so far — not yet calibrated ` +
           `(need ${CALIBRATION_MIN_SAMPLES - samples} more with a terminal outcome).`,
       };
       continue;
@@ -535,13 +535,13 @@ export function computeVoiceCalibration(
       status === 'trusted'
         ? `trusted — ${counts.aligned} of ${samples} verdicts aligned with outcomes`
         : `still learning — ${counts.aligned} of ${samples} verdicts aligned`;
-    out[lens] = {
+    out[lense] = {
       sample_count: samples,
       aligned: counts.aligned,
       missed: counts.missed,
       alignment,
       status,
-      prose: `${lens} lens: ${proseFragment}.`,
+      prose: `${lense} lense: ${proseFragment}.`,
     };
   }
 

--- a/tests/infrastructure/YamlRequestRepository.test.ts
+++ b/tests/infrastructure/YamlRequestRepository.test.ts
@@ -1,6 +1,6 @@
 // YamlRequestRepository — optimistic lock, findById dedupe, save() guards.
 //
-// Focused on the invariants added in the "fix: address 4-lens review"
+// Focused on the invariants added in the "fix: address 4-lense review"
 // commit: concurrent writes must conflict, mid-transition state is
 // deterministically resolvable, and save() refuses fresh aggregates.
 
@@ -253,14 +253,14 @@ test('save() produces no top-level duplicated completion_note in writer path', a
   }
 });
 
-test('listByState passes config.lenses to hydrate (custom lens YAML round-trips)', async () => {
+test('listByState passes config.lenses to hydrate (custom lense YAML round-trips)', async () => {
   // Regression: listByState used to drop config.lenses when calling
-  // hydrate, so a request whose reviews used a custom lens (declared
+  // hydrate, so a request whose reviews used a custom lense (declared
   // in guild.config.yaml `lenses:`) became unreadable on any
   // listAll-backed verb (chain / voices / tail). findById worked;
   // listByState did not. Silent breakage — the warn-and-skip
   // swallowed the error and callers saw an empty result.
-  const root = mkdtempSync(join(tmpdir(), 'guild-cli-repo-lens-'));
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-repo-lense-'));
   try {
     writeFileSync(
       join(root, 'guild.config.yaml'),
@@ -272,12 +272,12 @@ test('listByState passes config.lenses to hydrate (custom lens YAML round-trips)
     const req = Request.create({
       id: RequestId.generate(new Date('2026-04-18T00:00:00Z'), 1),
       from: 'alice',
-      action: 'try a custom lens',
+      action: 'try a custom lense',
       reason: 'r',
     });
     await repo.saveNew(req);
 
-    // Hand-author a review with a custom lens by writing YAML directly,
+    // Hand-author a review with a custom lense by writing YAML directly,
     // bypassing Review.create (which also needs `allowedLenses`).
     // This mirrors the wire contract on disk.
     const path = join(root, 'requests', 'pending', `${req.id.value}.yaml`);
@@ -290,7 +290,7 @@ test('listByState passes config.lenses to hydrate (custom lens YAML round-trips)
         by: 'alice',
         lense: 'rational',
         verdict: 'concern',
-        comment: 'custom lens on disk',
+        comment: 'custom lense on disk',
         at: '2026-04-18T00:00:01Z',
       },
     ];
@@ -385,7 +385,7 @@ test('save() does not throw spurious VersionConflict when reviews carries non-ob
   // entries that are not objects (loose-shape YAML, legacy import,
   // hand-edited file), but readVersion() used to count the raw
   // length. This created an identical loadedVersion vs maxOnDisk
-  // drift on a different field. Surfaced by a noir-lens devil
+  // drift on a different field. Surfaced by a noir-lense devil
   // review on the status_log fix that asked whether "any hydrate
   // skip rule ↔ counter mismatch" was closed as a class, not just
   // the one instance.

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -497,7 +497,7 @@ test('boot.verbs_available_now: actionable entries carry id + reason', () => {
 
 test('voices --with-calibration: aligns verdicts against terminal outcomes', () => {
   // Carol files sharp concerns on things that later fail — her
-  // devil-lens calibration should read as "trusted". Bob rubber-
+  // devil-lense calibration should read as "trusted". Bob rubber-
   // stamps ok on things that fail — "learning".
   const { root, cleanup } = bootstrap();
   try {
@@ -895,9 +895,9 @@ test('voices <name>: surfaces thanks in BOTH directions (given and received)', (
   }
 });
 
-test('voices: lens/verdict filters DO NOT surface thanks (reviews only)', () => {
-  // thanks have no lens and no verdict. A lens-scoped query is
-  // asking for reviews through that lens; including thanks would
+test('voices: lense/verdict filters DO NOT surface thanks (reviews only)', () => {
+  // thanks have no lense and no verdict. A lense-scoped query is
+  // asking for reviews through that lense; including thanks would
   // be a category error.
   const { root, cleanup } = bootstrap();
   try {
@@ -971,7 +971,7 @@ test('transcript: narrative prose names filer, action, executor, reviews', () =>
     assert.match(stdout, /refactor parser/);
     assert.match(stdout, /bob as executor/);
     assert.match(stdout, /Bob moved it to completed/);
-    assert.match(stdout, /devil lens/);
+    assert.match(stdout, /devil lense/);
     assert.match(stdout, /verdict of ok/);
     assert.match(stdout, /LGTM/);
     assert.match(stdout, /Final state: completed/);
@@ -1157,6 +1157,51 @@ test('review --dry-run: preview includes new review without persisting', () => {
     // After dry-run, real reviews list is still empty.
     const after = JSON.parse(runGate(root, ['show', rid(1)]).stdout);
     assert.equal(after.reviews.length, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+
+// ── suggest text-mode footer: context-sensitivity ─────────────────
+
+test('suggest --format text suppresses advisory footer for export verb', () => {
+  // GUILD_ACTOR-unset bootstrap: suggest returns verb=export which is
+  // a shell builtin used to set the env var, not a gate dispatch.
+  // The "# advisory — override freely" footer applies to heuristic
+  // gate verbs; pinning it onto an env-var bootstrap reads as
+  // "you can ignore this", which is wrong — without GUILD_ACTOR the
+  // agent stays anonymous. The footer is suppressed for export.
+  const { root, cleanup } = bootstrap();
+  try {
+    const out = runGate(root, ["suggest", "--format", "text"]);
+    assert.equal(out.status, 0);
+    assert.match(out.stdout, /export GUILD_ACTOR/);
+    // No advisory footer (which would land on stderr) for the
+    // export case.
+    assert.doesNotMatch(out.stderr, /advisory/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('suggest --format text keeps advisory footer for gate verbs', () => {
+  // Regression: the footer should still appear when the suggestion
+  // is a real gate dispatch (not export). Drives a request to
+  // pending-as-executor so suggest returns a non-null gate verb.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, [
+      "request",
+      "--from", "alice",
+      "--action", "do thing",
+      "--reason", "r",
+      "--executor", "bob",
+    ], { GUILD_ACTOR: "alice" });
+    const out = runGate(root, ["suggest", "--format", "text"], { GUILD_ACTOR: "bob" });
+    assert.equal(out.status, 0);
+    assert.match(out.stdout, /^→ approve/m);
+    assert.match(out.stderr, /advisory — override freely/);
   } finally {
     cleanup();
   }

--- a/tests/interface/reviewMarkers.test.ts
+++ b/tests/interface/reviewMarkers.test.ts
@@ -20,28 +20,28 @@ test('formatReviewMarkers: non-array yields padded empty string', () => {
   assert.equal(result.length, WIDTH);
 });
 
-test('formatReviewMarkers: single ok review renders as ✓<lens>', () => {
+test('formatReviewMarkers: single ok review renders as ✓<lense>', () => {
   const result = formatReviewMarkers([
     { lense: 'devil', verdict: 'ok' },
   ]);
   assert.ok(result.startsWith('✓devil'));
 });
 
-test('formatReviewMarkers: single concern review renders as !<lens>', () => {
+test('formatReviewMarkers: single concern review renders as !<lense>', () => {
   const result = formatReviewMarkers([
     { lense: 'devil', verdict: 'concern' },
   ]);
   assert.ok(result.startsWith('!devil'));
 });
 
-test('formatReviewMarkers: reject renders as x<lens>', () => {
+test('formatReviewMarkers: reject renders as x<lense>', () => {
   const result = formatReviewMarkers([
     { lense: 'devil', verdict: 'reject' },
   ]);
   assert.ok(result.startsWith('xdevil'));
 });
 
-test('formatReviewMarkers: unknown verdict renders as ?<lens> (defensive)', () => {
+test('formatReviewMarkers: unknown verdict renders as ?<lense> (defensive)', () => {
   const result = formatReviewMarkers([
     { lense: 'devil', verdict: 'weird' },
   ]);
@@ -57,7 +57,7 @@ test('formatReviewMarkers: multi-review output is space-separated', () => {
 });
 
 test('formatReviewMarkers: long marker strings are not truncated', () => {
-  // Three long-lens reviews exceed the 16-char padding width;
+  // Three long-lense reviews exceed the 16-char padding width;
   // the function should not clip — padding is a floor, not a cap.
   const result = formatReviewMarkers([
     { lense: 'cognitive', verdict: 'concern' },

--- a/tests/interface/unresponded.test.ts
+++ b/tests/interface/unresponded.test.ts
@@ -179,6 +179,42 @@ test('unresponded: missing actor (no GUILD_ACTOR, no --for) is an error', (t) =>
   assert.match(out.stderr, /actor/i);
 });
 
+test('unresponded: text output names --max-age-days at the point of consumption', (t) => {
+  // Discoverability: a reader scanning unresponded results who wants
+  // older items needs to see the flag without leaving for --help.
+  // Both the populated header and the empty-case prose carry the hint.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+
+  // Empty case
+  const empty = runGate(root, ['unresponded'], { GUILD_ACTOR: 'alice' });
+  assert.equal(empty.status, 0);
+  assert.match(empty.stdout, /--max-age-days/);
+
+  // Populated case: file a fast-track + concern review on it
+  const created = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'something to review',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  const id = extractId(created.stdout)!;
+  runGate(root, ['register', '--name', 'bob', '--category', 'professional']);
+  runGate(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'concern',
+    '--comment', 'flagged',
+  ]);
+
+  const populated = runGate(root, ['unresponded'], { GUILD_ACTOR: 'alice' });
+  assert.equal(populated.status, 0);
+  assert.match(populated.stdout, /window: 30 days, --max-age-days to change/);
+});
+
 test('unresponded: rejects unknown flags', (t) => {
   // Read-verb strict-flag discipline: a typo like `--max-age-day 7`
   // (singular) silently falling back to the 30-day default would be

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -97,7 +97,7 @@ test('collectUtterances: --lense filter excludes authored and non-matching revie
   }
 });
 
-test('collectUtterances: --verdict filter is independent of lens filter', () => {
+test('collectUtterances: --verdict filter is independent of lense filter', () => {
   const result = collectUtterances(corpus, { name: 'noir', verdict: 'ok' });
   // noir has two ok reviews (layer on 001? no, rin; user on 003 — noir).
   // Only user/ok on 003.
@@ -169,7 +169,7 @@ test('collectUtterances: authored utterance captures completion_note when presen
   }
 });
 
-test('collectUtterances: lens+verdict filters combine via AND', () => {
+test('collectUtterances: lense+verdict filters combine via AND', () => {
   const result = collectUtterances(corpus, {
     name: 'noir',
     lense: 'devil',


### PR DESCRIPTION
## Summary

Two small surface tweaks (A) plus a long-overdue spelling-drift cleanup (B). No source-code behavior changes beyond the two A items; B is a vocabulary alignment.

### (A) Surface tweaks

**`gate suggest --format text`**: suppress the `# advisory — override freely` footer when the suggestion is `verb: export` (the GUILD_ACTOR-unset bootstrap hint, not a gate dispatch). The advisory framing speaks to heuristic gate verbs; pinning it onto an env-var bootstrap reads as "you can ignore this", which is wrong — without GUILD_ACTOR the agent stays anonymous.

**`gate unresponded`** text-mode header names `--max-age-days` at the point of consumption: `(window: 30 days, --max-age-days to change)` for populated results, `--max-age-days to widen` in the empty case. Discoverability of an existing flag without leaving for `--help`. No new voice phrase; mechanical hint only.

Both A changes have new `ax.test` / `unresponded.test` assertions.

### (B) lens → lense alignment

The project's value object is `Lense` (idiosyncratic spelling) and the CLI flag is `--lense`. Source comments, docs, and lore had been drifting toward the standard English `lens` — substrate term and prose disagreed. This commit aligns:

- **Source**: `byLens` → `byLense` (internal var); calibration prose output `"${lense} lens:"` → `"${lense} lense:"` (so `gate voices` output reads "devil lense: 7 of 7" — slightly unusual to the English ear but consistent with the project term); comments `per-lens`, `lens-scoped`, `(actor, lens)` → `lense` variants; mcp plugin comment.
- **Docs**: `README.md`, `docs/concepts-for-newcomers.md`, `docs/verbs.md`, `docs/domain-fit/*`.
- **Lore**: principles 01, 03, 06, 07 (where lens appeared in prose).
- **Tests**: comments + test names + identifier strings; existing assertions on YAML field names (already `lense`) untouched.

**Skipped**: `CHANGELOG.md` — historical record, retroactive edits violate the changelog's append-only nature. Plural `lenses` unchanged everywhere — already unambiguous.

## Test plan

- [x] `npm test` — 532/532 passing (was 529; +3 = the two A test additions)
- [x] `npm run build` — clean tsc
- [x] `gate voices <other>` text mode output reads `devil lense: ...` — confirmed in sandbox
- [x] `gate suggest --format text` with no GUILD_ACTOR: stdout has the export hint, stderr no longer carries the advisory footer
- [x] `gate unresponded` text mode (both empty and populated): `--max-age-days` named in the header
- [x] Voice-budget audit (`tests/interface/voiceBudget.test.ts`) unaffected — no new pedagogical phrases introduced
- [x] Devil-reviewed in sandbox before commit

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_