### PR TITLE
docs: add CI / License / Node badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # guild-cli
 
+[![CI](https://github.com/eris-ths/guild-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/eris-ths/guild-cli/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-20%20%7C%2022-green)](./package.json)
+
 A small, secure, file-based CLI for a team of agents — human and AI —
 to ask each other for work, review it, and leave a trail that nothing
 in the loop can quietly rewrite.


### PR DESCRIPTION
## Summary

Three state badges at the top of the README:

- **CI** — points at the existing `.github/workflows/ci.yml`
- **License: MIT** — links to `./LICENSE`
- **Node 20 | 22** — matches the CI matrix and `package.json` engines

## Why these three (and not volume metrics)

The badges chosen are **state**, not **volume**. CI passing/failing, MIT license, supported Node versions — each is a fact a reader might want at the top: "does it run / what may I do with it / what do I need installed."

Volume metrics (download count, stars, forks) are deliberately omitted. They create a "raise the number" gradient on the writer's side, which is the exact failure mode principle 03 (legibility-costs) names. State badges have no such gradient.

## Test plan

- [x] Markdown renders cleanly (no syntax errors)
- [x] All three URLs resolve (CI workflow exists, LICENSE file exists, package.json engines field present)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_