### PR TITLE
fix: boot orientation gaps (executor blocker contradiction + unresponded count)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -209,6 +209,22 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     }
   }
 
+  // Unresponded-concerns count: same detector as `gate unresponded`
+  // so the two surfaces never disagree. Without it, the orientation
+  // status block reads "everything 0" for an actor who has unaddressed
+  // concerns on completed records — the gap that boot exists to close.
+  if (actor) {
+    try {
+      const entries = await c.unrespondedConcernsQ.run({
+        actor,
+        now: new Date(),
+      });
+      status.unresponded = entries.length;
+    } catch {
+      // requests/issues dirs may be missing — non-fatal.
+    }
+  }
+
   // tail + personal utterances share one JSON projection of the
   // request corpus so collectUtterances isn't double-invoked on the
   // same data — it's O(N*status_log) and N grows with history.
@@ -605,9 +621,11 @@ function deriveVerbsAvailableNow(
   // Surfaces "your pending request needs approval by host X" so
   // the actor sees WHY their queue isn't moving without having
   // to read suggested_next's prose. Skipped when the actor is
-  // already the candidate (e.g. host approving their own request)
-  // — that case shows up under actionable instead via the
-  // pending-as-executor predicate. Empty when nothing waits.
+  // already the candidate (e.g. host approving their own request,
+  // or executor != author approving as the named executor) — those
+  // cases show up under actionable via pending-as-executor, and
+  // double-listing the same id+verb here would contradict it.
+  // Empty when nothing waits.
   //
   // Shape decision: `candidates` is a list, not a single name, so
   // a content_root with N hosts (or zero) does not have to embed
@@ -627,6 +645,11 @@ function deriveVerbsAvailableNow(
       const isExecutor = r.executor?.value === actorLower;
       const isPair = r.with.some((p) => p.value === actorLower);
       if (!isAuthor && !isExecutor && !isPair) continue;
+      // Executor (when not also author) can self-approve via the
+      // pending-as-executor predicate — that already lives under
+      // actionable. Listing the same id+verb here as a blocker
+      // would contradict actionable for the same record.
+      if (isExecutor && !isAuthor) continue;
       requiresOtherActor.push({
         verb: 'approve',
         id: r.id.value,
@@ -636,7 +659,7 @@ function deriveVerbsAvailableNow(
           (hostNames.length === 0
             ? ' (none configured — see guild.config.yaml host_names)'
             : `. You are the ${
-                isAuthor ? 'author' : isExecutor ? 'executor' : 'pair'
+                isAuthor ? 'author' : isPair ? 'pair' : 'executor'
               } but cannot approve as yourself.`),
       });
     }

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -17,6 +17,14 @@ export interface StatusSummary {
   executing: { total: number; by_actor: number };
   open_issues: number;
   unreviewed: number;
+  /**
+   * Concern/reject verdicts on this actor's authored (or pair-made)
+   * requests with no follow-up record yet. Same detector as
+   * `gate unresponded`; populated by the caller when an actor is
+   * resolved (the underlying query is per-actor by definition).
+   * 0 when no actor is set, or when no concerns match.
+   */
+  unresponded: number;
   inbox_unread: number;
   last_activity: string | null;
 }
@@ -79,6 +87,7 @@ export function collectStatus(
     },
     open_issues: 0, // filled by caller if issues are available
     unreviewed,
+    unresponded: 0, // filled by caller (per-actor query; needs UC access)
     inbox_unread: 0, // filled by caller if inbox is available
     last_activity: lastActivity,
   };
@@ -121,6 +130,9 @@ function renderStatusText(s: StatusSummary): string {
   // Issues & inbox
   if (s.open_issues > 0) lines.push(`open issues: ${s.open_issues}`);
   if (s.unreviewed > 0) lines.push(`unreviewed: ${s.unreviewed}`);
+  if (s.unresponded > 0) {
+    lines.push(`unresponded concerns: ${s.unresponded} (gate unresponded)`);
+  }
   if (s.inbox_unread > 0) lines.push(`inbox unread: ${s.inbox_unread}`);
 
   // Last activity
@@ -160,6 +172,25 @@ export async function statusCmd(c: C, args: ParsedArgs): Promise<number> {
       summary.inbox_unread = msgs.filter((m) => !m.read).length;
     } catch {
       // inbox may not exist for this actor — non-fatal
+    }
+  }
+
+  // Enrich with unresponded-concerns count. Runs through the same
+  // query as `gate unresponded` so the two surfaces never disagree
+  // on the count. Per-actor by definition, so skip when no actor
+  // resolved. Default 30-day window matches the verb's default;
+  // no flag to widen here — boot/status are orientation surfaces,
+  // and the verb itself exposes `--max-age-days` for sweeps.
+  if (actor) {
+    try {
+      const entries = await c.unrespondedConcernsQ.run({
+        actor,
+        now: new Date(),
+      });
+      summary.unresponded = entries.length;
+    } catch {
+      // requests/issues dirs may be missing on a half-set-up root —
+      // non-fatal.
     }
   }
 

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -447,6 +447,100 @@ test('boot.verbs_available_now: host self-approval doesnt double-list as blocker
   }
 });
 
+test('boot.status.unresponded: counts unresponded concerns for the actor', () => {
+  // The orientation gap: an actor with concerns recorded against
+  // their completed work used to see status = all-zero, then
+  // separately have to remember to run `gate unresponded`. With
+  // the count surfaced in boot.status, a single boot call shows
+  // the concern queue exists. Same detector as `gate unresponded`,
+  // so the two surfaces never disagree.
+  const { root, cleanup } = bootstrap();
+  try {
+    // Register carol so she can review.
+    runGate(root, ['register', '--name', 'carol']);
+
+    // Lifecycle: alice files → human approves → bob executes → bob
+    // completes → carol records a devil/concern verdict.
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'rushed', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const id = rid(1);
+    runGate(root, ['approve', id, '--by', 'human']);
+    runGate(root, ['execute', id, '--by', 'bob']);
+    runGate(root, ['complete', id, '--by', 'bob']);
+    runGate(root, [
+      'review', id, '--by', 'carol', '--lense', 'devil',
+      '--verdict', 'concern', '--comment', 'rushed',
+    ]);
+
+    const { stdout: aliceBoot } = runGate(
+      root,
+      ['boot'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const alice = JSON.parse(aliceBoot);
+    assert.equal(
+      alice.status.unresponded,
+      1,
+      'alice (author) should see her unresponded concern in boot.status',
+    );
+
+    // Cross-check: gate status surfaces the same number.
+    const { stdout: aliceStatus } = runGate(
+      root,
+      ['status', '--format', 'json'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(JSON.parse(aliceStatus).unresponded, 1);
+
+    // bob (executor, not in authorship set) has no unresponded.
+    const { stdout: bobBoot } = runGate(
+      root,
+      ['boot'],
+      { GUILD_ACTOR: 'bob' },
+    );
+    assert.equal(JSON.parse(bobBoot).status.unresponded, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot.verbs_available_now: executor (≠author) doesnt double-list as blocker', () => {
+  // When the actor is a non-host executor named on a pending request
+  // they didn't author, the pending-as-executor predicate puts approve
+  // into actionable. Listing the same id+verb under requires_other_actor
+  // would contradict actionable for the same record — the gap a fresh
+  // agent reading boot would notice immediately.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'cross', '--reason', 'r', '--executor', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const p = JSON.parse(stdout);
+    const actionable = p.verbs_available_now.actionable;
+    const blockers = p.verbs_available_now.requires_other_actor;
+    assert.ok(
+      actionable.some(
+        (a: { verb: string; id: string }) =>
+          a.verb === 'approve' && a.id.startsWith('20'),
+      ),
+      'executor should see approve as actionable',
+    );
+    assert.equal(
+      blockers.length,
+      0,
+      'executor (≠ author) should not see their own approve as a blocker',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('write response suggested_next carries actor_resolved', () => {
   // 2.E: the boolean lets an orchestrator branch without parsing
   // `args.by` against the env. True when args.by is absent or


### PR DESCRIPTION
## Summary

Two friction points a fresh agent hit while touching `gate boot`:

**1. `requires_other_actor` contradicted `actionable` for the executor case.**
A non-host actor named as executor on a pending request they did not author saw the same `id+verb` in BOTH lists:

```json
"actionable": [
  {"verb": "approve", "id": "...", "reason": "you're the executor"}
],
"requires_other_actor": [
  {"verb": "approve", "id": "...", "candidates": ["human"],
   "reason": "approval requires a host actor. You are the executor but cannot approve as yourself."}
]
```

In reality bob (executor, ≠ author) can approve silently — the policy permits it, and `pending-as-executor` already lists it under `actionable`. The blocker was wrong on its face. Fix: skip `requires_other_actor` when `isExecutor && !isAuthor`.

**2. `boot.status` omitted unresponded-concern count.**
An author with concerns recorded against their completed work saw all-zero queues in boot, then had to separately remember `gate unresponded`:

```
"status": { pending: 0, approved: 0, executing: 0,
            open_issues: 0, unreviewed: 0, inbox_unread: 0 }   // but unresponded=1
```

A fresh agent reading boot would conclude "nothing to do" — incorrect. Fix: add a flat `unresponded: number` to `StatusSummary`, populated by the same query that drives `gate unresponded` so the two surfaces never disagree. Wired into both `gate boot` and `gate status` (text + json).

## Why this matters

Boot is the orientation surface — agents lean on it to decide what verb to fire. A contradiction with `actionable` undermines the discoverability hint, and a missing queue count makes the status block lie to the actor it's supposed to inform.

Same detector for unresponded as the verb (`UnrespondedConcernsQuery`), so the count and the verb output stay in lock-step.

## Test plan
- [x] `tests/interface/ax.test.ts` — new test "boot.verbs_available_now: executor (≠author) doesnt double-list as blocker" guards the contradiction case.
- [x] `tests/interface/ax.test.ts` — new test "boot.status.unresponded: counts unresponded concerns for the actor" guards the discoverability gap.
- [x] Existing test "host self-approval doesnt double-list as blocker" still passes (host-self case unchanged).
- [x] Existing test "requires_other_actor surfaces pending blockers" still passes (alice-as-author case unchanged: she still sees the blocker because she can't fire approve via pending-as-executor).
- [x] `npm test` — all 535 tests pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_