### PR TITLE
fix: strict-flag rejection across all read verbs

### DIFF
--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -1,5 +1,11 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
+
+const BOARD_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for', 'format']);
 import { Request } from '../../../domain/request/Request.js';
 import {
   computeReviewMarkerWidth,
@@ -37,6 +43,7 @@ import {
 const BOARD_STATES = ['pending', 'approved', 'executing'] as const;
 
 export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, BOARD_KNOWN_FLAGS, 'board');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -1,5 +1,15 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C, loadAllRequestsAsJson, parseOptionalIntOption } from './internal.js';
+
+const BOOT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'format',
+  'tail',
+  'utterances',
+]);
 import { collectStatus, StatusSummary } from './status.js';
 import { collectUtterances } from '../voices.js';
 import { Request } from '../../../domain/request/Request.js';
@@ -155,6 +165,7 @@ interface BootPayload {
 }
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, BOOT_KNOWN_FLAGS, 'boot');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -33,7 +33,16 @@ import {
  * intended for session orientation and narrative walks.
  */
 
+const VOICES_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'lense',
+  'verdict',
+  'limit',
+  'format',
+  'with-calibration',
+]);
+
 export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, VOICES_KNOWN_FLAGS, 'voices');
   const name = args.positional[0];
   if (!name) {
     throw new Error(
@@ -183,7 +192,10 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+const WHOAMI_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
+
 export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WHOAMI_KNOWN_FLAGS, 'whoami');
   const actor = process.env['GUILD_ACTOR'];
   if (!actor || actor.length === 0) {
     process.stderr.write(
@@ -233,7 +245,13 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
+// gate chain takes only positionals (id), no flags. Strict-reject keeps
+// noise like `--format json` from being silently ignored — chain is
+// text-only by design, and a typo should fail closed.
+const CHAIN_KNOWN_FLAGS: ReadonlySet<string> = new Set();
+
 export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, CHAIN_KNOWN_FLAGS, 'chain');
   const rootId = args.positional[0];
   if (!rootId) {
     throw new Error('Usage: gate chain <request-id | issue-id>');

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -62,6 +62,25 @@ const FAST_TRACK_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'with',
   'format',
 ]);
+// `gate list` and `gate pending` share `reqList`. pending only takes
+// `--for`; list adds the four narrowing filters. The list set is the
+// superset and is used at the reqList layer; the index dispatch
+// pre-checks the pending case before delegating, so unknown flags on
+// `gate pending` (e.g. `--from x`) are still caught with the right
+// verb name in the error.
+const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'state',
+  'for',
+  'from',
+  'executor',
+  'auto-review',
+]);
+const PENDING_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for']);
+const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'plain',
+  'format',
+  'fields',
+]);
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import {
@@ -126,7 +145,15 @@ export async function reqList(
   c: C,
   state: string,
   args: ParsedArgs,
+  verb: 'list' | 'pending' = 'list',
 ): Promise<number> {
+  // Different known-flag sets per verb so a typo on `gate pending`
+  // doesn't get a list-grade hint, and the error names the right verb.
+  rejectUnknownFlags(
+    args,
+    verb === 'pending' ? PENDING_KNOWN_FLAGS : LIST_KNOWN_FLAGS,
+    verb,
+  );
   const fromFilter = optionalOption(args, 'from');
   const executorFilter = optionalOption(args, 'executor');
   const autoReviewFilter = optionalOption(args, 'auto-review');
@@ -201,6 +228,7 @@ function describeFilters(filters: Record<string, string | undefined>): string {
 }
 
 export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, SHOW_KNOWN_FLAGS, 'show');
   const id = args.positional[0];
   if (!id)
     throw new Error(

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -1,5 +1,11 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
+
+const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'locale']);
 import { Request, StatusLogEntry } from '../../../domain/request/Request.js';
 import { collectUtterances, Utterance, RequestJSON } from '../voices.js';
 import { deriveSuggestedNext, SuggestedNext } from './writeFormat.js';
@@ -98,6 +104,7 @@ interface ResumePayload {
 }
 
 export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, RESUME_KNOWN_FLAGS, 'resume');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1,5 +1,11 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
+
+const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb']);
 
 /**
  * gate schema [--verb <name>] [--format json|text]
@@ -707,6 +713,7 @@ const VERBS: readonly VerbSchema[] = [
 ];
 
 export async function schemaCmd(_c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, SCHEMA_KNOWN_FLAGS, 'schema');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -1,6 +1,12 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
 import { C, warnIfMisconfiguredCwd } from './internal.js';
+
+const STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for', 'format']);
 
 /**
  * gate status [--for <name>] [--format json|text]
@@ -146,6 +152,7 @@ function renderStatusText(s: StatusSummary): string {
 }
 
 export async function statusCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, STATUS_KNOWN_FLAGS, 'status');
   const actor = optionalOption(args, 'for') ?? process.env['GUILD_ACTOR'] ?? null;
   const format = optionalOption(args, 'format') ?? 'json';
 

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -1,6 +1,12 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { deriveBootSuggestedNext, BootSuggestedNext } from './boot.js';
+
+const SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 /**
  * gate suggest [--format json|text]
@@ -29,6 +35,7 @@ interface SuggestPayload {
 }
 
 export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, SUGGEST_KNOWN_FLAGS, 'suggest');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/summarize.ts
+++ b/src/interface/gate/handlers/summarize.ts
@@ -1,6 +1,12 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+
+const SUMMARIZE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 /**
  * gate summarize <id> [--format text|json]
@@ -32,6 +38,7 @@ interface SummarizePayload {
 }
 
 export async function summarizeCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, SUMMARIZE_KNOWN_FLAGS, 'summarize');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate summarize <id> [--format text|json]');
   const format = optionalOption(args, 'format') ?? 'text';

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -1,6 +1,12 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+
+const TRANSCRIPT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 /**
  * gate transcript <id> [--format text|json]
@@ -49,6 +55,7 @@ interface TranscriptPayload {
 }
 
 export async function transcriptCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, TRANSCRIPT_KNOWN_FLAGS, 'transcript');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate transcript <id> [--format text|json]');
   const format = optionalOption(args, 'format') ?? 'text';

--- a/src/interface/gate/handlers/why.ts
+++ b/src/interface/gate/handlers/why.ts
@@ -1,6 +1,12 @@
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+
+const WHY_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 /**
  * gate why <id> [--format text|json]
@@ -45,6 +51,7 @@ interface WhyPayload {
 }
 
 export async function whyCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WHY_KNOWN_FLAGS, 'why');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate why <id> [--format text|json]');
   const format = optionalOption(args, 'format') ?? 'text';

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -296,7 +296,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       case 'request':
         return await reqCreate(c, args);
       case 'pending':
-        return await reqList(c, 'pending', args);
+        return await reqList(c, 'pending', args, 'pending');
       case 'board':
         return await boardCmd(c, args);
       case 'list': {
@@ -313,7 +313,7 @@ export async function main(argv: readonly string[]): Promise<number> {
           );
           return 1;
         }
-        return await reqList(c, state, args);
+        return await reqList(c, state, args, 'list');
       }
       case 'show':
         return await reqShow(c, args);

--- a/tests/interface/pairMode.test.ts
+++ b/tests/interface/pairMode.test.ts
@@ -113,7 +113,7 @@ test('gate request --with eris persists the field and `gate show` renders it', (
       '--action', 'paired work',
       '--reason', 'felt like it',
     ]);
-    const list = runGate(root, ['list', '--state', 'pending', '--format', 'text']);
+    const list = runGate(root, ['list', '--state', 'pending']);
     const id = list.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
     assert.ok(id);
     const show = runGate(root, ['show', id!, '--format', 'text']);
@@ -139,7 +139,7 @@ test('gate request --with accepts comma-separated list', () => {
       '--action', 'a',
       '--reason', 'r',
     ]);
-    const list = runGate(root, ['list', '--state', 'pending', '--format', 'text']);
+    const list = runGate(root, ['list', '--state', 'pending']);
     const id = list.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
     const show = runGate(root, ['show', id!, '--format', 'json']);
     const payload = JSON.parse(show.stdout);

--- a/tests/interface/resume.test.ts
+++ b/tests/interface/resume.test.ts
@@ -97,7 +97,7 @@ test('gate resume: mid-execution → executing loop + complete suggestion', () =
     // Discover the just-minted id rather than hardcoding a date —
     // `gate request` generates `<today>-<seq>` and the test must
     // run on any day.
-    const pending = runGate(root, ['pending', '--format', 'text']);
+    const pending = runGate(root, ['pending']);
     const id = pending.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
     assert.ok(id, 'expected a pending request after gate request');
     runGate(root, ['approve', id!, '--by', 'eris']);
@@ -131,7 +131,7 @@ test('gate resume: pending review → pending_review loop + review suggestion wi
       '--executor', 'alice',
       '--auto-review', 'bob',
     ]);
-    const list = runGate(root, ['list', '--state', 'pending', '--format', 'text']);
+    const list = runGate(root, ['list', '--state', 'pending']);
     const id = list.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
     assert.ok(id);
     runGate(root, ['approve', id!, '--by', 'eris']);
@@ -170,7 +170,7 @@ test('gate resume: unresponded concern on completed request surfaces in payload 
       '--reason', 'tech debt',
       '--auto-review', 'alice',
     ]);
-    const list = runGate(root, ['list', '--state', 'completed', '--format', 'text']);
+    const list = runGate(root, ['list', '--state', 'completed']);
     const id = list.stdout.match(/(\d{4}-\d{2}-\d{2}-\d{4})/)?.[1];
     assert.ok(id);
     runGate(root, [

--- a/tests/interface/unknownFlagRejection.test.ts
+++ b/tests/interface/unknownFlagRejection.test.ts
@@ -142,3 +142,50 @@ test('gate tail (no flags) still works', (t) => {
   const r = runGate(root, ['tail']);
   assert.equal(r.status, 0);
 });
+
+// --- read-verb sweep: every read verb rejects unknown flags ---
+//
+// Pre-sweep, only tail/doctor/repair/unresponded had this discipline;
+// the rest fail-opened. A typo like `gate pending --format json` would
+// silently render text instead of error. Each entry below uses
+// `--bogus-flag-xyz` (deliberately implausible) so the test surfaces
+// the discipline, not a flag-name overlap with future legitimate flags.
+//
+// Verbs that need a positional id are given a placeholder; the strict-
+// flag check fires before the id is parsed, so any value works.
+
+const READ_VERB_CASES: ReadonlyArray<{
+  verb: string;
+  args: readonly string[];
+}> = [
+  { verb: 'boot', args: [] },
+  { verb: 'status', args: [] },
+  { verb: 'board', args: [] },
+  { verb: 'suggest', args: [] },
+  { verb: 'resume', args: [] },
+  { verb: 'schema', args: [] },
+  { verb: 'show', args: ['2026-01-01-0001'] },
+  { verb: 'chain', args: ['2026-01-01-0001'] },
+  { verb: 'pending', args: [] },
+  { verb: 'list', args: ['--state', 'pending'] },
+  { verb: 'voices', args: ['alice'] },
+  { verb: 'whoami', args: [] },
+  { verb: 'summarize', args: ['2026-01-01-0001'] },
+  { verb: 'why', args: ['2026-01-01-0001'] },
+  { verb: 'transcript', args: ['2026-01-01-0001'] },
+];
+
+for (const { verb, args } of READ_VERB_CASES) {
+  test(`gate ${verb} rejects unknown flag --bogus-flag-xyz`, (t) => {
+    const { root, cleanup } = bootstrap();
+    t.after(cleanup);
+    runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
+    const r = runGate(root, [verb, ...args, '--bogus-flag-xyz']);
+    assert.notEqual(r.status, 0, `${verb} should exit non-zero on unknown flag`);
+    assert.match(
+      r.stderr,
+      new RegExp(`gate ${verb}: unknown flag.*--bogus-flag-xyz`),
+      `${verb} stderr should name the verb and the bogus flag`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`tail`, `doctor`, `repair`, and `unresponded` already rejected unknown flags. The other 15 read verbs fail-opened — a typo or wrong flag name silently slipped through with output that looked like success. The friction this closes:

```
$ gate pending --format json
2026-05-01-0001  [pending]  from=alice  ...   # ← still text, --format silently ignored
```

After this PR:

```
$ gate pending --format json
error: gate pending: unknown flag: --format
  valid flags for 'pending': --for
```

## Verbs covered

`boot, status, board, suggest, resume, schema, show, chain, pending, list, voices, whoami, summarize, why, transcript` — every read verb that previously fail-opened.

Each handler declares a `KNOWN_FLAGS` set matched against:
- its actual `optionalOption` / positional usage in the source
- the verb's schema entry in `schema.ts` where one exists
- the toplevel `--help` examples

`gate list` and `gate pending` share `reqList`; the dispatcher now passes the verb name so the error names the right command (`pending: unknown flag` vs `list: unknown flag`).

## Why this matters

The voiceBudget test for `unresponded` already documented this rationale: "Read-verb strict-flag discipline: a typo like `--max-age-day 7` (singular) silently falling back to the 30-day default would be the exact fail-open shape rejectUnknownFlags exists to prevent." That principle was applied piecemeal; this sweep makes it the read-surface default.

## Test plan
- [x] New 15-case parametric block in `tests/interface/unknownFlagRejection.test.ts` — each read verb gets a guard ensuring `--bogus-flag-xyz` is rejected with the verb's name in stderr.
- [x] Two existing tests in `resume.test.ts` and `pairMode.test.ts` passed `--format text` to `pending` / `list` — silently a no-op pre-sweep (those verbs are text-only). Dropped the dead flag from the test calls; the assertions on text output still hold.
- [x] `npm test` — 549/549 pass.

The sweep is mechanical, not behavioral — every legitimate caller that already typed a correct flag continues to work; only typos and "I'll try `--format json` everywhere" attempts fail closed.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_