### PR TITLE
fix: gate issues list — discoverability + JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate issues list` JSON output + `--state all` + bare-issues
+  hint.** Closes four discoverability gaps a fresh-agent dogfood
+  surfaced. (1) `--format json` now emits an array of nested issue
+  objects (notes preserved as a sub-array, not flattened as in text
+  format). (2) `--state all` returns every state in one call;
+  previously a reader had to invoke list four times. (3) When
+  `--state` is omitted, a stderr hint discloses the implicit
+  open-only filter and names the open-vs-active distinction with
+  `gate status`'s count: `# filtered to state=open; status counts
+  open+in_progress (active) — --state to override`. (4) A bare
+  `gate issues` (no subcommand) used to silently fall through to
+  list; it now emits a short hint at the most-common subcommands
+  and exits 1, mirroring how `gate list` handles missing `--state`.
+  The list semantics (worklist = open) and the status semantics
+  (triage = open+in_progress) intentionally differ — the difference
+  is exposed at the surface that produces the count, not papered
+  over by aligning them. Devil-reviewed
+  (`2026-05-01-0001`/`0002` in design sandbox).
+
 - **`lore/principles/08-voice-as-doctrine.md` + voice-budget audit.**
   Names the principle that the tool's prose — `suggested_next.reason`,
   schema descriptions, footers, finding messages — is the running

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -19,7 +19,10 @@ const ISSUES_ADD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'area',
   'text',
 ]);
-const ISSUES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['state']);
+const ISSUES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'state',
+  'format',
+]);
 const ISSUES_PROMOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
   'executor',
@@ -35,6 +38,23 @@ const ISSUES_TRANSITION_KNOWN_FLAGS: ReadonlySet<string> = new Set(['by']);
 
 export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
+  if (sub === undefined) {
+    // Pre-this-fix, a bare `gate issues` silently fell through to
+    // `issues list` (open-only). The user typed `issues` not `list`,
+    // so the silent fall-through hid the verb's actual surface from
+    // first-time callers. Mirror what `gate list` does for missing
+    // --state: short hint at common entry points, gesture at the full
+    // catalog, exit 1 so a script chained on the call notices.
+    process.stderr.write(
+      'gate issues needs a subcommand. common ones:\n' +
+        '  gate issues list                  # what is open\n' +
+        '  gate issues add --from <m> --severity <s> --area <a> --text <s>\n' +
+        '  gate issues note <id> --by <m> --text <s>\n' +
+        '  full set: add|list|note|resolve|defer|start|reopen|promote ' +
+        '(gate --help)\n',
+    );
+    return 1;
+  }
   if (sub === 'promote') {
     return await issuesPromote(c, args);
   }
@@ -101,10 +121,59 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(`✓ issue: ${i.id.value}\n`);
     return 0;
   }
-  if (sub === 'list' || sub === undefined) {
+  if (sub === 'list') {
     rejectUnknownFlags(args, ISSUES_LIST_KNOWN_FLAGS, 'issues list');
-    const state = optionalOption(args, 'state');
-    const items = await c.issueUC.list(state);
+    const stateRaw = optionalOption(args, 'state');
+    const format = optionalOption(args, 'format') ?? 'text';
+    if (format !== 'text' && format !== 'json') {
+      throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+    }
+
+    // `--state all` is sugar for "every state, no filter". Implemented
+    // here rather than in IssueUseCases because the use case is
+    // "list issues filtered by a *valid* state" and `all` is a CLI-
+    // level affordance, not a domain state. Distinguishing these
+    // keeps domain validation strict (parseIssueState rejects 'all').
+    let items: Awaited<ReturnType<typeof c.issueUC.list>>;
+    if (stateRaw === 'all') {
+      items = await c.issueUC.listAll();
+    } else {
+      items = await c.issueUC.list(stateRaw);
+    }
+
+    // Default-filter discoverability: when the caller passed nothing,
+    // the underlying list silently filters to state=open. Empty stdout
+    // gives no signal whether (a) zero issues, (b) filter excluded,
+    // or (c) error. Surface the filter on stderr — the same shape
+    // `gate list`/`gate pending` use to disclose implicit narrowing.
+    //
+    // The phrasing also closes the open-vs-active gap: status counts
+    // open+in_progress as "open_issues" (a triage glance), but list
+    // is a worklist (what's unclaimed). Naming the difference here
+    // means a reader who notices the count mismatch finds the answer
+    // at the surface that exposed it.
+    if (stateRaw === undefined && format === 'text') {
+      process.stderr.write(
+        '# filtered to state=open; status counts open+in_progress (active) ' +
+          '— --state to override (open|in_progress|deferred|resolved|all)\n',
+      );
+    }
+
+    if (format === 'json') {
+      // Shape pinned in 2026-05-01-0002 design review (devil C):
+      //   array of issue objects with notes nested. text format
+      //   flattens notes for human reading; json preserves structure
+      //   so programmatic consumers can walk them as a tree.
+      process.stdout.write(
+        JSON.stringify(
+          items.map((i) => i.toJSON()),
+          null,
+          2,
+        ) + '\n',
+      );
+      return 0;
+    }
+
     for (const i of items) {
       const j = i.toJSON();
       const proxyTag = j['invoked_by']

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -608,6 +608,22 @@ const VERBS: readonly VerbSchema[] = [
           description:
             "`note` appends an annotation without mutating severity/area/text — the issue record is otherwise immutable.",
         },
+        state: {
+          type: 'string',
+          description:
+            "`list` filter. Default: open (worklist semantic). " +
+            'Special: `all` returns every state with no filter. ' +
+            'Note: status.open_issues counts open+in_progress (triage) — ' +
+            'list and status report different scopes by design.',
+          enum: ['open', 'in_progress', 'deferred', 'resolved', 'all'],
+        },
+        format: {
+          type: 'string',
+          enum: ['text', 'json'],
+          description:
+            "`list` only. text (default) flattens notes for human reading; " +
+            'json keeps notes nested per issue.',
+        },
       },
     },
     output: { type: 'object' },

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -109,7 +109,12 @@ Requests:
 Issues:
   gate issues add --from <m> --severity <s> --area <a>
                   [--text <s> | --text - | <text>]
-  gate issues list [--state <s>]
+  gate issues list [--state <s>] [--format json|text]
+                       Default --state is open (worklist semantic).
+                       Use --state all to see every state, or pass a
+                       specific state. Note: status.open_issues
+                       counts open+in_progress (triage), so list and
+                       status report different scopes on purpose.
   gate issues resolve|defer|start|reopen <id>
   gate issues note <id> --by <m> [--text <s> | --text - | <text>]
   gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>]

--- a/tests/interface/issuesListSurface.test.ts
+++ b/tests/interface/issuesListSurface.test.ts
@@ -1,0 +1,229 @@
+// gate issues list — discoverability + JSON output.
+//
+// Surfaces this test pins:
+//   - default-state filter is announced on stderr (not silent)
+//   - `--state all` returns every state in one call
+//   - `--format json` emits an array of nested issue objects
+//   - bare `gate issues` (no subcommand) prints a hint and exits 1,
+//     instead of silently routing to `issues list`
+//
+// Why this exists: the open-vs-active mismatch between
+// `status.open_issues` (counts open+in_progress) and `gate issues list`
+// default (open only) used to be invisible. The hint text names that
+// difference at the surface where the reader sees it. See design
+// 2026-05-01-0001 / 0002 for the absorbed devil review that landed
+// on "expose the difference, don't hide it".
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-issues-list-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// Seed two issues across three states so list filtering is observable.
+function seedFixture(root: string): void {
+  runGate(root, [
+    'issues', 'add',
+    '--from', 'alice', '--severity', 'med', '--area', 'docs',
+    '--text', 'first',
+  ], { GUILD_ACTOR: 'alice' });
+  runGate(root, [
+    'issues', 'add',
+    '--from', 'alice', '--severity', 'high', '--area', 'infra',
+    '--text', 'second',
+  ], { GUILD_ACTOR: 'alice' });
+  // Move the second one to in_progress so the open-vs-all distinction
+  // is visible.
+  runGate(root, [
+    'issues', 'start', 'i-2026-05-01-0002',
+  ], { GUILD_ACTOR: 'alice' });
+}
+
+test('gate issues (no subcommand) emits a hint + exit 1', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['issues'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0, 'bare `issues` should fail closed');
+  assert.match(r.stderr, /needs a subcommand/);
+  // Hints at the most common entry points.
+  assert.match(r.stderr, /gate issues list/);
+  assert.match(r.stderr, /gate issues add/);
+  assert.match(r.stderr, /gate issues note/);
+  // Gestures at the full catalog without listing it inline.
+  assert.match(r.stderr, /add\|list\|note\|resolve\|defer\|start\|reopen\|promote/);
+});
+
+test('gate issues list (default) emits a stderr hint disclosing the open-only filter', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Re-date the seed for the test to find by id below.
+  const today = new Date().toISOString().slice(0, 10);
+  runGate(root, [
+    'issues', 'add',
+    '--from', 'alice', '--severity', 'med', '--area', 'docs',
+    '--text', 'lone',
+  ], { GUILD_ACTOR: 'alice' });
+  const r = runGate(root, ['issues', 'list'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  // The hint names the filter, the status mismatch, AND --state.
+  assert.match(r.stderr, /filtered to state=open/);
+  assert.match(r.stderr, /status counts open\+in_progress/);
+  assert.match(r.stderr, /--state to override/);
+  // The actual list still appears on stdout.
+  assert.match(r.stdout, new RegExp(`i-${today}`));
+});
+
+test('gate issues list --state open does NOT emit the default hint', (t) => {
+  // The hint exists to disclose an *implicit* filter. When the caller
+  // typed --state explicitly, there is nothing to disclose.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedFixture(root);
+  const r = runGate(
+    root,
+    ['issues', 'list', '--state', 'open'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /filtered to state=open/);
+});
+
+test('gate issues list --state all returns every state in one call', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedFixture(root);
+  const r = runGate(
+    root,
+    ['issues', 'list', '--state', 'all'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  // Open and in_progress fixture issues both surface.
+  assert.match(r.stdout, /open from=alice — first/);
+  assert.match(r.stdout, /in_progress from=alice — second/);
+});
+
+test('gate issues list --format json emits an array of nested issue objects', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Seed an open issue with a note so the json shape is visible.
+  runGate(root, [
+    'issues', 'add',
+    '--from', 'alice', '--severity', 'low', '--area', 'docs',
+    '--text', 'with-note',
+  ], { GUILD_ACTOR: 'alice' });
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `i-${today}-0001`;
+  runGate(root, [
+    'issues', 'note', id, '--by', 'bob', '--text', 'observed',
+  ], { GUILD_ACTOR: 'bob' });
+  const r = runGate(
+    root,
+    ['issues', 'list', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(items));
+  assert.equal(items.length, 1);
+  const issue = items[0];
+  assert.equal(issue.id, id);
+  assert.equal(issue.state, 'open');
+  assert.equal(issue.severity, 'low');
+  assert.equal(issue.area, 'docs');
+  assert.equal(issue.from, 'alice');
+  assert.equal(issue.text, 'with-note');
+  // Notes stay nested in json (the text format flattens them; the
+  // shape decision is documented in the design review for this fix).
+  assert.ok(Array.isArray(issue.notes));
+  assert.equal(issue.notes.length, 1);
+  assert.equal(issue.notes[0].by, 'bob');
+  assert.equal(issue.notes[0].text, 'observed');
+});
+
+test('gate issues list --format json suppresses the stderr hint', (t) => {
+  // The hint is for human readers scanning text; pumping prose into
+  // a json caller's stderr would be noise. Stay clean for pipelines.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedFixture(root);
+  const r = runGate(
+    root,
+    ['issues', 'list', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /filtered to state=open/);
+});
+
+test('gate issues list --state all --format json returns every issue as json', (t) => {
+  // The two flags compose: `--state all` widens the set, `--format
+  // json` shapes the output.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedFixture(root);
+  const r = runGate(
+    root,
+    ['issues', 'list', '--state', 'all', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  assert.equal(items.length, 2);
+  const states = items.map((i: { state: string }) => i.state).sort();
+  assert.deepEqual(states, ['in_progress', 'open']);
+});
+
+test('gate issues list --format bogus errors', (t) => {
+  // Format value validation, not flag-set rejection (--format itself
+  // is now a known flag for issues list).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['issues', 'list', '--format', 'yaml'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+});


### PR DESCRIPTION
## Summary

Four discoverability gaps a fresh-agent dogfood surfaced on `gate issues`. Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); a devil-review pass absorbed one substantive concern that reshaped the plan.

## Changes

### 1. `--format json`
```
$ gate issues list --format json
[
  { "id": "i-...", "severity": "med", "area": "docs", "state": "open",
    "from": "alice", "text": "...", "notes": [{ "by": "...", "at": "...", "text": "..." }] }
]
```
Array of issue objects with notes nested. The text format flattens notes for human reading; JSON keeps the structure so programmatic consumers can walk them.

### 2. `--state all`
```
$ gate issues list --state all
i-...-0001 [med/docs] open from=alice — first
i-...-0002 [high/infra] in_progress from=alice — second
```
One call returns every state. Previously: 4 calls.

### 3. Default-filter hint on stderr
```
$ gate issues list
# filtered to state=open; status counts open+in_progress (active) — --state to override (open|in_progress|deferred|resolved|all)
i-...-0001 [med/docs] open from=alice — ...
```
Suppressed when `--state` is explicit (nothing to disclose) or `--format json` (pipelines stay clean).

### 4. Bare `gate issues` → hint + exit 1
```
$ gate issues
gate issues needs a subcommand. common ones:
  gate issues list                  # what is open
  gate issues add --from <m> --severity <s> --area <a> --text <s>
  gate issues note <id> --by <m> --text <s>
  full set: add|list|note|resolve|defer|start|reopen|promote (gate --help)
```
Pre-fix silently routed to `issues list`; the verb's actual surface was hidden from first-time callers.

## Design note: deliberate semantic split

A v1 of this plan proposed "align `gate issues list` default to `open+in_progress` so it matches `status.open_issues`". The devil review pushed back: list is a worklist (open = unclaimed), status is a triage glance (active = open + in_progress). Forcing them to share semantics loses the worklist semantics that make list useful for "what should I pick up?"

v2 (this PR) keeps the two separate and **exposes the difference at the surface that produces the count**, via the stderr hint in (3). The reader who notices the count mismatch now finds the answer where they noticed it.

## Test plan
- [x] `tests/interface/issuesListSurface.test.ts` (new, 8 tests):
  - bare `gate issues` emits hint + exit 1
  - default list emits the open-only-filter hint
  - explicit `--state open` does NOT emit the hint
  - `--state all` returns every state
  - `--format json` emits nested issue objects with notes preserved
  - `--format json` suppresses the stderr hint
  - `--state all --format json` composes correctly
  - `--format yaml` errors with format-validation message
- [x] `npm test` — 557/557 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_