### PR TITLE
fix: gate inbox json + self/inactive message advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`gate inbox --format json` + self/inactive message advisories.**
+  Three friction points on the messages surface a fresh-agent
+  dogfood surfaced. (1) `gate inbox --format json` now emits an
+  array of inbox-entry objects with snake_case keys
+  ({from, to, type, text, at, read, read_at?, read_by?,
+  invoked_by?, related?}). Optional fields are OMITTED when
+  undefined (matches `gate show` JSON convention). (2)
+  `gate message --from X --to X` (self-message) emits a stderr
+  notice — same shape as the existing self-approve notice. The
+  act is allowed and recorded; the writer sees the edge they
+  crossed. (3) `gate message --to <inactive>` emits a stderr
+  notice naming the consequence ("the message landed in their
+  inbox but they may not be reading it"). `gate broadcast`
+  already filters inactive recipients; the DM path was silent —
+  asymmetric. The notice closes the asymmetry without making a
+  policy choice (deliver-or-block) the PR doesn't have a basis
+  for. Devil-reviewed (`2026-05-01-0001`/`0002` in design
+  sandbox); v2 absorbed phrasing trims and the omit-when-
+  undefined JSON shape rule.
+
 - **`gate issues list` JSON output + `--state all` + bare-issues
   hint.** Closes four discoverability gaps a fresh-agent dogfood
   surfaced. (1) `--format json` now emits an array of nested issue

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -10,6 +10,30 @@ import {
   emitInvokedByNotice,
   readStdin,
 } from './internal.js';
+import { InboxMessage } from '../../../application/ports/NotificationPort.js';
+
+/**
+ * Serialise an InboxMessage for `gate inbox --format json`. snake_case
+ * keys to match the on-disk YAML and the rest of the project's JSON
+ * surface (`gate show`, `gate issues list --format json`). Optional
+ * fields are omitted when undefined rather than emitted as null —
+ * pinned in design review 2026-05-01-0001/0002.
+ */
+function toInboxJson(m: InboxMessage): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    from: m.from,
+    to: m.to,
+    type: m.type,
+    text: m.text,
+    at: m.at,
+    read: m.read,
+  };
+  if (m.readAt !== undefined) out['read_at'] = m.readAt;
+  if (m.readBy !== undefined) out['read_by'] = m.readBy;
+  if (m.invokedBy !== undefined) out['invoked_by'] = m.invokedBy;
+  if (m.related !== undefined) out['related'] = m.related;
+  return out;
+}
 
 const MESSAGE_SEND_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
@@ -25,6 +49,7 @@ const MESSAGE_BROADCAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 const INBOX_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'for',
   'unread',
+  'format',
 ]);
 
 export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
@@ -40,6 +65,35 @@ export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
   if (text === '-') text = (await readStdin()).trim();
   const type = optionalOption(args, 'type');
   const invokedBy = deriveInvokedBy(from);
+
+  // Self-message advisory: matches the `gate approve` self-approval
+  // notice pattern. The act is allowed and recorded; the writer sees
+  // the edge they crossed. Catches typos (--to alice when --from
+  // alice) without forcing the writer to defend an intentional
+  // self-note.
+  if (from === to) {
+    process.stderr.write(
+      `notice: ${from} messaged themselves (self-message recorded).\n`,
+    );
+  }
+
+  // Inactive-recipient advisory: gate broadcast filters inactive
+  // members; gate message used to deliver silently. Asymmetric.
+  // Fetch the recipient member here to read the active flag — if
+  // the member doesn't exist at all, leave the lookup to
+  // MessageUseCases.send (it produces a richer error). Skip the
+  // active-check noise on self-message: if the writer just messaged
+  // themselves they already know their own state.
+  if (from !== to) {
+    const recipient = await c.memberUC.show(to);
+    if (recipient !== null && !recipient.active) {
+      process.stderr.write(
+        `notice: ${to} is inactive; the message landed in their inbox ` +
+          `but they may not be reading it.\n`,
+      );
+    }
+  }
+
   await c.messageUC.send({
     from,
     to,
@@ -102,10 +156,28 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, INBOX_KNOWN_FLAGS, 'inbox');
   const forName = requireOption(args, 'for', '--for required', 'GUILD_ACTOR');
   const unreadOnly = args.options['unread'] === true;
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
   const messages = await c.messageUC.inbox(forName);
   const filtered = unreadOnly
     ? messages.filter((m) => !m.read)
     : messages;
+
+  // JSON output: array of messages with snake_case keys (matches the
+  // on-disk YAML and `gate show` JSON convention) and omit-when-
+  // undefined for optional fields (read_at, read_by, invoked_by,
+  // related). Devil-reviewed in 2026-05-01-0001/0002 (design sandbox):
+  // omit beats null because the absent signal is honest — null would
+  // suggest "explicitly not yet" which we don't mean for sender-side
+  // optional fields.
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(filtered.map(toInboxJson), null, 2) + '\n',
+    );
+    return 0;
+  }
 
   if (filtered.length === 0) {
     const suffix = unreadOnly ? ' (unread only)' : '';

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -656,9 +656,20 @@ const VERBS: readonly VerbSchema[] = [
     summary: 'list messages for a member; mark-read as subcommand',
     input: {
       type: 'object',
-      properties: { for: str, unread: { type: 'boolean' } },
+      properties: {
+        for: str,
+        unread: { type: 'boolean' },
+        format: formatField,
+      },
     },
-    output: { type: 'array' },
+    output: {
+      type: 'array',
+      description:
+        '--format json: array of inbox-entry objects with snake_case ' +
+        "keys ({from, to, type, text, at, read, read_at?, read_by?, " +
+        'invoked_by?, related?}). Optional fields are omitted when ' +
+        'undefined.',
+    },
   },
   {
     name: 'doctor',

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -123,7 +123,7 @@ Issues:
 Messages:
   gate message --from <m> --to <m> [--text <s> | --text -]
   gate broadcast --from <m> [--text <s> | --text -]
-  gate inbox --for <m> [--unread]
+  gate inbox --for <m> [--unread] [--format json|text]
   gate inbox mark-read [N] [--for <m>]
 
 States: pending | approved | executing | completed | failed | denied

--- a/tests/interface/messageSurface.test.ts
+++ b/tests/interface/messageSurface.test.ts
@@ -1,0 +1,265 @@
+// gate message + gate inbox surface fixes.
+//
+// Pins three behaviours surfaced by fresh-agent dogfood:
+//   - self-message emits a stderr notice (mirrors self-approve)
+//   - message to inactive recipient emits a stderr notice
+//     (broadcast already filters them; DM was silent — asymmetric)
+//   - gate inbox --format json emits an array of snake_case entries
+//     with optional fields omitted when undefined
+//
+// Pre-fix: all three were silent / missing. Each is fail-open by
+// design — the act is allowed, the writer is told what edge they
+// crossed. Mirrors the pattern lore/principles/02 names: weak
+// signals at principle-edges, not policy enforcement.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-msg-surface-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const name of ['alice', 'bob', 'carol']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function deactivate(root: string, name: string): void {
+  const p = join(root, 'members', `${name}.yaml`);
+  writeFileSync(
+    p,
+    readFileSync(p, 'utf8').replace('active: true', 'active: false'),
+  );
+}
+
+// ── self-message notice ──────────────────────────────────────────
+
+test('gate message --from X --to X emits a self-message notice on stderr', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'alice', '--text', 'self note'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, 'self-message is allowed (fail-open)');
+  assert.match(r.stderr, /notice: alice messaged themselves/);
+  assert.match(r.stderr, /self-message recorded/);
+  // The success line still goes to stdout — pipelines stay clean.
+  assert.match(r.stdout, /✓ message sent: alice → alice/);
+});
+
+test('gate message --from X --to Y (different actors) emits no self-message notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'hi'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /messaged themselves/);
+});
+
+// ── inactive-recipient notice ────────────────────────────────────
+
+test('gate message --to <inactive> emits an inactive notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  deactivate(root, 'carol');
+  const r = runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'carol', '--text', 'hi'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, 'delivery still succeeds (fail-open)');
+  assert.match(r.stderr, /notice: carol is inactive/);
+  // The phrasing names the consequence the reader cares about, not
+  // a policy choice (deliver-or-block) we are not making here.
+  assert.match(r.stderr, /landed in their inbox/);
+  assert.match(r.stderr, /may not be reading it/);
+});
+
+test('gate message --to <active> emits no inactive notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'hi'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /is inactive/);
+});
+
+test('gate message --from X --to X (self-message) skips the inactive check', (t) => {
+  // The writer just messaged themselves; pestering them about their
+  // own active flag is noise. The self-message notice carries the
+  // "edge crossed" signal already.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  deactivate(root, 'alice');
+  const r = runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'alice', '--text', 'self'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /messaged themselves/);
+  assert.doesNotMatch(r.stderr, /alice is inactive/);
+});
+
+// ── inbox --format json ──────────────────────────────────────────
+
+test('gate inbox --format json emits array of snake_case entries', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'hello'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(
+    root,
+    ['inbox', '--for', 'bob', '--format', 'json'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(items));
+  assert.equal(items.length, 1);
+  const m = items[0];
+  // Required fields all present, snake_case.
+  assert.equal(m.from, 'alice');
+  assert.equal(m.to, 'bob');
+  assert.equal(m.type, 'message');
+  assert.equal(m.text, 'hello');
+  assert.equal(typeof m.at, 'string');
+  assert.equal(m.read, false);
+  // Optional fields OMITTED (not null) when undefined. Pinned in
+  // 2026-05-01-0001/0002 design review (devil B1).
+  assert.equal('read_at' in m, false);
+  assert.equal('read_by' in m, false);
+  assert.equal('invoked_by' in m, false);
+  assert.equal('related' in m, false);
+});
+
+test('gate inbox --format json includes optional fields when present', (t) => {
+  // After mark-read, read_at + read_by populate. Verifies the
+  // omit-when-undefined rule cleanly inverts: present-when-defined.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'hello'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runGate(root, ['inbox', 'mark-read', '1', '--for', 'bob'], {
+    GUILD_ACTOR: 'bob',
+  });
+  const r = runGate(
+    root,
+    ['inbox', '--for', 'bob', '--format', 'json'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  const m = items[0];
+  assert.equal(m.read, true);
+  assert.equal(typeof m.read_at, 'string');
+  assert.equal(m.read_by, 'bob');
+});
+
+test('gate inbox --format json --unread filters and still emits json', (t) => {
+  // The --unread filter applies before serialisation; json shape
+  // stays an array regardless.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'one'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runGate(
+    root,
+    ['message', '--from', 'alice', '--to', 'bob', '--text', 'two'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runGate(root, ['inbox', 'mark-read', '1', '--for', 'bob'], {
+    GUILD_ACTOR: 'bob',
+  });
+  const r = runGate(
+    root,
+    ['inbox', '--for', 'bob', '--unread', '--format', 'json'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].text, 'two');
+  assert.equal(items[0].read, false);
+});
+
+test('gate inbox --format json on an empty inbox emits []', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['inbox', '--for', 'alice', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.deepEqual(JSON.parse(r.stdout), []);
+});
+
+test('gate inbox --format bogus errors with format validation', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['inbox', '--for', 'alice', '--format', 'yaml'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+});


### PR DESCRIPTION
## Summary

Three friction points on the messages/inbox surface a fresh-agent dogfood surfaced. Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); devil pass tightened phrasings and pinned the JSON shape.

## Changes

### 1. `gate inbox --format json`

```
$ gate inbox --for bob --format json
[
  { "from": "alice", "to": "bob", "type": "message", "text": "hello",
    "at": "...", "read": true, "read_at": "...", "read_by": "bob" }
]
```

Array of inbox entries with snake_case keys (matches on-disk YAML and `gate show` JSON convention). **Optional fields are omitted when undefined** — devil-reviewed and pinned: `null` would suggest "explicit not-yet" which we don't mean for sender-side optional fields.

Schema entry on `inbox` learns the `format` property; the output description names the shape inline.

### 2. Self-message advisory

```
$ gate message --from alice --to alice --text "self note"
notice: alice messaged themselves (self-message recorded).
✓ message sent: alice → alice
```

Mirrors the self-approve notice's terseness. The act is allowed and recorded; the writer sees the edge they crossed. Catches typos (`--to alice` when `--from alice` intended a colleague) without forcing the writer to defend an intentional self-note.

### 3. Inactive-recipient advisory

```
$ gate message --from alice --to carol --text "hi"
notice: carol is inactive; the message landed in their inbox but they may not be reading it.
✓ message sent: alice → carol
```

Closes the asymmetry with `gate broadcast`, which already filters inactive recipients. The DM path was silent. Phrasing names the consequence the reader cares about (will it be seen?), not a deliver-or-block policy choice this PR doesn't have a basis for.

## Test plan
- [x] `tests/interface/messageSurface.test.ts` (new, 10 tests):
  - self-message notice present, and absent for cross-actor message
  - inactive-recipient notice present, and absent for active recipient
  - self-message suppresses inactive check (writer's own state is noise to them)
  - JSON shape: required fields present, optional fields omitted when undefined
  - JSON shape: optional fields present after mark-read
  - `--unread` + `--format json` compose
  - empty inbox + `--format json` emits `[]`
  - `--format yaml` errors with format validation
- [x] `npm test` — 567/567 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_