### PR TITLE
fix: align Member.displayName to snake_case + whoami surfaces it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Changed
+- **Member YAML: `displayName` → `display_name` on save.** Aligns the
+  one camelCase field on disk with the rest of the project's
+  snake_case convention (`auto_review`, `read_at`, `status_log`,
+  `created_at`, `invoked_by`). The hydrate path
+  (`YamlMemberRepository`) already accepts both forms; new writes
+  always use snake_case. Existing member YAMLs in users'
+  content_roots keep loading. Bundled fixtures
+  (`examples/quick-start`, `examples/dogfood-session`,
+  `examples/agent-voices`) migrated mechanically. Single-cycle cut
+  per 0.x policy — no dual-emit phase. Devil-reviewed
+  (2026-05-01-0001/0002).
+
 ### Added
+- **`gate whoami` surfaces `display_name`.** When a member YAML
+  carries a `display_name`, the orientation line now reads
+  `you are noir — Noir (Critic) (member)` rather than the pre-fix
+  `you are noir (member)` which hid the chosen presentation. Em-
+  dash separator follows the pattern other surfaces use to compose
+  name/label pairs; the trailing role-in-parens is unchanged. When
+  no display_name exists, the line stays in its original concise
+  form.
+
 - **`gate inbox --format json` + self/inactive message advisories.**
   Three friction points on the messages surface a fresh-agent
   dogfood surfaced. (1) `gate inbox --format json` now emits an

--- a/examples/agent-voices/members/eris.yaml
+++ b/examples/agent-voices/members/eris.yaml
@@ -1,4 +1,4 @@
 name: eris
 category: professional
 active: true
-displayName: Eris
+display_name: Eris

--- a/examples/dogfood-session/members/kiri.yaml
+++ b/examples/dogfood-session/members/kiri.yaml
@@ -1,4 +1,4 @@
 name: kiri
 category: professional
 active: true
-displayName: Kiri (Author)
+display_name: Kiri (Author)

--- a/examples/dogfood-session/members/noir.yaml
+++ b/examples/dogfood-session/members/noir.yaml
@@ -1,4 +1,4 @@
 name: noir
 category: professional
 active: true
-displayName: Noir (Critic)
+display_name: Noir (Critic)

--- a/examples/dogfood-session/members/rin.yaml
+++ b/examples/dogfood-session/members/rin.yaml
@@ -1,4 +1,4 @@
 name: rin
 category: professional
 active: true
-displayName: Rin (Critic)
+display_name: Rin (Critic)

--- a/examples/quick-start/members/alice.yaml
+++ b/examples/quick-start/members/alice.yaml
@@ -1,4 +1,4 @@
 name: alice
 category: core
 active: true
-displayName: Alice
+display_name: Alice

--- a/examples/quick-start/members/bob.yaml
+++ b/examples/quick-start/members/bob.yaml
@@ -1,4 +1,4 @@
 name: bob
 category: professional
 active: true
-displayName: Bob
+display_name: Bob

--- a/src/domain/member/Member.ts
+++ b/src/domain/member/Member.ts
@@ -62,8 +62,13 @@ export class Member {
       category: this.props.category,
       active: this.props.active,
     };
+    // snake_case key on disk to match the rest of the project's
+    // YAML convention (auto_review, status_log, created_at,
+    // invoked_by). hydrate accepts both `display_name` and
+    // `displayName` for backwards-compatibility with member YAMLs
+    // written by older versions; new writes always use snake_case.
     if (this.props.displayName !== undefined) {
-      out['displayName'] = this.props.displayName;
+      out['display_name'] = this.props.displayName;
     }
     return out;
   }

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -209,7 +209,8 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
 
   const members = await c.memberUC.list();
   const actorLower = actor.toLowerCase();
-  const isMember = members.some((m) => m.name.value === actorLower);
+  const memberRecord = members.find((m) => m.name.value === actorLower);
+  const isMember = memberRecord !== undefined;
   const isHost = c.config.hostNames.includes(actorLower);
   const role = isMember
     ? 'member'
@@ -217,7 +218,16 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
       ? 'host'
       : 'unknown (not in members/ or host_names)';
 
-  process.stdout.write(`you are ${actor} (${role})\n`);
+  // Surface display_name when present: name and display_name carry
+  // different signals — name is identity, display_name is the
+  // human-facing label. Hiding display_name at the orientation
+  // surface meant the member's chosen presentation lived only in
+  // YAML and `guild list`. Em-dash separator follows how other
+  // surfaces compose name/label pairs; the role parens stay so the
+  // visual block parses left-to-right (name — label (role)).
+  const displayName = memberRecord?.displayName;
+  const displayChunk = displayName ? ` — ${displayName}` : '';
+  process.stdout.write(`you are ${actor}${displayChunk} (${role})\n`);
 
   const limit = parseOptionalIntOption(args, 'limit') ?? 5;
 

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -110,9 +110,10 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
       name: parsedName.value,
       category: canonicalCategory,
       active: true,
-      // Key name mirrors the written YAML (`displayName`, camelCase)
-      // to preserve "what-you-see-is-what-gets-saved" parity.
-      ...(displayName ? { displayName } : {}),
+      // Key name mirrors the written YAML (`display_name`,
+      // snake_case) to preserve "what-you-see-is-what-gets-saved"
+      // parity.
+      ...(displayName ? { display_name: displayName } : {}),
     };
     if (format === 'json') {
       process.stdout.write(

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -72,7 +72,100 @@ test('register: happy path writes members/<name>.yaml with canonical fields', ()
     assert.match(yaml, /name: klee/);
     assert.match(yaml, /category: professional/);
     assert.match(yaml, /active: true/);
-    assert.match(yaml, /displayName: Klee/);
+    // snake_case key on disk — matches the rest of the project's
+    // YAML convention. hydrate accepts both forms for back-compat
+    // with member YAMLs written by older versions; new writes
+    // always use snake_case.
+    assert.match(yaml, /display_name: Klee/);
+    // Negative: the camelCase key MUST NOT also appear (single-cycle
+    // cut, not dual-emit). Pre-fix shape used `displayName`; new
+    // writes are snake_case only.
+    assert.doesNotMatch(yaml, /displayName:/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: dry-run preview uses display_name (snake_case), matches save shape', () => {
+  // What-you-see-is-what-gets-saved parity. Pre-fix the preview
+  // emitted `displayName` to mirror the (then-camelCase) save;
+  // the save is now snake_case so the preview matches.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { status, stdout } = runGate(root, [
+      'register',
+      '--name', 'previewone',
+      '--display-name', 'Preview One',
+      '--dry-run',
+    ]);
+    assert.equal(status, 0);
+    assert.match(stdout, /display_name: "Preview One"/);
+    assert.doesNotMatch(stdout, /displayName:/);
+    // Side effect: dry-run does NOT actually write the file.
+    assert.equal(
+      existsSync(join(root, 'members', 'previewone.yaml')),
+      false,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: hydrate still accepts legacy camelCase displayName on read', () => {
+  // Backwards compatibility: member YAMLs written by older versions
+  // carry `displayName` (camelCase). The save path is now snake_case
+  // only, but hydrate must keep reading both — otherwise upgrading
+  // would orphan existing display names.
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(
+      join(root, 'members', 'legacy.yaml'),
+      'name: legacy\ncategory: professional\nactive: true\ndisplayName: Legacy Display\n',
+    );
+    const { status, stdout } = runGate(
+      root,
+      ['whoami'],
+      { GUILD_ACTOR: 'legacy' },
+    );
+    assert.equal(status, 0);
+    // The display name from the legacy camelCase YAML is surfaced.
+    assert.match(stdout, /you are legacy — Legacy Display \(member\)/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('whoami: surfaces display_name when present (em-dash separator)', () => {
+  // Pre-fix whoami showed only the name+role: "you are noir
+  // (member)". The display_name was stored on disk but invisible
+  // at the orientation surface. Now: "you are noir — Noir
+  // (Critic) (member)".
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, [
+      'register',
+      '--name', 'noir',
+      '--display-name', 'Noir (Critic)',
+    ]);
+    const { stdout } = runGate(root, ['whoami'], { GUILD_ACTOR: 'noir' });
+    assert.match(stdout, /you are noir — Noir \(Critic\) \(member\)/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('whoami: omits the display_name chunk when absent', () => {
+  // Members without a display_name keep the original concise
+  // shape; the em-dash is conditional, not always present.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['register', '--name', 'plain']);
+    const { stdout } = runGate(root, ['whoami'], { GUILD_ACTOR: 'plain' });
+    // Pin the first line shape exactly. (Other lines may carry em-
+    // dashes — e.g. the "no utterances yet — try ..." onboarding
+    // hint — which is unrelated to the display_name surfacing.)
+    const firstLine = stdout.split('\n')[0]!;
+    assert.equal(firstLine, 'you are plain (member)');
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary

Two friction points on the register surface a fresh-agent dogfood surfaced. Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); a devil-review pass shaped both the migration strategy and the `whoami` output format.

## Changes

### 1. Member YAML: `displayName` → `display_name` on save

```diff
 name: noir
 category: professional
 active: true
-displayName: Noir (Critic)
+display_name: Noir (Critic)
```

Member was the lone outlier on the disk-shape convention — every other entity uses snake_case for compound keys (`auto_review`, `read_at`, `status_log`, `created_at`, `invoked_by`).

**Single-cycle cut, not dual-emit.** The `YamlMemberRepository` hydrate path already accepts both forms (that pre-existing tolerance is what makes the cut safe). Existing member YAMLs in users' content_roots keep loading; only new writes change. Bundled fixtures in `examples/{quick-start,dogfood-session,agent-voices}` migrated mechanically — they double as the docs surface teaching the shape.

### 2. `gate whoami` surfaces `display_name`

```
$ gate whoami       # before
you are noir (member)

$ gate whoami       # after
you are noir — Noir (Critic) (member)
```

Em-dash separator follows the pattern other surfaces use to compose name/label pairs; the trailing role-in-parens is unchanged. When no `display_name` exists, the line stays at its original concise form (em-dash conditional, not always present).

The devil-review v1 proposed `you are noir (Noir (Critic) (member))` with nested parens that read poorly. v2 absorbed the em-dash + outer-role-parens shape so the visual block parses left-to-right (name — label (role)).

## Test plan
- [x] `register: happy path writes ... canonical fields` — asserts `display_name` (snake_case) AND negative-asserts `displayName` is absent (single-cycle cut).
- [x] `register: dry-run preview uses display_name` — what-you-see-is-what-gets-saved parity, plus negative-asserts no file written.
- [x] `register: hydrate still accepts legacy camelCase displayName` — pins the back-compat invariant: a YAML written by an older version still surfaces its display name via `whoami` after upgrade.
- [x] `whoami: surfaces display_name when present (em-dash separator)`.
- [x] `whoami: omits the display_name chunk when absent` — first-line shape pinned exactly so the assertion doesn't couple to other output lines (e.g. the "no utterances yet — try ..." onboarding hint legitimately contains em-dashes).
- [x] `npm test` — 571/571 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_