### PR TITLE
fix: declare --dry-run in schema + stderr notice on text format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **`gate schema` declares `dry-run` on every write verb that
+  accepts it.** Pre-fix the schema entries for approve / deny /
+  execute / complete / fail / review / thank did NOT declare
+  `dry-run` as an input property — so MCP wirings reading `gate
+  schema` saw a tool surface strictly less capable than the
+  runtime (which accepted `--dry-run` via KNOWN_FLAGS). `register`
+  declared it but as a string; the parser treats it as a boolean
+  flag with optional `=true`/`=false` suffix. Now all eight verbs
+  share a single `dryRunField` declaration (`{type: 'boolean'}`)
+  pointing at the preview-envelope contract. Fresh-agent dogfood
+  surfaced; devil-reviewed (`2026-05-01-0001`/`0002`) to extend
+  the fix to register so the asymmetry doesn't just move.
+
+- **`gate <verb> --dry-run --format text` emits a one-line stderr
+  notice naming why the format is fixed.** The dry-run envelope
+  (dry_run / verb / would_transition / preview) has no useful
+  text rendering, so stdout stays JSON regardless of `--format`.
+  Pre-fix: silent JSON when `--format text` was passed. Post-fix:
+  `# --dry-run preview is structured (json envelope); --format
+  text would lose dry_run/verb/would_transition.` Suppressed for
+  `--format json` (pipelines stay clean).
+
+### Deferred
+- **`--dry-run` coverage on creation/annotation verbs.** Ten verbs
+  do not yet support the preview envelope: `request`, `fast-track`,
+  `message`, `broadcast`, `issues add`, `issues note`,
+  `issues start`/`defer`/`resolve`/`reopen`, `issues promote`. The
+  help text scopes "any write verb above" to the
+  approve/deny/execute/complete/fail/review/thank set, so the
+  current state is asymmetry-by-design rather than a bug; expanding
+  to the creation/annotation set requires either handler-side
+  preview construction or use-case-side dry-run flag plumbing.
+  Recorded here so a future reader who hits `gate request --dry-run:
+  unknown flag` finds the trail rather than silence.
+
 ### Changed
 - **Member YAML: `displayName` → `display_name` on save.** Aligns the
   one camelCase field on disk with the rest of the project's

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -138,6 +138,13 @@ export function isDryRun(args: ParsedArgs): boolean {
  * (review). `preview` always reflects the unsaved in-memory object
  * so the caller sees exactly what would land if they dropped
  * `--dry-run`.
+ *
+ * When the caller passed `--format text`, the envelope is still JSON
+ * (the dry_run/verb/would_transition triple has no useful text
+ * rendering) — but a one-line stderr notice names that contract so
+ * the format-flag override doesn't read as silent fail-open. The
+ * notice points at WHY the format is fixed (the envelope is
+ * structured) rather than just announcing the override.
  */
 export function emitDryRunPreview(p: {
   verb: string;
@@ -146,7 +153,14 @@ export function emitDryRunPreview(p: {
   fromState?: string;
   toState?: string;
   after: { toJSON(): Record<string, unknown> };
+  format?: string;
 }): void {
+  if (p.format !== undefined && p.format !== 'json') {
+    process.stderr.write(
+      '# --dry-run preview is structured (json envelope); --format ' +
+        `${p.format} would lose dry_run/verb/would_transition.\n`,
+    );
+  }
   const envelope: Record<string, unknown> = {
     dry_run: true,
     verb: p.verb,

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -468,7 +468,7 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
     const r = await c.requestUC.approve(id, by, note, invokedBy, { dryRun: true });
-    emitDryRunPreview({ verb: 'approve', id, by, fromState, toState: r.state, after: r });
+    emitDryRunPreview({ verb: 'approve', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
   const r = await c.requestUC.approve(id, by, note, invokedBy);
@@ -504,7 +504,7 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
     const r = await c.requestUC.deny(id, by, reason, invokedBy, { dryRun: true });
-    emitDryRunPreview({ verb: 'deny', id, by, fromState, toState: r.state, after: r });
+    emitDryRunPreview({ verb: 'deny', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
   const r = await c.requestUC.deny(id, by, reason, invokedBy);
@@ -524,7 +524,7 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
     const r = await c.requestUC.execute(id, by, note, invokedBy, { dryRun: true });
-    emitDryRunPreview({ verb: 'execute', id, by, fromState, toState: r.state, after: r });
+    emitDryRunPreview({ verb: 'execute', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
   const r = await c.requestUC.execute(id, by, note, invokedBy);
@@ -544,7 +544,7 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
     const r = await c.requestUC.complete(id, by, note, invokedBy, { dryRun: true });
-    emitDryRunPreview({ verb: 'complete', id, by, fromState, toState: r.state, after: r });
+    emitDryRunPreview({ verb: 'complete', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
   const r = await c.requestUC.complete(id, by, note, invokedBy);
@@ -578,7 +578,7 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
     const r = await c.requestUC.fail(id, by, reason, invokedBy, { dryRun: true });
-    emitDryRunPreview({ verb: 'fail', id, by, fromState, toState: r.state, after: r });
+    emitDryRunPreview({ verb: 'fail', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
   const r = await c.requestUC.fail(id, by, reason, invokedBy);

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -90,7 +90,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     });
     // Review doesn't transition state — omit would_transition, let
     // the preview payload carry the new review entry in `reviews`.
-    emitDryRunPreview({ verb: 'review', id, by, after: updated });
+    emitDryRunPreview({ verb: 'review', id, by, after: updated, format: parseFormat(args) });
     return 0;
   }
   const updated = await c.requestUC.review({

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -57,6 +57,21 @@ const formatField: JsonSchema = {
   enum: ['json', 'text'],
   description: 'output format (agent-first default: json for read; text for write)',
 };
+// Shared dry-run schema field. Boolean (the parser accepts bare
+// `--dry-run`, `--dry-run=true`, `--dry-run=false`). Declared on every
+// write verb that supports the preview envelope (approve/deny/execute/
+// complete/fail/review/thank/register) so MCP wirings reading the
+// schema see the runtime contract honestly. Pre-this-fix, register
+// declared it as a string and the seven other verbs didn't declare
+// it at all — the runtime accepted --dry-run on all eight, but the
+// schema lied by omission.
+const dryRunField: JsonSchema = {
+  type: 'boolean',
+  description:
+    'preview the would-be write without persisting. Output is a ' +
+    'json envelope (dry_run/verb/would_transition/preview) regardless ' +
+    'of --format.',
+};
 
 // Inner property shape of every `suggested_next` payload, exported
 // as a named const so multiple verb output schemas (write response,
@@ -446,7 +461,7 @@ const VERBS: readonly VerbSchema[] = [
           'member category; defaults to "professional". Canonical: core/professional/assignee/trial/special/host. Host is NOT accepted via CLI (edit guild.config.yaml).',
         ),
         'display-name': strOpt('human-readable display label, optional'),
-        'dry-run': strOpt('preview the YAML without writing to disk'),
+        'dry-run': dryRunField,
         format: formatField,
       },
       required: ['name'],
@@ -484,6 +499,7 @@ const VERBS: readonly VerbSchema[] = [
         by: strOpt('approver (defaults to $GUILD_ACTOR)'),
         note: str,
         format: formatField,
+        'dry-run': dryRunField,
       },
       required: ['id'],
     },
@@ -501,6 +517,7 @@ const VERBS: readonly VerbSchema[] = [
         reason: strOpt('alias for --note'),
         note: strOpt('closure note; falls back to positional arg'),
         format: formatField,
+        'dry-run': dryRunField,
       },
       required: ['id'],
     },
@@ -512,7 +529,13 @@ const VERBS: readonly VerbSchema[] = [
     summary: 'transition approved → executing',
     input: {
       type: 'object',
-      properties: { id: idStr, by: str, note: str, format: formatField },
+      properties: {
+        id: idStr,
+        by: str,
+        note: str,
+        format: formatField,
+        'dry-run': dryRunField,
+      },
       required: ['id'],
     },
     output: writeResponseSchema,
@@ -523,7 +546,13 @@ const VERBS: readonly VerbSchema[] = [
     summary: 'transition executing → completed',
     input: {
       type: 'object',
-      properties: { id: idStr, by: str, note: str, format: formatField },
+      properties: {
+        id: idStr,
+        by: str,
+        note: str,
+        format: formatField,
+        'dry-run': dryRunField,
+      },
       required: ['id'],
     },
     output: writeResponseSchema,
@@ -534,7 +563,14 @@ const VERBS: readonly VerbSchema[] = [
     summary: 'transition executing → failed (terminal)',
     input: {
       type: 'object',
-      properties: { id: idStr, by: str, reason: str, note: str, format: formatField },
+      properties: {
+        id: idStr,
+        by: str,
+        reason: str,
+        note: str,
+        format: formatField,
+        'dry-run': dryRunField,
+      },
       required: ['id'],
     },
     output: writeResponseSchema,
@@ -552,6 +588,7 @@ const VERBS: readonly VerbSchema[] = [
         verdict: { type: 'string', enum: ['ok', 'concern', 'reject'] },
         comment: strOpt('review body; "-" for STDIN'),
         format: formatField,
+        'dry-run': dryRunField,
       },
       required: ['id', 'by', 'lense', 'verdict'],
     },
@@ -570,6 +607,7 @@ const VERBS: readonly VerbSchema[] = [
         by: str,
         reason: strOpt('optional prose; "-" for STDIN'),
         format: formatField,
+        'dry-run': dryRunField,
       },
       required: ['to', 'for'],
     },

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -61,7 +61,7 @@ export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
 
   if (isDryRun(args)) {
     const updated = await c.requestUC.thank({ ...ucInput, dryRun: true });
-    emitDryRunPreview({ verb: 'thank', id, by, after: updated });
+    emitDryRunPreview({ verb: 'thank', id, by, after: updated, format: parseFormat(args) });
     return 0;
   }
 

--- a/tests/interface/dryRunSurface.test.ts
+++ b/tests/interface/dryRunSurface.test.ts
@@ -1,0 +1,194 @@
+// gate write verbs --dry-run: schema declares it + format-text notice.
+//
+// Pre-fix gaps:
+//   1. The schema entries for approve/deny/execute/complete/fail/
+//      review/thank did NOT declare 'dry-run' as a property — so an
+//      MCP wiring reading `gate schema` saw a tool surface strictly
+//      less capable than the runtime (which accepted --dry-run via
+//      KNOWN_FLAGS). register declared it, but as `strOpt` (string),
+//      not boolean — same misalignment in a different shape.
+//   2. `--dry-run --format text` emitted JSON with no signal that
+//      --format was overridden. Silent fail-open against an explicit
+//      flag.
+//
+// This test pins the schema declarations (single shape across all
+// eight verbs) and the stderr notice (named-why phrasing).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-dryrun-surface-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// ── schema declarations ──────────────────────────────────────────
+
+const DRY_RUN_VERBS: readonly string[] = [
+  'register',
+  'approve',
+  'deny',
+  'execute',
+  'complete',
+  'fail',
+  'review',
+  'thank',
+];
+
+for (const verb of DRY_RUN_VERBS) {
+  test(`schema: ${verb} declares dry-run as a boolean property`, (t) => {
+    // The runtime KNOWN_FLAGS for each of these verbs already
+    // accepts --dry-run; pre-fix the schema didn't say so, leaving
+    // MCP wirings to either guess or stay strict (and lose access
+    // to the preview envelope).
+    const { root, cleanup } = bootstrap();
+    t.after(cleanup);
+    const r = runGate(root, ['schema', '--verb', verb, '--format', 'json']);
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    const v = payload.verbs.find((x: { name: string }) => x.name === verb);
+    assert.ok(v, `${verb} should be in the schema`);
+    const props = v.input.properties;
+    assert.ok(
+      'dry-run' in props,
+      `${verb} schema should declare 'dry-run' property`,
+    );
+    assert.equal(
+      props['dry-run'].type,
+      'boolean',
+      `${verb}'s 'dry-run' should be {type: 'boolean'}, ` +
+        `not '${props['dry-run'].type}' — single declaration shape ` +
+        'across all dry-run verbs.',
+    );
+    // Sanity: the description names what the runtime actually does.
+    assert.match(
+      props['dry-run'].description,
+      /preview/i,
+      `${verb}'s dry-run description should name the preview semantic`,
+    );
+  });
+}
+
+// ── --dry-run + --format text → stderr notice ────────────────────
+
+test('approve --dry-run --format text emits a one-line stderr notice', (t) => {
+  // The notice names WHY the format is fixed (envelope is structured)
+  // rather than just announcing the override. Pre-fix: silent JSON.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `${today}-0001`;
+  const r = runGate(
+    root,
+    ['approve', id, '--by', 'human', '--dry-run', '--format', 'text'],
+    { GUILD_ACTOR: 'human' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /--dry-run preview is structured/);
+  assert.match(r.stderr, /--format text/);
+  assert.match(
+    r.stderr,
+    /would lose dry_run\/verb\/would_transition/,
+    'notice should name what the json envelope carries that text would lose',
+  );
+  // Stdout still emits the json envelope regardless — the notice
+  // does not block, only informs.
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.dry_run, true);
+});
+
+test('approve --dry-run --format json suppresses the stderr notice', (t) => {
+  // The notice exists for format=text callers who would otherwise
+  // not realise their format flag was overridden. JSON callers
+  // already get what they asked for; pumping prose into stderr
+  // would be noise for pipelines.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `${today}-0001`;
+  const r = runGate(
+    root,
+    ['approve', id, '--by', 'human', '--dry-run', '--format', 'json'],
+    { GUILD_ACTOR: 'human' },
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stderr, /--dry-run preview is structured/);
+});
+
+test('review --dry-run --format text also emits the notice (annotation verb)', (t) => {
+  // Annotation verbs (review, thank) share the preview envelope
+  // shape — would_transition is omitted but the rest still emits
+  // as JSON. The notice fires for the same reason: format=text
+  // would lose the envelope keys.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executor', 'bob'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `${today}-0001`;
+  runGate(root, ['approve', id, '--by', 'human'], { GUILD_ACTOR: 'human' });
+  runGate(root, ['execute', id, '--by', 'bob'], { GUILD_ACTOR: 'bob' });
+  runGate(root, ['complete', id, '--by', 'bob'], { GUILD_ACTOR: 'bob' });
+  const r = runGate(
+    root,
+    [
+      'review', id,
+      '--by', 'alice', '--lense', 'devil', '--verdict', 'ok',
+      '--comment', 'fine', '--dry-run', '--format', 'text',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, /--dry-run preview is structured/);
+});


### PR DESCRIPTION
## Summary

Two friction points on the `--dry-run` surface a fresh-agent dogfood surfaced. Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); devil review extended (1) to `register` so the declaration shape stays uniform across all eight dry-run verbs.

## Changes

### 1. `gate schema` declares `--dry-run` on every write verb that accepts it

Pre-fix: only `register` declared `dry-run` as a property, and as `strOpt` (string). The other seven verbs that accept it (approve, deny, execute, complete, fail, review, thank) didn't declare it at all. MCP wirings reading the schema saw a tool surface strictly less capable than the runtime accepted via `KNOWN_FLAGS`.

Post-fix: a shared `dryRunField` const declares `{type: 'boolean'}` with a description pointing at the preview-envelope contract. Used on all eight verbs (register's existing string declaration corrected to boolean — same misalignment, just in a different shape).

### 2. `--dry-run --format text` → stderr notice

Pre-fix: `emitDryRunPreview` always emitted JSON. text-format callers got JSON with no signal that `--format` was overridden. Silent fail-open against an explicit flag.

Post-fix:
```
$ gate approve <id> --by human --dry-run --format text
# --dry-run preview is structured (json envelope); --format text would lose dry_run/verb/would_transition.
{ "dry_run": true, "verb": "approve", ... }
```

The notice names the **why** (envelope is structured) and what would be lost. JSON callers see nothing on stderr.

## Deferred

`--dry-run` coverage on creation/annotation verbs (10 verbs: `request`, `fast-track`, `message`, `broadcast`, `issues add`, `issues note`, `issues start`/`defer`/`resolve`/`reopen`, `issues promote`). The help text scopes "any write verb above" to a specific set so the current asymmetry is documented, not silent — expanding requires handler-side preview construction or use-case-side flag plumbing. Recorded in CHANGELOG so a future reader hitting `gate request --dry-run: unknown flag` finds the trail rather than silence.

## Test plan
- [x] `tests/interface/dryRunSurface.test.ts` (new, 11 cases):
  - 8 parametric per-verb schema assertions (`dry-run` declared, `type='boolean'`, description names "preview")
  - `approve --dry-run --format text` emits the named-why notice
  - `approve --dry-run --format json` suppresses the notice
  - `review --dry-run --format text` emits the notice (annotation verb, no `would_transition` but same envelope contract)
- [x] `npm test` — 582/582 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_