### PR TITLE
fix: review editor empty-body aborts with context-aware error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **`gate review`: empty editor body aborts with a context-aware
+  error.** Pre-fix, when the user opened the editor (no
+  `--comment`/positional/stdin) and saved without writing,
+  `readCommentViaEditor` returned an empty string and the caller's
+  generic "review comment is required (use --comment <s>, …, or
+  run interactively so $EDITOR opens)" error fired — but the
+  "run interactively" hint was misleading because the user had
+  just done so. Post-fix the editor flow throws its own message:
+
+      editor returned an empty review body; aborting. Re-run and
+      write content above the scissors line, or use --comment /
+      --comment - / a positional.
+
+  Surfaces the empty effort at the layer that produced it; matches
+  `git commit`'s "empty message aborts" semantic. The function
+  docstring (which already named this throw, but pre-fix the
+  implementation only honored the editor-failure cases) is now
+  honest. Devil-reviewed (`2026-05-01-0001`/`0002`); the user-
+  facing message dropped its "matches git commit behavior"
+  rationale — that justification belongs in the source comment,
+  not in the recovery instructions.
+
 - **`gate schema` declares `dry-run` on every write verb that
   accepts it.** Pre-fix the schema entries for approve / deny /
   execute / complete / fail / review / thank did NOT declare

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -253,6 +253,14 @@ export function pickEditor(): string {
  *   - the editor exits with non-zero status (e.g. `:cq` in vim)
  *   - the cleaned body is empty after stripping the scissors block
  *
+ * The empty-body throw matches `git commit` semantics — empty
+ * message aborts with an explicit error, never silently records a
+ * blank entry. Pre-fix the function returned `''` and let the
+ * caller's generic "review comment is required (use --comment ...
+ * or run interactively so $EDITOR opens)" error fire — but the
+ * caller's hint is misleading when the user just *did* run
+ * interactively. The throw at this layer carries the right context.
+ *
  * The caller is expected to surface the thrown Error to the user
  * with the outer CLI error handler.
  */
@@ -308,7 +316,15 @@ export async function readCommentViaEditor(context: {
       );
     }
     const raw = fs.readFileSync(file, 'utf8');
-    return stripEditorComments(raw);
+    const body = stripEditorComments(raw);
+    if (body.length === 0) {
+      throw new Error(
+        'editor returned an empty review body; aborting. ' +
+          'Re-run and write content above the scissors line, ' +
+          'or use --comment / --comment - / a positional.',
+      );
+    }
+    return body;
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/interface/editorComment.test.ts
+++ b/tests/interface/editorComment.test.ts
@@ -4,7 +4,16 @@ import {
   EDITOR_SCISSORS,
   stripEditorComments,
   pickEditor,
+  readCommentViaEditor,
 } from '../../src/interface/gate/handlers/internal.js';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+} from 'node:fs';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
 
 // --- stripEditorComments -----------------------------------------------
 
@@ -154,3 +163,121 @@ test('pickEditor: platform fallback when all env vars unset', () => {
     },
   );
 });
+
+// --- readCommentViaEditor ----------------------------------------------
+//
+// The spawn path is hard to mock portably; here we provide a real fake-
+// editor (a small shell script) that mutates the file the way a real
+// editor would, so the spawn-and-readback contract is exercised end-to-
+// end. POSIX-only — Windows shell scripts have a different shape and
+// the editor flow on Windows is well-covered by readers' real Notepad
+// usage. The skip keeps `npm test` green on the CI windows matrix.
+
+// Async-aware env override. The synchronous `withEnv` above restores
+// the env synchronously around fn(), which is wrong for async work
+// (the env is restored before spawnSync runs inside the awaited fn).
+// This variant awaits before restoring.
+async function withEnvAsync<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key];
+    if (overrides[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = overrides[key];
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  }
+}
+
+async function withFakeEditor<T>(
+  scriptBody: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'guild-fakeed-'));
+  const scriptPath = join(dir, 'fake-editor.sh');
+  writeFileSync(scriptPath, `#!/bin/sh\n${scriptBody}\n`, 'utf8');
+  chmodSync(scriptPath, 0o755);
+  return withEnvAsync(
+    { GIT_EDITOR: scriptPath, VISUAL: undefined, EDITOR: undefined },
+    async () => {
+      try {
+        return await fn();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+}
+
+const POSIX_ONLY = platform() === 'win32' ? { skip: true } : {};
+
+test(
+  'readCommentViaEditor: throws when editor leaves an empty body',
+  POSIX_ONLY,
+  async () => {
+    // The fake editor is a no-op — it leaves the template untouched.
+    // The template's only above-scissors content is two blank lines,
+    // so `stripEditorComments` returns ''. Pre-fix the function
+    // returned the empty string and the caller's generic "review
+    // comment is required" error fired with a hint that misled the
+    // user about what just happened ("or run interactively so $EDITOR
+    // opens" — which they just did). Post-fix, the editor flow throws
+    // its own context-aware abort message.
+    await withFakeEditor(': # no-op', async () => {
+      await assert.rejects(
+        readCommentViaEditor({
+          id: '2026-04-15-0001',
+          by: 'alice',
+          lense: 'devil',
+          verdict: 'concern',
+        }),
+        (err: Error) => {
+          assert.match(err.message, /editor returned an empty review body/);
+          assert.match(err.message, /aborting/);
+          // The message names the recovery paths the user actually has.
+          assert.match(err.message, /scissors line/);
+          assert.match(err.message, /--comment/);
+          return true;
+        },
+      );
+    });
+  },
+);
+
+test(
+  'readCommentViaEditor: returns the body when editor writes content',
+  POSIX_ONLY,
+  async () => {
+    // Sanity for the happy path: the function reads back what the
+    // editor wrote, runs it through stripEditorComments, returns the
+    // trimmed result.
+    //
+    // The fake editor writes "real review content" above the
+    // template's scissors line. stripEditorComments keeps it.
+    const script =
+      `printf '%s\\n' 'real review content' > "$1.tmp" && cat "$1" >> "$1.tmp" && mv "$1.tmp" "$1"`;
+    await withFakeEditor(script, async () => {
+      const result = await readCommentViaEditor({
+        id: '2026-04-15-0001',
+        by: 'alice',
+        lense: 'devil',
+        verdict: 'concern',
+      });
+      assert.equal(result, 'real review content');
+    });
+  },
+);


### PR DESCRIPTION
## Summary

When the user runs `gate review <id> --by ... --lense ... --verdict ...` interactively (no `--comment` / positional / stdin) and the editor opens, saving without writing pre-fix produced this misleading error:

```
review comment is required (use --comment <s>, --comment - for STDIN, a positional argument, or run interactively so $EDITOR opens)
```

The "or run interactively so $EDITOR opens" hint is wrong — the user just did. They get four input forms suggested; three are irrelevant in this state and the fourth misdescribes what happened.

The function's own docstring already advertised an empty-body throw, but the implementation drifted: it returned an empty string and let the caller's generic error fire. This PR makes the implementation match the docstring.

Post-fix:

```
$ gate review <id> ...        # editor opens, save without writing
error: editor returned an empty review body; aborting. Re-run and write content above the scissors line, or use --comment / --comment - / a positional.
```

Names the recovery paths the user actually has. Matches `git commit`'s "empty message aborts" semantic — silent no-op would let the user think something was recorded when nothing was.

The "matches git commit" rationale moved from the user-facing message to the function header comment (devil's phrasing trim).

## Test plan
- [x] `tests/interface/editorComment.test.ts` grows two end-to-end cases that exercise the spawn path with a real fake-editor shell script:
  - empty-body throw fires with the expected message and recovery hints
  - happy path: editor writes content above scissors → returns the trimmed body
- [x] Both new tests are POSIX-only (skipped on Windows — Windows shell scripts have a different shape; the editor flow on Windows is covered by readers' real Notepad usage).
- [x] Adds a `withEnvAsync` helper because the existing `withEnv` restores `process.env` synchronously around `fn()` — wrong for async work where `spawnSync` runs inside the awaited fn after env was already restored.
- [x] `npm test` — 584/584 pass.

Designed via 2026-05-01-0001/0002 with a devil-review pass that absorbed two phrasing tweaks (drop "matches git commit behavior" rationale from user message; confirmed abort-with-error over silent no-op).

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_