### PR TITLE
fix: voice calibration counts concern+failed as aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **Voice calibration: `verdict=concern + state=failed` counts as
+  aligned.** The source-code header in `src/interface/gate/voices.ts`
+  documented v1 alignment rules including
+  `verdict=concern + state=failed → aligned (you flagged it, it
+  broke)`, but the implementation had `// verdict === 'concern'
+  intentionally excluded` and dropped ALL concern verdicts from
+  both counts. Reviewers who used `concern` as their primary signal
+  got zero calibration credit and registered as `uncalibrated`
+  forever. Doc-code drift; the code now matches the documented
+  rules: `concern + failed → aligned`, `concern + completed → soft`
+  (excluded). The `reject + completed → overruled` case keeps its
+  existing "counted as missed" semantic, and a comment now names
+  the choice (the alternative — "the risk you flagged was
+  reviewed and held" — isn't separately observable from the record
+  alone, so we pick the conservative work-as-evidence read).
+  Devil-reviewed (`2026-05-01-0001`/`0002`).
+
+- **`gate schema`: voices entry declares `--with-calibration`** with
+  a description that names the JSON-only semantic honestly: the
+  flag opts into the `{utterances, calibration}` JSON object shape
+  (default: bare array), but text mode emits the calibration footer
+  regardless of this flag. Pre-fix the runtime accepted the flag
+  via `KNOWN_FLAGS` but the schema didn't declare it, and the
+  text-mode behaviour was undocumented — fresh agents reading the
+  schema saw an undocumented flag and a hidden text-mode override.
+
 - **`gate review`: empty editor body aborts with a context-aware
   error.** Pre-fix, when the user opened the editor (no
   `--comment`/positional/stdin) and saved without writing,

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -367,6 +367,13 @@ const VERBS: readonly VerbSchema[] = [
         verdict: str,
         limit: str,
         format: formatField,
+        'with-calibration': {
+          type: 'boolean',
+          description:
+            'JSON mode only: opts into the {utterances, calibration} ' +
+            'object shape (default bare array). Text mode emits the ' +
+            'calibration footer regardless of this flag.',
+        },
       },
       required: ['name'],
     },

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -445,12 +445,18 @@ export function renderUtterance(
 //                                                 absorbed; neither a
 //                                                 win nor a miss)
 //   verdict=reject   + state=failed    → aligned (you said no, it broke)
-//   verdict=reject   + state=completed → overruled (you said no, it
+//   verdict=reject   + state=completed → overruled — counted as missed
+//                                                   (you said no, it
 //                                                   shipped anyway;
 //                                                   ambiguous signal —
 //                                                   could be wrong call,
 //                                                   could be reviewed
-//                                                   risk that held)
+//                                                   risk that held; we
+//                                                   pick the conservative
+//                                                   read because the
+//                                                   alternative is not
+//                                                   separately observable
+//                                                   from the record alone)
 //
 // Denied requests don't contribute (they never executed; no outcome
 // to compare against). `concern + completed` is counted as soft —
@@ -503,12 +509,30 @@ export function computeVoiceCalibration(
       const v = rv.verdict;
       if (v === 'ok') {
         if (state === 'completed') bucket.aligned += 1;
+        // verdict=ok + state=failed → missed. you said fine, it wasn't.
         else bucket.missed += 1;
       } else if (v === 'reject') {
         if (state === 'failed') bucket.aligned += 1;
+        // verdict=reject + state=completed: header calls this
+        // `overruled` (you said no, it shipped anyway). counted as
+        // missed here — conservative read: from a work-as-evidence
+        // lens, the no was wrong because the work landed. the
+        // alternative ("the risk you flagged was reviewed and held")
+        // is plausible but not separately observable from this
+        // record alone, so we don't try to distinguish.
         else bucket.missed += 1;
+      } else if (v === 'concern') {
+        // verdict=concern + state=failed → aligned. you flagged it,
+        // it broke. pre-fix this branch was missing — concern was
+        // excluded entirely, so reviewers who used `concern` as
+        // their primary signal got zero calibration credit and
+        // registered as uncalibrated forever. matches v1 alignment
+        // rules in the header above.
+        if (state === 'failed') bucket.aligned += 1;
+        // verdict=concern + state=completed → soft. issues may have
+        // been absorbed; neither a win nor a miss. excluded from
+        // both counts so the score doesn't get biased either way.
       }
-      // verdict === 'concern' intentionally excluded — see header.
     }
   }
 

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -738,6 +738,102 @@ test('voices calibration: samples < 5 reads as "uncalibrated"', () => {
   }
 });
 
+test('voices calibration: verdict=concern + state=failed counts as aligned', () => {
+  // Pre-fix this case was excluded entirely — the source-code
+  // header documented `concern + failed → aligned` but the
+  // implementation had `// verdict === 'concern' intentionally
+  // excluded`. Reviewers who used `concern` as their primary
+  // signal got zero credit and registered as uncalibrated forever.
+  // This test pins the contract directly so the documented v1
+  // alignment rules can't quietly drift again.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['register', '--name', 'carol']);
+    // 5 cycles, all failures, carol flags `concern` on each. Pre-
+    // fix: 0 samples (uncalibrated). Post-fix: 5 aligned, trusted.
+    for (let n = 1; n <= 5; n++) {
+      const id = rid(n);
+      runGate(
+        root,
+        ['request', '--from', 'alice', '--action', `t${n}`, '--reason', 'r', '--executor', 'alice'],
+        { GUILD_ACTOR: 'alice' },
+      );
+      runGate(root, ['approve', id, '--by', 'alice']);
+      runGate(root, ['execute', id, '--by', 'alice']);
+      runGate(root, ['fail', id, '--by', 'alice', '--reason', 'nope']);
+      runGate(root, [
+        'review', id, '--by', 'carol',
+        '--lense', 'devil', '--verdict', 'concern', '--comment', 'flagged',
+      ]);
+    }
+    const { stdout } = runGate(
+      root,
+      ['voices', 'carol', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const calib = JSON.parse(stdout).calibration;
+    assert.equal(calib.by_lens.devil.aligned, 5);
+    assert.equal(calib.by_lens.devil.missed, 0);
+    assert.equal(calib.by_lens.devil.sample_count, 5);
+    assert.equal(calib.by_lens.devil.status, 'trusted');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voices calibration: verdict=concern + state=completed stays excluded (soft)', () => {
+  // The other concern branch — concern+completed = "soft", neither
+  // a win nor a miss. The header rationale: the work landed, which
+  // is consistent with "concern was noted and addressed" AND with
+  // "concern was overblown" — counting it either way would bias
+  // the score. Excluded from sample_count entirely.
+  //
+  // Pre-fix this was already the de-facto behaviour (because ALL
+  // concerns were excluded). Post-fix, concern+failed counts as
+  // aligned but concern+completed must stay excluded — pin that
+  // boundary so a future "count all concerns somehow" refactor
+  // doesn't quietly change the soft semantic.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['register', '--name', 'carol']);
+    // 5 cycles, all completed, carol's concerns. Expected: 0 samples
+    // (all soft, all excluded), uncalibrated.
+    for (let n = 1; n <= 5; n++) {
+      const id = rid(n);
+      runGate(
+        root,
+        ['request', '--from', 'alice', '--action', `t${n}`, '--reason', 'r', '--executor', 'alice'],
+        { GUILD_ACTOR: 'alice' },
+      );
+      runGate(root, ['approve', id, '--by', 'alice']);
+      runGate(root, ['execute', id, '--by', 'alice']);
+      runGate(root, ['complete', id, '--by', 'alice']);
+      runGate(root, [
+        'review', id, '--by', 'carol',
+        '--lense', 'devil', '--verdict', 'concern', '--comment', 'noted',
+      ]);
+    }
+    const { stdout } = runGate(
+      root,
+      ['voices', 'carol', '--format', 'json', '--with-calibration'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const calib = JSON.parse(stdout).calibration;
+    // The bucket exists (it's created on first sight of any verdict
+    // for the lense) but soft verdicts don't increment aligned or
+    // missed — sample_count stays 0 and status reads as uncalibrated.
+    // The boundary we're pinning: soft does NOT bias the score.
+    const devil = calib.by_lens.devil;
+    assert.ok(devil, 'devil bucket should exist for the touched lense');
+    assert.equal(devil.aligned, 0);
+    assert.equal(devil.missed, 0);
+    assert.equal(devil.sample_count, 0);
+    assert.equal(devil.status, 'uncalibrated');
+  } finally {
+    cleanup();
+  }
+});
+
 // ── gate thank: cross-actor appreciation primitive ──────────────
 
 test('thank: records appreciation with by/to/reason on the request', () => {


### PR DESCRIPTION
## Summary

Voice calibration's `verdict=concern + state=failed` case was documented in the source-code header as `aligned (you flagged it, it broke)` but the implementation had `// verdict === 'concern' intentionally excluded` and dropped ALL concern verdicts. Doc-code drift surfaced by fresh-agent dogfood.

Concrete failure mode: a reviewer who flagged real problems with `concern` verdicts on work that subsequently failed got **zero calibration credit** and registered as `uncalibrated` forever. The existing carol/bob test scenario uses `ok`+`reject` only — which is part of why the bug went unnoticed.

Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); devil pass added the dedicated concern+failed test and the comment-link for the `reject + completed → counted as missed` choice.

## Changes

### 1. `concern + failed → aligned`

```
verdict=concern + state=failed    → aligned   (NEW: was excluded)
verdict=concern + state=completed → soft      (UNCHANGED: excluded)
verdict=ok      + state=completed → aligned   (UNCHANGED)
verdict=ok      + state=failed    → missed    (UNCHANGED)
verdict=reject  + state=failed    → aligned   (UNCHANGED)
verdict=reject  + state=completed → missed    (UNCHANGED, now
                                               commented as
                                               "overruled,
                                               conservatively
                                               counted as missed")
```

The `reject + completed → overruled` case keeps its existing "counted as missed" semantic — the comment now names the choice (the alternative interpretation, "the risk you flagged was reviewed and held", isn't separately observable from the record alone, so we pick the conservative work-as-evidence read).

### 2. `gate schema` declares `--with-calibration`

Pre-fix, the runtime accepted the flag via `KNOWN_FLAGS` but the schema didn't advertise it. The text-mode behaviour (footer emits regardless of the flag) was undocumented. The new schema description:

> JSON mode only: opts into the `{utterances, calibration}` object shape (default bare array). Text mode emits the calibration footer regardless of this flag.

Honest naming of the JSON-only semantic; no behaviour change.

## Test plan
- [x] New: `voices calibration: verdict=concern + state=failed counts as aligned` — 5 cycles of concern+failed → `aligned=5, status=trusted`. Pins the new contract directly so the carol/bob math doesn't have to carry it.
- [x] New: `voices calibration: verdict=concern + state=completed stays excluded (soft)` — 5 cycles of concern+completed → `aligned=0, missed=0, sample_count=0, status=uncalibrated`. Preserves the boundary so a future "count all concerns somehow" refactor can't quietly bias the score.
- [x] Existing `voices --with-calibration: aligns verdicts against terminal outcomes` (carol/bob trusted/learning scenario) stays green — neither actor uses concern verdicts; numbers unchanged.
- [x] `npm test` — 586/586 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_