### PR TITLE
fix: doctor surfaces unrecognized .yaml files + dirs in requests/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **`gate doctor` surfaces unrecognized .yaml files and unexpected
+  subdirectories under `requests/`.** Pre-fix, `listByState`'s regex
+  filter (`^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$`) silently dropped
+  off-pattern entries — a `bad.yaml` in `requests/pending/`, a
+  `2026-05-01-7.yaml` (wrong digit count), an `oops-dir/`
+  subdirectory under `<state>/`, or even a properly-named
+  `2026-05-01-9999.yaml` placed at `requests/` root (wrong directory
+  level) — all stayed there forever and `gate doctor` reported the
+  root as clean. Two new finding kinds: `unrecognized_file` (off-
+  pattern .yaml in any record location) maps to quarantine in
+  repair (gate ignores them anyway; moving to `quarantine/` is safe
+  and reversible). `unrecognized_directory` (subdir under `<state>/`
+  or non-state directory at requests/ root) maps to **no-op** —
+  contents are unknown and quarantining a tree is invasive; the
+  operator must inspect first. Boundary: only `.yaml` files and
+  directories are flagged; `notes.txt`, `README.md`, `.gitkeep`
+  and other repo artifacts are intentionally ignored. Devil-
+  reviewed (`2026-05-01-0001`/`0002`).
+
+### Deferred
+- **Unrecognized-file scan for `issues/` and `members/`.** These
+  directories have flat (non-state) layouts and their own filename
+  patterns (`i-YYYY-MM-DD-NNNN.yaml` and `[a-z][a-z0-9_-]{0,31}.yaml`
+  respectively). The first cut ships requests-only; extending the
+  same scanner to issues and members is mechanical but distinct
+  enough to warrant its own PR. Recorded so a future reader who
+  hits "doctor missed my misplaced issue.yaml" finds the trail.
+
 - **Voice calibration: `verdict=concern + state=failed` counts as
   aligned.** The source-code header in `src/interface/gate/voices.ts`
   documented v1 alignment rules including

--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -85,6 +85,21 @@ export class DiagnosticUseCases {
     const beforeRequests = findings.length;
     const requestBundle = this.buildRepos(areaCollector('requests'));
     const requests = await requestBundle.requests.listAll();
+    // Off-pattern .yaml files (typo'd names) and subdirectories
+    // under <state>/ are silently dropped by listByState's regex.
+    // Surface them as findings so a misplaced file that gate
+    // ignored is no longer invisible. Fresh-agent dogfood
+    // surfaced this gap (2026-05-01 design sandbox) — pre-fix,
+    // a bad.yaml in requests/pending/ stayed there forever and
+    // doctor reported the root as clean.
+    const unrecognized = await requestBundle.requests.listUnrecognizedFiles();
+    const requestCollector = areaCollector('requests');
+    for (const u of unrecognized) {
+      requestCollector(
+        u.path,
+        `unrecognized ${u.kind}: ${u.reason}`,
+      );
+    }
     const requestMalformed = findings.length - beforeRequests;
 
     const beforeIssues = findings.length;

--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -2,6 +2,23 @@ import { Request } from '../../domain/request/Request.js';
 import { RequestId } from '../../domain/request/RequestId.js';
 import { RequestState } from '../../domain/request/RequestState.js';
 
+/**
+ * One unrecognized file discovered by a directory walk under
+ * `<contentRoot>/requests/`. These are files that listByState's
+ * regex filter silently drops — off-pattern names, .yaml files at
+ * the wrong directory level, or subdirectories where leaf files
+ * are expected. Surfaced by the diagnostic so doctor can warn
+ * about them; pre-this they were invisible.
+ */
+export interface UnrecognizedRequestFile {
+  /** Absolute path to the entry. */
+  readonly path: string;
+  /** What kind of entry was found (file vs directory). */
+  readonly kind: 'file' | 'directory';
+  /** Why it was flagged — short, suitable for inclusion in a finding message. */
+  readonly reason: string;
+}
+
 export interface RequestRepository {
   findById(id: RequestId): Promise<Request | null>;
   listByState(state: RequestState): Promise<Request[]>;
@@ -14,6 +31,15 @@ export interface RequestRepository {
    * state directories during the scan.
    */
   listAll(): Promise<Request[]>;
+  /**
+   * Walk the requests directory and surface entries that don't
+   * match the expected layout — .yaml files at off-pattern names
+   * (silent listByState drops), .yaml files at the requests/ root
+   * (wrong directory level), or subdirectories under <state>/
+   * (no legitimate place there). Used exclusively by the
+   * diagnostic; never affects lifecycle reads.
+   */
+  listUnrecognizedFiles(): Promise<UnrecognizedRequestFile[]>;
   /** Persist; positions file under current state directory. */
   save(request: Request): Promise<void>;
   /**

--- a/src/domain/diagnostic/DiagnosticReport.ts
+++ b/src/domain/diagnostic/DiagnosticReport.ts
@@ -18,6 +18,8 @@ export type DiagnosticKind =
   | 'hydration_error'
   | 'yaml_parse_error'
   | 'duplicate_id'
+  | 'unrecognized_file'
+  | 'unrecognized_directory'
   | 'unknown';
 
 export interface DiagnosticFinding {
@@ -75,6 +77,16 @@ export function classifyMessage(message: string): DiagnosticKind {
   }
   if (m.includes('duplicate') || m.includes('collision')) {
     return 'duplicate_id';
+  }
+  // Match the directory-prefix BEFORE the file-prefix so a message
+  // mentioning "unrecognized directory: ..." doesn't get misclassified
+  // as 'unrecognized_file'. Both prefixes come from the diagnostic's
+  // unrecognized-entry scan in YamlRequestRepository.listUnrecognizedFiles.
+  if (m.includes('unrecognized directory')) {
+    return 'unrecognized_directory';
+  }
+  if (m.includes('unrecognized file')) {
+    return 'unrecognized_file';
   }
   if (
     m.includes('skipping') ||

--- a/src/domain/repair/RepairPlan.ts
+++ b/src/domain/repair/RepairPlan.ts
@@ -110,6 +110,20 @@ function actionForKind(f: DiagnosticFinding): RepairAction {
         rationale:
           'duplicate id — automatic resolution risks data loss; operator must compare and reconcile manually',
       };
+    case 'unrecognized_file':
+      return {
+        finding: f,
+        kind: 'quarantine',
+        rationale:
+          'off-pattern .yaml in a record directory; gate ignores it via the regex filter, so quarantining moves it out of clutter without losing the contents (recoverable from quarantine/)',
+      };
+    case 'unrecognized_directory':
+      return {
+        finding: f,
+        kind: 'no_op',
+        rationale:
+          'unexpected directory; contents unknown and quarantining a tree is invasive — operator must inspect and decide whether the directory is recoverable elsewhere or should be removed',
+      };
     case 'unknown':
       return {
         finding: f,

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -14,7 +14,21 @@ import {
   RequestRepository,
   RequestIdCollision,
   RequestVersionConflict,
+  UnrecognizedRequestFile,
 } from '../../application/ports/RequestRepository.js';
+import { lstatSync, type Stats } from 'node:fs';
+
+// Best-effort lstat — returns null for entries that disappear between
+// the listing and the stat call (e.g. concurrent transition writing
+// then deleting the old-state file). Diagnostic shouldn't crash on
+// races, so a missing entry just gets dropped from the finding set.
+function lstatSafe(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
 import {
   MAX_DIR_ENTRIES,
   existsSafe,
@@ -82,6 +96,72 @@ export class YamlRequestRepository implements RequestRepository {
       REQUEST_STATES.map((state) => this.listByState(state)),
     );
     return dedupeRequestsById(perState.flat());
+  }
+
+  async listUnrecognizedFiles(): Promise<UnrecognizedRequestFile[]> {
+    // Scope: .yaml files only — the diagnostic is opinionated about
+    // *attempted records*. notes.txt / README.md / .gitkeep are
+    // legitimately useful for repo authors to leave in record
+    // directories and not surfaced as health issues. Subdirectories
+    // under <state>/ ARE surfaced (nothing legitimately ever lands
+    // there).
+    const out: UnrecognizedRequestFile[] = [];
+    const idPattern = /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
+    const stateSet = new Set<string>(REQUEST_STATES);
+
+    // 1. Walk each state directory: surface .yaml files that don't
+    //    match the id pattern (typo, wrong digit count, hand-edited
+    //    name) and any subdirectories (no legitimate place there).
+    for (const state of REQUEST_STATES) {
+      const entries = listDirSafe(this.config.paths.requests, state);
+      for (const name of entries) {
+        const abs = join(this.config.paths.requests, state, name);
+        const stat = lstatSafe(abs);
+        if (stat === null) continue;
+        if (stat.isDirectory()) {
+          out.push({
+            path: abs,
+            kind: 'directory',
+            reason: `subdirectory under <state>/ — no legitimate place for nested directories in the request layout`,
+          });
+          continue;
+        }
+        if (!name.endsWith('.yaml')) continue;
+        if (idPattern.test(name)) continue;
+        out.push({
+          path: abs,
+          kind: 'file',
+          reason: `.yaml filename does not match YYYY-MM-DD-NNNN.yaml — likely typo or hand-edited`,
+        });
+      }
+    }
+
+    // 2. Walk requests/ root: surface .yaml files at this level
+    //    (they belong inside a state subdirectory) and any
+    //    non-state-named directories.
+    const rootEntries = listDirSafe(this.config.paths.requests, '.');
+    for (const name of rootEntries) {
+      const abs = join(this.config.paths.requests, name);
+      const stat = lstatSafe(abs);
+      if (stat === null) continue;
+      if (stat.isDirectory()) {
+        if (stateSet.has(name)) continue; // expected
+        out.push({
+          path: abs,
+          kind: 'directory',
+          reason: `directory at requests/ root that is not a state name (expected: ${REQUEST_STATES.join(', ')})`,
+        });
+        continue;
+      }
+      if (!name.endsWith('.yaml')) continue;
+      out.push({
+        path: abs,
+        kind: 'file',
+        reason: `.yaml file at requests/ root — should live under <state>/`,
+      });
+    }
+
+    return out;
   }
 
   async saveNew(request: Request): Promise<void> {

--- a/src/interface/gate/handlers/repair.ts
+++ b/src/interface/gate/handlers/repair.ts
@@ -48,6 +48,8 @@ const VALID_KINDS: ReadonlySet<DiagnosticKind> = new Set([
   'hydration_error',
   'yaml_parse_error',
   'duplicate_id',
+  'unrecognized_file',
+  'unrecognized_directory',
   'unknown',
 ]);
 

--- a/tests/application/DiagnosticUseCases.test.ts
+++ b/tests/application/DiagnosticUseCases.test.ts
@@ -62,6 +62,15 @@ class FakeRequestRepo implements RequestRepository {
     }
     return this.items;
   }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
+    // Test fakes don't simulate directory walks; the diagnostic
+    // off-pattern surface is exercised end-to-end in the interface
+    // test (tests/interface/doctorUnrecognized.test.ts) where a
+    // real filesystem fixture provides realistic input.
+    return [];
+  }
   async findById(_id: RequestId): Promise<Request | null> {
     return null;
   }

--- a/tests/interface/doctorUnrecognized.test.ts
+++ b/tests/interface/doctorUnrecognized.test.ts
@@ -1,0 +1,187 @@
+// gate doctor — unrecognized files in record directories.
+//
+// Pre-fix gap: listByState's regex filter (^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$)
+// silently dropped off-pattern entries. A `bad.yaml` in
+// `requests/pending/` or a `2026-05-01-7777.yaml` at the wrong directory
+// level was invisible to gate forever; doctor reported the root as
+// clean while the directory was not. This test pins the new
+// `unrecognized_file` / `unrecognized_directory` finding kinds and
+// the boundary (yaml + dirs surfaced; .txt / .md / dotfiles ignored).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-doctor-unrec-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  // Create the standard state subdirs so we can plant entries inside.
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+  input?: string,
+): { stdout: string; stderr: string; status: number } {
+  const opts: Parameters<typeof spawnSync>[2] = {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  };
+  if (input !== undefined) opts.input = input;
+  const r = spawnSync(process.execPath, [GATE, ...args], opts);
+  return {
+    stdout: typeof r.stdout === 'string' ? r.stdout : '',
+    stderr: typeof r.stderr === 'string' ? r.stderr : '',
+    status: r.status ?? -1,
+  };
+}
+
+test('doctor: off-pattern .yaml under <state>/ surfaces as unrecognized_file', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, 'requests', 'pending', 'bad.yaml'), 'stray');
+  writeFileSync(join(root, 'requests', 'pending', '2026-05-01-7.yaml'), 'wrong-digits');
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  // Doctor exits non-zero when findings exist.
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{ kind: string; source: string; message: string }>;
+  const offPattern = findings.filter((f) => f.kind === 'unrecognized_file');
+  assert.equal(offPattern.length, 2, '2 off-pattern .yaml files expected');
+  // The message points at the layout the user is missing.
+  for (const f of offPattern) {
+    assert.match(f.message, /YYYY-MM-DD-NNNN\.yaml/);
+  }
+  // Sources are absolute paths to the planted files.
+  const sources = offPattern.map((f) => f.source).sort();
+  assert.equal(sources.length, 2);
+  assert.match(sources[0]!, /2026-05-01-7\.yaml$/);
+  assert.match(sources[1]!, /bad\.yaml$/);
+});
+
+test('doctor: subdirectory under <state>/ surfaces as unrecognized_directory', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'requests', 'pending', 'oops-dir'));
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{ kind: string; message: string }>;
+  const dirs = findings.filter((f) => f.kind === 'unrecognized_directory');
+  assert.equal(dirs.length, 1);
+  assert.match(dirs[0]!.message, /no legitimate place for nested directories/);
+});
+
+test('doctor: .yaml file at requests/ root (wrong directory level) is surfaced', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Pattern-matching name but at the wrong directory level — pre-fix
+  // this was invisible because listByState only scans state subdirs.
+  writeFileSync(join(root, 'requests', '2026-05-01-9999.yaml'), 'misplaced');
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{ kind: string; message: string; source: string }>;
+  const rootFiles = findings.filter(
+    (f) => f.kind === 'unrecognized_file' && /requests\/2026-05-01-9999\.yaml$/.test(f.source),
+  );
+  assert.equal(rootFiles.length, 1);
+  assert.match(rootFiles[0]!.message, /should live under <state>\//);
+});
+
+test('doctor: non-state directory at requests/ root is surfaced', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'requests', 'random-dir'));
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{ kind: string; message: string; source: string }>;
+  const dirs = findings.filter(
+    (f) => f.kind === 'unrecognized_directory' && /random-dir$/.test(f.source),
+  );
+  assert.equal(dirs.length, 1);
+  assert.match(dirs[0]!.message, /not a state name/);
+  // Message lists the expected state names so the user knows what
+  // the layout is supposed to be without leaving for --help.
+  assert.match(dirs[0]!.message, /pending/);
+  assert.match(dirs[0]!.message, /denied/);
+});
+
+test('doctor: non-yaml files (notes.txt, .gitkeep) are NOT surfaced', (t) => {
+  // Boundary: the diagnostic is opinionated about *attempted records*.
+  // notes.txt / README.md / .gitkeep are legitimately useful for repo
+  // authors to leave in record directories and not surfaced as health
+  // issues. Pin the boundary so a future "warn on anything unexpected"
+  // refactor doesn't quietly start flagging conventional repo artifacts.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, 'requests', 'pending', 'notes.txt'), 'human notes');
+  writeFileSync(join(root, 'requests', 'pending', '.gitkeep'), '');
+  writeFileSync(join(root, 'requests', 'pending', 'README.md'), '# notes');
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  // No findings → exit 0.
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.findings, []);
+});
+
+test('repair --apply: unrecognized_file is quarantined; unrecognized_directory is no-op', (t) => {
+  // The kind/action mapping in RepairPlan: off-pattern .yaml files
+  // get quarantined (gate ignores them anyway, moving them out is
+  // safe and reversible). Directories are no-op because their
+  // contents are unknown and quarantining a tree is invasive — the
+  // operator must inspect first. Pin the boundary so a future
+  // "quarantine everything unknown" refactor doesn't silently
+  // start moving directories.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, 'requests', 'pending', 'bad.yaml'), 'stray');
+  mkdirSync(join(root, 'requests', 'pending', 'oops-dir'));
+
+  const planJson = runGate(root, ['doctor', '--format', 'json']);
+  const r = runGate(
+    root,
+    ['repair', '--apply'],
+    {},
+    planJson.stdout,
+  );
+  assert.equal(r.status, 0);
+  // The file got quarantined.
+  assert.match(r.stdout, /\[quarantined\].*bad\.yaml/);
+  // The directory was a no-op.
+  assert.match(r.stdout, /\[no_op\].*oops-dir/);
+});

--- a/tests/interface/doctorUnrecognized.test.ts
+++ b/tests/interface/doctorUnrecognized.test.ts
@@ -113,8 +113,13 @@ test('doctor: .yaml file at requests/ root (wrong directory level) is surfaced',
   assert.notEqual(r.status, 0);
   const payload = JSON.parse(r.stdout);
   const findings = payload.findings as Array<{ kind: string; message: string; source: string }>;
+  // Path separator: source carries native separators (`/` on POSIX,
+  // `\` on Windows). Normalise to forward slashes for the suffix
+  // assertion so the test passes on both CI runners.
   const rootFiles = findings.filter(
-    (f) => f.kind === 'unrecognized_file' && /requests\/2026-05-01-9999\.yaml$/.test(f.source),
+    (f) =>
+      f.kind === 'unrecognized_file' &&
+      /requests\/2026-05-01-9999\.yaml$/.test(f.source.replace(/\\/g, '/')),
   );
   assert.equal(rootFiles.length, 1);
   assert.match(rootFiles[0]!.message, /should live under <state>\//);


### PR DESCRIPTION
## Summary

`gate doctor` was silently blind to off-pattern `.yaml` files and unexpected subdirectories in the `requests/` tree. Surfaced by fresh-agent dogfood: a `bad.yaml` planted in `requests/pending/` stayed there forever, and `gate doctor` reported the root as **clean** while the directory was not.

`listByState`'s regex filter (`^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$`) silently drops anything that doesn't match. Real failure modes pre-fix:
- user copies a request from another root with a typo in the name → ignored forever, no signal
- ID generation bug produces a wrong-digit-count filename → same silent drop
- debug script leaves a stray `.yaml` → invisible
- file placed at `requests/` root (instead of `<state>/`) → invisible

Designed via gate-review (2026-05-01-0001 → 0002 in a local sandbox); devil pass narrowed scope to `requests/` only and shaped the file-vs-directory split.

## Changes

Two new finding kinds:

| Kind | Triggered by | Repair action |
|------|-------------|---------------|
| `unrecognized_file` | Off-pattern `.yaml` under `<state>/` (typo, wrong digit count) **or** any `.yaml` at `requests/` root (wrong directory level) | **quarantine** — gate ignores them anyway; moving to `quarantine/<timestamp>/` is safe and reversible |
| `unrecognized_directory` | Subdirectory under `<state>/` **or** non-state-named directory at `requests/` root | **no-op** — contents are unknown and quarantining a tree is invasive; operator must inspect first |

```
$ gate doctor
✗ requests  0 total, 5 malformed
    [unrecognized_file] /.../requests/pending/2026-05-01-7.yaml
      unrecognized file: .yaml filename does not match YYYY-MM-DD-NNNN.yaml — likely typo or hand-edited
    [unrecognized_file] /.../requests/pending/bad.yaml
      unrecognized file: .yaml filename does not match YYYY-MM-DD-NNNN.yaml — likely typo or hand-edited
    [unrecognized_directory] /.../requests/pending/oops-dir
      unrecognized directory: subdirectory under <state>/ — no legitimate place for nested directories in the request layout
    [unrecognized_file] /.../requests/2026-05-01-9999.yaml
      unrecognized file: .yaml file at requests/ root — should live under <state>/
    [unrecognized_directory] /.../requests/random-dir
      unrecognized directory: directory at requests/ root that is not a state name (expected: pending, approved, executing, completed, failed, denied)

✗ 5 finding(s) — exit 1
```

### Boundary: only `.yaml` files and directories surface

`notes.txt`, `README.md`, `.gitkeep`, and other conventional repo artifacts are intentionally ignored — record directories sometimes carry useful documentation alongside the records, and flagging those would train operators to ignore the diagnostic. Pinned with a comment in the scanner so a future "warn on anything unexpected" refactor finds the rationale.

## Deferred

Same scan for `issues/` and `members/`. Different filename patterns (`i-YYYY-MM-DD-NNNN.yaml` for issues; `[a-z][a-z0-9_-]{0,31}.yaml` for members) and flat (non-state) layouts. Mechanical but distinct enough for its own PR. Recorded in CHANGELOG.

## Test plan
- [x] `tests/interface/doctorUnrecognized.test.ts` (new, 6 cases):
  - off-pattern `.yaml` under `<state>/` → `unrecognized_file`
  - subdir under `<state>/` → `unrecognized_directory`
  - properly-named `.yaml` at `requests/` root → `unrecognized_file`
  - non-state dir at `requests/` root → `unrecognized_directory` (with state names in message)
  - non-yaml + dotfiles → **NOT** surfaced (boundary preserved)
  - `repair --apply`: file quarantined, directory no-op
- [x] DiagnosticUseCases test fakes grow a stub `listUnrecognizedFiles` returning `[]` — the off-pattern surface is exercised end-to-end against a real fs fixture in the new test, not in the application-layer fakes.
- [x] `npm test` — 592/592 pass.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_