### PR TITLE
fix: doctor extends unrecognized scan to issues + members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,52 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   and other repo artifacts are intentionally ignored. Devil-
   reviewed (`2026-05-01-0001`/`0002`).
 
+- **`gate doctor` extends the unrecognized-file scan to `issues/`
+  and `members/`.** Same shape of fix as the requests-side scan,
+  for the same class of bug. Pre-fix, an `i-bogus.yaml` in
+  `issues/` (typo'd id), a capitalised-prefix `I-2026-05-01-0001.yaml`,
+  or — most painfully — an `Alice.yaml` in `members/` (uppercase
+  first letter) were silently dropped by each repository's listAll
+  regex (`^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$` for issues,
+  `^[a-z][a-z0-9_-]{0,31}\.yaml$` for members) and `gate doctor`
+  reported a clean root while the member was missing from `gate
+  list`. Now each off-pattern `.yaml` surfaces as
+  `unrecognized_file` (→ quarantine in repair) and any
+  subdirectory under `issues/` or `members/` surfaces as
+  `unrecognized_directory` (→ no-op in repair, contents unknown
+  and quarantining a tree is invasive). The four common
+  member-name typos covered explicitly by tests: uppercase first
+  letter, leading digit, leading underscore, name >32 chars.
+  Boundary unchanged: only `.yaml` files and subdirectories are
+  flagged; `notes.txt`, `README.md`, `.gitkeep` ignored.
+
+  Internal cleanup absorbed (devil-review concern D1 from
+  `2026-05-01-0001`): each repo now exports a single
+  `*_FILE_PATTERN` constant that both `listAll` (filters records)
+  and `listUnrecognizedFiles` (surfaces non-matches) consume, so
+  the two paths cannot drift. Pre-fix, `YamlRequestRepository`
+  duplicated the same regex literal across two methods — latent
+  drift bug surfaced by the design sandbox and fixed at the same
+  time. The shared port type renamed `UnrecognizedRequestFile` →
+  `UnrecognizedRecordEntry` and moved to its own module
+  (`src/application/ports/UnrecognizedRecordEntry.ts`); 5
+  callsites updated mechanically. Devil-reviewed
+  (`2026-05-01-0001`/`0002`).
+
 ### Deferred
-- **Unrecognized-file scan for `issues/` and `members/`.** These
-  directories have flat (non-state) layouts and their own filename
-  patterns (`i-YYYY-MM-DD-NNNN.yaml` and `[a-z][a-z0-9_-]{0,31}.yaml`
-  respectively). The first cut ships requests-only; extending the
-  same scanner to issues and members is mechanical but distinct
-  enough to warrant its own PR. Recorded so a future reader who
-  hits "doctor missed my misplaced issue.yaml" finds the trail.
+- **Cross-area unrecognized-file scan.** A file with the wrong
+  area's pattern sitting in the wrong area (e.g., an
+  `i-2026-05-01-0001.yaml` left under `members/`, or
+  `alice.yaml` left under `issues/`) is still invisible because
+  each scan only walks its own area and only flags files that
+  don't match its OWN pattern. The misplaced file matches the
+  member pattern so the issues-area scan ignores it, and vice
+  versa. Out of scope for this PR — the cross-area decision
+  depends on whether such files should auto-relocate or just be
+  flagged, which is a policy choice this PR doesn't have a basis
+  for. Recorded so a future reader who hits "I have an
+  i-prefix file in members/ and doctor doesn't see it" finds the
+  trail. Devil-reviewed concern D3 from `2026-05-01-0001`.
 
 - **Voice calibration: `verdict=concern + state=failed` counts as
   aligned.** The source-code header in `src/interface/gate/voices.ts`

--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -77,34 +77,40 @@ export class DiagnosticUseCases {
           message: msg,
         });
 
+    // Three areas, one shape: each gets its hydration pass via
+    // listAll (any malformed file → onMalformed → finding) AND a
+    // directory-walk pass via listUnrecognizedFiles (anything the
+    // listAll regex silently drops → finding). The unrecognized
+    // walk is what closed the requests-area "bad.yaml stayed
+    // invisible" gap (CHANGELOG #106); extending the same pattern
+    // to issues + members closes the same class of gap there
+    // (e.g. an Alice.yaml uppercase typo silently dropping the
+    // member from gate list).
     const beforeMembers = findings.length;
     const memberBundle = this.buildRepos(areaCollector('members'));
     const members = await memberBundle.members.listAll();
+    const memberCollector = areaCollector('members');
+    for (const u of await memberBundle.members.listUnrecognizedFiles()) {
+      memberCollector(u.path, `unrecognized ${u.kind}: ${u.reason}`);
+    }
     const memberMalformed = findings.length - beforeMembers;
 
     const beforeRequests = findings.length;
     const requestBundle = this.buildRepos(areaCollector('requests'));
     const requests = await requestBundle.requests.listAll();
-    // Off-pattern .yaml files (typo'd names) and subdirectories
-    // under <state>/ are silently dropped by listByState's regex.
-    // Surface them as findings so a misplaced file that gate
-    // ignored is no longer invisible. Fresh-agent dogfood
-    // surfaced this gap (2026-05-01 design sandbox) — pre-fix,
-    // a bad.yaml in requests/pending/ stayed there forever and
-    // doctor reported the root as clean.
-    const unrecognized = await requestBundle.requests.listUnrecognizedFiles();
     const requestCollector = areaCollector('requests');
-    for (const u of unrecognized) {
-      requestCollector(
-        u.path,
-        `unrecognized ${u.kind}: ${u.reason}`,
-      );
+    for (const u of await requestBundle.requests.listUnrecognizedFiles()) {
+      requestCollector(u.path, `unrecognized ${u.kind}: ${u.reason}`);
     }
     const requestMalformed = findings.length - beforeRequests;
 
     const beforeIssues = findings.length;
     const issueBundle = this.buildRepos(areaCollector('issues'));
     const issues = await issueBundle.issues.listAll();
+    const issueCollector = areaCollector('issues');
+    for (const u of await issueBundle.issues.listUnrecognizedFiles()) {
+      issueCollector(u.path, `unrecognized ${u.kind}: ${u.reason}`);
+    }
     const issueMalformed = findings.length - beforeIssues;
 
     // Run doctor plugins (if any)

--- a/src/application/ports/IssueRepository.ts
+++ b/src/application/ports/IssueRepository.ts
@@ -1,4 +1,5 @@
 import { Issue, IssueId, IssueState } from '../../domain/issue/Issue.js';
+import { UnrecognizedRecordEntry } from './UnrecognizedRecordEntry.js';
 
 export interface IssueRepository {
   findById(id: IssueId): Promise<Issue | null>;
@@ -10,6 +11,14 @@ export interface IssueRepository {
    * commands (gate chain) that need the full corpus.
    */
   listAll(): Promise<Issue[]>;
+  /**
+   * Walk the issues directory and surface entries that don't match
+   * the expected layout — .yaml files whose name doesn't match the
+   * `i-YYYY-MM-DD-NNNN.yaml` pattern (silent listAll drops) and
+   * subdirectories (issues is a flat layout; nested dirs have no
+   * legitimate place). Used exclusively by the diagnostic.
+   */
+  listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]>;
   save(issue: Issue): Promise<void>;
   /**
    * Create a brand-new issue file. Must fail with `IssueIdCollision` if

--- a/src/application/ports/MemberRepository.ts
+++ b/src/application/ports/MemberRepository.ts
@@ -1,10 +1,20 @@
 import { Member } from '../../domain/member/Member.js';
 import { MemberName } from '../../domain/member/MemberName.js';
+import { UnrecognizedRecordEntry } from './UnrecognizedRecordEntry.js';
 
 export interface MemberRepository {
   findByName(name: MemberName): Promise<Member | null>;
   exists(name: MemberName): Promise<boolean>;
   listAll(): Promise<Member[]>;
+  /**
+   * Walk the members directory and surface entries that don't match
+   * the expected layout — .yaml files whose name doesn't match the
+   * `[a-z][a-z0-9_-]{0,31}.yaml` pattern (silent listAll drops:
+   * uppercase, leading digit, too long) and subdirectories (flat
+   * layout; nested dirs have no legitimate place). Used exclusively
+   * by the diagnostic.
+   */
+  listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]>;
   save(member: Member): Promise<void>;
   /** Host names (not real members but valid actors: eris, nao, etc.) */
   listHostNames(): Promise<string[]>;

--- a/src/application/ports/RequestRepository.ts
+++ b/src/application/ports/RequestRepository.ts
@@ -1,23 +1,7 @@
 import { Request } from '../../domain/request/Request.js';
 import { RequestId } from '../../domain/request/RequestId.js';
 import { RequestState } from '../../domain/request/RequestState.js';
-
-/**
- * One unrecognized file discovered by a directory walk under
- * `<contentRoot>/requests/`. These are files that listByState's
- * regex filter silently drops — off-pattern names, .yaml files at
- * the wrong directory level, or subdirectories where leaf files
- * are expected. Surfaced by the diagnostic so doctor can warn
- * about them; pre-this they were invisible.
- */
-export interface UnrecognizedRequestFile {
-  /** Absolute path to the entry. */
-  readonly path: string;
-  /** What kind of entry was found (file vs directory). */
-  readonly kind: 'file' | 'directory';
-  /** Why it was flagged — short, suitable for inclusion in a finding message. */
-  readonly reason: string;
-}
+import { UnrecognizedRecordEntry } from './UnrecognizedRecordEntry.js';
 
 export interface RequestRepository {
   findById(id: RequestId): Promise<Request | null>;
@@ -39,7 +23,7 @@ export interface RequestRepository {
    * (no legitimate place there). Used exclusively by the
    * diagnostic; never affects lifecycle reads.
    */
-  listUnrecognizedFiles(): Promise<UnrecognizedRequestFile[]>;
+  listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]>;
   /** Persist; positions file under current state directory. */
   save(request: Request): Promise<void>;
   /**

--- a/src/application/ports/UnrecognizedRecordEntry.ts
+++ b/src/application/ports/UnrecognizedRecordEntry.ts
@@ -1,0 +1,24 @@
+/**
+ * One unrecognized entry discovered by a directory walk under a
+ * record area (`requests/`, `issues/`, or `members/`). These are
+ * files or directories that the area's `listAll` regex filter
+ * silently drops — off-pattern names, .yaml files at the wrong
+ * directory level (requests only — issues/members are flat), or
+ * subdirectories where leaf files are expected.
+ *
+ * Surfaced by the diagnostic so `gate doctor` can warn about them;
+ * pre-this they were invisible to the operator.
+ *
+ * The shape is shared across `RequestRepository`, `IssueRepository`,
+ * and `MemberRepository` because the diagnostic treats them
+ * identically — area tagging happens at the use-case layer, not on
+ * the entry itself, so a single shape keeps the call sites uniform.
+ */
+export interface UnrecognizedRecordEntry {
+  /** Absolute path to the entry. */
+  readonly path: string;
+  /** What kind of entry was found (file vs directory). */
+  readonly kind: 'file' | 'directory';
+  /** Why it was flagged — short, suitable for inclusion in a finding message. */
+  readonly reason: string;
+}

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -15,6 +15,7 @@ import {
   IssueIdCollision,
   IssueVersionConflict,
 } from '../../application/ports/IssueRepository.js';
+import { UnrecognizedRecordEntry } from '../../application/ports/UnrecognizedRecordEntry.js';
 import {
   MAX_DIR_ENTRIES,
   existsSafe,
@@ -24,11 +25,27 @@ import {
   writeTextSafeAtomic,
 } from './safeFs.js';
 import { join } from 'node:path';
+import { lstatSync, type Stats } from 'node:fs';
 import { GuildConfig } from '../config/GuildConfig.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 import { parseYamlSafe } from './parseYamlSafe.js';
 
+// Single source of truth for the on-disk issue filename pattern.
+// listAll filters by it; listUnrecognizedFiles surfaces any .yaml
+// that does NOT match. Defined once so the two paths cannot drift.
 const FILE_PATTERN = /^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
+
+// Best-effort lstat — returns null for entries that disappear between
+// the listing and the stat call. Diagnostic shouldn't crash on races,
+// so a missing entry just gets dropped from the finding set. Mirrors
+// the helper in YamlRequestRepository.
+function lstatSafe(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
 
 export class YamlIssueRepository implements IssueRepository {
   constructor(private readonly config: GuildConfig) {}
@@ -60,6 +77,37 @@ export class YamlIssueRepository implements IssueRepository {
       if (parsed === undefined) continue;
       const issue = hydrate(parsed, absSource, this.config.onMalformed);
       if (issue) out.push(issue);
+    }
+    return out;
+  }
+
+  async listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]> {
+    // Scope: .yaml files only — repo authors may legitimately leave
+    // notes.txt / README.md / .gitkeep here. Subdirectories ARE
+    // surfaced (issues is a flat layout; nested dirs have no
+    // legitimate place). The diagnostic targets *attempted records*,
+    // not arbitrary repo artifacts.
+    const out: UnrecognizedRecordEntry[] = [];
+    const entries = listDirSafe(this.config.paths.issues, '.');
+    for (const name of entries) {
+      const abs = join(this.config.paths.issues, name);
+      const stat = lstatSafe(abs);
+      if (stat === null) continue;
+      if (stat.isDirectory()) {
+        out.push({
+          path: abs,
+          kind: 'directory',
+          reason: `subdirectory under issues/ — no legitimate place for nested directories in the issue layout`,
+        });
+        continue;
+      }
+      if (!name.endsWith('.yaml')) continue;
+      if (FILE_PATTERN.test(name)) continue;
+      out.push({
+        path: abs,
+        kind: 'file',
+        reason: `.yaml filename does not match i-YYYY-MM-DD-NNNN.yaml — likely typo or hand-edited`,
+      });
     }
     return out;
   }

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -2,6 +2,7 @@ import YAML from 'yaml';
 import { Member } from '../../domain/member/Member.js';
 import { MemberName } from '../../domain/member/MemberName.js';
 import { MemberRepository } from '../../application/ports/MemberRepository.js';
+import { UnrecognizedRecordEntry } from '../../application/ports/UnrecognizedRecordEntry.js';
 import {
   MAX_DIR_ENTRIES,
   existsSafe,
@@ -10,9 +11,25 @@ import {
   writeTextSafe,
 } from './safeFs.js';
 import { join } from 'node:path';
+import { lstatSync, type Stats } from 'node:fs';
 import { GuildConfig } from '../config/GuildConfig.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 import { parseYamlSafe } from './parseYamlSafe.js';
+
+// Single source of truth for the on-disk member filename pattern.
+// listAll filters by it; listUnrecognizedFiles surfaces any .yaml
+// that does NOT match. Defined once so the two paths cannot drift —
+// e.g. an `Alice.yaml` (uppercase) silently dropped from listAll
+// must surface as unrecognized so the operator sees the typo.
+const MEMBER_FILE_PATTERN = /^[a-z][a-z0-9_-]{0,31}\.yaml$/;
+
+function lstatSafe(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * File layout: <config.paths.members>/<name>.yaml
@@ -40,7 +57,7 @@ export class YamlMemberRepository implements MemberRepository {
 
   async listAll(): Promise<Member[]> {
     const files = listDirSafe(this.config.paths.members, '.').filter((f) =>
-      /^[a-z][a-z0-9_-]{0,31}\.yaml$/.test(f),
+      MEMBER_FILE_PATTERN.test(f),
     );
     const out: Member[] = [];
     for (const f of files.slice(0, MAX_DIR_ENTRIES)) {
@@ -51,6 +68,42 @@ export class YamlMemberRepository implements MemberRepository {
       if (data === undefined) continue;
       const m = hydrate(data, name, absSource, this.config.onMalformed);
       if (m) out.push(m);
+    }
+    return out;
+  }
+
+  async listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]> {
+    // Scope: .yaml files only — repo authors may legitimately leave
+    // notes.txt / README.md / .gitkeep here. Subdirectories ARE
+    // surfaced (members is a flat layout; nested dirs have no
+    // legitimate place).
+    //
+    // The pattern catches the most likely typos that drop a member
+    // from `gate list` silently: `Alice.yaml` (uppercase first
+    // letter), `1alice.yaml` (leading digit), `_alice.yaml` (leading
+    // underscore), or names exceeding 32 characters. Pre-this they
+    // disappeared without trace; now doctor flags the file by name.
+    const out: UnrecognizedRecordEntry[] = [];
+    const entries = listDirSafe(this.config.paths.members, '.');
+    for (const name of entries) {
+      const abs = join(this.config.paths.members, name);
+      const stat = lstatSafe(abs);
+      if (stat === null) continue;
+      if (stat.isDirectory()) {
+        out.push({
+          path: abs,
+          kind: 'directory',
+          reason: `subdirectory under members/ — no legitimate place for nested directories in the member layout`,
+        });
+        continue;
+      }
+      if (!name.endsWith('.yaml')) continue;
+      if (MEMBER_FILE_PATTERN.test(name)) continue;
+      out.push({
+        path: abs,
+        kind: 'file',
+        reason: `.yaml filename does not match [a-z][a-z0-9_-]{0,31}.yaml — likely typo (uppercase, leading digit, leading underscore, or too long)`,
+      });
     }
     return out;
   }

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -14,8 +14,8 @@ import {
   RequestRepository,
   RequestIdCollision,
   RequestVersionConflict,
-  UnrecognizedRequestFile,
 } from '../../application/ports/RequestRepository.js';
+import { UnrecognizedRecordEntry } from '../../application/ports/UnrecognizedRecordEntry.js';
 import { lstatSync, type Stats } from 'node:fs';
 
 // Best-effort lstat — returns null for entries that disappear between
@@ -41,6 +41,13 @@ import {
 import { GuildConfig } from '../config/GuildConfig.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 import { parseYamlSafe } from './parseYamlSafe.js';
+
+// Single source of truth for the on-disk request filename pattern.
+// listByState filters by it; listUnrecognizedFiles surfaces anything
+// .yaml that does NOT match. Defined once so the two paths cannot
+// drift — if listByState ever tightens (e.g. to require 4-digit
+// sequences), the unrecognized scan tightens with it.
+const REQUEST_ID_FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
 
 /**
  * Layout: <paths.requests>/<state>/<id>.yaml
@@ -72,7 +79,7 @@ export class YamlRequestRepository implements RequestRepository {
 
   async listByState(state: RequestState): Promise<Request[]> {
     const files = listDirSafe(this.config.paths.requests, state)
-      .filter((f) => /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/.test(f))
+      .filter((f) => REQUEST_ID_FILE_PATTERN.test(f))
       .slice(0, MAX_DIR_ENTRIES);
     const out: Request[] = [];
     for (const f of files) {
@@ -98,15 +105,14 @@ export class YamlRequestRepository implements RequestRepository {
     return dedupeRequestsById(perState.flat());
   }
 
-  async listUnrecognizedFiles(): Promise<UnrecognizedRequestFile[]> {
+  async listUnrecognizedFiles(): Promise<UnrecognizedRecordEntry[]> {
     // Scope: .yaml files only — the diagnostic is opinionated about
     // *attempted records*. notes.txt / README.md / .gitkeep are
     // legitimately useful for repo authors to leave in record
     // directories and not surfaced as health issues. Subdirectories
     // under <state>/ ARE surfaced (nothing legitimately ever lands
     // there).
-    const out: UnrecognizedRequestFile[] = [];
-    const idPattern = /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
+    const out: UnrecognizedRecordEntry[] = [];
     const stateSet = new Set<string>(REQUEST_STATES);
 
     // 1. Walk each state directory: surface .yaml files that don't
@@ -127,7 +133,7 @@ export class YamlRequestRepository implements RequestRepository {
           continue;
         }
         if (!name.endsWith('.yaml')) continue;
-        if (idPattern.test(name)) continue;
+        if (REQUEST_ID_FILE_PATTERN.test(name)) continue;
         out.push({
           path: abs,
           kind: 'file',

--- a/tests/application/DiagnosticUseCases.test.ts
+++ b/tests/application/DiagnosticUseCases.test.ts
@@ -40,6 +40,15 @@ class FakeMemberRepo implements MemberRepository {
     }
     return this.items;
   }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
+    // Test fakes don't simulate directory walks; the diagnostic
+    // off-pattern surface is exercised end-to-end in the interface
+    // test (tests/interface/doctorUnrecognized.test.ts) where a
+    // real filesystem fixture provides realistic input.
+    return [];
+  }
   async save(_m: Member): Promise<void> {}
   async listHostNames(): Promise<string[]> {
     return [];
@@ -99,6 +108,11 @@ class FakeIssueRepo implements IssueRepository {
       this.onMalformed?.(`/fake${this.fakeArea}/${i}.yaml`, this.malformedMessages[i]!);
     }
     return this.items;
+  }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
+    return [];
   }
   async save(_i: Issue): Promise<void> {}
   async saveNew(_i: Issue): Promise<void> {}

--- a/tests/application/IssueUseCases.sortContract.test.ts
+++ b/tests/application/IssueUseCases.sortContract.test.ts
@@ -28,6 +28,11 @@ class ShuffledIssueRepo implements IssueRepository {
   async listAll(): Promise<Issue[]> {
     return [...this.items];
   }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
+    return [];
+  }
   async save(_i: Issue): Promise<void> {}
   async saveNew(_i: Issue): Promise<void> {}
   async nextSequence(_d: string): Promise<number> {
@@ -43,6 +48,11 @@ class StubMemberRepo implements MemberRepository {
     return true;
   }
   async listAll(): Promise<Member[]> {
+    return [];
+  }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
     return [];
   }
   async save(_m: Member): Promise<void> {}

--- a/tests/application/MessageUseCases.test.ts
+++ b/tests/application/MessageUseCases.test.ts
@@ -35,6 +35,11 @@ class FakeMemberRepo implements MemberRepository {
   async listAll(): Promise<Member[]> {
     return Array.from(this.members.values());
   }
+  async listUnrecognizedFiles(): Promise<
+    Array<{ path: string; kind: 'file' | 'directory'; reason: string }>
+  > {
+    return [];
+  }
   async save(_m: Member): Promise<void> {}
   async listHostNames(): Promise<string[]> {
     return this.hosts;

--- a/tests/interface/doctorUnrecognizedIssuesMembers.test.ts
+++ b/tests/interface/doctorUnrecognizedIssuesMembers.test.ts
@@ -4,8 +4,8 @@
 // Pre-fix gap: YamlIssueRepository.listAll's regex filter
 // (^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$) and YamlMemberRepository's
 // regex filter (^[a-z][a-z0-9_-]{0,31}\.yaml$) silently dropped
-// off-pattern entries. An `i-bogus.yaml` in `issues/` or an
-// `Alice.yaml` in `members/` (uppercase first letter) was invisible
+// off-pattern entries. An `i-bogus.yaml` in `issues/` or a
+// `Dave.yaml` in `members/` (uppercase first letter) was invisible
 // to gate forever; doctor reported the root as clean while the
 // member was missing from `gate list`. This test pins:
 //   - off-pattern .yaml files surface as `unrecognized_file`
@@ -14,6 +14,11 @@
 //     leading digit, leading underscore, too long)
 //   - the boundary stays consistent with requests: .txt / .md /
 //     dotfiles ignored, only .yaml + dirs surfaced.
+//
+// Cross-platform note: the uppercase typo cases use names that
+// don't case-fold-collide with anything in `bootstrap()` because
+// Windows NTFS is case-insensitive by default — `Alice.yaml` and
+// `alice.yaml` would resolve to the same file there.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -135,9 +140,15 @@ test('doctor: off-pattern .yaml under members/ surfaces (the four common typos)'
   // the root as clean while the file sat there in plain view.
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
+  // Pick uppercase-prefix typo names that DON'T case-fold to any
+  // lowercase fixture name — Windows NTFS is case-insensitive by
+  // default, so `Alice.yaml` would be the same file as the
+  // `alice.yaml` planted by bootstrap() and the test would see only
+  // 3 findings instead of 4. `Dave` has no lowercase counterpart in
+  // the fixture, so the case test stays portable across CI runners.
   writeFileSync(
-    join(root, 'members', 'Alice.yaml'),
-    'name: Alice\ncategory: professional\nactive: true\n',
+    join(root, 'members', 'Dave.yaml'),
+    'name: Dave\ncategory: professional\nactive: true\n',
   );
   writeFileSync(
     join(root, 'members', '1bob.yaml'),
@@ -147,9 +158,12 @@ test('doctor: off-pattern .yaml under members/ surfaces (the four common typos)'
     join(root, 'members', '_carol.yaml'),
     'name: carol\ncategory: professional\nactive: true\n',
   );
-  // Name >32 chars: 'a' + 32 chars = 33 chars before .yaml
+  // Name >32 chars: 'z' + 32 chars = 33 chars before .yaml.
+  // (Use `z` not `a` so this also doesn't case-fold-collide with
+  // any other planted file.)
+  const tooLongName = 'z' + 'y'.repeat(32);
   writeFileSync(
-    join(root, 'members', 'a' + 'b'.repeat(32) + '.yaml'),
+    join(root, 'members', `${tooLongName}.yaml`),
     'name: too-long\ncategory: professional\nactive: true\n',
   );
 
@@ -179,9 +193,9 @@ test('doctor: off-pattern .yaml under members/ surfaces (the four common typos)'
   // Sort is by codepoint so digits (0x31) < uppercase (0x41) <
   // underscore (0x5f) < lowercase (0x61).
   assert.equal(basenames[0], '1bob.yaml');
-  assert.equal(basenames[1], 'Alice.yaml');
+  assert.equal(basenames[1], 'Dave.yaml');
   assert.equal(basenames[2], '_carol.yaml');
-  assert.equal(basenames[3], 'a' + 'b'.repeat(32) + '.yaml');
+  assert.equal(basenames[3], `${tooLongName}.yaml`);
   // The message names the pattern so the operator can debug without
   // leaving for --help.
   for (const f of offPattern) {
@@ -238,9 +252,12 @@ test('repair --apply: off-pattern issue file is quarantined; off-pattern member 
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   writeFileSync(join(root, 'issues', 'bogus.yaml'), 'stray');
+  // Use `Dave.yaml` (no `dave.yaml` in the bootstrap fixture) so the
+  // case-insensitive Windows filesystem doesn't fold this into the
+  // existing `alice.yaml` and silently un-plant the test input.
   writeFileSync(
-    join(root, 'members', 'Alice.yaml'),
-    'name: Alice\ncategory: professional\nactive: true\n',
+    join(root, 'members', 'Dave.yaml'),
+    'name: Dave\ncategory: professional\nactive: true\n',
   );
 
   const planJson = runGate(root, ['doctor', '--format', 'json']);
@@ -253,5 +270,5 @@ test('repair --apply: off-pattern issue file is quarantined; off-pattern member 
   assert.equal(r.status, 0);
   // Both files were quarantined.
   assert.match(r.stdout, /\[quarantined\].*bogus\.yaml/);
-  assert.match(r.stdout, /\[quarantined\].*Alice\.yaml/);
+  assert.match(r.stdout, /\[quarantined\].*Dave\.yaml/);
 });

--- a/tests/interface/doctorUnrecognizedIssuesMembers.test.ts
+++ b/tests/interface/doctorUnrecognizedIssuesMembers.test.ts
@@ -1,0 +1,257 @@
+// gate doctor — unrecognized files in issues/ and members/.
+//
+// Companion to doctorUnrecognized.test.ts (which covers requests/).
+// Pre-fix gap: YamlIssueRepository.listAll's regex filter
+// (^i-\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$) and YamlMemberRepository's
+// regex filter (^[a-z][a-z0-9_-]{0,31}\.yaml$) silently dropped
+// off-pattern entries. An `i-bogus.yaml` in `issues/` or an
+// `Alice.yaml` in `members/` (uppercase first letter) was invisible
+// to gate forever; doctor reported the root as clean while the
+// member was missing from `gate list`. This test pins:
+//   - off-pattern .yaml files surface as `unrecognized_file`
+//   - subdirectories surface as `unrecognized_directory`
+//   - the four common typo cases for member names (uppercase,
+//     leading digit, leading underscore, too long)
+//   - the boundary stays consistent with requests: .txt / .md /
+//     dotfiles ignored, only .yaml + dirs surfaced.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-doctor-im-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  // Need at least one valid request state subdir so the requests scan
+  // doesn't surface its own findings and pollute area filters.
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  // A baseline valid member so listAll has something to count.
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+  input?: string,
+): { stdout: string; stderr: string; status: number } {
+  const opts: Parameters<typeof spawnSync>[2] = {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  };
+  if (input !== undefined) opts.input = input;
+  const r = spawnSync(process.execPath, [GATE, ...args], opts);
+  return {
+    stdout: typeof r.stdout === 'string' ? r.stdout : '',
+    stderr: typeof r.stderr === 'string' ? r.stderr : '',
+    status: r.status ?? -1,
+  };
+}
+
+test('doctor: off-pattern .yaml under issues/ surfaces as unrecognized_file', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Three off-pattern names that listAll's regex silently drops:
+  //   - missing the i- prefix
+  //   - too-short sequence (only 2 digits — pattern requires 3-4)
+  //   - capitalised prefix (`I-` instead of `i-`)
+  // (We deliberately don't pick "month 13" or other semantic-date
+  // violations: the regex is `\d{2}` and validates digit count, not
+  // calendar reality, so a month-13 filename actually matches.)
+  writeFileSync(join(root, 'issues', 'bogus.yaml'), 'stray');
+  writeFileSync(join(root, 'issues', 'i-2026-05-01-99.yaml'), 'short-seq');
+  writeFileSync(join(root, 'issues', 'I-2026-05-01-0001.yaml'), 'cap-prefix');
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{
+    area: string;
+    kind: string;
+    source: string;
+    message: string;
+  }>;
+  const offPattern = findings.filter(
+    (f) => f.area === 'issues' && f.kind === 'unrecognized_file',
+  );
+  assert.equal(offPattern.length, 3, '3 off-pattern .yaml files in issues/ expected');
+  for (const f of offPattern) {
+    // Message points at the layout the user is missing.
+    assert.match(f.message, /i-YYYY-MM-DD-NNNN\.yaml/);
+  }
+});
+
+test('doctor: subdirectory under issues/ surfaces as unrecognized_directory', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'issues', 'archived'));
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{
+    area: string;
+    kind: string;
+    source: string;
+    message: string;
+  }>;
+  const dirs = findings.filter(
+    (f) => f.area === 'issues' && f.kind === 'unrecognized_directory',
+  );
+  assert.equal(dirs.length, 1);
+  assert.match(dirs[0]!.message, /no legitimate place for nested directories/);
+});
+
+test('doctor: off-pattern .yaml under members/ surfaces (the four common typos)', (t) => {
+  // D4 from devil review (req 2026-05-01-0001): the four
+  // pattern-violating cases that silently drop a member from `gate
+  // list`. This is the ACTUAL bug a fresh agent hits when their
+  // member name renders as missing — pre-this scan, doctor reported
+  // the root as clean while the file sat there in plain view.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(
+    join(root, 'members', 'Alice.yaml'),
+    'name: Alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', '1bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', '_carol.yaml'),
+    'name: carol\ncategory: professional\nactive: true\n',
+  );
+  // Name >32 chars: 'a' + 32 chars = 33 chars before .yaml
+  writeFileSync(
+    join(root, 'members', 'a' + 'b'.repeat(32) + '.yaml'),
+    'name: too-long\ncategory: professional\nactive: true\n',
+  );
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{
+    area: string;
+    kind: string;
+    source: string;
+    message: string;
+  }>;
+  const offPattern = findings.filter(
+    (f) => f.area === 'members' && f.kind === 'unrecognized_file',
+  );
+  assert.equal(
+    offPattern.length,
+    4,
+    '4 off-pattern member files expected (uppercase, leading digit, leading underscore, too long)',
+  );
+  // Path separator: source carries native separators (`/` on POSIX,
+  // `\` on Windows). Normalise to forward slashes for the suffix
+  // assertion so the test passes on both CI runners.
+  const basenames = offPattern
+    .map((f) => f.source.replace(/\\/g, '/').split('/').pop())
+    .sort();
+  // Sort is by codepoint so digits (0x31) < uppercase (0x41) <
+  // underscore (0x5f) < lowercase (0x61).
+  assert.equal(basenames[0], '1bob.yaml');
+  assert.equal(basenames[1], 'Alice.yaml');
+  assert.equal(basenames[2], '_carol.yaml');
+  assert.equal(basenames[3], 'a' + 'b'.repeat(32) + '.yaml');
+  // The message names the pattern so the operator can debug without
+  // leaving for --help.
+  for (const f of offPattern) {
+    assert.match(f.message, /\[a-z\]\[a-z0-9_-\]\{0,31\}\.yaml/);
+  }
+});
+
+test('doctor: subdirectory under members/ surfaces as unrecognized_directory', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'members', 'archived'));
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.notEqual(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const findings = payload.findings as Array<{
+    area: string;
+    kind: string;
+    source: string;
+    message: string;
+  }>;
+  const dirs = findings.filter(
+    (f) => f.area === 'members' && f.kind === 'unrecognized_directory',
+  );
+  assert.equal(dirs.length, 1);
+  assert.match(dirs[0]!.message, /no legitimate place for nested directories/);
+});
+
+test('doctor: non-yaml files in issues/ and members/ are NOT surfaced', (t) => {
+  // Boundary mirrors requests-side test: the scan is opinionated
+  // about *attempted records*. notes.txt / README.md / .gitkeep are
+  // legitimately useful for repo authors to leave in record
+  // directories.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, 'issues', 'notes.txt'), 'human notes');
+  writeFileSync(join(root, 'issues', '.gitkeep'), '');
+  writeFileSync(join(root, 'issues', 'README.md'), '# notes');
+  writeFileSync(join(root, 'members', 'notes.txt'), 'roster notes');
+  writeFileSync(join(root, 'members', '.gitkeep'), '');
+  writeFileSync(join(root, 'members', 'README.md'), '# roster');
+
+  const r = runGate(root, ['doctor', '--format', 'json']);
+  assert.equal(r.status, 0, 'no findings → exit 0');
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.findings, []);
+});
+
+test('repair --apply: off-pattern issue file is quarantined; off-pattern member file is quarantined', (t) => {
+  // Mirror the requests-side repair contract: off-pattern .yaml in
+  // any record directory gets quarantined (the listAll regex was
+  // ignoring it anyway, moving it to quarantine/ is safe and
+  // reversible).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, 'issues', 'bogus.yaml'), 'stray');
+  writeFileSync(
+    join(root, 'members', 'Alice.yaml'),
+    'name: Alice\ncategory: professional\nactive: true\n',
+  );
+
+  const planJson = runGate(root, ['doctor', '--format', 'json']);
+  const r = runGate(
+    root,
+    ['repair', '--apply'],
+    {},
+    planJson.stdout,
+  );
+  assert.equal(r.status, 0);
+  // Both files were quarantined.
+  assert.match(r.stdout, /\[quarantined\].*bogus\.yaml/);
+  assert.match(r.stdout, /\[quarantined\].*Alice\.yaml/);
+});


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from #106. Same shape of fix as the requests-side scan, for the same class of bug.

- **Pre-fix**: an `Alice.yaml` in `members/` (uppercase first letter) was silently dropped by `listAll`'s `^[a-z][a-z0-9_-]{0,31}\.yaml$` filter — the member disappeared from `gate list` and `gate doctor` reported the root as clean. Same pattern for an `i-bogus.yaml` in `issues/` (typo'd id) or a capitalised-prefix `I-2026-05-01-0001.yaml`.
- **Post-fix**: off-pattern `.yaml` under any record area surfaces as `unrecognized_file` (→ quarantine in repair); subdirectories under `issues/` or `members/` surface as `unrecognized_directory` (→ no-op, since contents are unknown and quarantining a tree is invasive).
- The four common member-name typos covered explicitly by tests: uppercase first letter, leading digit, leading underscore, name >32 chars.
- Boundary unchanged from #106: only `.yaml` files and subdirectories flagged; `notes.txt`, `README.md`, `.gitkeep` ignored.

## Internal cleanup absorbed (devil concern D1)

Each repo now exports a single `*_FILE_PATTERN` const that **both** `listAll` (filters records) and `listUnrecognizedFiles` (surfaces non-matches) consume — the two paths cannot drift. Pre-fix, `YamlRequestRepository` already duplicated the regex literal across two methods (latent drift bug surfaced by the design sandbox; cleaned at the same time).

The shared port type renamed `UnrecognizedRequestFile` → `UnrecognizedRecordEntry` and moved to its own module (`src/application/ports/UnrecognizedRecordEntry.ts`); 5 callsites updated mechanically.

## Devil review

Designed in the dogfood sandbox via `2026-05-01-0001`/`0002`. Concerns absorbed:
- **D1** — pattern drift between `listAll` and the scan: fixed via the shared const above.
- **D2** — rename ripple cost vs honesty: rename now (one consumer is the cheapest moment).
- **D3** — cross-area scan (i-prefix file in members/ etc.) recorded as Deferred. It's a policy choice (auto-relocate vs flag) this PR doesn't have a basis for.
- **D4** — explicit test coverage for the four common member-name typos.

## Test plan

- [x] `tests/interface/doctorUnrecognizedIssuesMembers.test.ts` — 6 new tests
  - off-pattern `.yaml` under `issues/` surfaces as `unrecognized_file`
  - subdir under `issues/` surfaces as `unrecognized_directory`
  - the four common member-name typos all surface as `unrecognized_file`
  - subdir under `members/` surfaces as `unrecognized_directory`
  - non-yaml (`notes.txt`, `.gitkeep`, `README.md`) NOT surfaced
  - `repair --apply` quarantines off-pattern issue + member files
- [x] Existing `doctorUnrecognized.test.ts` (12 tests) still passes
- [x] Three test fakes (`DiagnosticUseCases.test.ts`, `IssueUseCases.sortContract.test.ts`, `MessageUseCases.test.ts`) updated to satisfy the new port method
- [x] Full suite: 598/598 pass

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_