### PR TITLE
fix: gate register surfaces the absolute path it wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Fixed
+- **`gate register` surfaces the absolute path it wrote, on both
+  stderr (humans) and JSON (orchestrators).** Closes the silent
+  parent-config-pickup gap a fresh-agent dogfood surfaced. Pre-
+  fix, running `gate register --name newcomer` from a subdir of
+  an active guild silently walked up the tree, found the parent's
+  `guild.config.yaml`, and wrote `<parent>/members/newcomer.yaml`
+  with no signal — the agent had no clue their YAML landed in
+  someone else's repo. Same gap hit no-config-found cases (cwd
+  used as the implicit content_root).
+
+  Post-fix, `gate register` emits one stderr notice on success:
+  ```
+  notice: wrote /abs/path/members/<name>.yaml (config: /abs/path/guild.config.yaml)
+  ```
+  When no config was discovered the second segment becomes
+  `config: none — cwd used as fallback root`, naming the implicit
+  default explicitly. The JSON success envelope gains
+  `where_written` (absolute path of the saved file) and
+  `config_file` (absolute path of `guild.config.yaml` in use, or
+  `null`) so MCP consumers parse structured fields rather than
+  scraping stderr.
+
+  Symmetric on `--dry-run`: the preview header now shows the
+  absolute path (was: relative `members/<name>.yaml`) and the
+  stderr notice fires with `would write` (not `wrote`) so the
+  preview is not less honest about location than the real write.
+  Notice does NOT fire on error paths (collision, host-name
+  reservation, validation) — pinned by test. Devil-reviewed
+  (`2026-05-01-0001`/`0002`); v2 absorbed the JSON-contract,
+  dry-run-symmetry, and error-boundary concerns.
+
 - **`gate doctor` surfaces unrecognized .yaml files and unexpected
   subdirectories under `requests/`.** Pre-fix, `listByState`'s regex
   filter (`^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$`) silently dropped

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import {
   ParsedArgs,
   optionalOption,
@@ -98,6 +99,14 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
     );
   }
 
+  // Where the file will land — resolved once and shared by the
+  // dry-run preview, the JSON success envelope, and the stderr
+  // notice. The dry-run path uses the same value so the preview is
+  // not less honest about location than the real write (devil
+  // concern D3 on req 2026-05-01-0002).
+  const whereWritten = join(c.config.paths.members, `${parsedName.value}.yaml`);
+  const configFile = c.config.configFile;
+
   if (dryRun) {
     // Compose the YAML shape without hitting disk. Lets an agent
     // confirm what's about to land before committing. Run the
@@ -117,16 +126,27 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
     };
     if (format === 'json') {
       process.stdout.write(
-        JSON.stringify({ ok: true, dry_run: true, preview }, null, 2) + '\n',
+        JSON.stringify(
+          {
+            ok: true,
+            dry_run: true,
+            preview,
+            where_written: whereWritten,
+            config_file: configFile,
+          },
+          null,
+          2,
+        ) + '\n',
       );
     } else {
       process.stdout.write(
-        `dry-run: would write members/${parsedName.value}.yaml:\n` +
+        `dry-run: would write ${whereWritten}:\n` +
           Object.entries(preview)
             .map(([k, v]) => `  ${k}: ${JSON.stringify(v)}`)
             .join('\n') +
           '\n',
       );
+      process.stderr.write(formatPathNotice(whereWritten, configFile, true));
     }
     return 0;
   }
@@ -145,6 +165,8 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
           id: member.name.value,
           state: 'active',
           message: `registered: ${member.name.value} (${member.category})`,
+          where_written: whereWritten,
+          config_file: configFile,
           suggested_next: {
             verb: 'boot',
             args: {},
@@ -163,5 +185,36 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
         `  next: export GUILD_ACTOR=${member.name.value} && gate boot\n`,
     );
   }
+  // Notice fires AFTER memberUC.create succeeds — collisions /
+  // host-name reservation / validation errors throw earlier and
+  // never reach here, so the line never falsely claims a write
+  // (devil concern D4). Stderr keeps stdout machine-readable in
+  // both --format text and --format json.
+  process.stderr.write(formatPathNotice(whereWritten, configFile, false));
   return 0;
+}
+
+/**
+ * One-line stderr notice surfacing where the member YAML landed and
+ * which `guild.config.yaml` was in effect. Solves the silent
+ * parent-config-pickup gap (`gate register` from a subdir of an
+ * active guild silently writing into the parent's members/) and
+ * the no-config fallback case (no guild.config.yaml found, cwd
+ * used as content_root) at the same time. The fresh-agent dogfood
+ * surfacing this gap is recorded in the design sandbox under
+ * `2026-05-01-0001`/`0002`.
+ */
+function formatPathNotice(
+  whereWritten: string,
+  configFile: string | null,
+  dryRun: boolean,
+): string {
+  const wherePart = dryRun
+    ? `would write ${whereWritten}`
+    : `wrote ${whereWritten}`;
+  const configPart =
+    configFile === null
+      ? `config: none — cwd used as fallback root`
+      : `config: ${configFile}`;
+  return `notice: ${wherePart} (${configPart})\n`;
 }

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -317,3 +317,140 @@ test('register: assertActor error surfaces the register hint', () => {
     cleanup();
   }
 });
+
+// ---------------------------------------------------------------
+// Path-disclosure notice (designed in 2026-05-01-0001/0002).
+//
+// Pre-this, `gate register` from a subdir of an active guild
+// silently wrote into the parent's members/ directory — fresh
+// agents had no signal where their YAML actually landed. Same gap
+// hit no-config-found cases (cwd used as fallback root). The
+// fix surfaces the absolute path on stderr (humans) AND in the
+// JSON envelope (orchestrators) so both contracts stay honest.
+// ---------------------------------------------------------------
+
+test('register: success-text emits stderr notice naming the absolute path written + config in use', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['register', '--name', 'pathy']);
+    assert.equal(r.status, 0);
+    // Stderr carries one notice line; stdout stays parseable.
+    assert.match(
+      r.stderr,
+      new RegExp(
+        `^notice: wrote ${escapeRegex(join(root, 'members', 'pathy.yaml'))} \\(config: ${escapeRegex(join(root, 'guild.config.yaml'))}\\)\\n$`,
+      ),
+    );
+    assert.doesNotMatch(r.stdout, /notice:/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: success-json adds where_written + config_file fields AND emits the stderr notice', () => {
+  // Devil concern D2 on req 2026-05-01-0002: JSON is the
+  // orchestrator contract, stderr is the human contract — both
+  // must be honest. Pin both surfaces so a future refactor
+  // can't drop one quietly.
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, [
+      'register',
+      '--name', 'jsony',
+      '--format', 'json',
+    ]);
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(
+      payload.where_written,
+      join(root, 'members', 'jsony.yaml'),
+    );
+    assert.equal(
+      payload.config_file,
+      join(root, 'guild.config.yaml'),
+    );
+    assert.match(r.stderr, /^notice: wrote /);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: dry-run preview also surfaces the absolute path + config (devil D3 — dry-run not less honest than real write)', () => {
+  // Pre-fix the dry-run preview said `would write
+  // members/<name>.yaml` (relative path) while the real write
+  // was about to land at an absolute path possibly on a parent
+  // guild. That asymmetry was the whole gap. Both paths now
+  // disclose the same way.
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, [
+      'register',
+      '--name', 'dryone',
+      '--dry-run',
+    ]);
+    assert.equal(r.status, 0);
+    // Preview header carries the absolute path now.
+    assert.match(
+      r.stdout,
+      new RegExp(`^dry-run: would write ${escapeRegex(join(root, 'members', 'dryone.yaml'))}:`),
+    );
+    // Stderr notice fires on dry-run too, with `would write` (not
+    // `wrote`) so the verb stays honest.
+    assert.match(r.stderr, /^notice: would write /);
+    assert.match(
+      r.stderr,
+      new RegExp(`config: ${escapeRegex(join(root, 'guild.config.yaml'))}`),
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: error case (collision) does NOT emit the path notice', () => {
+  // Devil concern D4 on req 2026-05-01-0002: the notice claims a
+  // write happened. It must fire ONLY after memberUC.create
+  // succeeds. Collisions throw before reaching the emit point;
+  // host-name reservation and validation errors throw earlier
+  // still. Pin the boundary so a future refactor doesn't move
+  // the emit ahead of the create.
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['register', '--name', 'alice']);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /already exists/);
+    assert.doesNotMatch(r.stderr, /^notice: wrote/m);
+    assert.doesNotMatch(r.stderr, /^notice: would write/m);
+  } finally {
+    cleanup();
+  }
+});
+
+test('register: no-config fallback path surfaces "config: none" so the implicit-cwd case is named explicitly', () => {
+  // The other half of the silent-pickup gap: an agent who runs
+  // gate register in an empty dir with no parent config gets cwd
+  // used as content_root with no warning. Post-fix the notice
+  // names it (`config: none — cwd used as fallback root`) so the
+  // agent learns the implicit default exists.
+  const root = mkdtempSync(join(tmpdir(), 'guild-register-nocfg-'));
+  try {
+    const r = runGate(root, ['register', '--name', 'cwdsolo']);
+    assert.equal(r.status, 0);
+    assert.match(
+      r.stderr,
+      new RegExp(
+        `^notice: wrote ${escapeRegex(join(root, 'members', 'cwdsolo.yaml'))} \\(config: none — cwd used as fallback root\\)\\n$`,
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Escape regex special chars so absolute paths from tmpdir() can
+// be embedded in `new RegExp(...)`. Native path separators differ
+// across CI runners (POSIX `/`, Windows `\`) and `\` would
+// otherwise consume the next character of the literal path.
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Closes the silent parent-config-pickup gap a fresh-agent dogfood surfaced after #107 merged. From a subdir of an active guild, `gate register --name newcomer` walked up the tree, found the parent's `guild.config.yaml`, and silently wrote into the parent's `members/`. The fresh agent had no signal their YAML landed in someone else's repo.

```
$ mkdir -p /foo/sub && cd /foo/sub
$ gate register --name newcomer
✓ registered: newcomer [professional]
$ ls .
(empty)
$ ls /foo/members/
newcomer.yaml   # ← landed here without any indication
```

Same gap also hit the no-config-found case (cwd silently used as the implicit content_root, no warning).

## Fix

- **stderr notice on success** names absolute path + config in effect (humans):
  ```
  notice: wrote /abs/members/<name>.yaml (config: /abs/guild.config.yaml)
  ```
  When no config was found: `(config: none — cwd used as fallback root)` — names the implicit default explicitly.

- **JSON envelope** gains `where_written` + `config_file` structured fields (orchestrators):
  ```json
  {
    "ok": true,
    "id": "newcomer",
    "where_written": "/abs/members/newcomer.yaml",
    "config_file": "/abs/guild.config.yaml",
    ...
  }
  ```

- **`--dry-run`** symmetry: preview header now shows absolute path (was: relative `members/<name>.yaml`) and emits the same notice with `would write` instead of `wrote`. Pre-fix the dry-run was less honest than the real write.

- **Error paths** do NOT emit the notice. Collision / host-name reservation / validation throw before reaching the emit point; pinned by test.

## Devil review (design sandbox `2026-05-01-0001`/`0002`)

- **D1** noise creep on success-stderr: scoped tightly to path disclosure, no other "register did Y" additions.
- **D2** JSON contract honesty: structured `where_written` + `config_file` fields added.
- **D3** dry-run symmetry: preview must not be less honest than the real write — fixed.
- **D4** error-case boundary: notice MUST NOT fire when no file was written — pinned by test.

## Test plan

- [x] `tests/interface/register.test.ts` — 5 new tests (success-text notice / success-json fields + notice / dry-run symmetry / error-no-notice / no-config fallback names "config: none")
- [x] All 17 register tests pass
- [x] Full suite: 603/603

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_