### PR TITLE
change: voices/tail JSON renames camelCase → snake_case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Changed
+- **`gate voices` / `gate tail` JSON: `request_id` / `invoked_by` /
+  `completion_note` / `deny_reason` / `failure_reason` (was:
+  `requestId` / `invokedBy` / `completionNote` / `denyReason` /
+  `failureReason`).** The voices stream is the project's
+  highest-traffic JSON surface and was the lone camelCase outlier;
+  every other JSON surface (`gate show`, `gate inbox`, `gate
+  status`, `gate register` JSON envelope, `gate boot.hints`, etc.)
+  was already snake_case (`created_at`, `read_at`, `display_name`,
+  `auto_review`, `status_log`, `where_written`, `config_file`).
+  The mismatch made cross-tool consumers carry a translation layer
+  for one stream only.
+
+  Single-cycle cut per 0.x policy (same shape as the `displayName
+  → display_name` rename in PR #102) — no dual-emit phase. Fresh-
+  agent dogfood (post-PR #107) surfaced the inconsistency; devil-
+  reviewed (`2026-05-01-0001`/`0002`) to confirm scope: rename
+  the TS fields too so the text-path readers (`renderUtterance`
+  in `voices.ts`, the `tail` summary block in `boot.ts`, the
+  bilingual `resume.ts`) stay consistent with the JSON. The
+  `gate schema` declarations did not advertise the voices output
+  shape, so no schema update was needed.
+
+  Downstream JSON parsers (MCP wirings, ad-hoc scripts) that
+  read these fields must update key names. Records on disk are
+  unchanged — this is purely an output-shape rename, not a
+  storage migration.
+
 ### Fixed
 - **`gate register` surfaces the absolute path it wrote, on both
   stderr (humans) and JSON (orchestrators).** Closes the silent

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -741,11 +741,11 @@ function renderBootText(p: BootPayload): string {
     lines.push(`recent (${p.tail.length}):`);
     for (const u of p.tail.slice(0, 5)) {
       if (u.kind === 'review') {
-        lines.push(`  ${u.at}  req=${u.requestId}  [${u.lense}/${u.verdict}] by ${u.by}`);
+        lines.push(`  ${u.at}  req=${u.request_id}  [${u.lense}/${u.verdict}] by ${u.by}`);
       } else if (u.kind === 'thank') {
-        lines.push(`  ${u.at}  req=${u.requestId}  thank ${u.by} → ${u.to}`);
+        lines.push(`  ${u.at}  req=${u.request_id}  thank ${u.by} → ${u.to}`);
       } else {
-        lines.push(`  ${u.at}  req=${u.requestId}  authored by ${u.from}`);
+        lines.push(`  ${u.at}  req=${u.request_id}  authored by ${u.from}`);
       }
     }
   }
@@ -754,9 +754,9 @@ function renderBootText(p: BootPayload): string {
     lines.push(`your recent (${p.your_recent.length}):`);
     for (const u of p.your_recent.slice(0, 3)) {
       if (u.kind === 'review') {
-        lines.push(`  ${u.at}  req=${u.requestId}  [${u.lense}/${u.verdict}]`);
+        lines.push(`  ${u.at}  req=${u.request_id}  [${u.lense}/${u.verdict}]`);
       } else {
-        lines.push(`  ${u.at}  req=${u.requestId}  authored`);
+        lines.push(`  ${u.at}  req=${u.request_id}  authored`);
       }
     }
   }

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -386,19 +386,19 @@ function composeRestorationProseEn(ctx: {
   if (lastUtterance) {
     const age = ageHint(lastUtterance.at, new Date().toISOString());
     if (lastUtterance.kind === 'review') {
-      const proxyHint = lastUtterance.invokedBy
-        ? ` (invoked by ${lastUtterance.invokedBy})`
+      const proxyHint = lastUtterance.invoked_by
+        ? ` (invoked by ${lastUtterance.invoked_by})`
         : '';
       lines.push(
-        `Your last voice (utterance, ${age}) was a review on req=${lastUtterance.requestId} — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
+        `Your last voice (utterance, ${age}) was a review on req=${lastUtterance.request_id} — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  "${truncate(lastUtterance.comment, 240)}"`);
     } else if (lastUtterance.kind === 'thank') {
-      const proxyHint = lastUtterance.invokedBy
-        ? ` (invoked by ${lastUtterance.invokedBy})`
+      const proxyHint = lastUtterance.invoked_by
+        ? ` (invoked by ${lastUtterance.invoked_by})`
         : '';
       lines.push(
-        `Your last voice (utterance, ${age}) was a thank → ${lastUtterance.to} on req=${lastUtterance.requestId}${proxyHint}:`,
+        `Your last voice (utterance, ${age}) was a thank → ${lastUtterance.to} on req=${lastUtterance.request_id}${proxyHint}:`,
       );
       lines.push(`  re: ${truncate(lastUtterance.action, 120)}`);
       if (lastUtterance.reason !== undefined) {
@@ -409,15 +409,15 @@ function composeRestorationProseEn(ctx: {
         lastUtterance.with && lastUtterance.with.length > 0
           ? ` (shaped with ${lastUtterance.with.join(', ')})`
           : '';
-      const proxyHint = lastUtterance.invokedBy
-        ? ` (invoked by ${lastUtterance.invokedBy})`
+      const proxyHint = lastUtterance.invoked_by
+        ? ` (invoked by ${lastUtterance.invoked_by})`
         : '';
       lines.push(
-        `Your last voice (utterance, ${age}) was authoring req=${lastUtterance.requestId}${proxyHint}${withHint}:`,
+        `Your last voice (utterance, ${age}) was authoring req=${lastUtterance.request_id}${proxyHint}${withHint}:`,
       );
       lines.push(`  action: ${truncate(lastUtterance.action, 120)}`);
-      if (lastUtterance.completionNote) {
-        lines.push(`  note:   ${truncate(lastUtterance.completionNote, 240)}`);
+      if (lastUtterance.completion_note) {
+        lines.push(`  note:   ${truncate(lastUtterance.completion_note, 240)}`);
       }
     }
   } else {
@@ -528,19 +528,19 @@ function composeRestorationProseJa(ctx: {
   if (lastUtterance) {
     const age = ageHint(lastUtterance.at, new Date().toISOString());
     if (lastUtterance.kind === 'review') {
-      const proxyHint = lastUtterance.invokedBy
-        ? `（${lastUtterance.invokedBy} が代行）`
+      const proxyHint = lastUtterance.invoked_by
+        ? `（${lastUtterance.invoked_by} が代行）`
         : '';
       lines.push(
-        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} へのレビュー — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.request_id} へのレビュー — [${lastUtterance.lense}/${lastUtterance.verdict}]${proxyHint}:`,
       );
       lines.push(`  「${truncate(lastUtterance.comment, 240)}」`);
     } else if (lastUtterance.kind === 'thank') {
-      const proxyHint = lastUtterance.invokedBy
-        ? `（${lastUtterance.invokedBy} が代行）`
+      const proxyHint = lastUtterance.invoked_by
+        ? `（${lastUtterance.invoked_by} が代行）`
         : '';
       lines.push(
-        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} への感謝 → ${lastUtterance.to}${proxyHint}:`,
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.request_id} への感謝 → ${lastUtterance.to}${proxyHint}:`,
       );
       lines.push(`  re: ${truncate(lastUtterance.action, 120)}`);
       if (lastUtterance.reason !== undefined) {
@@ -551,15 +551,15 @@ function composeRestorationProseJa(ctx: {
         lastUtterance.with && lastUtterance.with.length > 0
           ? `（${lastUtterance.with.join('、')} と一緒に）`
           : '';
-      const proxyHint = lastUtterance.invokedBy
-        ? `（${lastUtterance.invokedBy} が代行）`
+      const proxyHint = lastUtterance.invoked_by
+        ? `（${lastUtterance.invoked_by} が代行）`
         : '';
       lines.push(
-        `直近の発話 (utterance, ${age}): req=${lastUtterance.requestId} の起票${proxyHint}${withHint}:`,
+        `直近の発話 (utterance, ${age}): req=${lastUtterance.request_id} の起票${proxyHint}${withHint}:`,
       );
       lines.push(`  action: ${truncate(lastUtterance.action, 120)}`);
-      if (lastUtterance.completionNote) {
-        lines.push(`  note:   ${truncate(lastUtterance.completionNote, 240)}`);
+      if (lastUtterance.completion_note) {
+        lines.push(`  note:   ${truncate(lastUtterance.completion_note, 240)}`);
       }
     }
   } else {

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -86,24 +86,24 @@ export type ThankJSON = {
 export type AuthoredUtterance = {
   readonly kind: 'authored';
   readonly at: string;
-  readonly requestId: string;
+  readonly request_id: string;
   // Who authored the containing request. Useful when tail streams
   // utterances from every actor and the reader needs to see who said
   // what without looking up the id.
   readonly from: string;
   // Actual CLI invoker when the creation was proxied (GUILD_ACTOR
-  // differed from --from). Same semantic as ReviewUtterance.invokedBy;
+  // differed from --from). Same semantic as ReviewUtterance.invoked_by;
   // the source is the `invoked_by` field on the status_log[0] entry.
   // Undefined for the self-invocation common case.
-  readonly invokedBy?: string;
+  readonly invoked_by?: string;
   readonly action: string;
   readonly reason: string;
   // Any closure text the lifecycle ended on. Only one of these is
-  // populated for a given request: completed → completionNote,
-  // denied → denyReason, failed → failureReason.
-  readonly completionNote?: string;
-  readonly denyReason?: string;
-  readonly failureReason?: string;
+  // populated for a given request: completed → completion_note,
+  // denied → deny_reason, failed → failure_reason.
+  readonly completion_note?: string;
+  readonly deny_reason?: string;
+  readonly failure_reason?: string;
   // Pair-mode Layer 1: dialogue partners during formation (empty if
   // solo). Surfaced on the utterance so readers of voices / tail /
   // resume see "with whom" without fetching the raw request.
@@ -113,12 +113,12 @@ export type AuthoredUtterance = {
 export type ReviewUtterance = {
   readonly kind: 'review';
   readonly at: string;
-  readonly requestId: string;
+  readonly request_id: string;
   // Who wrote the review. Same rationale as AuthoredUtterance.from.
   readonly by: string;
   // Actual CLI invoker when different from `by` (typically an AI
   // agent acting on the member's behalf). Undefined when they agree.
-  readonly invokedBy?: string;
+  readonly invoked_by?: string;
   // The action of the containing request, so the reader has context
   // for what the review was *about* without chasing the id.
   readonly action: string;
@@ -140,10 +140,10 @@ export type ReviewUtterance = {
 export type ThankUtterance = {
   readonly kind: 'thank';
   readonly at: string;
-  readonly requestId: string;
+  readonly request_id: string;
   readonly by: string;
   readonly to: string;
-  readonly invokedBy?: string;
+  readonly invoked_by?: string;
   // Action of the containing request for context, same rationale as
   // ReviewUtterance.action.
   readonly action: string;
@@ -197,7 +197,7 @@ export function collectUtterances(
       const u: AuthoredUtterance = {
         kind: 'authored',
         at: r.created_at,
-        requestId: r.id,
+        request_id: r.id,
         from: r.from,
         action: r.action,
         reason: r.reason,
@@ -208,19 +208,19 @@ export function collectUtterances(
       // proxy-reviews. Guarded so pre-invoked_by records stay clean.
       const createdEntry = r.status_log?.[0];
       if (createdEntry && createdEntry.invoked_by !== undefined) {
-        (u as { invokedBy?: string }).invokedBy = createdEntry.invoked_by;
+        (u as { invoked_by?: string }).invoked_by = createdEntry.invoked_by;
       }
       // Pick whichever closure field the lifecycle produced. A request
       // can only be in one terminal state at a time, so at most one of
       // these is set.
       if (r.completion_note) {
-        (u as { completionNote?: string }).completionNote = r.completion_note;
+        (u as { completion_note?: string }).completion_note = r.completion_note;
       }
       if (r.deny_reason) {
-        (u as { denyReason?: string }).denyReason = r.deny_reason;
+        (u as { deny_reason?: string }).deny_reason = r.deny_reason;
       }
       if (r.failure_reason) {
-        (u as { failureReason?: string }).failureReason = r.failure_reason;
+        (u as { failure_reason?: string }).failure_reason = r.failure_reason;
       }
       if (r.with && r.with.length > 0) {
         (u as { with?: ReadonlyArray<string> }).with = r.with;
@@ -237,7 +237,7 @@ export function collectUtterances(
       const reviewUtterance: ReviewUtterance = {
         kind: 'review',
         at: rv.at,
-        requestId: r.id,
+        request_id: r.id,
         action: r.action,
         by: rv.by,
         lense: rv.lense,
@@ -245,7 +245,7 @@ export function collectUtterances(
         comment: rv.comment,
       };
       if (rv.invoked_by !== undefined) {
-        (reviewUtterance as { invokedBy?: string }).invokedBy = rv.invoked_by;
+        (reviewUtterance as { invoked_by?: string }).invoked_by = rv.invoked_by;
       }
       out.push(reviewUtterance);
     }
@@ -266,7 +266,7 @@ export function collectUtterances(
         const thankUtterance: ThankUtterance = {
           kind: 'thank',
           at: th.at,
-          requestId: r.id,
+          request_id: r.id,
           action: r.action,
           by: th.by,
           to: th.to,
@@ -275,7 +275,7 @@ export function collectUtterances(
           (thankUtterance as { reason?: string }).reason = th.reason;
         }
         if (th.invoked_by !== undefined) {
-          (thankUtterance as { invokedBy?: string }).invokedBy = th.invoked_by;
+          (thankUtterance as { invoked_by?: string }).invoked_by = th.invoked_by;
         }
         out.push(thankUtterance);
       }
@@ -376,24 +376,24 @@ export function renderUtterance(
     // includeActor=false (voices groups by actor so `from` is
     // redundant, but the proxy invoker isn't). Matches the review
     // branch's treatment.
-    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
-    lines.push(`[${u.at}] req=${u.requestId} authored${actor}${proxy}${withSuffix}`);
+    const proxy = u.invoked_by ? ` [invoked_by=${u.invoked_by}]` : '';
+    lines.push(`[${u.at}] req=${u.request_id} authored${actor}${proxy}${withSuffix}`);
     pushMultilineField(lines, '  action: ', u.action);
     pushMultilineField(lines, '  reason: ', u.reason);
     // At most one of these is set per request (completed / denied /
     // failed are mutually exclusive terminal states).
-    if (u.completionNote) pushMultilineField(lines, '  note:   ', u.completionNote);
-    if (u.denyReason) pushMultilineField(lines, '  denied: ', u.denyReason);
-    if (u.failureReason) pushMultilineField(lines, '  failed: ', u.failureReason);
+    if (u.completion_note) pushMultilineField(lines, '  note:   ', u.completion_note);
+    if (u.deny_reason) pushMultilineField(lines, '  denied: ', u.deny_reason);
+    if (u.failure_reason) pushMultilineField(lines, '  failed: ', u.failure_reason);
   } else if (u.kind === 'review') {
     // Always expose `invoked_by` when present, even when includeActor
     // is false (voices groups by actor, so the `by` is redundant —
     // but the proxy-invoker isn't). Keeps the stream honest about
     // who actually ran the command vs who the act is attributed to.
     const actor = includeActor ? ` by ${u.by}` : '';
-    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
+    const proxy = u.invoked_by ? ` [invoked_by=${u.invoked_by}]` : '';
     lines.push(
-      `[${u.at}] req=${u.requestId} [${u.lense}/${u.verdict}]${actor}${proxy}`,
+      `[${u.at}] req=${u.request_id} [${u.lense}/${u.verdict}]${actor}${proxy}`,
     );
     lines.push(`  re: ${u.action}`);
     for (const line of u.comment.split('\n')) {
@@ -406,9 +406,9 @@ export function renderUtterance(
     // have a giver AND a receiver, and both are load-bearing. Hiding
     // `by` when voices groups by one of them would leave the reader
     // asking "thanked by whom?" on every line.
-    const proxy = u.invokedBy ? ` [invoked_by=${u.invokedBy}]` : '';
+    const proxy = u.invoked_by ? ` [invoked_by=${u.invoked_by}]` : '';
     lines.push(
-      `[${u.at}] req=${u.requestId} thank ${u.by} → ${u.to}${proxy}`,
+      `[${u.at}] req=${u.request_id} thank ${u.by} → ${u.to}${proxy}`,
     );
     lines.push(`  re: ${u.action}`);
     if (u.reason !== undefined) {

--- a/tests/interface/pairMode.test.ts
+++ b/tests/interface/pairMode.test.ts
@@ -78,7 +78,7 @@ test('renderUtterance appends "(with ...)" on authored lines; unchanged when sol
     {
       kind: 'authored',
       at: '2026-04-16T00:00:00Z',
-      requestId: 'x',
+      request_id: 'x',
       from: 'alice',
       action: 'a',
       reason: 'r',
@@ -91,7 +91,7 @@ test('renderUtterance appends "(with ...)" on authored lines; unchanged when sol
     {
       kind: 'authored',
       at: '2026-04-16T00:00:00Z',
-      requestId: 'x',
+      request_id: 'x',
       from: 'alice',
       action: 'a',
       reason: 'r',

--- a/tests/interface/voices.test.ts
+++ b/tests/interface/voices.test.ts
@@ -68,9 +68,9 @@ test('collectUtterances returns all authored + review utterances for an actor', 
   // kiri authored req 001 and 003, reviewed nothing.
   assert.equal(result.length, 2);
   assert.equal(result[0]?.kind, 'authored');
-  assert.equal(result[0]?.requestId, '2026-04-14-001');
+  assert.equal(result[0]?.request_id, '2026-04-14-001');
   assert.equal(result[1]?.kind, 'authored');
-  assert.equal(result[1]?.requestId, '2026-04-14-003');
+  assert.equal(result[1]?.request_id, '2026-04-14-003');
 });
 
 test('collectUtterances returns mixed authored + review for an actor who wears both hats', () => {
@@ -79,11 +79,11 @@ test('collectUtterances returns mixed authored + review for an actor who wears b
   // Sorted by timestamp: devil@11:00, noir-authored@12:00, user@14:00.
   assert.equal(result.length, 3);
   assert.equal(result[0]?.kind, 'review');
-  assert.equal(result[0]?.requestId, '2026-04-14-001');
+  assert.equal(result[0]?.request_id, '2026-04-14-001');
   assert.equal(result[1]?.kind, 'authored');
-  assert.equal(result[1]?.requestId, '2026-04-14-002');
+  assert.equal(result[1]?.request_id, '2026-04-14-002');
   assert.equal(result[2]?.kind, 'review');
-  assert.equal(result[2]?.requestId, '2026-04-14-003');
+  assert.equal(result[2]?.request_id, '2026-04-14-003');
 });
 
 test('collectUtterances: --lense filter excludes authored and non-matching reviews', () => {
@@ -133,39 +133,39 @@ test('collectUtterances: sorts results chronologically ascending', () => {
 test('collectUtterances: authored utterance captures deny_reason when present', () => {
   const result = collectUtterances(corpus, { name: 'noir' });
   const authored = result.find(
-    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-002',
+    (u) => u.kind === 'authored' && u.request_id === '2026-04-14-002',
   );
   assert.ok(authored, 'expected noir-authored denied request');
   if (authored?.kind === 'authored') {
-    assert.equal(authored.denyReason, 'scope creep');
-    assert.equal(authored.completionNote, undefined);
-    assert.equal(authored.failureReason, undefined);
+    assert.equal(authored.deny_reason, 'scope creep');
+    assert.equal(authored.completion_note, undefined);
+    assert.equal(authored.failure_reason, undefined);
   }
 });
 
 test('collectUtterances: authored utterance captures failure_reason when present', () => {
   const result = collectUtterances(corpus, { name: 'kiri' });
   const failed = result.find(
-    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-003',
+    (u) => u.kind === 'authored' && u.request_id === '2026-04-14-003',
   );
   assert.ok(failed, 'expected kiri-authored failed request');
   if (failed?.kind === 'authored') {
-    assert.equal(failed.failureReason, 'upstream outage');
-    assert.equal(failed.completionNote, undefined);
-    assert.equal(failed.denyReason, undefined);
+    assert.equal(failed.failure_reason, 'upstream outage');
+    assert.equal(failed.completion_note, undefined);
+    assert.equal(failed.deny_reason, undefined);
   }
 });
 
 test('collectUtterances: authored utterance captures completion_note when present', () => {
   const result = collectUtterances(corpus, { name: 'kiri' });
   const completed = result.find(
-    (u) => u.kind === 'authored' && u.requestId === '2026-04-14-001',
+    (u) => u.kind === 'authored' && u.request_id === '2026-04-14-001',
   );
   assert.ok(completed, 'expected kiri-authored completed request');
   if (completed?.kind === 'authored') {
-    assert.equal(completed.completionNote, 'shipped');
-    assert.equal(completed.denyReason, undefined);
-    assert.equal(completed.failureReason, undefined);
+    assert.equal(completed.completion_note, 'shipped');
+    assert.equal(completed.deny_reason, undefined);
+    assert.equal(completed.failure_reason, undefined);
   }
 });
 
@@ -219,9 +219,9 @@ test('collectUtterances: limit truncates after sort', () => {
   const asc = collectUtterances(corpus, { limit: 2 });
   assert.equal(asc.length, 2);
   // ascending: earliest two are 001-authored (10:00) and 001-review-devil (11:00)
-  assert.equal(asc[0]?.requestId, '2026-04-14-001');
+  assert.equal(asc[0]?.request_id, '2026-04-14-001');
   assert.equal(asc[0]?.kind, 'authored');
-  assert.equal(asc[1]?.requestId, '2026-04-14-001');
+  assert.equal(asc[1]?.request_id, '2026-04-14-001');
   assert.equal(asc[1]?.kind, 'review');
 });
 
@@ -229,7 +229,7 @@ test('collectUtterances: order desc reverses the chronology', () => {
   const desc = collectUtterances(corpus, { order: 'desc', limit: 1 });
   assert.equal(desc.length, 1);
   // descending: most recent is 003-review-user (14:00)
-  assert.equal(desc[0]?.requestId, '2026-04-14-003');
+  assert.equal(desc[0]?.request_id, '2026-04-14-003');
   assert.equal(desc[0]?.kind, 'review');
 });
 
@@ -321,15 +321,15 @@ test('collectUtterances: review invoked_by flows onto the utterance', () => {
   assert.ok(u);
   assert.equal(u.kind, 'review');
   if (u.kind === 'review') {
-    assert.equal(u.invokedBy, 'claude');
+    assert.equal(u.invoked_by, 'claude');
   }
 });
 
-test('collectUtterances: review without invoked_by leaves invokedBy undefined', () => {
+test('collectUtterances: review without invoked_by leaves invoked_by undefined', () => {
   const [u] = collectUtterances(corpus, { name: 'noir', lense: 'devil' });
   assert.ok(u);
   if (u.kind === 'review') {
-    assert.equal(u.invokedBy, undefined);
+    assert.equal(u.invoked_by, undefined);
   }
 });
 
@@ -465,11 +465,11 @@ test('collectUtterances: authored utterance lifts invoked_by from status_log[0]'
   assert.ok(u);
   assert.equal(u.kind, 'authored');
   if (u.kind === 'authored') {
-    assert.equal(u.invokedBy, 'claude');
+    assert.equal(u.invoked_by, 'claude');
   }
 });
 
-test('collectUtterances: authored utterance leaves invokedBy undefined when not proxied', () => {
+test('collectUtterances: authored utterance leaves invoked_by undefined when not proxied', () => {
   const reqs: RequestJSON[] = [
     {
       id: '2026-04-18-0099',
@@ -484,7 +484,7 @@ test('collectUtterances: authored utterance leaves invokedBy undefined when not 
   ];
   const [u] = collectUtterances(reqs, { name: 'eris' });
   assert.ok(u);
-  if (u.kind === 'authored') assert.equal(u.invokedBy, undefined);
+  if (u.kind === 'authored') assert.equal(u.invoked_by, undefined);
 });
 
 test('renderUtterance authored: shows [invoked_by=<actor>] when present', () => {


### PR DESCRIPTION
## Summary

Closes the JSON convention inconsistency surfaced by the post-#107 fresh-agent dogfood. `gate voices` and `gate tail` were emitting `requestId` / `invokedBy` / `completionNote` / `denyReason` / `failureReason` while every other JSON surface in the project was already snake_case (`created_at`, `read_at`, `display_name`, `auto_review`, `status_log`, `where_written`, `config_file`).

```diff
 [
   {
     "kind": "authored",
     "at": "2026-05-01T15:16:02.311Z",
-    "requestId": "2026-05-01-0001",
+    "request_id": "2026-05-01-0001",
     "from": "alice",
     "action": "try",
     "reason": "sample"
   }
 ]
```

The voices stream is one of the highest-traffic JSON surfaces (it's also the calibration substrate for `--with-calibration`); having one outlier forced cross-tool consumers to carry a translation layer for it alone.

## Scope

- TS field names AND JSON keys both renamed at the boundary so the text-path readers stay consistent with the JSON. Affected:
  - `src/interface/gate/voices.ts` — type defs + `collectUtterances` builders + `renderUtterance` readers
  - `src/interface/gate/handlers/boot.ts` — tail/your-recent summary block
  - `src/interface/gate/handlers/resume.ts` — both English and Japanese bilingual paths
- `gate schema` does NOT advertise the voices output shape (only the input count flags), so no schema update needed.
- Records on disk are unchanged — purely an output-shape rename, not a storage migration.

## Single-cycle cut per 0.x policy

Same shape as the `displayName → display_name` rename in #102: no dual-emit phase. Downstream parsers must update key names in one cycle.

## Devil review

Designed in dogfood sandbox (`2026-05-01-0001`/`0002`):

- **D1** text-path readers: rename TS fields too so internal/external conventions stay unified.
- **D2** tail relevance: tail consumes the same `collectUtterances` shape, so the rename auto-propagates (PR #4 will then add tail's `--format json`).
- **D3** schema: cleared (voices output not in schema).
- **D4** test count: 65 occurrences across 6 files, mechanical sed-style rename. Tests stay green.

## Test plan

- [x] `tests/interface/voices.test.ts` (32 tests) updated and pass
- [x] `tests/interface/pairMode.test.ts` (9 tests) updated and pass
- [x] Smoke test: `gate voices alice --format json` emits `request_id` snake_case
- [x] Full suite: 603/603

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_