### PR TITLE
fix: gate boot --format text discloses content_root when surprising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **`gate boot --format text` surfaces `content root: <path>
+  (config: <path>)` when the situation is surprising.** Sibling
+  to the PR #108 register-notice fix: closes the silent parent-
+  config-pickup gap on the READ side. Pre-fix, `gate boot --format
+  text` showed neither `config_file` nor `resolved_content_root`
+  (both fields existed in the JSON envelope but the text
+  rendering omitted them), so an agent who ran boot for
+  orientation got no path signal even when the cwd was a subdir
+  of an active guild and gate had silently walked up to a
+  parent's `guild.config.yaml`.
+
+  Post-fix, the orientation block emits one line **only when the
+  situation is surprising** — voice budget is preserved by
+  staying silent at the alignment case (cwd === resolved
+  content_root, config present and discovered). Two trigger
+  cases:
+
+  - **Subdir of an active guild** (`cwd != resolved_content_root`)
+    — `content root: /abs/path (config: /abs/path/guild.config.yaml)`
+  - **No config found, cwd used as fallback** (`config_file ===
+    null` and there's data) — `content root: /abs/path (config:
+    none — cwd used as fallback root)`
+
+  Suppressed when `misconfigured_cwd` already fired (no-config +
+  no-data, the bigger warning takes over) so the disclosure is
+  surfaced exactly once. JSON envelope gains `cwd_outside_content_root`
+  boolean for orchestrators reading the structured contract.
+  Phrasing matches PR #108's `(config: ...)` segment for cross-
+  verb recognition. Devil-reviewed (`2026-05-01-0001`/`0002`);
+  v2 absorbed the voice-budget concern (D1) by gating the
+  emission on the surprising cases.
+
 ### Changed
 - **`gate voices` / `gate tail` JSON: `request_id` / `invoked_by` /
   `completion_note` / `deny_reason` / `failure_reason` (was:

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import {
   ParsedArgs,
   optionalOption,
@@ -98,6 +99,19 @@ interface BootPayload {
    */
   hints: {
     misconfigured_cwd: boolean;
+    /**
+     * `cwd_outside_content_root`: true iff the caller's cwd is NOT
+     * the same directory as `resolved_content_root`. Distinguishes
+     * "you ran gate from a subdir of an active guild and your write
+     * went into the parent's records" (true) from "you ran gate at
+     * the guild root, everything is where you expect" (false). The
+     * silent-parent-config-pickup gap a fresh-agent dogfood
+     * surfaced after #107 was the case this flag detects.
+     *
+     * Always false when `misconfigured_cwd` is true (the misconfigured
+     * block already discloses verbosely; we don't double-up).
+     */
+    cwd_outside_content_root: boolean;
     config_file: string | null;
     resolved_content_root: string;
     content_root_health: {
@@ -255,6 +269,18 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     members.length === 0 &&
     allRequests.length === 0;
 
+  // Subdir-pickup detection: cwd is NOT the same directory as the
+  // resolved content_root. The case the post-#107 fresh-agent
+  // dogfood surfaced — running gate from `/foo/sub/` when an
+  // `/foo/guild.config.yaml` exists silently writes into `/foo/`.
+  // Suppressed when misconfiguredCwd already fired so the bigger
+  // warning isn't doubled. Kept false at exactly the alignment
+  // case (`cwd === resolved_content_root`) to keep the 99% normal
+  // run quiet — voice budget.
+  const cwdOutsideContentRoot =
+    !misconfiguredCwd &&
+    resolve(process.cwd()) !== resolve(c.config.contentRoot);
+
   // Content-root health: lightweight summary of malformed records.
   // We piggyback on DiagnosticUseCases which already walks every
   // area; its onMalformed collector picks up YAML that failed to
@@ -318,6 +344,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     last_activity: status.last_activity,
     hints: {
       misconfigured_cwd: misconfiguredCwd,
+      cwd_outside_content_root: cwdOutsideContentRoot,
       config_file: c.config.configFile,
       resolved_content_root: c.config.contentRoot,
       content_root_health: contentRootHealth,
@@ -704,6 +731,24 @@ function renderBootText(p: BootPayload): string {
     );
     lines.push(
       `        or use a wrapper that cd's before invoking gate.mjs.`,
+    );
+  } else if (
+    p.hints.cwd_outside_content_root ||
+    p.hints.config_file === null
+  ) {
+    // Surface the resolved content_root + config when the cwd is
+    // surprising (subdir of an active guild) or implicit (no config
+    // found, cwd silently used as fallback root). Suppressed at the
+    // alignment case to keep the normal run quiet — voice budget.
+    // Phrasing matches the `(config: ...)` segment of `gate
+    // register`'s notice (PR #108) for cross-verb recognition.
+    const configSegment =
+      p.hints.config_file === null
+        ? 'config: none — cwd used as fallback root'
+        : `config: ${p.hints.config_file}`;
+    lines.push('');
+    lines.push(
+      `content root: ${p.hints.resolved_content_root} (${configSegment})`,
     );
   }
   const health = p.hints.content_root_health;

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -303,3 +303,145 @@ test('gate boot: suggested_next=null for registered member', () => {
     cleanup();
   }
 });
+
+// ---------------------------------------------------------------
+// content_root disclosure (designed in 2026-05-01-0001/0002).
+//
+// Pre-fix, `gate boot --format text` showed neither config_file
+// nor resolved_content_root, so an agent who ran gate from a
+// subdir of an active guild — the silent parent-config-pickup
+// gap PR #108 closed on the WRITE side — got no signal on the
+// READ side either. The fix surfaces the orientation line ONLY
+// when the situation is surprising (subdir / no-config), keeping
+// the 99% normal run quiet (voice budget). JSON payload now
+// carries the boolean `cwd_outside_content_root` for
+// orchestrators.
+// ---------------------------------------------------------------
+
+test('gate boot text: aligned cwd (cwd === content_root) emits NO content-root disclosure', () => {
+  // Voice budget: the 99% case (operator at the guild root) stays
+  // exactly as it was. Pin the absence so a future "always
+  // disclose" refactor can't regress the noise level.
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout, status } = runGate(
+      root,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 0);
+    assert.doesNotMatch(stdout, /^content root:/m);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: subdir of active guild discloses content_root + parent config', () => {
+  // The case PR #108 closed on the write side. boot is the
+  // orientation surface — agents running boot to "see where I am"
+  // need the same disclosure.
+  const { root, cleanup } = bootstrap();
+  try {
+    const sub = join(root, 'sub');
+    mkdirSync(sub);
+    const { stdout, status } = runGate(
+      sub,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(status, 0);
+    assert.match(
+      stdout,
+      // Line shape matches PR #108's `(config: ...)` segment for
+      // cross-verb recognition.
+      new RegExp(
+        `^content root: ${escapeRegex(root)} \\(config: ${escapeRegex(join(root, 'guild.config.yaml'))}\\)$`,
+        'm',
+      ),
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: no-config-found case discloses cwd-as-fallback', () => {
+  // The other half of the gap: an agent in /tmp/foo with no
+  // parent guild gets cwd silently used as content_root. Pre-fix
+  // they had no signal that the implicit default was in play.
+  // Post-fix the line names it: `(config: none — cwd used as
+  // fallback root)`. The misconfigured_cwd block (no-config + no-
+  // data) keeps its bigger warning; this fires for the no-config
+  // + has-data case (someone deliberately using cwd as root).
+  const root = mkdtempSync(join(tmpdir(), 'guild-boot-nocfg-'));
+  try {
+    // Plant a member so we're past the misconfigured_cwd trigger.
+    mkdirSync(join(root, 'members'));
+    writeFileSync(
+      join(root, 'members', 'solo.yaml'),
+      'name: solo\ncategory: professional\nactive: true\n',
+    );
+    const { stdout, status } = runGate(
+      root,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: 'solo' },
+    );
+    assert.equal(status, 0);
+    assert.match(
+      stdout,
+      new RegExp(
+        `^content root: ${escapeRegex(root)} \\(config: none — cwd used as fallback root\\)$`,
+        'm',
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('gate boot JSON: cwd_outside_content_root flag distinguishes aligned from subdir', () => {
+  // Orchestrator contract: the disclosure also reaches MCP via a
+  // structured boolean, not just the text rendering. Pin both
+  // truth values so a future refactor can't drop the field.
+  const { root, cleanup } = bootstrap();
+  try {
+    // aligned: cwd === root → false
+    const aligned = JSON.parse(
+      runGate(root, ['boot'], { GUILD_ACTOR: 'alice' }).stdout,
+    );
+    assert.equal(aligned.hints.cwd_outside_content_root, false);
+
+    // subdir: cwd is one level deeper → true
+    const sub = join(root, 'sub');
+    mkdirSync(sub);
+    const subdir = JSON.parse(
+      runGate(sub, ['boot'], { GUILD_ACTOR: 'alice' }).stdout,
+    );
+    assert.equal(subdir.hints.cwd_outside_content_root, true);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: misconfigured_cwd block suppresses content_root disclosure (no double-up)', () => {
+  // When misconfigured_cwd fires (no config + no data), the bigger
+  // warning block already discloses the resolved path. The new
+  // disclosure must NOT also fire — voice budget says one
+  // surface owns the disclosure at a time.
+  const root = mkdtempSync(join(tmpdir(), 'guild-boot-misconf-'));
+  try {
+    const { stdout } = runGate(
+      root,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: '' },
+    );
+    assert.match(stdout, /no guild.config.yaml found/);
+    // The new line must NOT fire alongside the bigger warning.
+    assert.doesNotMatch(stdout, /^content root:/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Sibling to #108. PR #108 closed the silent parent-config-pickup gap on the **write** surface (`gate register`); this closes the same gap on the **read** surface (`gate boot`). Pre-fix, `gate boot --format text` showed neither `config_file` nor `resolved_content_root` (both existed in the JSON envelope but text rendering omitted them), so an agent running boot for orientation got no path signal even when their cwd was a subdir of an active guild silently routing through a parent's `guild.config.yaml`.

```diff
$ cd /foo/sub  # empty subdir of /foo (which has guild.config.yaml)
$ GUILD_ACTOR=alice gate boot --format text
── you are alice (member) ──
+
+content root: /foo (config: /foo/guild.config.yaml)

queues: pending=0 approved=0 ...
```

## Voice-budget conscious — emits ONLY when surprising

Devil concern D1 absorbed via conditional emission. Stays silent at the 99% normal case (cwd === resolved content_root, config discovered):

| State | Trigger | Emits? |
|-------|---------|--------|
| Aligned (`cwd === content_root`, config present) | — | No (silent) |
| Subdir of active guild | `cwd_outside_content_root` | Yes — `content root: /foo (config: /foo/guild.config.yaml)` |
| No-config fallback (cwd used as root, has data) | `config_file === null && !misconfigured_cwd` | Yes — `content root: /tmp/foo (config: none — cwd used as fallback root)` |
| Misconfigured cwd (no-config, no-data) | `misconfigured_cwd === true` | No — bigger warning block already discloses |

Disclosure is surfaced exactly once — the misconfigured_cwd block keeps its existing verbose warning; the new line suppresses when that fires.

## Orchestrator contract

JSON envelope gains `hints.cwd_outside_content_root: boolean`. MCP consumers read the structured field; the text rendering is for humans. Phrasing matches PR #108's `(config: ...)` segment for cross-verb recognition.

## Devil review (design sandbox `2026-05-01-0001`/`0002`)

- **D1** voice budget — gated emission via conditional triggers (above).
- **D2** phrasing parity with #108 — `(config: ...)` segment matches verbatim.
- **D3** JSON unaffected — fields already exist; only adds `cwd_outside_content_root`.
- **D4** JP path — boot has no JP variant (verified). resume.ts is the bilingual surface; not in scope.

## Test plan

- [x] `tests/interface/boot.test.ts` — 5 new tests (aligned-silent / subdir-discloses / no-config-discloses / cwd_outside flag truth values / misconfigured suppresses)
- [x] All 19 boot tests pass
- [x] Full suite: 608/608

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_