### PR TITLE
add: gate tail gains --format json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Added
+- **`gate tail --format json`** closes the asymmetry that left
+  `tail` as the lone read verb without JSON output. Sibling verbs
+  (`voices`, `list`, `board`, `show`, `status`, `whoami`,
+  `inbox`, `issues list`) all support `--format json|text`; tail
+  was bare-text-only. Empty stream emits `[]` (not an error
+  envelope) so `jq` pipelines don't have to branch on "is this
+  an array or an error". Utterance keys are snake_case
+  (`request_id` / `invoked_by` / `completion_note` /
+  `deny_reason` / `failure_reason`) inheriting the post-#109
+  contract — shipping the rename first means tail's JSON debuts
+  in the right shape and never goes through a transient
+  camelCase phase. The `gate schema` entry for tail now
+  advertises both `limit` and `format` flags so MCP wirings
+  discover them. A typo on the format value (`--format josn`)
+  rejects loudly rather than silently degrading. Devil-reviewed
+  in design sandbox (`2026-05-01-0001`).
+
 ### Fixed
 - **`gate boot --format text` surfaces `content root: <path>
   (config: <path>)` when the situation is surprising.** Sibling

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -148,14 +148,15 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
-const TAIL_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
+const TAIL_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit', 'format']);
 
 export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   // Strict-reject unknown flags. `gate tail` has a small surface
-  // (positional N + --limit); typos like `--from noir` would otherwise
-  // be silently ignored and the caller would read "unfiltered" as
-  // "filtered" — exactly the fail-open pattern we want surfaced.
-  // Pilot opt-in: other verbs migrate individually in follow-up PRs.
+  // (positional N + --limit + --format); typos like `--from noir`
+  // would otherwise be silently ignored and the caller would read
+  // "unfiltered" as "filtered" — exactly the fail-open pattern we
+  // want surfaced. Pilot opt-in: other verbs migrate individually
+  // in follow-up PRs.
   rejectUnknownFlags(args, TAIL_KNOWN_FLAGS, 'tail');
 
   let n: number | undefined;
@@ -173,11 +174,26 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   }
   const limit = n ?? 20;
 
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
   const allJson = await loadAllRequestsAsJson(c);
   const utterances = collectUtterances(allJson, {
     limit,
     order: 'desc',
   });
+
+  if (format === 'json') {
+    // Empty list emits `[]` (not an error envelope) so pipeline
+    // consumers can `jq` over the result without branching on
+    // "is this an array or an error?". Same shape as `gate
+    // voices --format json`. Keys are snake_case post-#109
+    // (request_id / invoked_by / completion_note / ...).
+    process.stdout.write(JSON.stringify(utterances, null, 2) + '\n');
+    return 0;
+  }
 
   if (utterances.length === 0) {
     process.stdout.write('(no utterances on this content_root yet)\n');

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -352,7 +352,13 @@ const VERBS: readonly VerbSchema[] = [
     name: 'tail',
     category: 'read',
     summary: 'unified recent-activity stream across all actors',
-    input: { type: 'object' },
+    input: {
+      type: 'object',
+      properties: {
+        limit: { type: 'string', description: 'max utterances (default 20); --limit or positional N' },
+        format: formatField,
+      },
+    },
     output: { type: 'array' },
   },
   {

--- a/tests/interface/tailFormat.test.ts
+++ b/tests/interface/tailFormat.test.ts
@@ -1,0 +1,171 @@
+// gate tail --format json — agent-facing JSON output.
+//
+// Pre-fix, gate tail was the lone read-verb without --format json
+// support. Sibling verbs (voices, list, board, show, status,
+// whoami) all support both formats. After PR #109 unified the
+// utterance JSON shape to snake_case, exposing tail JSON closes
+// the asymmetry without requiring a follow-up rename.
+//
+// These tests pin:
+//   - empty stream emits `[]` (not error envelope) so jq pipelines
+//     don't have to branch
+//   - utterance JSON keys are snake_case (request_id / invoked_by /
+//     completion_note / deny_reason / failure_reason) inheriting
+//     the post-#109 contract
+//   - --format text stays the existing default
+//   - the gate schema entry for tail declares both flags
+//   - typo on --format value rejects loudly (`gate tail --format
+//     josn` should not silently degrade)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-tail-format-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('gate tail --format json: empty stream emits [] (not error envelope)', (t) => {
+  // jq pipelines should not have to branch on "is this an array or
+  // an error". Same boundary `gate voices --format json` honors.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['tail', '--format', 'json']);
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout.trim(), '[]');
+});
+
+test('gate tail --format json: emits utterances with snake_case keys (post-#109)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Plant one fast-tracked request so the stream has something
+  // to render. fast-track produces an `authored` utterance.
+  const ft = runGate(
+    root,
+    [
+      'fast-track',
+      '--from', 'alice',
+      '--action', 'try',
+      '--reason', 'sample',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(ft.status, 0, `fast-track failed: ${ft.stderr}`);
+
+  const r = runGate(root, ['tail', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const arr = JSON.parse(r.stdout);
+  assert.equal(Array.isArray(arr), true);
+  assert.equal(arr.length, 1);
+  const u = arr[0];
+  assert.equal(u.kind, 'authored');
+  // snake_case contract from #109 is preserved through tail.
+  assert.ok('request_id' in u);
+  assert.equal(typeof u.request_id, 'string');
+  assert.ok(!('requestId' in u), 'must not emit camelCase requestId');
+});
+
+test('gate tail (no --format) still defaults to text', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['fast-track', '--from', 'alice', '--action', 'a', '--reason', 'b'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(root, ['tail']);
+  assert.equal(r.status, 0);
+  // Text rendering shape — a header line.
+  assert.match(r.stdout, /most recent utterance\(s\)/);
+});
+
+test('gate tail --format <invalid> rejects', (t) => {
+  // A typo like `--format josn` must not silently degrade to text.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['tail', '--format', 'josn']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
+});
+
+test('gate tail --format json: positional N still controls limit', (t) => {
+  // The positional-N + --limit shape from text mode carries to
+  // JSON unchanged — pin so a future refactor doesn't drop one.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  for (let i = 0; i < 3; i++) {
+    runGate(
+      root,
+      [
+        'fast-track',
+        '--from', 'alice',
+        '--action', `a${i}`,
+        '--reason', 'b',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+  }
+  const r = runGate(root, ['tail', '2', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const arr = JSON.parse(r.stdout);
+  assert.equal(arr.length, 2);
+});
+
+test('gate schema declares tail format flag (orchestrator contract)', (t) => {
+  // MCP wirings consume `gate schema` to discover what flags each
+  // verb accepts. Pre-fix tail's schema entry was bare `input: {}`;
+  // post-fix it advertises both `limit` and `format`.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['schema']);
+  assert.equal(r.status, 0);
+  const schema = JSON.parse(r.stdout);
+  const tail = schema.verbs.find((v: { name: string }) => v.name === 'tail');
+  assert.ok(tail, 'tail must be in schema');
+  assert.ok(tail.input.properties.format, 'tail must advertise --format');
+  assert.ok(tail.input.properties.limit, 'tail must advertise --limit');
+});


### PR DESCRIPTION
## Summary

Closes the asymmetry that left `tail` as the lone read verb without JSON output. Every other read verb (`voices`, `list`, `board`, `show`, `status`, `whoami`, `inbox`, `issues list`) supports `--format json|text`; tail was bare-text-only.

```diff
$ gate tail --format json
- error: gate tail: unknown flag: --format
-   valid flags for 'tail': --limit
+ [
+   {
+     "kind": "authored",
+     "at": "2026-05-01T15:27:03.198Z",
+     "request_id": "2026-05-01-0001",
+     "from": "alice",
+     "action": "try",
+     "reason": "sample"
+   }
+ ]
```

## Boundary calls

- **Empty stream emits `[]`** (not an error envelope) so `jq` pipelines don't have to branch on "is this an array or an error". Same shape as `gate voices --format json`.
- **Utterance keys are snake_case** (`request_id` / `invoked_by` / `completion_note` / `deny_reason` / `failure_reason`) inheriting the post-#109 contract. Shipping #109 first means tail's JSON debuts in the right shape and never goes through a transient camelCase phase (the order constraint named at #4 design time).
- **`gate schema` entry for tail advertises both `limit` and `format`** flags so MCP wirings discover them. Pre-fix the entry was bare `input: {}` — runtime accepted `--limit` but the schema didn't advertise it.
- **Typo rejection**: `--format josn` errors loudly rather than silently degrading to text.

## Devil review (design sandbox `2026-05-01-0001`)

Order constraint: ship #3 (#109) first so tail JSON debuts in snake_case directly. Empty-list `[]` (not error envelope) matches voices / list. Schema entry update is mechanical.

## Test plan

- [x] `tests/interface/tailFormat.test.ts` — 6 new tests
  - Empty stream emits `[]`
  - Populated stream uses snake_case keys
  - `--format text` (default) preserved
  - `--format <invalid>` rejected
  - Positional N + `--format json` interaction
  - `gate schema` advertises `format` + `limit`
- [x] Full suite: 614/614 (was 608)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_