### PR TITLE
add: principle 09 + gate doctor content_root disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 ## [Unreleased]
 
 ### Added
+- **`lore/principles/09-orientation-disclosure.md`.** Names the
+  rule three empirical PRs (#108 register stderr notice, #110
+  boot text disclosure, this PR's doctor disclosure) had been
+  re-deriving instance-by-instance: a verb whose output is a
+  count / finding / status *about* a content_root must let the
+  operator verify the content_root identity in surprising cases,
+  and stay quiet otherwise. The conditional emission is the
+  whole design — voice budget says we don't burn a line on the
+  99% case where cwd === content_root and config sits where
+  expected. Surfaced via the kiri-author / noir-devil / mira-mirror
+  review session in the dogfood sandbox; mira's mirror role
+  (paraphrase + meta-question) flagged that we'd been ad-hoc'ing
+  the same pattern across PRs without naming the rule. Pinning
+  it so the next opt-in (status? board?) doesn't re-litigate.
+
+- **`gate doctor` discloses the resolved content_root + config
+  when surprising.** Carries the principle 09 pattern to doctor.
+  Pre-fix, `gate doctor` reported "members 1 total, 0 malformed"
+  with no signal about WHICH content_root those numbers applied
+  to. An operator running doctor from a subdir of an active
+  guild had no clue the diagnostic walked up to a parent. Post-
+  fix, doctor emits the canonical line shape ONLY when
+  surprising:
+    - Subdir of an active guild → `content root: /abs (config: /abs/guild.config.yaml)`
+    - No-config fallback (cwd as implicit root, has data) →
+      `content root: /abs (config: none — cwd used as fallback root)`
+  Suppressed when `misconfigured_cwd` already fires (no-config +
+  no-data, the bigger warning owns disclosure) so the operator
+  sees exactly one disclosure surface at a time. `--summary`
+  mode also discloses; `--format json` is unaffected (text-only
+  per principle 09 boundary). New shared formatter
+  `formatContentRootDisclosure` in `internal.ts` so a third
+  caller doesn't copy-paste.
+
 - **`gate tail --format json`** closes the asymmetry that left
   `tail` as the lone read verb without JSON output. Sibling verbs
   (`voices`, `list`, `board`, `show`, `status`, `whoami`,

--- a/examples/dogfood-session/members/mira.yaml
+++ b/examples/dogfood-session/members/mira.yaml
@@ -1,0 +1,4 @@
+name: mira
+category: professional
+active: true
+display_name: Mira (Mirror)

--- a/lore/principles/09-orientation-disclosure.md
+++ b/lore/principles/09-orientation-disclosure.md
@@ -1,0 +1,120 @@
+# Orientation disclosure
+
+**A verb that produces a count, finding, or status about a
+content_root must let the operator verify the content_root
+identity in surprising cases — and stay quiet otherwise.**
+
+## Statement
+
+The operator's mental model when reading any output from `gate`
+is: *"this number / this state applies to **which content_root?**"*
+For most invocations the answer is obvious — `cwd === content_root`,
+config sits at `cwd/guild.config.yaml`, the answer is "right
+here." For some invocations the answer is non-obvious — `gate`
+walked up to a parent's `guild.config.yaml` and the operator's
+cwd is a subdir of an active guild, or there was no config at all
+and `cwd` was silently used as the fallback root. In those cases
+the operator's mental model and `gate`'s reality have drifted,
+and any number / finding / state the verb emits is no longer
+trustworthy without verification.
+
+So: every verb whose output is a count, finding, or status
+*about* a content_root has a duty to make the content_root
+identity verifiable when the situation is surprising. Disclosure
+is conditional, not perpetual — voice budget says we don't burn
+a line on the 99% case where the operator is exactly where they
+expect to be.
+
+## What "surprising" means here
+
+The trigger has two cases, both detectable at the verb layer:
+
+1. **`cwd !== resolved_content_root`** — operator ran the verb
+   from a subdirectory; gate walked up to a parent's config.
+   Their writes / reads target the parent.
+2. **`config_file === null` and the content_root has data** —
+   no `guild.config.yaml` was found; cwd was silently used as
+   the implicit content_root. The operator may not realize the
+   fallback default exists.
+
+A bigger warning takes precedence (`misconfigured_cwd`: no config
++ no data) — that case has its own diagnostic block. When the
+bigger warning fires, the disclosure stays silent: **disclosure
+is exactly one surface at a time**.
+
+## Which verbs disclose
+
+A verb owes disclosure when its output is *about* a content_root
+and the operator's mental model is load-bearing for trusting
+that output:
+
+- **`gate boot`** — orientation surface; status counts apply to
+  the content_root the verb just resolved. Discloses (PR #110).
+- **`gate doctor`** — produces findings / area totals about a
+  content_root. Discloses (this principle).
+- **`gate register`** — write surface; the YAML lands somewhere
+  specific. Stderr-discloses on success (PR #108).
+
+A verb does *not* owe disclosure when its output is id-scoped
+and the content_root identity is incidental:
+
+- **`gate show <id>`** — the id IS the resolution; the operator
+  already trusts that the right record came back because they
+  named it.
+- **`gate whoami`** — actor-scoped; the GUILD_ACTOR env is the
+  resolution.
+
+Other verbs (status, board, list, voices, tail, chain, suggest,
+schema) inherit the test case-by-case as the dogfood surfaces
+the gap. The default for new verbs: if the operator's mental
+model could plausibly disagree with the resolved content_root,
+disclose conditionally.
+
+## Phrasing
+
+One canonical line shape, used identically across verbs so the
+operator recognises the orientation cue without re-reading:
+
+```
+content root: <abs> (config: <abs>/guild.config.yaml)
+content root: <abs> (config: none — cwd used as fallback root)
+```
+
+The `(config: ...)` segment matches `gate register`'s success
+notice (PR #108) verbatim. Same shape, same parens, same em-dash.
+
+## Why this is a separate principle
+
+Principle 03 (legibility costs) says the tool labels what's been
+silenced. This principle is a corollary specific to the
+content_root identity question — the identity isn't silenced per
+se, but it's invisible by default at most surfaces, and the
+invisibility becomes a silent failure exactly when the operator
+expects one content_root and gets another.
+
+Principle 02 (advisory not directive) says the tool flags edges
+without forbidding crossings. Disclosure here is advisory in the
+same shape: the verb still runs, still produces output, still
+exits zero — it just adds one line so the operator can check the
+identity if they want.
+
+Principle 08 (voice as doctrine) says the tool's prose carries
+lore. The phrasing convergence — `(config: ...)` reused across
+register / boot / doctor — is the voice substrate that makes the
+rule learnable from the runtime alone.
+
+## What this principle is NOT
+
+- **Not a mandate to disclose everywhere.** Voice budget is real.
+  The conditional emission is the whole design — perpetual
+  disclosure would degrade to noise within a session.
+- **Not a substitute for `gate doctor`.** Doctor is the deep
+  diagnostic; orientation disclosure is one line on a hot
+  surface saying "you're acting on this content_root."
+- **Not part of the JSON contract for every verb.** Where a
+  verb's JSON envelope has natural room for a structured
+  boolean (`gate boot.hints.cwd_outside_content_root` does;
+  `gate doctor` doesn't yet), the boolean joins the contract.
+  Where it doesn't, text-only is acceptable. Asymmetry between
+  text and JSON modes is the lesser evil compared to inflating
+  every JSON envelope.

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -3,7 +3,11 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
-import { C, warnIfMisconfiguredCwd } from './internal.js';
+import {
+  C,
+  formatContentRootDisclosure,
+  warnIfMisconfiguredCwd,
+} from './internal.js';
 import {
   DiagnosticReport,
   DiagnosticAreaSummary,
@@ -55,6 +59,13 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
   }
 
   if (summaryOnly) {
+    const disclosure = formatContentRootDisclosure(
+      c.config,
+      process.cwd(),
+    );
+    if (disclosure !== null && totals > 0) {
+      process.stdout.write(`${disclosure}\n`);
+    }
     writeSummaryLine('members', report.summary.members);
     writeSummaryLine('requests', report.summary.requests);
     writeSummaryLine('issues', report.summary.issues);
@@ -64,6 +75,21 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
 
   // text (default)
   process.stdout.write('gate doctor — content root health\n\n');
+  // Surface the resolved content_root + config when surprising —
+  // same trigger and phrasing as PR #110's boot-text disclosure
+  // and PR #108's register notice. The 99% normal run (cwd ===
+  // content_root, config present) stays quiet. Suppressed when
+  // totals === 0 because the bigger misconfigured-cwd warning
+  // (warnIfMisconfiguredCwd above) already discloses verbosely
+  // in that case — keeps disclosure to exactly one surface at a
+  // time. See lore/principles/09-orientation-disclosure.md.
+  const disclosure = formatContentRootDisclosure(
+    c.config,
+    process.cwd(),
+  );
+  if (disclosure !== null && totals > 0) {
+    process.stdout.write(`${disclosure}\n\n`);
+  }
   writeAreaSection('members', report.summary.members, report.findings);
   writeAreaSection('requests', report.summary.requests, report.findings);
   writeAreaSection('issues', report.summary.issues, report.findings);

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from 'node:path';
 import { buildContainer } from '../../shared/container.js';
 import { optionalOption, ParsedArgs } from '../../shared/parseArgs.js';
 import { RequestJSON } from '../voices.js';
@@ -194,6 +195,43 @@ export function warnIfMisconfiguredCwd(c: C, isEmpty: boolean): void {
       `    that contains guild.config.yaml, or run 'gate register --name <you>'\n` +
       `    here if you really mean to use this directory as the guild root.)\n`,
   );
+}
+
+/**
+ * Formats one orientation line surfacing where the operator's
+ * verb just acted, when the situation is surprising — voice budget
+ * stays clean at the alignment case.
+ *
+ * Returns the line (no trailing newline) when ANY of:
+ *   - cwd is not the resolved content root (subdir of an active guild)
+ *   - no config file was found (cwd silently used as fallback root)
+ * Returns null otherwise.
+ *
+ * The shape:
+ *   `content root: <abs> (config: <abs>/guild.config.yaml)`
+ *   `content root: <abs> (config: none — cwd used as fallback root)`
+ *
+ * Phrasing matches `gate register`'s success notice (PR #108)
+ * `(config: ...)` segment so the operator recognises the
+ * orientation cue across verbs without re-reading.
+ *
+ * Pure formatter — caller decides where the line goes (stderr,
+ * stdout text body, etc.) and whether to additionally guard on
+ * misconfigured-cwd (the bigger warning takes precedence; see
+ * `warnIfMisconfiguredCwd` and lore/principles/09-orientation-
+ * disclosure.md for the rule).
+ */
+export function formatContentRootDisclosure(
+  config: { configFile: string | null; contentRoot: string },
+  cwd: string,
+): string | null {
+  const cwdOutside = resolvePath(cwd) !== resolvePath(config.contentRoot);
+  if (config.configFile !== null && !cwdOutside) return null;
+  const configSegment =
+    config.configFile === null
+      ? 'config: none — cwd used as fallback root'
+      : `config: ${config.configFile}`;
+  return `content root: ${config.contentRoot} (${configSegment})`;
 }
 
 // --- Editor fallback for long-form review comments ---------------------

--- a/tests/interface/doctorContentRoot.test.ts
+++ b/tests/interface/doctorContentRoot.test.ts
@@ -1,0 +1,191 @@
+// gate doctor — content_root orientation disclosure.
+//
+// Carries the same conditional-disclosure pattern PR #108
+// (register stderr notice) and PR #110 (boot text content_root
+// line) introduced. Pre-fix, `gate doctor` reported "members 1
+// total, 0 malformed" without disclosing WHICH content_root
+// produced those numbers — an operator running doctor from a
+// subdir of an active guild had no signal that the diagnostic
+// walked up to a parent guild.
+//
+// Pinned here:
+//   - aligned cwd (cwd === content_root, config present) stays
+//     silent (voice budget)
+//   - subdir of active guild → discloses with parent's config
+//   - misconfigured_cwd (no config + no data) suppresses the
+//     disclosure (the bigger warning owns that surface; one
+//     disclosure surface at a time per
+//     lore/principles/09-orientation-disclosure.md)
+//   - --summary mode also discloses
+//   - --format json is unaffected (text-only disclosure;
+//     JSON contract unchanged on doctor side per the principle)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-doc-cr-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  // One member so totals > 0 — the disclosure suppress-on-empty
+  // boundary stays out of the picture for the basic cases.
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('doctor text: aligned cwd (cwd === content_root) stays silent', (t) => {
+  // The 99% normal case. Pin the absence so a future "always
+  // disclose" refactor can't regress voice budget.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['doctor']);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /^content root:/m);
+});
+
+test('doctor text: subdir of active guild discloses content_root + parent config', (t) => {
+  // The case PR #108 closed on register and PR #110 closed on
+  // boot — doctor inherits the same gap. Now discloses with the
+  // canonical line shape (matches register/boot phrasing
+  // verbatim per principle 09).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const sub = join(root, 'sub');
+  mkdirSync(sub);
+  const r = runGate(sub, ['doctor']);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    new RegExp(
+      `^content root: ${escapeRegex(root)} \\(config: ${escapeRegex(join(root, 'guild.config.yaml'))}\\)$`,
+      'm',
+    ),
+  );
+});
+
+test('doctor text: no-config-found case discloses cwd-as-fallback (totals > 0)', (t) => {
+  // The other half of the disclosure trigger: an operator using
+  // cwd as implicit content_root (no parent config) gets the
+  // `(config: none — cwd used as fallback root)` segment naming
+  // the implicit default.
+  const root = mkdtempSync(join(tmpdir(), 'guild-doc-cr-nocfg-'));
+  try {
+    mkdirSync(join(root, 'members'));
+    writeFileSync(
+      join(root, 'members', 'solo.yaml'),
+      'name: solo\ncategory: professional\nactive: true\n',
+    );
+    const r = runGate(root, ['doctor']);
+    assert.equal(r.status, 0);
+    assert.match(
+      r.stdout,
+      new RegExp(
+        `^content root: ${escapeRegex(root)} \\(config: none — cwd used as fallback root\\)$`,
+        'm',
+      ),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('doctor text: misconfigured_cwd (no config + no data) suppresses content_root disclosure', (t) => {
+  // Principle 09: disclosure is exactly one surface at a time.
+  // The bigger misconfigured-cwd warning takes over when totals
+  // === 0 + config null; the new disclosure must NOT also fire.
+  const root = mkdtempSync(join(tmpdir(), 'guild-doc-cr-misc-'));
+  try {
+    const r = runGate(root, ['doctor']);
+    // The bigger warning fires on stderr.
+    assert.match(r.stderr, /no guild.config.yaml found/);
+    // The new disclosure must NOT fire alongside it.
+    assert.doesNotMatch(r.stdout, /^content root:/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('doctor --summary: subdir case also discloses', (t) => {
+  // The --summary mode is the agent-friendly compact view. The
+  // disclosure applies there too — same trigger, same line.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const sub = join(root, 'sub');
+  mkdirSync(sub);
+  const r = runGate(sub, ['doctor', '--summary']);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    new RegExp(
+      `^content root: ${escapeRegex(root)} \\(config: ${escapeRegex(join(root, 'guild.config.yaml'))}\\)$`,
+      'm',
+    ),
+  );
+});
+
+test('doctor --format json: JSON envelope unaffected by the new disclosure', (t) => {
+  // Principle 09: where a verb's JSON envelope doesn't have
+  // natural room for the structured boolean, text-only is
+  // acceptable. Doctor JSON is `{summary, findings}` — pinning
+  // that no `content_root` / `cwd_outside_content_root` field
+  // sneaks in here means the JSON consumers' contract stays
+  // backwards-compatible. (Future: if a structured field is
+  // wanted, it gets its own PR with a CHANGELOG entry.)
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const sub = join(root, 'sub');
+  mkdirSync(sub);
+  const r = runGate(sub, ['doctor', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  // No content_root field on the JSON side.
+  assert.equal(payload.content_root, undefined);
+  assert.equal(payload.cwd_outside_content_root, undefined);
+  // The JSON shape stays the same as before — summary + findings.
+  assert.ok(payload.summary);
+  assert.ok(Array.isArray(payload.findings));
+});
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Names the rule three PRs had been re-deriving instance-by-instance, and lands the third instance in the same change.

The trigger surfaced when I dogfooded the kiri-author / noir-devil / mira-mirror review session: noir attacked specific failure modes (voice budget creep, DRY-vs-coupling, JSON symmetry); **mira's mirror role flagged the meta-question neither author nor devil named** — "what's the spec for when a verb discloses content_root?" Without a written rule, every PR re-litigates ad-hoc instances.

Pinned as `lore/principles/09-orientation-disclosure.md`:

> A verb that produces a count, finding, or status about a content_root must let the operator verify the content_root identity in surprising cases — and stay quiet otherwise.

## Doctor as the demonstration

```diff
$ cd /foo/sub  # subdir of /foo, which has guild.config.yaml
$ gate doctor
gate doctor — content root health
+
+content root: /foo (config: /foo/guild.config.yaml)
+
✓ members   1 total, 0 malformed
✓ requests  0 total, 0 malformed
✓ issues    0 total, 0 malformed

✓ clean — no malformed records detected
```

- `--summary` mode also discloses (same trigger, same line).
- `--format json` is unaffected — text-only per principle 09 boundary (where a verb's JSON envelope doesn't have natural room, asymmetry is the lesser evil compared to inflating the contract).
- Aligned cwd stays silent (voice budget).
- `misconfigured_cwd` (no config + no data) suppresses the disclosure: one surface at a time.

## Shared formatter

`formatContentRootDisclosure(config, cwd) → string | null` in `internal.ts`. Answers noir-devil's D2 (DRY vs coupling) for the doctor caller. Future opt-ins (status? board?) call the same formatter so the cue stays canonical.

## Why a lore principle, not just a code comment

Principle 03 (legibility costs) names that the tool labels what's been silenced. **The content_root identity isn't silenced per se — it's invisible by default at most surfaces, and the invisibility becomes a silent failure exactly when the operator's mental model and gate's reality have drifted.** That's a distinct enough concern to warrant its own slot in the principle stack, with an explicit "which verbs disclose / which don't" boundary.

## Devil + Mirror review (design sandbox)

- **noir (devil)** — concerned about voice budget creep across verbs, DRY-vs-coupling, JSON contract symmetry.
- **mira (mirror)** — paraphrased both sides, surfaced the unnamed meta-question, recommended pinning the rule alongside the code change rather than separately.

The Mirror role added genuinely different signal from Devil (paraphrase + meta-frame vs. attack); see commit message for details. Two-Persona Devil with three personas worked — `⚠ self-review` warning cleared because author / devil / mirror were three different actors. Closes the limitation called out at the end of the previous session ("Devil の本物の対立構造じゃない、self-review しちゃってる").

## Companion fixture

The first commit (`chore(dogfood): add mira member to dogfood-session fixture`) is what made the three-persona review possible. Bundled here because the persona expansion enabled the design process that produced this PR.

## Test plan

- [x] `tests/interface/doctorContentRoot.test.ts` — 6 new tests (aligned-silent / subdir-discloses / no-config-discloses / misconfigured-suppresses / --summary discloses / --format json unaffected)
- [x] Full suite: 620/620

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_