### PR TITLE
docs: bring lore/README + AGENT + verbs.md current with #108-#114

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -75,7 +75,7 @@ gate review <id> --by <m> --lense <l> --verdict <v> --comment "..."
 ## Reading
 
 ```bash
-gate show <id>                          # request detail (JSON default)
+gate show <id> [--fields k1,k2] [--plain]  # request detail (JSON default; --fields trims, --plain unquotes a single field for shell substitution)
 gate list --state <s> [--for <m>]       # filtered list
 gate pending [--for <m>]                # shortcut for --state pending
 gate board [--for <m>]                  # pending + approved + executing in one view
@@ -204,11 +204,37 @@ CHANGELOG before relying on either behavior.)
 This affects AI agents particularly often: an agent reading
 `.mcp.json` may assume the env works for direct CLI calls, and the
 error message ("no such member") points at the actor name rather
-than the real cause (cwd). `gate boot` surfaces this via
-`hints.misconfigured_cwd: true` (JSON) and a warning block
-(text) — it fires only when no `guild.config.yaml` was found
-AND the fallback content_root is empty, so intentional fresh
-starts are not flagged.
+than the real cause (cwd). Three orientation surfaces flag this,
+each catching a different version of the gap (per
+[`lore/principles/09-orientation-disclosure.md`](./lore/principles/09-orientation-disclosure.md)):
+
+1. **`gate register`** — emits one stderr notice on success naming
+   the absolute path written + config in effect:
+   `notice: wrote /abs/members/<name>.yaml (config: /abs/guild.config.yaml)`.
+   When no config was discovered: `(config: none — cwd used as
+   fallback root)`. The JSON envelope also carries
+   `where_written` and `config_file` fields. Catches the
+   write-side disorientation at the moment the file lands.
+
+2. **`gate boot`** — JSON envelope carries
+   `hints.cwd_outside_content_root: bool` + `hints.config_file: string|null`
+   + `hints.resolved_content_root: string` + `hints.misconfigured_cwd: bool`.
+   Text mode emits a `content root: <abs> (config: <abs>)` line
+   when surprising (cwd != content_root, or no config found with
+   data present). The bigger `misconfigured_cwd` warning
+   (no-config + no-data) takes precedence and emits its own
+   block — only one disclosure surface fires at a time.
+
+3. **`gate doctor`** — text mode also emits the same
+   `content root: <abs> (config: <abs>)` line under the same
+   conditions, so an operator running `doctor` for a health
+   check sees which content_root produced the findings without
+   needing to round-trip through `boot`.
+
+The disclosure stays silent at the alignment case (cwd ===
+content_root, config present at `cwd/guild.config.yaml`) — voice
+budget. Phrasing is identical across the three surfaces so the
+cue carries cross-verb without re-reading.
 
 ## Deep dives
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -817,15 +817,33 @@ Now:
 
 ```
 $ gate register --name claude --category professional
-✓ registered: claude (professional)
+✓ registered: claude [professional]
+  next: export GUILD_ACTOR=claude && gate boot
+notice: wrote /abs/path/members/claude.yaml (config: /abs/path/guild.config.yaml)
 ```
 
 - `--category` defaults to `professional` (aliases: `pro`, `prof`,
   `member`).
 - Re-registering the same name is a no-op error, not a silent
   overwrite.
-- `--dry-run` previews the YAML without writing.
+- `--dry-run` previews the YAML without writing — the preview
+  header now shows the absolute path, and a stderr notice fires
+  with `would write` instead of `wrote` (symmetric with the
+  real-write disclosure).
 - `--category host` is rejected — hosts go in `guild.config.yaml`.
+
+**Path-disclosure notice (post-PR #108).** The stderr `notice:`
+line names where the YAML actually landed, plus which
+`guild.config.yaml` was in effect. When gate walked up to a
+parent's config — or fell back to cwd because no config was
+found — that's where the silent gap used to be. The notice
+makes both cases visible. The JSON envelope (`--format json`)
+carries the same disclosure as structured fields:
+`{where_written: "/abs/path/members/<name>.yaml", config_file:
+"/abs/path/guild.config.yaml" | null}`. See
+[`lore/principles/09-orientation-disclosure.md`](../lore/principles/09-orientation-disclosure.md)
+for the rule the disclosure honours, and `gate boot` /
+`gate doctor` for the read-side counterparts.
 
 **Design note.** Registration must be frictionless so an agent's
 first interaction with a content_root doesn't stall on schema

--- a/lore/README.md
+++ b/lore/README.md
@@ -35,9 +35,17 @@ identified during a v0.3.0 review session (2026-04-28,
 Claude Opus 4.6) — it was already present in the code but
 unnamed. Principle 08 was named during the design pass for the
 voice-budget audit (2026-05-01, nao + Claude Opus 4.7), which
-PR #94's six-point surface set forced into focus. They are not
-timeless truths — they are stances, named, so a future reader can
-engage with them rather than re-derive them.
+PR #94's six-point surface set forced into focus. Principles
+09 and 10 were named in a fresh-agent dogfood session
+(2026-05-01, nao + Claude Opus 4.7) using the **three-voice
+review pattern** (kiri-author / noir-devil / mira-mirror):
+multiple PRs each had been re-deriving the rule without naming
+it (#108/#110 register+boot orientation disclosure → 09;
+#103/#105/#111 schema-vs-runtime drift + ~10 bare output
+schemas → 10). The mira-mirror role surfaced each as a
+meta-question neither author nor devil had named. They are not
+timeless truths — they are stances, named, so a future reader
+can engage with them rather than re-derive them.
 
 ## Reading path
 
@@ -48,11 +56,13 @@ If you have 5 minutes:
 Those two carry the most weight for how agents interact with the
 tool.
 
-If you have 20 minutes, read all eight in order. They compose:
-each builds on the previous. Principle 08 (voice as doctrine) is
-the most recent — read it after the first seven, because it names
-the substrate by which the others reach readers who never open
-this directory.
+If you have 20 minutes, read all ten in order. They compose:
+each builds on the previous. Principles 09 (orientation
+disclosure) and 10 (schema as contract) are the most recent and
+the most agent-first — 10 is structurally the foundation 09 was
+implicitly leaning on (without "schema is contract," 09's
+"missing disclosure was a contract bug" claim doesn't have a
+contract to be a bug *of*). Read them after the first eight.
 
 ## Relationship to `alexandria/`
 


### PR DESCRIPTION
## Summary

Doc maintenance after recent principle adds (09 orientation disclosure, 10 schema as contract) and the disclosure-surface PRs (#108 register notice, #110 boot text, #112 doctor). The README and its linked docs had pockets that predated the new behaviour.

Audited every README-linked doc; three needed updates, three were generic enough to stay current.

## Files updated

### `lore/README.md`

- Origin notes now cover principles 09 and 10, including the **three-voice review pattern** (kiri/noir/mira) that surfaced them and the foundation relationship 10→09.
- Reading-path "all eight" → "all ten"; explicit guidance to read 09+10 last (most agent-first; 10 is structurally the foundation 09 leans on).

### `AGENT.md`

- Troubleshooting section about silent-fall-back-to-cwd was pre-#108/#110/#112; rewritten to name the **three orientation surfaces** (register stderr notice, boot text/JSON disclosure, doctor text disclosure) with links to principle 09.
- `gate show <id>` line now shows the agent-first `--fields` and `--plain` flags (added to schema in #114; were already runtime-accepted but undocumented at this depth).

### `docs/verbs.md`

- Register example output reflects post-#108 reality (snake_case category bracket, "next:" hint, stderr notice line).
- New paragraph on the path-disclosure notice + JSON envelope fields (`where_written`, `config_file`), linking to principle 09 and the read-side counterparts (boot, doctor).

## Files audited but unchanged

- **`README.md`** — generic enough; talks about lore/principles as a directory link, no count claims.
- **`README.ja.md`** — high-level Japanese summary; didn't reach the disclosure-surface depth.
- **`docs/concepts-for-newcomers.md`** — points at `lore/principles/` as a directory; no specific principle count.

## Test plan

No code changes — pure docs. Tests still pass at 626/626.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_