### PR TITLE
docs: name the container/passage architecture; generalize principle 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,32 @@ A worked example content_root with config, members, and a multi-actor
 session lives in [`examples/quick-start/`](./examples/quick-start/);
 a longer real session is in [`examples/dogfood-session/`](./examples/dogfood-session/).
 
-### Two CLIs
+### Architecture: container with one passage
 
-- **`guild`** — member management (the who).
-- **`gate`** — request lifecycle, review, issues, messages (the what).
+`guild` is the **container** — content_root, members, config, the
+YAML substrate records outlive sessions on. `gate` is **one
+passage** through it: the request-lifecycle / review / dialogue
+surface where most agent activity flows.
+
+- **`guild`** (CLI) — operator-facing meta layer for the container:
+  list members, validate the roster, create members from outside
+  any session. Small, stable, script-friendly.
+- **`gate`** (CLI) — agent-facing passage: requests, reviews,
+  issues, messages, doctor / repair, and the schema agents read
+  to dispatch. Larger, evolves faster, the surface most agents
+  live in.
+
+The two CLIs share the same content_root substrate. `gate
+register` and `guild new` write the same `members/<name>.yaml`
+files — two views of the same act (one from inside the passage,
+one from outside the container).
+
+The container has one passage today and is shaped to accept
+others — different shapes of agent interaction on the same
+substrate could land alongside `gate` without absorbing into
+it. Until a second passage is needed, the inside of the container
+looks like one CLI for agents (`gate`) plus a thin operator
+helper (`guild`).
 
 Full surface in [`AGENT.md`](./AGENT.md); per-verb examples in
 [`docs/verbs.md`](./docs/verbs.md).

--- a/lore/principles/10-schema-as-contract.md
+++ b/lore/principles/10-schema-as-contract.md
@@ -1,20 +1,24 @@
 # Schema as contract
 
-**`gate schema` is the agent dispatch contract. The runtime must
-not accept inputs the schema doesn't advertise, and must not emit
+**Any agent-dispatchable tool inside the guild must publish a
+schema that is its dispatch contract. The runtime must not
+accept inputs the schema doesn't advertise, and must not emit
 outputs the schema doesn't describe.**
 
 ## Statement
 
-When an AI agent (or any orchestrator) integrates `gate` via MCP
-or any schema-driven dispatch, it reads `gate schema` to learn
-what verbs exist, what flags each takes, and what shape each
-returns. From that read, it builds a wiring it then trusts at
-runtime. If the schema is incomplete, the agent's wiring is
-either narrower than the runtime (missing flags it could be using)
-or broader than the runtime (advertising features the runtime
-doesn't honour). Both forms are silent failures: the wiring
-"looks right" but produces wrong behaviour at the moment of use.
+`guild` (the project) is a container with one passage today —
+`gate`, the request-lifecycle / review / dialogue surface — and
+is shaped to accept others. Whichever passage an AI agent (or any
+orchestrator) integrates via MCP or schema-driven dispatch, the
+agent reads that passage's `schema` to learn what verbs exist,
+what flags each takes, and what shape each returns. From that
+read, it builds a wiring it then trusts at runtime. If the schema
+is incomplete, the agent's wiring is either narrower than the
+runtime (missing flags it could be using) or broader than the
+runtime (advertising features the runtime doesn't honour). Both
+forms are silent failures: the wiring "looks right" but produces
+wrong behaviour at the moment of use.
 
 So the schema isn't documentation — it's the **contract**. It must
 match the runtime in both directions:
@@ -44,9 +48,12 @@ empirical responses" — and empirical responses are not
 contracts; they're observations of one moment.
 
 Principle 04 (records outlive writers) applies here doubly: the
-schema is part of the public surface that outlives the writer.
-A schema that's incomplete now becomes a load-bearing source of
-ambiguity for every downstream wiring.
+schema is part of the public surface that outlives the writer,
+**and outlives any single passage**. The container holds the
+substrate; passages come and go. A schema that's incomplete now
+becomes a load-bearing source of ambiguity for every downstream
+wiring of *that passage*, and the agent ecosystem grows with the
+container, not with any one tool.
 
 Principle 09 (orientation disclosure) names that verbs disclose
 content_root identity when surprising. **That principle was
@@ -56,16 +63,23 @@ contract bug," only "it was annoying." With it, the asymmetry
 between what `gate boot` claimed (via schema) and what it
 delivered (via the JSON envelope) was the bug.
 
+This principle generalizes naturally: when a second passage
+lands inside the guild, the same contract obligation applies to
+its schema. Operator helpers like `guild` itself (admin / script
+surface, not agent dispatch) are out of scope — the principle
+governs *agent-dispatchable* surfaces.
+
 ## Concrete obligations
 
-A verb's schema entry must satisfy:
+For each verb in any agent-dispatchable passage's schema:
 
 1. **Input completeness.** `Object.keys(input.properties)`
    minus positionals equals the runtime's `KNOWN_FLAGS`. PRs
    that add a flag to `KNOWN_FLAGS` must add the matching
    `input.properties` entry in the same change. PRs that
-   remove a flag must remove both. Mechanical CI test pending
-   (this is a tracked follow-up).
+   remove a flag must remove both. Mechanically enforced by
+   `tests/interface/schemaInputDriftDetector.test.ts` for
+   `gate`; future passages plug in similarly.
 
 2. **Output specificity.** `output` must describe the actual
    shape — not `{ type: 'array' }` or `{ type: 'object' }`
@@ -81,10 +95,9 @@ A verb's schema entry must satisfy:
 4. **Runtime validates against schema.** A test exists that
    takes a real invocation's output and validates it against
    the declared schema. This makes the schema unforgeable at
-   the TS-implementation/schema-declaration boundary: if the
-   runtime emits a shape that doesn't match the schema, EITHER
-   the runtime regressed OR the schema is wrong; either way,
-   CI catches it.
+   the implementation/declaration boundary: if the runtime emits
+   a shape that doesn't match the schema, EITHER the runtime
+   regressed OR the schema is wrong; either way, CI catches it.
 
 ## What this principle is NOT
 
@@ -106,20 +119,33 @@ A verb's schema entry must satisfy:
 
 ## Tracked follow-ups
 
-When this principle was named, the codebase had:
+When this principle was named, the codebase had ~10 read verbs
+with bare output schemas (`{ type: 'array' }`, `{ type: 'object'
+}`) and no mechanical drift detector for the input side.
 
-- ~10 read verbs with bare output schemas (`{ type: 'array' }`,
-  `{ type: 'object' }`). This PR fleshes 2 (`tail`, `voices`)
-  using a shared `utteranceArraySchema`. The remaining 8
-  (`status`, `whoami`, `show`, `chain`, `list`, `pending`,
-  `repair`, `issues *`) are mechanical and queued as follow-up
-  PRs.
-- No mechanical drift detector for the input side. PRs #103
-  (`--dry-run`), #105 (`--with-calibration`), #111 (`tail
-  --format`) all hit the same drift after-the-fact. Adding a
-  CI-level test that compares each handler's `KNOWN_FLAGS`
-  against its schema entry is the natural enforcement vehicle;
-  queued as the next follow-up.
+- **Input-side drift detector (#114) — done.** Mechanical CI
+  test compares each handler's `KNOWN_FLAGS` against its schema
+  entry; surfaces 8 existing drift instances on first run. PRs
+  that add a flag to KNOWN_FLAGS without the matching
+  `schema.input.properties` entry now fail at CI.
+
+- **Output-side fleshing — partial.** PR #113 fleshes `tail` and
+  `voices` via a shared `utteranceArraySchema`. Remaining bare-
+  output read verbs (`status`, `whoami`, `show`, `chain`, `list`,
+  `pending`, `repair`, `issues *`) are mechanical and queued.
+  Done in clusters where multiple verbs share a shape:
+  `show`/`list`/`pending` share the `Request` shape;
+  `status`/`board` share the `StatusSummary` shape.
+
+- **Second-passage application — anticipatory.** When a second
+  agent-dispatchable passage lands inside the guild alongside
+  `gate`, this principle applies to its schema too. The drift
+  detector and runtime-validates-schema tests generalize
+  cleanly — the test infrastructure walks "every verb the
+  passage advertises in its schema" rather than gate-specific
+  paths, so plugging in is mostly a configuration change. Until
+  that day, the principle's gate-specific instances are the
+  reference implementation.
 
 The deferred list is the work-queue, not a rot risk: once the
 principle is named, every bare schema is a known violation, and


### PR DESCRIPTION
## Summary

The README's "Two CLIs" framing read `guild` and `gate` as siblings. The actual architecture — and the one we want to preserve — is **container and passage**:

```
guild  ← the container (content_root, members, config, YAML substrate)
└── gate            ← one passage (request-lifecycle / review / dialogue)
└── …               ← shaped to accept additional passages alongside gate
```

The container holds the durable substrate (YAML records, lore principles); passages are specific shapes of agent interaction within it. There is one passage today (`gate`) and the architecture is shaped to accept others without absorbing them into `gate`.

This isn't a promise of future work; it's a stance about **where** any expansion goes (alongside gate, inside guild) rather than **what** it would be.

## What changes

### `README.md` — "Two CLIs" → "Architecture: container with one passage"

Names the container/passage distinction. Frames the `gate register` / `guild new` overlap as "two views of the same act" (one from inside the passage, one from outside the container). Leaves explicit space for future passages without naming them.

### `lore/principles/10-schema-as-contract.md` — generalized

Language sharpened from "**`gate schema`** is the contract" to "**any agent-dispatchable passage's schema** is the contract."

- Headline statement: gate-specific → tool-general
- "Why this is a separate principle": new paragraph noting the principle generalizes to additional passages and that operator helpers like `guild` itself (admin / script, not agent dispatch) are out of scope
- "Concrete obligations": framed as "any agent-dispatchable passage" with gate's tests cited as the reference implementation
- "Tracked follow-ups": #114 input-drift detector marked done (it landed); adds an "anticipatory" note that the test infrastructure generalizes cleanly when a second passage arrives

## Why not number this as a new principle (11)?

Naming "container with one passage" as its own numbered principle would be premature — only one passage exists, so the pattern hasn't repeated. The recipe used for principles 09 and 10 was to wait until the structure surfaced in multiple instances before pinning it. That discipline applies here too.

So this PR sharpens **principle 10** (which already governs schema contracts) to read as tool-general rather than gate-specific, and uses the README to express the architectural stance prose-first. If a second passage lands later, that's the moment to consider promoting "container/passage" to a numbered principle.

## Test plan

No code changes. Tests still pass at 626/626.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_