### PR TITLE
fix(agora): stale reason prose + drop suggested_next.args.by bias (#121, #122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+### Fixed
+- **agora `suggested_next.reason` no longer carries stale "(when
+  implemented)" / "(... lands in subsequent commits)" prose.**
+  ([#121](https://github.com/eris-ths/guild-cli/issues/121))
+  agora landed one verb per commit, and each commit's reason
+  string was written when the next verb was genuinely future.
+  Subsequent commits made those verbs real but didn't rewrite
+  the older reason strings. Post-fix, `agora new` and `agora
+  move` reason text reads as post-implementation. Regression
+  test in `tests/passages/agora/suggestedNextContract.test.ts`
+  scans every agora verb's `suggested_next.reason` for known
+  stale phrases — guards against drift returning.
+
+  Surfaced by another Claude instance playing agora interactively
+  with nao (see [#117](https://github.com/eris-ths/guild-cli/issues/117)).
+  Principle 09 (orientation disclosure) adjacent — surface
+  drifted from substrate.
+
+### Changed
+- **agora `suggested_next.args.by` is no longer pre-filled with
+  the just-acted actor.**
+  ([#122](https://github.com/eris-ths/guild-cli/issues/122))
+  Pre-fix, `agora play / move / suspend / resume` all set
+  `suggested_next.args.by` to the calling actor, implicitly
+  recommending **same-actor continuation**. For Sandbox plays
+  with multi-actor alternation (e.g., AI agent + human, or two
+  AI personas), this biased the orchestrator toward "same
+  person continues" — counter to the rhythm those plays take.
+
+  Post-fix, `args.by` is omitted from all four. `args` carries
+  only the load-bearing field (`play_id`); the orchestrator (or
+  human + AI pair) decides who acts next per their own
+  alternation model. Per principle 11 (AI-first, human as
+  projection): agora's substrate doesn't carry policy about
+  who runs verbs.
+
+  Behavior change for any orchestrator that read `args.by`
+  without questioning. The verb name (`suggested_next.verb`)
+  and `args.play_id` are unchanged and remain the load-bearing
+  recommendation.
+
+  Regression test pins the absence of `by` for play / move /
+  suspend / resume going forward.
+
 ### Added
 - **`agora` — second passage under guild (alpha).** A play / narrative
   surface alongside `gate`'s request-lifecycle / review surface.

--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -94,10 +94,13 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
           where_written,
           config_file: deps.config.configFile,
           suggested_next: {
+            // args.by intentionally omitted (issue #122) — see play.ts
+            // for the rationale. Multi-actor Sandbox plays alternate;
+            // agora doesn't bias toward same-actor continuation.
             verb: 'move',
-            args: { play_id: play.id, by },
+            args: { play_id: play.id },
             reason:
-              'Move appended. Continue with another `agora move`, leave a cliff with `agora suspend`, or close the session with `agora conclude` (suspend / resume / conclude land in subsequent commits).',
+              'Move appended. Continue with another `agora move`, leave a cliff with `agora suspend`, or close the session with `agora conclude`.',
           },
         },
         null,

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -98,7 +98,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
             verb: 'list',
             args: {},
             reason:
-              'New game definition saved. `agora list` shows every game and play in the content root; `agora play --slug <slug>` (when implemented) starts a session against this definition.',
+              'New game definition saved. `agora list` shows every game and play in the content root; `agora play --slug <slug>` starts a session against this definition.',
           },
         },
         null,

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -88,10 +88,14 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
           where_written,
           config_file: deps.config.configFile,
           suggested_next: {
+            // args.by intentionally omitted (issue #122) — agora doesn't
+            // recommend who acts next; the orchestrator (or human + AI
+            // pair) decides per their alternation model. Sandbox plays
+            // shouldn't be biased toward same-actor continuation.
             verb: 'move',
-            args: { play_id: play.id, by },
+            args: { play_id: play.id },
             reason:
-              'Play started — append a move to advance, or `agora suspend` to leave a cliff for the next session. (move/suspend/resume verbs land in subsequent commits.)',
+              'Play started. Append a move to advance, leave a cliff with `agora suspend`, or close with `agora conclude`.',
           },
         },
         null,

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -107,8 +107,10 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
           where_written,
           config_file: deps.config.configFile,
           suggested_next: {
+            // args.by intentionally omitted (issue #122) — see play.ts
+            // for the rationale.
             verb: 'move',
-            args: { play_id: play.id, by },
+            args: { play_id: play.id },
             reason:
               'Play resumed. The cliff/invitation that paused you is in `resumed_suspension`; address it with the next move (or suspend again if the answer surfaces another cliff).',
           },

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -107,8 +107,12 @@ export async function suspendPlay(
           where_written,
           config_file: deps.config.configFile,
           suggested_next: {
+            // args.by intentionally omitted (issue #122) — the next
+            // resumer is often a different actor (and frequently a
+            // different session of the same actor). agora doesn't
+            // pre-fill the recommendation.
             verb: 'resume',
-            args: { play_id: play.id, by },
+            args: { play_id: play.id },
             reason:
               'Play suspended. The cliff and invitation are recorded; the next instance reading this play sees the suspension and acts on the invitation. To pick up: agora resume <play-id>.',
           },

--- a/tests/passages/agora/suggestedNextContract.test.ts
+++ b/tests/passages/agora/suggestedNextContract.test.ts
@@ -1,0 +1,269 @@
+// agora suggested_next contract regression tests.
+//
+// Issues #121 and #122 from the play-report by another Claude
+// instance. This test pins the post-fix contract so the same
+// drift can't reappear silently.
+//
+// (#121) suggested_next.reason text drift:
+//   - Pre-fix, agora new and agora move had reason strings
+//     written during incremental commit sequence ("(when
+//     implemented)", "(... lands in subsequent commits)") that
+//     remained when subsequent verbs landed. surface drifted
+//     from substrate.
+//   - Post-fix, no agora verb's suggested_next.reason mentions
+//     unimplemented future state. This test scans every verb's
+//     JSON output for known-stale phrases.
+//
+// (#122) suggested_next.args.by alternation bias:
+//   - Pre-fix, agora play/move/suspend/resume all set
+//     suggested_next.args.by to the just-acted actor, implicitly
+//     recommending same-actor continuation.
+//   - Post-fix, args.by is omitted — the orchestrator (or
+//     human + AI pair) decides who acts next. agora doesn't
+//     carry policy about actor continuation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AGORA = resolve(here, '../../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'agora-suggested-next-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runAgora(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [AGORA, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// ---- (#121) reason drift detector ----
+
+const STALE_PHRASES: ReadonlyArray<{ phrase: RegExp; description: string }> = [
+  { phrase: /\(when implemented\)/, description: '"(when implemented)" — verb is now implemented' },
+  { phrase: /lands? in subsequent commits?/i, description: '"lands in subsequent commits" — those commits are merged' },
+  { phrase: /\(when [a-z\s]+ lands?\)/, description: '"(when X lands)" parenthetical — X has landed' },
+  { phrase: /will be implemented/i, description: '"will be implemented" — verb already exists' },
+];
+
+function assertNoStaleReason(payload: { suggested_next?: { reason?: unknown } | null }): void {
+  if (!payload.suggested_next) return; // null is valid (terminal verbs)
+  const reason = payload.suggested_next.reason;
+  if (typeof reason !== 'string') return;
+  for (const { phrase, description } of STALE_PHRASES) {
+    assert.doesNotMatch(
+      reason,
+      phrase,
+      `suggested_next.reason contains stale phrase: ${description}\n  reason was: ${reason}`,
+    );
+  }
+}
+
+test('agora new: suggested_next.reason has no stale "(when implemented)" prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleReason(JSON.parse(r.stdout));
+});
+
+test('agora play: suggested_next.reason has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runAgora(
+    root,
+    ['play', '--slug', 'g', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleReason(JSON.parse(r.stdout));
+});
+
+test('agora move: suggested_next.reason has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+  const r = runAgora(
+    root,
+    ['move', playId, '--text', 't', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleReason(JSON.parse(r.stdout));
+});
+
+test('agora suspend / resume: suggested_next.reason has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+
+  const susp = runAgora(
+    root,
+    ['suspend', playId, '--cliff', 'c', '--invitation', 'i', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(susp.status, 0);
+  assertNoStaleReason(JSON.parse(susp.stdout));
+
+  const res = runAgora(
+    root,
+    ['resume', playId, '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(res.status, 0);
+  assertNoStaleReason(JSON.parse(res.stdout));
+});
+
+// ---- (#122) suggested_next.args.by absence ----
+
+test('agora play: suggested_next.args does NOT carry by (alternation-neutral)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runAgora(
+    root,
+    ['play', '--slug', 'g', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  // play_id is essential context; by is policy and intentionally absent.
+  assert.equal(typeof payload.suggested_next.args.play_id, 'string');
+  assert.equal(payload.suggested_next.args.by, undefined,
+    'args.by must be absent — agora does not bias same-actor continuation (issue #122)');
+});
+
+test('agora move: suggested_next.args does NOT carry by', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+  const r = runAgora(
+    root,
+    ['move', playId, '--text', 't', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.suggested_next.args.by, undefined);
+});
+
+test('agora suspend / resume: suggested_next.args does NOT carry by', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+
+  const susp = JSON.parse(
+    runAgora(
+      root,
+      ['suspend', playId, '--cliff', 'c', '--invitation', 'i', '--format', 'json'],
+      { GUILD_ACTOR: 'alice' },
+    ).stdout,
+  );
+  assert.equal(susp.suggested_next.args.by, undefined);
+
+  const res = JSON.parse(
+    runAgora(
+      root,
+      ['resume', playId, '--format', 'json'],
+      { GUILD_ACTOR: 'alice' },
+    ).stdout,
+  );
+  assert.equal(res.suggested_next.args.by, undefined);
+});
+
+test('agora new: suggested_next.args is empty (no policy, no recommendations)', (t) => {
+  // For new, there's no play_id yet to recommend. args is just {}.
+  // Pin to confirm we don't accidentally start adding args here either.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.suggested_next.args, {});
+});


### PR DESCRIPTION
## Summary

Closes [#121](https://github.com/eris-ths/guild-cli/issues/121) and [#122](https://github.com/eris-ths/guild-cli/issues/122) — both surfaced by another Claude instance's interactive Sandbox play with nao after agora landed in main (#119).

## #121 — stale "(when implemented)" prose

agora landed one verb per commit. Each commit's `suggested_next.reason` was written when the next verb was genuinely future. Subsequent commits made those verbs real but didn't rewrite the older reason strings.

```diff
// agora new's suggested_next.reason
-"...`agora play --slug <slug>` (when implemented) starts a session..."
+"...`agora play --slug <slug>` starts a session..."

// agora move's suggested_next.reason
-"...close with `agora conclude` (suspend / resume / conclude land in subsequent commits)."
+"...close the session with `agora conclude`."
```

An MCP wiring reading the JSON envelope and parsing reason text could (incorrectly) decide the suggested verb isn't dispatchable. **Surface drifted from substrate** (principle 09 adjacent).

## #122 — `suggested_next.args.by` biased same-actor continuation

```diff
// agora play / move / suspend / resume — args.by removed
 suggested_next: {
   verb: 'move',
-  args: { play_id: play.id, by },
+  args: { play_id: play.id },
   reason: '...',
 }
```

For **Sandbox plays with multi-actor alternation** (the play-report's actual use case: another Claude + nao taking turns), pre-fix `args.by` recommended same-actor continuation — biased the orchestrator against alternation.

Per **principle 11** (AI-first, human as projection): agora's substrate doesn't carry policy about who runs verbs. The orchestrator (or human + AI pair) decides per their alternation model. `args.play_id` is the load-bearing field; `args.by` was always redundant (the caller knows their own actor).

Behavior change for any orchestrator that read `args.by` without questioning. The verb name (`suggested_next.verb`) and `args.play_id` are unchanged.

## Tests

`tests/passages/agora/suggestedNextContract.test.ts` — **8 new regression tests**:

**Stale-prose detector** (4 tests): scans every agora verb's `suggested_next.reason` for known stale phrases (`when implemented`, `lands in subsequent commits`, `(when X lands)`, `will be implemented`). Guards against the same drift returning silently.

**args.by absence** (4 tests): pins that play / move / suspend / resume's `suggested_next.args.by` is `undefined` post-fix. Future refactors that re-introduce the field fail loud here.

## Test plan

- [x] Stale-prose detector passes for all 4 reason-emitting verbs
- [x] args.by absence asserted for play / move / suspend / resume
- [x] new's args is empty `{}` (no policy creep there either)
- [x] Existing 688 tests still pass — full suite: 696/696

## Credit

Surfaced by another Claude instance with read-only access, via play-report on [issue #117](https://github.com/eris-ths/guild-cli/issues/117). Filed by Claude Opus 4.7 (designer) on their behalf.

The third issue from the play-report ([#120](https://github.com/eris-ths/guild-cli/issues/120) — gate `issues add` input asymmetry) is gate-side and lands in a separate PR. The fourth ([#123](https://github.com/eris-ths/guild-cli/issues/123) — cross-passage voice) is architectural / tracking and stays open.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_