### PR TITLE
fix(agora): clear stale "(when X lands)" prose from text-mode `next:` hints

### DIFF
--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -111,7 +111,7 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
     process.stdout.write(
       `✓ move ${move.id} appended to ${play.id} on game=${play.game} by ${by}\n` +
         `  next: agora move ${play.id} --by ${by} "<text>"  (continue)\n` +
-        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (when suspend lands)\n`,
+        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (leave a cliff)\n`,
     );
   }
   return 0;

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -108,7 +108,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   } else {
     process.stdout.write(
       `✓ created game: ${game.slug} [${game.kind}] — ${game.title}\n` +
-        `  next: agora list  (or agora play --slug ${game.slug} when play lands)\n`,
+        `  next: agora list  (or agora play --slug ${game.slug} to start a session)\n`,
     );
   }
   // Stderr notice mirrors gate register's path-disclosure line shape

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -105,8 +105,8 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
   } else {
     process.stdout.write(
       `✓ play started: ${play.id} [${play.state}] on game=${play.game}\n` +
-        `  next: agora move ${play.id} --by ${by} "<text>"  (when move lands)\n` +
-        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (when suspend lands)\n`,
+        `  next: agora move ${play.id} --by ${by} "<text>"\n` +
+        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (leave a cliff)\n`,
     );
   }
   const configSegment =

--- a/tests/passages/agora/suggestedNextContract.test.ts
+++ b/tests/passages/agora/suggestedNextContract.test.ts
@@ -76,7 +76,11 @@ function runAgora(
 const STALE_PHRASES: ReadonlyArray<{ phrase: RegExp; description: string }> = [
   { phrase: /\(when implemented\)/, description: '"(when implemented)" — verb is now implemented' },
   { phrase: /lands? in subsequent commits?/i, description: '"lands in subsequent commits" — those commits are merged' },
-  { phrase: /\(when [a-z\s]+ lands?\)/, description: '"(when X lands)" parenthetical — X has landed' },
+  // Matches "when X lands" anywhere — not just `(when X lands)` —
+  // because the drift can sit inside a longer parenthetical
+  // (`(or agora play --slug X when play lands)`) where "(when"
+  // never appears as a literal opener.
+  { phrase: /\bwhen [a-z][a-z\s]* lands?\b/i, description: '"when X lands" prose — X has landed' },
   { phrase: /will be implemented/i, description: '"will be implemented" — verb already exists' },
 ];
 
@@ -89,6 +93,23 @@ function assertNoStaleReason(payload: { suggested_next?: { reason?: unknown } | 
       reason,
       phrase,
       `suggested_next.reason contains stale phrase: ${description}\n  reason was: ${reason}`,
+    );
+  }
+}
+
+// Text-mode (`next:` hint) shares the same drift vocabulary as the
+// JSON `suggested_next.reason`, but lives in a separate code path
+// in each handler. The original #121 fix targeted the JSON side
+// only; surfaced during a dogfood play that "(when play lands)"
+// was still on screen after play had landed. Per principle 11
+// (AI-first, human as projection), substrate (JSON) and projection
+// (text) can diverge silently — pin both.
+function assertNoStaleText(stdout: string): void {
+  for (const { phrase, description } of STALE_PHRASES) {
+    assert.doesNotMatch(
+      stdout,
+      phrase,
+      `text-mode stdout contains stale phrase: ${description}\n  stdout was: ${stdout}`,
     );
   }
 }
@@ -173,6 +194,90 @@ test('agora suspend / resume: suggested_next.reason has no stale prose', (t) => 
   );
   assert.equal(res.status, 0);
   assertNoStaleReason(JSON.parse(res.stdout));
+});
+
+// ---- (#121, follow-up) text-mode `next:` hint drift detector ----
+
+test('agora new (text): `next:` hint has no stale "(when X lands)" prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleText(r.stdout);
+});
+
+test('agora play (text): `next:` hint has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runAgora(
+    root,
+    ['play', '--slug', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleText(r.stdout);
+});
+
+test('agora move (text): `next:` hint has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+  const r = runAgora(
+    root,
+    ['move', playId, '--text', 't'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assertNoStaleText(r.stdout);
+});
+
+test('agora suspend / resume (text): `next:` hint has no stale prose', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const playId = JSON.parse(
+    runAgora(root, ['play', '--slug', 'g', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  ).play_id;
+
+  const susp = runAgora(
+    root,
+    ['suspend', playId, '--cliff', 'c', '--invitation', 'i'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(susp.status, 0);
+  assertNoStaleText(susp.stdout);
+
+  const res = runAgora(
+    root,
+    ['resume', playId],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(res.status, 0);
+  assertNoStaleText(res.stdout);
 });
 
 // ---- (#122) suggested_next.args.by absence ----


### PR DESCRIPTION
## Summary

- #124 fixed `suggested_next.reason` (JSON envelope) but missed the text-mode `next:` hint — a separate code path with the same drift risk. Surfaced during a dogfood play of agora: "(when play lands)" was still on screen after `agora play` had landed.
- Per principle 11 (AI-first, human as projection), substrate (JSON) and projection (text) can diverge silently. The regression test now scans both surfaces with the same `STALE_PHRASES` vocabulary.
- The detector regex is broadened to match "when X lands" anywhere — not just `(when X lands)` literals — because the drift can sit inside a longer parenthetical (`(or agora play --slug X when play lands)`) where "(when" never appears as the opener.

## Changes

- `src/passages/agora/interface/handlers/new.ts`: `(when play lands)` → `to start a session`
- `src/passages/agora/interface/handlers/play.ts`: `(when move lands)` removed; `(when suspend lands)` → `(leave a cliff)`
- `src/passages/agora/interface/handlers/move.ts`: `(when suspend lands)` → `(leave a cliff)`
- `tests/passages/agora/suggestedNextContract.test.ts`: 4 new text-mode parallel cases (new / play / move / suspend+resume), broadened `STALE_PHRASES` regex

## Test plan

- [x] `npm test` passes (700/700)
- [x] Verified the test catches the regression by stash-reverting `new.ts` fix — test 5 fails as expected
- [x] Manual dogfood: `agora new` / `play` / `move` / `suspend` / `resume` / `conclude` text output reads clean

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_