### PR TITLE
docs: post-merge cleanup — devil-review is alpha, all 11 verbs landed

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -164,7 +164,7 @@ on suspend, surfaced in resume's success output) is the
 the substrate, not the agent's psychology. Per principle 11
 (AI-first, human as projection).
 
-## devil-review (third passage — security backstop, snapshot)
+## devil-review (third passage — security backstop, alpha)
 
 `devil` is the third passage under guild — alongside `gate` and
 `agora`. Where gate carries decisions and agora carries narrative,
@@ -197,14 +197,12 @@ devil entry <rev-id> --persona <p> --lense <l> --kind <k> --text "<prose>"
 devil list [--state <open|concluded>] [--target-type <pr|file|function|commit>]
 devil show <rev-id>
 devil conclude <rev-id> --synthesis "<prose>" [--unresolved e-001,e-002,...] [--by <m>]
+devil dismiss <rev-id> <entry-id> --reason <r> [--note "..."] [--by <m>]
+devil resolve <rev-id> <entry-id> [--commit <sha>] [--by <m>]
+devil suspend <rev-id> --cliff "..." --invitation "..." [--by <m>]
+devil resume  <rev-id>  [--note "..."] [--by <m>]
+devil ingest  <rev-id>  --from <ultrareview|claude-security|scg> <input-path> [--by <m>]
 devil schema [--verb <name>]                            # principle 10 contract
-
-# Landing in subsequent commits per #126:
-# devil dismiss <entry-id> --reason <r> [--note "..."]
-# devil resolve <entry-id> [--commit <sha>]
-# devil suspend <rev-id> --cliff "..." --invitation "..."
-# devil resume  <rev-id>  [--note "..."]
-# devil ingest  <rev-id>  --from <ultrareview|claude-security|scg> <input>
 ```
 
 devil records live under `<content_root>/devil/`:
@@ -262,9 +260,13 @@ Conclusion is verdict-less: `--synthesis` prose is required, and
 or-resolve before closing. Substrate-explicit "these threads stay
 open."
 
-Status: snapshot. CLI has six verbs (open / entry / list / show /
-conclude / schema). dismiss / resolve / suspend / resume / ingest
-land in subsequent commits before the merge to main.
+Status: alpha. v1 surface complete — all 11 verbs from #126 are
+invokable (open / entry / list / show / dismiss / resolve / suspend
+/ resume / ingest / conclude / schema). Real-world adapter shims
+that translate actual `/ultrareview` `bugs.json` / Claude Security
+findings / SCG verdict output into devil's strict v0 ingest JSON
+shapes are out of scope for the in-tree passage and would land as
+separate utilities (or in the source tools themselves).
 
 ## Diagnostic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,51 +9,67 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ### Added
 
-- **`devil` — third passage under guild (snapshot, security
-  backstop).** A multi-persona, lense-enforced review surface
-  that **composes with single-pass tools** (Anthropic
-  `/ultrareview`, Claude Security, supply-chain-guard) rather
-  than replacing them. Designed to **raise the security
-  knowledge floor** for code reviewed by authors who haven't
-  met OWASP top 10 — not to guarantee protection, but to keep
-  the dialogue honest when a finding is dismissed.
+- **`devil` — third passage under guild (alpha, security
+  backstop).** ([#127](https://github.com/eris-ths/guild-cli/pull/127))
+  A multi-persona, lense-enforced review surface that
+  **composes with single-pass tools** (Anthropic `/ultrareview`,
+  Claude Security, supply-chain-guard) rather than replacing
+  them. Designed to **raise the security knowledge floor** for
+  code reviewed by authors who haven't met OWASP top 10 — not
+  to guarantee protection, but to keep the dialogue honest when
+  a finding is dismissed.
 
-  Verbs (6 + schema in this snapshot; remaining 5 verbs land
-  before the merge to main):
+  Complete v1 surface from #126: 11 verbs.
 
-  - `devil open` — start a review session against a target
-    (`--type pr|file|function|commit`)
-  - `devil entry` — append a hand-rolled entry. Per-kind
-    validation: `kind=finding` requires `--severity` AND
-    `--severity-rationale` (the friction that forces
+  - `devil open <ref> --type <pr|file|function|commit>` —
+    start a review session against a target.
+  - `devil entry <rev-id>` — append a hand-rolled entry.
+    Per-kind validation: `kind=finding` requires `--severity`
+    AND `--severity-rationale` (the friction that forces
     exploitability-context reasoning, Claude Security style);
-    `kind=gate` is reserved for `devil ingest`
+    `kind=gate` is reserved for `devil ingest`.
   - `devil list` — enumerate reviews (filter by `--state` and
-    `--target-type`)
+    `--target-type`).
   - `devil show <rev-id>` — full detail (entries / suspensions
     / resumes / conclusion); JSON form is `review.toJSON()`,
-    same shape as the on-disk YAML
-  - `devil conclude <rev-id>` — terminal state transition.
-    `--synthesis` prose required (verdict-less close), optional
-    `--unresolved e-001,e-002,...` lists entry ids deliberately
-    left open
-  - `devil schema` — principle 10 dispatch contract (grows
-    commit-by-commit as verbs land)
-
-  Landing in subsequent commits before merge:
-  - `devil dismiss <entry-id>` / `devil resolve <entry-id>` —
-    finding status transitions
-  - `devil suspend` / `devil resume` — cliff/invitation cycle
-    borrowed from agora (softer semantics: does NOT block other
-    entries)
-  - `devil ingest --from <ultrareview|claude-security|scg>` —
-    automated source adapters
+    same shape as the on-disk YAML.
+  - `devil dismiss <rev-id> <entry-id> --reason <r>
+    [--note "..."]` — mark a finding-entry dismissed with a
+    structured reason (one of: `not-applicable | accepted-risk
+    | false-positive | out-of-scope | mitigated-elsewhere`).
+    Refuses re-dismiss and refuses dismiss-after-conclude.
+  - `devil resolve <rev-id> <entry-id> [--commit <sha>]` —
+    mark a finding-entry resolved, optionally citing the commit
+    that landed the fix (`resolved_by_commit` becomes part of
+    the substrate).
+  - `devil suspend <rev-id> --cliff "..." --invitation "..."` —
+    record a cliff/invitation pause on a thread of the review.
+    Softer than agora's suspend: does NOT block other entries;
+    just records re-entry context.
+  - `devil resume <rev-id> [--note "..."]` — pick up the most
+    recent un-paired suspension. Surfaces the closing
+    cliff/invitation in the response.
+  - `devil ingest <rev-id> --from <ultrareview|claude-security|scg> <input>` —
+    append entries from an automated source's output. Strict
+    v0 input JSON shapes per source; logs each invocation to
+    `re_run_history`. SCG ingest produces one `kind=gate`
+    entry on the `supply-chain` lense; ultrareview /
+    claude-security produce N `kind=finding` entries.
+  - `devil conclude <rev-id> --synthesis "<prose>"
+    [--unresolved e-001,e-002,...]` — terminal state
+    transition. Verdict-less close (no `ok|concern|reject`);
+    synthesis prose is required. Lense-coverage gate: every
+    lense in the catalog needs at least one entry (a
+    `kind: skip` entry counts when its text declares why) —
+    silent skipping defeats the floor-raising design.
+  - `devil schema [--verb <name>]` — principle 10 dispatch
+    contract for the passage.
 
   Substrate path: `<content_root>/devil/reviews/<rev-id>.yaml`
   (rev-id format: `rev-YYYY-MM-DD-NNN`, sequence per
   content_root per day).
 
-  v0 lense catalog (11): `injection`, `injection-parser`,
+  v1 lense catalog (11): `injection`, `injection-parser`,
   `path-network`, `auth-access`, `memory-safety`, `crypto`,
   `deserialization`, `protocol-encoding` (Claude Security's 8
   categories) plus `composition`, `temporal`, `supply-chain`
@@ -63,12 +79,14 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   raising design refuses silent skip on supply chain per #126
   decision C).
 
-  v0 persona catalog (3 hand-rolled): `red-team` (adversarial
-  framing strict), `author-defender` (articulate the author's
-  framing + assumptions), `mirror` (read both, surface
-  contradictions and shared blind spots). Ingest-only personas
-  (`ultrareview-fleet`, `claude-security`, `scg-supply-chain-gate`)
-  join the catalog with their matching ingest verbs.
+  v1 persona catalog (6): three hand-rolled — `red-team`
+  (adversarial framing strict), `author-defender` (articulate
+  the author's framing + assumptions), `mirror` (read both,
+  surface contradictions and shared blind spots) — plus three
+  ingest-only personas attributable only via `devil ingest`:
+  `ultrareview-fleet`, `claude-security`, `scg-supply-chain-gate`.
+  `devil entry` refuses to attribute hand-rolled entries to
+  ingest-only personas (`PersonaIsIngestOnly`).
 
   Entry kinds: `finding` / `assumption` / `resistance` / `skip`
   / `synthesis` / `gate` (the last reserved for ingest paths).
@@ -76,7 +94,7 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   the design intent — `assumption` makes trust-assumptions
   explicit so they can be contested (`--addresses`); `resistance`
   holds verdict-less concern across re-entry without forcing it
-  to ok|concern|reject.
+  to `ok|concern|reject`.
 
   Architecture in practice:
   - principle 11 (AI-first): every verb's JSON envelope is the
@@ -85,18 +103,15 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
     detector applied at the schema level (lessons from #121
     extended).
   - principle 10 (schema as contract): `devil schema`
-    advertises every implemented verb's input + output;
-    `VERBS` array grows commit-by-commit so the contract is
-    honest about what's actually invokable.
+    advertises every implemented verb's input + output.
   - principle 09 (orientation disclosure): every write verb
     emits the same `notice: wrote <abs> (config: <abs>)` line
     shape as `gate register` and `agora new`.
   - principle 04 (records outlive writers): all state mutations
     are append-only at the array level (entries / suspensions /
     resumes / re_run_history). Status mutation on findings
-    (dismiss/resolve, landing later) replaces the entry value
-    at the same id slot — append-only at the array level
-    preserved.
+    (dismiss/resolve) replaces the entry value at the same id
+    slot — append-only at the array level preserved.
 
   State machine (intentionally thinner than agora's):
 
@@ -107,11 +122,26 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   No `suspended` state — suspend/resume cycles are append-only
   history and do **not** block other entries. Multiple
   reviewers can be working simultaneously; the cliff/invitation
-  records re-entry context only.
+  records re-entry context only. (Contrast agora's Play, where
+  suspend genuinely blocks moves.)
 
   Optimistic CAS via `DevilReviewVersionConflict` on every
   appending operation; `saveConclusion` uses state-CAS
-  (`open` → `concluded`).
+  (`open` → `concluded`); `replaceEntry` (used by dismiss /
+  resolve) carries CAS on entries.length AND the targeted id.
+  The CAS is *sequential* not atomic — it catches the
+  load-then-act-then-write race that AI agents naturally
+  produce when re-entering between sessions, but does NOT
+  prevent two simultaneous writer processes from both passing
+  the check (last-write-wins under true OS concurrency). Trust
+  assumption named in the repository docstring: "one CLI
+  process at a time per content_root."
+
+  Strict v0 ingest input JSON shapes (per source) are
+  documented in `src/passages/devil/interface/handlers/ingest.ts`.
+  Real-world adapter shims that translate actual upstream tool
+  output into those shapes are out of scope for the in-tree
+  passage and would land as separate utilities.
 
   Design rationale, three-source landscape comparison
   (`/ultrareview` vs Claude Security vs SCG), the seven shapes
@@ -126,13 +156,18 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   of the adversarial-gate-sequence shape devil-review's own
   `kind: gate` entry was designed to ingest.
 
-  ~5,000 LOC, ~80 contract tests across 9 test files in the
-  initial snapshot; further verbs ship in subsequent commits.
+  Per-content_root custom lense override loader
+  (`<content_root>/devil/lenses/<name>.yaml`) is intentionally
+  out of scope for v1. The catalog interface (`LenseCatalog`)
+  is the seam; v1 ships the bundled defaults adapter only.
 
-  Branch: `snapshot/devil-review`. Lands on main when the
-  remaining verbs (dismiss / resolve / suspend / resume /
-  ingest) are wired and the dogfood loop has surfaced the
-  shape adjustments worth making before broader use.
+  ~5,500 LOC, ~140 contract tests across 14 test files. Built
+  iteratively on `snapshot/devil-review` (12 + 5 commits)
+  through three dogfood passes — self-review of
+  `YamlDevilReviewRepository.ts` surfaced the lense-coverage
+  gate gap (e-006) before merge, and the cumulative
+  skip-with-reason audit posture (e-014) was named as a
+  side-effect of the gate's design.
 
 ### Fixed
 - **agora `suggested_next.reason` no longer carries stale "(when

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm install
 npm run build
 node ./bin/gate.mjs --help     # request lifecycle / review / dialogue
 node ./bin/agora.mjs --help    # play / narrative (suspend/resume primitives)
-node ./bin/devil.mjs --help    # security-backstop review (snapshot)
+node ./bin/devil.mjs --help    # security-backstop review (alpha)
 node ./bin/guild.mjs --help    # member management
 ```
 
@@ -108,7 +108,7 @@ through it today, each a distinct shape of agent interaction:
   effect. The design rationale lives in
   [issue #117](https://github.com/eris-ths/guild-cli/issues/117).
 - **`devil`** (CLI) — the security-backstop review passage
-  (snapshot, landing under `bin/devil.mjs`). A **multi-persona,
+  (alpha, shipping under `bin/devil.mjs`). A **multi-persona,
   lense-enforced, time-extended review surface** that composes
   with single-pass tools (Anthropic `/ultrareview`, Claude
   Security, supply-chain-guard) rather than replacing them.
@@ -148,8 +148,7 @@ Full surface in [`AGENT.md`](./AGENT.md); per-verb examples in
 [`docs/verbs.md`](./docs/verbs.md). Agora's own README
 ([`src/passages/agora/README.md`](./src/passages/agora/README.md))
 covers its layout, status, and lore upstream. devil-review is
-documented inline in `AGENT.md` and `docs/verbs.md` until it
-graduates from snapshot.
+documented inline in `AGENT.md` and `docs/verbs.md`.
 
 ### Test
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1047,7 +1047,7 @@ The agora-specific README at
 [`src/passages/agora/README.md`](../src/passages/agora/README.md)
 covers layout, status, and lore upstream in more detail.
 
-## Devil-review — the third passage (snapshot)
+## Devil-review — the third passage (alpha)
 
 `devil` is the third passage under guild, alongside `gate` and
 `agora`. Where gate carries decisions and agora carries narrative,
@@ -1075,7 +1075,7 @@ friction (lense catalog, persona commitment, severity rationale)
 is the floor-raising mechanism; expect to spend more time per
 review than gate review takes.
 
-### Worked example (snapshot loop)
+### Worked example (end-to-end loop)
 
 ```bash
 $ devil open src/foo.ts --type file
@@ -1145,9 +1145,10 @@ $ devil conclude rev-2026-05-03-001 \
 | `mirror` | Read both. Surface contradictions, things both sides missed, load-bearing assumptions neither named. |
 
 Ingest-only personas (`ultrareview-fleet`, `claude-security`,
-`scg-supply-chain-gate`) join the catalog with their matching
-ingest verbs, which land later. Hand-rolled `devil entry` cannot
-attribute to ingest-only personas.
+`scg-supply-chain-gate`) are in the catalog but cannot be used by
+hand — `devil entry` refuses them with `PersonaIsIngestOnly`. The
+matching `devil ingest --from <source>` verb is the only path that
+attributes entries to those personas.
 
 ### Lenses (v0 catalog of 11)
 
@@ -1185,26 +1186,22 @@ closed" or "we forgot to update them."
 After conclude no further entries / suspensions / resumes /
 re-runs are accepted (terminal state).
 
-### Status (snapshot)
+### Status (alpha)
 
-CLI verbs in this snapshot:
-
-```
-devil open / entry / list / show / conclude / schema
-```
-
-Landing in subsequent commits per #126:
+The complete v1 surface from #126 is landed:
 
 ```
-devil dismiss / resolve / suspend / resume / ingest (×3 sources)
+devil open / entry / list / show / dismiss / resolve / suspend
+       / resume / ingest / conclude / schema
 ```
 
-The end-to-end loop (`open → entry → list/show → conclude`) is
-usable today on the snapshot branch. dismiss / resolve cover
-finding status mutation; suspend / resume add cliff/invitation
-re-entry context (softer than agora's — does not block other
-entries); ingest wires the automated source paths
-(`/ultrareview`, Claude Security, SCG).
+dismiss / resolve cover finding status mutation; suspend / resume
+add cliff/invitation re-entry context (softer than agora's — do
+not block other entries); ingest wires the automated source paths
+(`/ultrareview`, Claude Security, SCG) using strict v0 input JSON
+shapes documented in the handler. Real-world adapters that
+translate actual upstream tool output into those shapes live
+outside the in-tree passage.
 
 For substrate paths and the persona/lense schema reference, see
 the `## devil-review` section of [`AGENT.md`](../AGENT.md).

--- a/src/passages/devil/infrastructure/BundledPersonaCatalog.ts
+++ b/src/passages/devil/infrastructure/BundledPersonaCatalog.ts
@@ -6,10 +6,12 @@ import {
 import { PersonaCatalog } from '../application/PersonaCatalog.js';
 
 /**
- * v0 persona catalog: the 3 hand-rolled defaults from
- * domain/defaultPersonas.ts (red-team / author-defender / mirror).
- * Ingest-only personas join the catalog when their matching ingest
- * verbs land in subsequent commits.
+ * v1 persona catalog: 6 personas total — 3 hand-rolled
+ * (red-team / author-defender / mirror) + 3 ingest-only
+ * (ultrareview-fleet / claude-security / scg-supply-chain-gate).
+ * Ingest-only personas are in the catalog so `devil ingest --from
+ * <source>` can attribute to them; `devil entry` refuses them via
+ * `PersonaIsIngestOnly`.
  */
 export class BundledPersonaCatalog implements PersonaCatalog {
   private readonly map: ReadonlyMap<string, Persona>;

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -64,8 +64,9 @@ const ENTRY_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  * --persona must exist in the catalog AND not be ingest_only
  * (only `devil ingest` may attribute to ingest-only personas).
  *
- * --lense must exist in the catalog. Custom lenses (per-content_root
- * YAML overrides) land later; v0 catalog is the 11 bundled defaults.
+ * --lense must exist in the catalog. Per-content_root custom-lense
+ * override loader is intentionally out of scope for v1; the v1
+ * catalog ships the 11 bundled defaults via BundledLenseCatalog.
  *
  * State-machine boundary: only `open` reviews accept entries.
  * Concluded reviews surface DevilReviewAlreadyConcluded.

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -6,11 +6,10 @@
 // (Anthropic /ultrareview, Claude Security, supply-chain-guard)
 // rather than replacing them. Design lives in issue #126.
 //
-// This is the v0 scaffold. Only `devil schema` and `devil --help`
-// are wired. open / entry / ingest / dismiss / resolve / suspend /
-// resume / conclude / list / show land in subsequent commits, agora
-// pattern. The schema verb's VERBS array grows as each verb lands,
-// keeping the agent contract honest about what's actually invokable.
+// v1 surface (PR #127) lands all 11 verbs from the design issue:
+// schema / open / entry / list / show / dismiss / resolve / suspend
+// / resume / conclude / ingest. The schema verb's VERBS array
+// reflects every implemented verb, keeping the agent contract honest.
 //
 // AI-first per principle 11: the substrate is machine-parseable
 // JSON / snake_case YAML / explicit-flag CLI. Any future
@@ -34,7 +33,7 @@ import { suspendReview } from './handlers/suspend.js';
 import { resumeReview } from './handlers/resume.js';
 import { ingestSource } from './handlers/ingest.js';
 
-const HELP = `devil-review — security-backstop review passage (v0 scaffold)
+const HELP = `devil-review — security-backstop review passage (alpha, 11 verbs)
 
 Usage:
   devil open <target-ref> --type <pr|file|function|commit>
@@ -133,15 +132,12 @@ Usage:
   devil schema [--verb <name>] [--format json|text]
                               Agent dispatch contract for this passage
                               (principle 10). draft-07 JSON Schema subset.
-                              Lists every implemented verb; grows as
-                              subsequent commits add verbs per #126.
+                              Lists every implemented verb.
 
   devil --help                 This help.
   devil --version              Print version and exit.
 
-All v1 verbs from issue #126 are now invokable in this snapshot.
-
-Passage status: complete v1 surface. All 11 verbs from issue #126 are invokable.
+Passage status: alpha (v1 complete). All 11 verbs from issue #126 are invokable.
 Substrate: shares content_root and members/ with gate and agora. Reviews
 land at <content_root>/devil/reviews/<rev-id>.yaml.
 
@@ -160,7 +156,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 0;
   }
   if (argv[0] === '--version') {
-    process.stdout.write('devil-review (under guild-cli) — snapshot/devil-review\n');
+    process.stdout.write('devil-review (under guild-cli) — alpha (v1 complete, #126)\n');
     return 0;
   }
 

--- a/tests/passages/devil/cliBoot.test.ts
+++ b/tests/passages/devil/cliBoot.test.ts
@@ -1,6 +1,6 @@
 // devil-review — CLI scaffold tests.
 //
-// Pin the v0 scaffold contract: --help / --version work, schema
+// Pin the alpha CLI surface contract: --help / --version work, schema
 // verb runs (json + text formats), unknown verbs surface a "v0
 // scaffold" error message that names the issue (so a confused agent
 // can pull #126 for the design context).
@@ -43,7 +43,8 @@ test('devil with no args prints help and exits 0', (t) => {
   const r = runDevil(root, []);
   assert.equal(r.status, 0);
   assert.match(r.stdout, /devil-review .* security-backstop/);
-  assert.match(r.stdout, /v0 scaffold/);
+  assert.match(r.stdout, /alpha .* 11 verbs/);
+  assert.match(r.stdout, /v1 complete/);
 });
 
 test('devil --help prints help and exits 0', (t) => {
@@ -60,7 +61,7 @@ test('devil --version prints version and exits 0', (t) => {
   t.after(cleanup);
   const r = runDevil(root, ['--version']);
   assert.equal(r.status, 0);
-  assert.match(r.stdout, /devil-review .* snapshot/);
+  assert.match(r.stdout, /devil-review .* alpha \(v1 complete/);
 });
 
 test('devil schema --format json emits the v1 contract (11 verbs, complete)', (t) => {


### PR DESCRIPTION
## Summary

Post-merge cleanup for devil-review (#127). Removes stale "snapshot / landing soon / v0 scaffold" markers across docs and code that referred to mid-flight states no longer applicable now that the complete v1 surface (11 verbs) is on main.

Tight scope: only stale-prose touches, no behavior changes.

## Files touched

- `src/passages/devil/interface/index.ts` — HELP heading "(v0 scaffold)" → "(alpha, 11 verbs)"; --version "snapshot/devil-review" → "alpha (v1 complete, #126)"; top-of-file comment block updated
- `src/passages/devil/infrastructure/BundledPersonaCatalog.ts` — docstring describes the v1 catalog (6 personas: 3 hand-rolled + 3 ingest-only) instead of the v0 (3 hand-rolled, "rest land in subsequent commits")
- `src/passages/devil/interface/handlers/entry.ts` — docstring re: lense catalog: out-of-scope future loader replaces the prior "land later" framing
- `AGENT.md` — heading snapshot → alpha; removed the "Landing in subsequent commits" comment block from the verb listing (the 5 verbs are live now); Status footer rewritten ("v1 surface complete")
- `README.md` — install-line "(snapshot)" → "(alpha)"; architecture block "(snapshot, landing under)" → "(alpha, shipping under)"; removed "graduates from snapshot" footer
- `docs/verbs.md` — section heading "(snapshot)" → "(alpha)"; "Worked example (snapshot loop)" → "Worked example (end-to-end loop)"; persona/status notes updated; Status block rewritten as a single complete-v1 listing
- `CHANGELOG.md` — `[Unreleased]` devil-review entry rewrote to reflect the merged v1 state: all 11 verbs described inline, v1 lense + persona catalog framings, removed the "remaining 5 verbs land before the merge to main" / "Landing in subsequent commits before merge" / "Branch: snapshot/devil-review, Lands on main when..." paragraphs that no longer apply. Added the dogfood-surfaced observations the prior entry didn't mention (e-006 lense-coverage gap that was fixed before merge; the cumulative-skip-with-reason audit posture; the named "one CLI process at a time per content_root" trust assumption from the CAS softening).
- `tests/passages/devil/cliBoot.test.ts` — `/v0 scaffold/` and `/devil-review .* snapshot/` assertions updated to match the new HELP/--version output

## Items intentionally NOT touched (still accurate as future work)

- "Per-content_root custom-lense override loader" references in `docs/verbs.md` and `entry.ts` handler docstring — that loader truly is out-of-scope for v1 with the catalog interface as the future seam.
- The agora #121 fix entry in `CHANGELOG` that quotes "(... lands in subsequent commits)" — that's the regression-test description quoting the OLD fixed prose, not a stale claim.

## Other observations from the post-merge sweep (filed as comments / future work, NOT touched in this PR)

A devil-on-devil dogfood across 11 lenses surfaced three items, all kept out of this PR's scope:

1. **`supply-chain` lense's "mandatory delegate to SCG" is documented intent, not runtime enforcement.** `devil ingest --from scg` accepts any pre-formatted JSON matching the strict v0 shape; nothing checks SCG actually produced it. Author-defender's softening: "operator wires SCG to devil-ingest in their CI/git-hook/ops workflow; devil itself stays a substrate-only tool." Architectural — fix would be either runtime SCG-availability check or moving SCG invocation into devil. Larger than docs scope; defer to a v2 design conversation.
2. **Bird's-eye micro-inconsistencies**: (a) `lense` semantics differ between gate (free-form config) and devil (catalog-enforced 11), same spelling but different enforcement; (b) `defaultLenses.ts` docstring still says "v0 with 11 default" while CHANGELOG/CLI now say "v1"; (c) devil dismiss/resolve emit `dismissed_by`/`resolved_by` while other write verbs emit just `by`. Not bugs; minor doc drift. Will land as a tiny separate PR after this one (decided in a suspend/resume cycle during the dogfood — keeps bisectability).
3. **Methodology gap (mirror's synthesis)**: `lense-coverage gate` enforces lense-by-lense thinking but cannot detect cross-lense coherence drift; bird's-eye review has no first-class verb in devil. Possible v2 candidate: a "coherence" or "system" meta-lense, OR a docs convention that bird's-eye reviews are filed as separate review sessions targeting the system as a whole. Defer to v2 design conversation.

## Test plan

- [x] `npm test` passes (886/886 across Node 20+22)
- [x] `bin/devil.mjs --help` reads cleanly (alpha framing, all 11 verbs)
- [x] `bin/devil.mjs --version` reports "alpha (v1 complete, #126)"
- [x] `bin/devil.mjs schema --format json` lists 11 verbs in canonical order
- [x] devil-on-devil dogfood across all 11 lenses + 6 personas + ingest from all 3 sources end-to-end usable on this branch

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_