### PR TITLE
chore(post-session): close framing-arc agora play + soften agora CAS docstring (parallel to devil #129)

### DIFF
--- a/examples/three-passages-framing/README.md
+++ b/examples/three-passages-framing/README.md
@@ -11,21 +11,29 @@ framing now linked from `README.md` § Architecture and from
 
 The agora play in this content_root is **the conversation itself
 preserved as substrate** — not a reconstruction, not a tutorial.
-Move 001 captured the framing proposal; the suspend cliff/invitation
-held the question "do these words land for you?" for nao to address
-at re-entry.
+Move 001 captured the framing proposal. The play was suspended
+with a cliff/invitation pair while waiting for nao's response.
+Once nao accepted ("気に入った"), the play was resumed with a
+closing note, move 002 recorded the acceptance + the
+projection-layer landing in PR #130, and the play was concluded.
+
+The full arc — propose → suspend on invitation → resume with the
+answer → conclude — is the substrate-honest shape of a single
+conversation that resolves cleanly. If a future use surfaces
+breakage in the framing, a new play would `--addresses` this one
+rather than mutating it (terminal state, append-only at the
+contest level).
 
 ## Why this is here
 
 Most agora examples one might write would be constructed —
 designed to teach a verb. This one isn't. It's a one-off
-single-actor session that captured a real thinking-about-thinking
-arc, then was suspended (not concluded) so the question to nao
-remains open in the substrate. That shape — verdict-less,
-preserved, suspended-on-invitation — is what agora is for.
-
-If you came here looking for "what does agora look like in
-normal use?", read `agora/plays/three-passages-framed/2026-05-03-001.yaml`.
+single-actor (claude) + interlocutor (nao via human-in-the-loop)
+session that captured a real thinking-about-thinking arc and
+concluded once the conversation reached agreement. That shape —
+verdict-less synthesis (`concluded_note`), preserved in
+substrate, with the suspend/resume cycle recording the
+open-question-then-answer flow — is what agora is for.
 
 ## Read it
 
@@ -34,10 +42,11 @@ cd examples/three-passages-framing
 GUILD_ACTOR=claude node ../../bin/agora.mjs show 2026-05-03-001 --format text
 ```
 
-The output shows the play's full state including the suspended
-cliff/invitation pair. The substrate-side Zeigarnik effect
-(issue #117) — whoever opens this play next reads what was
-paused on without a separate query.
+The output shows the play's full state: 2 moves, 1 suspension
+paired with 1 resume, conclusion with note. The cliff/invitation
+of the suspension are still in the substrate (append-only) so a
+future reader sees the question that was held open and the
+resume-note that closed it.
 
 ## Structure
 
@@ -47,7 +56,9 @@ paused on without a separate query.
 - `agora/games/three-passages-framed.yaml` — the Sandbox game
   definition.
 - `agora/plays/three-passages-framed/2026-05-03-001.yaml` — the
-  play with one move and one suspension (no resume yet).
+  concluded play with 2 moves, 1 suspend, 1 resume, and a
+  `concluded_note` recording nao's acceptance and the
+  projection layer that landed.
 
 ## What this is not
 
@@ -57,6 +68,7 @@ paused on without a separate query.
   philosophical. Most won't be. This one is the artifact of one
   conversation, preserved so the substrate has a real example
   alongside the constructed ones.
-- Not concluded — the play is `suspended`. nao's response to the
-  invitation will be the next move (resume + move on a real
-  content_root).
+- Not perpetually open — the play is **concluded**. The
+  framing-acceptance arc resolved; mutation now requires a new
+  play that `--addresses` this one (substrate stays append-only
+  at the contest level).

--- a/examples/three-passages-framing/agora/plays/three-passages-framed/2026-05-03-001.yaml
+++ b/examples/three-passages-framing/agora/plays/three-passages-framed/2026-05-03-001.yaml
@@ -1,6 +1,6 @@
 id: 2026-05-03-001
 game: three-passages-framed
-state: suspended
+state: concluded
 started_at: 2026-05-03T10:40:09.454Z
 started_by: claude
 moves:
@@ -14,6 +14,14 @@ moves:
       devil は 警戒 / 監査 / 守 とも言える。 採用したのは、 (a) 単漢字 1 字の対応 (判 / 探 / 守) で 三角形が綺麗、
       (b) ユーザー視点での問いとして自然 (これをやるか? / これは何だろう? / これで誰か壊れない?)、 (c) 既存 design
       intent との整合 (gate verdict / agora dwelling / devil floor) の 3 点。"
+  - id: "002"
+    at: 2026-05-03T12:11:35.036Z
+    by: claude
+    text: "framing accepted as-is: gate=判断 / agora=探索 / devil=守備. projection layer は
+      PR #130 で landed (README + AGENT + concepts + per-passage READMEs). この
+      play 自体は examples/three-passages-framing/ として preserved (PR #130)。
+      substrate-honest な完了として、 次の move は 「framing が後の use で破綻する場合」 にのみ追加されるべき (新
+      play で addresses する shape)。"
 suspensions:
   - at: 2026-05-03T10:40:28.070Z
     by: claude
@@ -24,3 +32,13 @@ suspensions:
       なら、 この framing を README / docs/concepts-for-newcomers / 各 passage の README
       に projection する shape を考える (実装ではなく、 explanatory layer として — 理屈は元々あったが
       symbolic shorthand がなかった)。
+resumes:
+  - at: 2026-05-03T12:11:25.487Z
+    by: claude
+    note: nao が 探索 / 守備 framing を accept ("気に入った"). substrate-honest closure として
+      cliff/invitation cycle を閉じる。
+concluded_at: 2026-05-03T12:11:42.786Z
+concluded_by: claude
+concluded_note: "判断 / 探索 / 守備 framing が nao 承認で land。 docs/playbook.md (PR #131)
+  で combos まで含めた full surface に展開。 この play は完結 — framing 自体への異議 / 改訂は新 play で
+  addresses。"

--- a/src/passages/agora/application/PlayRepository.ts
+++ b/src/passages/agora/application/PlayRepository.ts
@@ -7,6 +7,24 @@ import { Play, PlayMove, ResumeEntry, SuspensionEntry } from '../domain/Play.js'
  * The game subdirectory keeps plays scoped to their definition —
  * a Quest game's plays don't mingle with a Sandbox game's plays in
  * the same flat directory.
+ *
+ * Every mutating operation uses *sequential* optimistic CAS — the
+ * caller passes the array length they loaded; the implementation
+ * re-reads the file and refuses if the on-disk count has changed.
+ * This catches the load-then-act-then-write race that AI agents
+ * naturally produce when re-entering between sessions: instance A
+ * loads, instance B writes, instance A's CAS check surfaces B's
+ * write before clobbering it.
+ *
+ * The CAS is **not** a true file-locked atomic compare-and-swap.
+ * Two processes that load + check + write within the same OS
+ * scheduler quantum can both pass the check and both write —
+ * last-write-wins. The trust assumption (named explicitly in
+ * sister-passage devil-review's docstring after dogfood e-001)
+ * is that the typical guild-cli invocation is **one CLI process
+ * at a time per content_root**. Under that assumption the CAS
+ * holds; under true concurrent OS-level write traffic the
+ * substrate would need file locking (out of v0 scope).
  */
 export interface PlayRepository {
   /**

--- a/src/passages/agora/infrastructure/YamlPlayRepository.ts
+++ b/src/passages/agora/infrastructure/YamlPlayRepository.ts
@@ -29,6 +29,18 @@ import { parseYamlSafe } from '../../../infrastructure/persistence/parseYamlSafe
  * One subdirectory per game keeps plays scoped to their definition,
  * which (a) makes `agora list --game <slug>` cheap and (b) prevents
  * id collision pressure across games (each game has its own counter).
+ *
+ * Every mutating operation writes via writeTextSafeAtomic so concurrent
+ * READERS never see a torn file (atomic .tmp + rename). The "CAS" on
+ * the relevant array length (or `state` for conclude) is *sequential*
+ * not atomic: it catches the load-then-act-then-write race that AI
+ * agents naturally produce when re-entering between sessions, but
+ * does NOT prevent two simultaneous writer processes from both
+ * passing the check and both writing (last-write-wins under true
+ * OS-level concurrency). See the PlayRepository interface doc and
+ * devil-review's parallel softening (#129 e-001 / e-002) for the
+ * trust assumption ("one CLI process at a time per content_root")
+ * this rests on.
  */
 export class YamlPlayRepository implements PlayRepository {
   private readonly base: string;
@@ -272,9 +284,17 @@ export class YamlPlayRepository implements PlayRepository {
    * Shared append-with-CAS helper. Re-reads the on-disk file,
    * checks the named array's length matches `expectedCount`,
    * appends the entry, optionally flips the `state` field,
-   * atomic-writes back. Same shape protects every state-changing
-   * append — principle 11 (AI-natural): re-entering instances
-   * detect concurrent appenders rather than silently overwrite.
+   * atomic-writes back.
+   *
+   * Per principle 11 (AI-natural): re-entering instances catch
+   * sequential append races — the load-then-act-then-write window
+   * where instance A loaded count=N, instance B wrote count=N+1,
+   * instance A's CAS check sees N+1 != N and refuses rather than
+   * clobbering B. Under true OS-level concurrent writers (two
+   * agora processes hitting the same play in the same scheduler
+   * quantum) the read-modify-write sequence itself is not atomic,
+   * and last-write-wins semantics apply. See repository interface
+   * doc for the trust assumption this rests on.
    */
   private async appendArrayWithCAS(
     play: Play,


### PR DESCRIPTION
## Summary

Two small post-session tidying items from the open-TODO list nao asked me to push through.

### A: `examples/three-passages-framing/` — close the framing arc

PR #130 persisted the agora play that captured the gate=判断 / agora=探索 / devil=守備 framing. The play was suspended with cliff/invitation pair holding the question "do these words land for you?" open. nao said "気に入った" — this commit performs the substrate-honest closure:

- `agora resume 2026-05-03-001 --note "..."` — resume note records nao's acceptance
- `agora move 2026-05-03-001 --text "..."` — move 002 records the framing acceptance + the projection layer that landed in PR #130 / PR #131
- `agora conclude 2026-05-03-001 --note "..."` — terminal close. Future challenges to the framing would file a new play that `--addresses` this one rather than mutating it.
- README.md updated to reflect the concluded state. The full arc — propose → suspend on invitation → resume with the answer → conclude — is now visible in the example as the substrate-honest shape of a single conversation that resolves cleanly.

The example now shows the full agora cycle including conclusion, not just the open suspension state PR #130 left.

### B: agora CAS docstring softening (parallel to devil's #129)

Devil's PR #129 softened the CAS docstring from "concurrent appenders detect each other" to "sequential append races" and named the trust assumption explicitly ("one CLI process at a time per content_root"). The fix made the substrate honest about what CAS actually guarantees.

Devil's commit message noted: "agora's YamlPlayRepository was the source pattern for this CAS shape and carries the same overclaim. If the trust-assumption framing proves correct under broader use, agora's docstring should get the same softening."

It surfaced today via the bird's-eye / `coherence` lense from the recent dogfood — docstring drift between sister passages *is* a coherence-lense finding (the kind the new lense was introduced to catch). This commit propagates the softening:

- `src/passages/agora/application/PlayRepository.ts` — top-of-interface docstring rewritten to name the sequential-CAS guarantee + trust assumption + file-lock out-of-scope; cross-references devil's parallel softening
- `src/passages/agora/infrastructure/YamlPlayRepository.ts` — top-of-class docstring matches; `appendArrayWithCAS` inline docstring softened

No code changes; full suite still 888/888.

## The two passages now agree

After this PR, agora and devil carry the same CAS guarantee statement and the same named trust assumption. The coherence lense's introduction (PR #129) and this propagation (this PR) are the same audit-trail story: lense surfaces drift, drift gets fixed.

## Test plan

- [x] `npm test` passes (888/888 — no code/behavior changes)
- [x] `agora show 2026-05-03-001` on the updated example renders cleanly with conclusion
- [x] `agora list --state concluded` lists the play (was previously unlisted at that filter)

## Other open TODOs (recap, not in this PR)

| ID | item | status |
|----|------|--------|
| C | v0.4.0 release tag | pending nao judgment |
| D | lore graduation: e-014 cumulative-skip-with-reason audit posture → principle 12 candidate | mira-discipline wait for second-instance trigger |
| E/F | issue #117 (agora design) / #123 (cross-passage voice) | both verified open as design-tracking; no action |
| G | per-content_root lense override loader | v2 design |
| H | gate-vs-devil lense semantics convergence | v2 design |
| I | multi-instance review on #126 | v2 / waiting |
| J | bird's-eye review target = "system as a whole" enum addition | v2 design |
| K | gate's read-surface accretion (15+ read verbs) refactor | larger scope, defer |
| L | real-world adapter shims for /ultrareview / Claude Security / SCG → devil v0 ingest format | out-of-tree, separate utility |

This PR closes A + B (the immediate tractable items). The rest need nao judgment, multi-instance trigger, or larger-scope planning.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_