### PR TITLE
release: v0.4.0 (three-passage release) + SECURITY.md devil-review section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+(no entries yet)
+
+## [0.4.0] — 2026-05-03
+
+> **Three-passage release.** Two new CLI passages land alongside `gate`:
+> `agora` (second passage — play / narrative / exploration; suspend
+> and resume as first-class primitives), and `devil-review` (third
+> passage — security-backstop multi-persona scrutiny that composes
+> with `/ultrareview` / Claude Security / supply-chain-guard). The
+> three-passage architecture is named in `lore/principles/11-ai-first
+> -human-as-projection.md`; the dispatch shorthand (gate=判断 /
+> agora=探索 / devil=守備) is now in README / AGENT / per-passage
+> READMEs; `docs/playbook.md` collects the cross-passage combos
+> (including the bug-killing recipe). Two example content_roots
+> are preserved as substrate (`examples/three-passages-framing/`
+> shows agora's full propose→suspend→resume→conclude arc).
+
+### Documentation
+
+- **`docs/playbook.md`** ([#131](https://github.com/eris-ths/guild-cli/pull/131))
+  — practical guide for combining `gate` / `agora` / `devil` on real
+  work. Each section is a recipe: 6 gate-only patterns, 4 agora-only,
+  4 devil-only, 4 combos (including the bug-killing flow as
+  `issue → agora → gate (+ devil if security)`), and 8 tips for AI
+  agents. Linked from AGENT.md (top callout), README.md (depth
+  ladder), and docs/concepts-for-newcomers.md (Where-to-go-next).
+
+- **判断 / 探索 / 守備 framing** ([#130](https://github.com/eris-ths/guild-cli/pull/130))
+  — single-kanji + English shorthand for the three passages added to
+  README / README.ja / AGENT / docs/concepts-for-newcomers + per-passage
+  READMEs. Per principle 11 (AI-first), the framing is a dispatch
+  tool, not a metaphor — AI agents recognize the shape and route
+  to the matching passage. `examples/three-passages-framing/`
+  preserves the agora play that captured the framing decision as
+  a real artifact (concluded in [#132](https://github.com/eris-ths/guild-cli/pull/132)).
+
+- **agora's `src/passages/agora/README.md`** rewrote post-merge
+  (was stale "v0 skeleton" claim from snapshot phase; now reflects
+  the v1 surface). New **`src/passages/devil/README.md`** parallel
+  to agora's. **Post-merge cleanup pass** ([#128](https://github.com/eris-ths/guild-cli/pull/128))
+  removed stale "snapshot / landing soon / v0 scaffold" markers
+  across docs and code.
+
 ### Fixed
 
 - **devil-review `--from scg` ingest: SCG now runtime-enforced as a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,88 @@
 ## Threat model
 
 `guild-cli` is a local file-based CLI for managing small-team artifacts
-(members, requests, reviews, issues). It is **not** designed for
-multi-tenant or network exposure. The trust boundary is "anyone with
-write access to `content_root`".
+(members, requests, reviews, issues, agora plays, devil-review reviews).
+It is **not** designed for multi-tenant or network exposure. The trust
+boundary is "anyone with write access to `content_root`".
+
+## Security-backstop passage: `devil-review`
+
+Since v0.4.0, `guild-cli` ships **`devil-review`** — a third passage
+explicitly designed as a **security-knowledge-floor substrate** for
+code reviewed by authors who haven't met OWASP top 10. It is not a
+replacement for this Security Model document or for upstream tools
+like Anthropic `/ultrareview`, Claude Security, or
+[supply-chain-guard](https://github.com/eris-ths/supply-chain-guard).
+It composes with them: the upstream tools' findings flow in via
+`devil ingest --from <source>`; multi-persona deliberation happens
+on top of the substrate.
+
+**What `devil-review` enforces** (relevant to this threat model):
+
+- **Catalog-enforced lense coverage at conclude.** A reviewer cannot
+  conclude a `devil-review` session without leaving at least one
+  entry per lense in the v1 catalog (12 lenses, including the
+  Claude-Security-aligned 8: `injection / injection-parser /
+  path-network / auth-access / memory-safety / crypto /
+  deserialization / protocol-encoding`, plus `composition /
+  temporal / supply-chain / coherence`). A `kind: skip` entry
+  with declared reason satisfies coverage; silent skipping is
+  refused. The friction is the floor.
+- **`supply-chain` lense mandatory delegate to SCG.** When
+  `devil ingest --from scg` is invoked, the verb runtime-checks
+  for `scg` on `PATH` (POSIX `which scg` / Windows `where scg`)
+  and refuses if absent. Documented intent is now runtime-enforced
+  (PR #129 e-001 fix).
+- **Severity rationale required on findings.** `kind: finding`
+  entries require both `--severity` AND `--severity-rationale`.
+  The rationale forces exploitability-context reasoning: same
+  category may carry different severity in different repos
+  (Claude Security influence; the rationale is what makes that
+  decision auditable).
+- **Append-only audit trail for dismissals.** `devil dismiss`
+  requires a structured reason from a fixed enum (`not-applicable
+  | accepted-risk | false-positive | out-of-scope |
+  mitigated-elsewhere`). The substrate keeps the dismissal trail;
+  re-dismissing a dismissed entry is refused. Future audit can
+  grep `devil/reviews/*.yaml` for "what did we say about this
+  category", not just "what passed".
+
+**What `devil-review` does NOT enforce** (read this carefully):
+
+- It does NOT prevent insecure code from being merged. A reviewer
+  who skips every lense with `irrelevant because n/a` and concludes
+  with empty synthesis can pass the gate. The substrate captures
+  the dismissal so a future audit can see the decision was made;
+  it doesn't prevent the decision.
+- It is NOT a code scanner. Its `ingest` verbs depend on upstream
+  tools producing the strict v0 input JSON shape. Real-world
+  adapter shims that translate `/ultrareview` `bugs.json` /
+  Claude Security findings export / SCG verdict output into
+  devil's shape are **out of scope for the in-tree passage** and
+  would land as separate utilities (or in the source tools
+  themselves).
+- It is shape-mismatched for **general bug-fix review**. See
+  `docs/playbook.md` § "When NOT to use devil" — routine bugs
+  (off-by-one, null checks, UI fixes) don't fit the
+  security-shaped lense catalog and would degrade the substrate
+  with cargo-cult skip-with-reason entries. Use `gate review`
+  with the configurable lense list (default
+  `devil / layer / cognitive / user`) for general code review.
+
+**Trust assumption (named explicitly per PR #129 e-001 / e-002 fix
+and propagated to agora in PR #132):** `devil-review`'s optimistic
+CAS is **sequential**, not atomic. The same trust assumption applies
+across all passages — *one CLI process at a time per content_root*.
+Under that assumption, CAS catches the load-then-act-then-write race
+that AI agents naturally produce when re-entering between sessions.
+Under true OS-level concurrent writers (two processes hitting the
+same record in the same scheduler quantum), last-write-wins
+semantics apply. File locking is out of v0 scope.
+
+For full details: `src/passages/devil/README.md`,
+[issue #126](https://github.com/eris-ths/guild-cli/issues/126)
+(design rationale), and `docs/playbook.md` (combos with `gate` /
+`agora`).
 
 ## Invariants enforced in code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guild-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guild-cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guild-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Guild CLI — DDD/TS member & request management with Two-Persona Devil Review",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts the **v0.4.0 release** + adds devil-review section to **SECURITY.md** (closing a discoverability gap).

### v0.4.0 release prep

The release is the **three-passage architecture** ship: `agora` (PR #119) and `devil-review` (PR #127 + the iteration cycle that followed) join `gate` under one container.

- New `## [0.4.0] — 2026-05-03` heading with brief release-summary block naming the two new passages, the dispatch shorthand (判断 / 探索 / 守備), the playbook, and the example content_roots
- New `### Documentation` section captures the substantive doc landings that didn't have explicit `[Unreleased]` entries before this PR (#128 / #130 / #131 / #132)
- Existing entries (Fixed / Changed / Added) preserved as-is below the new summary
- Empty `## [Unreleased]` header re-introduced for future PRs
- `package.json` bumped 0.3.0 → 0.4.0

After this PR merges, I'll request before pushing the `v0.4.0` git tag.

### SECURITY.md: devil-review section

SECURITY.md was written pre-devil (v0.3.0 era). Now that devil-review IS the in-tree security substrate, it should be mentioned. Added "Security-backstop passage: `devil-review`" section covering:

- **What devil enforces** — catalog-enforced lense coverage, supply-chain mandatory SCG delegate (runtime-checked), severity rationale required, append-only dismissal trail
- **What devil does NOT enforce** (load-bearing — readers should not mistake design intent for "security guaranteed"): doesn't prevent insecure code from being merged; isn't a code scanner; shape-mismatched for general bug-fix review
- **Trust assumption named explicitly**: sequential CAS, one CLI process at a time per content_root (now consistent across all 3 passages per devil PR #129 + agora PR #132)
- Cross-references to `src/passages/devil/README.md`, issue #126, `docs/playbook.md`

The "does NOT enforce" list is load-bearing — devil is a *substrate that raises the floor*; the floor only raises if reviewers actually do the work. Honest framing in SECURITY.md keeps the design intent intact.

## Test plan

- [x] `npm test` passes (888/888 — no code changes; only docs + version bump)
- [x] CHANGELOG renders cleanly with the new structure (Unreleased empty, [0.4.0] populated, [0.3.0] unchanged below)
- [x] `package.json` version reflects the new release

## Next after merge

1. **Tag `v0.4.0`** — will ask before pushing the tag
2. **v2 design issue** filed separately covering G (per-content_root lense override loader) + H (gate-vs-devil lense semantics convergence) + J (bird's-eye target.type extension)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_