### PR TITLE
fix(gate): list / pending accept --format json|text (closes asymmetry surfaced by bird's-eye check)

### DIFF
--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -74,8 +74,9 @@ const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
   'executor',
   'auto-review',
+  'format',
 ]);
-const PENDING_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for']);
+const PENDING_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for', 'format']);
 const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'plain',
   'format',
@@ -187,6 +188,40 @@ export async function reqList(
     process.stderr.write(
       `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
     );
+  }
+
+  // --format closes the asymmetry surfaced in the post-merge bird's-eye
+  // check (2026-05-03): every other gate read verb (board / status /
+  // voices / tail / show / why / summarize) accepts --format json|text;
+  // list / pending were text-only. JSON envelope mirrors board's shape:
+  // top-level `requests` array of full request.toJSON(), `_meta` carries
+  // the state being listed (informational for both list and pending) and
+  // any active filter so a JSON consumer sees what the stderr notice
+  // shows to humans.
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  if (format === 'json') {
+    const filterEcho: Record<string, string> = {};
+    if (fromFilter !== undefined) filterEcho['from'] = fromFilter;
+    if (executorFilter !== undefined) filterEcho['executor'] = executorFilter;
+    if (autoReviewFilter !== undefined) filterEcho['auto_review'] = autoReviewFilter;
+    if (forFilter !== undefined) {
+      filterEcho['for'] = forFilter;
+      filterEcho['for_source'] = explicitFor !== undefined ? '--for' : 'GUILD_ACTOR';
+    }
+    const payload: Record<string, unknown> = {
+      requests: items.map((r) => r.toJSON()),
+      _meta: {
+        state,
+        verb,
+        ...(Object.keys(filterEcho).length > 0 ? { filter: filterEcho } : {}),
+      },
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
   }
 
   if (items.length === 0) {

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -560,17 +560,32 @@ const VERBS: readonly VerbSchema[] = [
         from: str,
         executor: str,
         'auto-review': str,
+        format: {
+          type: 'string',
+          enum: ['json', 'text'],
+          description: "default 'text'; --format json emits {requests, _meta} envelope",
+        },
       },
       required: ['state'],
     },
-    output: { type: 'array' },
+    output: { type: 'object' },
   },
   {
     name: 'pending',
     category: 'read',
     summary: 'list requests in pending state',
-    input: { type: 'object', properties: { for: str } },
-    output: { type: 'array' },
+    input: {
+      type: 'object',
+      properties: {
+        for: str,
+        format: {
+          type: 'string',
+          enum: ['json', 'text'],
+          description: "default 'text'; --format json emits {requests, _meta} envelope",
+        },
+      },
+    },
+    output: { type: 'object' },
   },
   {
     name: 'board',

--- a/tests/interface/listPendingFormat.test.ts
+++ b/tests/interface/listPendingFormat.test.ts
@@ -1,0 +1,255 @@
+// gate `list` and `pending`: --format json|text contract.
+//
+// Pre-fix, neither verb accepted --format — text-only output, breaking
+// the asymmetry vs every other gate read verb (board / status / voices
+// / tail / show / why / summarize). Surfaced by the post-merge
+// bird's-eye check report on 2026-05-03; PR adds the JSON envelope.
+//
+// JSON shape mirrors board's `_meta` convention:
+//   {
+//     requests: [<request.toJSON()>...],
+//     _meta: { state, verb, filter? }
+//   }
+// `_meta.filter` is omitted when no filter applied.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-list-pending-format-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const dir of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, dir));
+  }
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function seedTwoPending(root: string): void {
+  for (const action of ['fix one', 'fix two']) {
+    runGate(
+      root,
+      [
+        'request',
+        '--from', 'alice',
+        '--action', action,
+        '--reason', 'r',
+      ],
+      {},
+    );
+  }
+}
+
+// ---- list ----
+
+test('gate list --format json emits {requests, _meta} envelope', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'json'],
+  );
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(payload.requests), 'requests must be an array');
+  assert.equal(payload.requests.length, 2);
+  // Each request entry is a full Request.toJSON()
+  for (const req of payload.requests) {
+    assert.ok(req.id);
+    assert.equal(req.state, 'pending');
+    assert.equal(req.from, 'alice');
+  }
+  // _meta carries state + verb (always present)
+  assert.equal(payload._meta.state, 'pending');
+  assert.equal(payload._meta.verb, 'list');
+  // No filter applied → no _meta.filter
+  assert.equal(payload._meta.filter, undefined);
+});
+
+test('gate list --format json with --from filter echoes filter in _meta', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--from', 'alice', '--format', 'json'],
+  );
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.requests.length, 2);
+  assert.equal(payload._meta.filter.from, 'alice');
+});
+
+test('gate list --format json with empty result returns empty requests array', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // No seed — state is empty.
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'json'],
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.requests, []);
+  assert.equal(payload._meta.state, 'pending');
+});
+
+test('gate list --format text preserves prior text behavior', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'text'],
+  );
+  assert.equal(r.status, 0);
+  // Text output has no JSON envelope, just the per-request lines.
+  assert.doesNotMatch(r.stdout, /^\{/);
+  assert.match(r.stdout, /fix one/);
+  assert.match(r.stdout, /fix two/);
+});
+
+test('gate list (no --format) defaults to text', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending'],
+  );
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /^\{/);
+});
+
+test('gate list --format invalid is rejected', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'yaml'],
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
+});
+
+// ---- pending ----
+
+test('gate pending --format json emits the same envelope, with _meta.verb=pending', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(root, ['pending', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.requests.length, 2);
+  assert.equal(payload._meta.state, 'pending');
+  assert.equal(payload._meta.verb, 'pending');
+  assert.equal(payload._meta.filter, undefined);
+});
+
+test('gate pending --format json with --for filter echoes filter source', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['pending', '--for', 'alice', '--format', 'json'],
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload._meta.filter.for, 'alice');
+  assert.equal(payload._meta.filter.for_source, '--for');
+});
+
+test('gate pending --format json with GUILD_ACTOR scopes and reports source', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(
+    root,
+    ['pending', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload._meta.filter.for, 'alice');
+  assert.equal(payload._meta.filter.for_source, 'GUILD_ACTOR');
+});
+
+test('gate pending --format text preserves prior text behavior', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const r = runGate(root, ['pending', '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /^\{/);
+  assert.match(r.stdout, /fix one/);
+});
+
+test('gate pending --format invalid is rejected', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['pending', '--format', 'yaml']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
+});
+
+// ---- still-rejects-unknown-flags after the format addition ----
+
+test('gate list still rejects unknown flags (format addition is targeted)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['list', '--state', 'pending', '--bogus-flag-xyz', 'x'],
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown flag/i);
+});
+
+test('gate pending still rejects unknown flags (format addition is targeted)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['pending', '--bogus-flag-xyz', 'x']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown flag/i);
+});

--- a/tests/interface/unknownFlagRejection.test.ts
+++ b/tests/interface/unknownFlagRejection.test.ts
@@ -146,10 +146,14 @@ test('gate tail (no flags) still works', (t) => {
 // --- read-verb sweep: every read verb rejects unknown flags ---
 //
 // Pre-sweep, only tail/doctor/repair/unresponded had this discipline;
-// the rest fail-opened. A typo like `gate pending --format json` would
+// the rest fail-opened. A typo like `gate pending --invalid-flag` would
 // silently render text instead of error. Each entry below uses
 // `--bogus-flag-xyz` (deliberately implausible) so the test surfaces
 // the discipline, not a flag-name overlap with future legitimate flags.
+// (Historical note: pre-2026-05-03, `--format` was itself an "unknown
+// flag" on `pending` / `list`; the bird's-eye check report surfaced
+// the asymmetry vs other read verbs and `--format json|text` is now
+// accepted on both. Tested in tests/interface/listPendingFormat.test.ts.)
 //
 // Verbs that need a positional id are given a placeholder; the strict-
 // flag check fires before the id is parsed, so any value works.


### PR DESCRIPTION
## Summary

Closes the asymmetry surfaced by the post-merge bird's-eye check report (claim #1, 2026-05-03): every gate read verb except `list` and `pending` accepted `--format json|text`. Pre-fix, `gate pending --format json` errored with "unknown flag".

This is the same shape of fix as PR #111 (which added `--format json` to `gate tail`). Coherence-lense observation per devil-review's classification — sister verbs should agree on which flags they accept.

## What this fix pins

- **`src/interface/gate/handlers/request.ts`**
  - `LIST_KNOWN_FLAGS` and `PENDING_KNOWN_FLAGS` gain `format`
  - `reqList` parses `--format` (default `text`), validates `json|text`
  - JSON branch emits envelope mirroring `board`'s `_meta` convention:
    ```json
    {
      "requests": [<request.toJSON()>...],
      "_meta": {
        "state": "pending",
        "verb": "pending",
        "filter": {                      // present iff filters applied
          "from": "alice",
          "for": "alice",
          "for_source": "GUILD_ACTOR"    // mirrors board's same field
        }
      }
    }
    ```

- **`src/interface/gate/handlers/schema.ts`** — `list` and `pending` declare `format` in input schema; output type → `object` (envelope, not bare array)

- **`tests/interface/unknownFlagRejection.test.ts`** — top-of-section comment updated. Previously cited `gate pending --format json` as a typo example pre-sweep; that example is now legitimate. Replaced with `--invalid-flag` + a historical note pointing at the new test file.

- **`tests/interface/listPendingFormat.test.ts` (new, 13 tests)** — pins the new contract: envelope shape, filter echoing in `_meta.filter` with `for_source`, empty-result envelope (empty `requests` + no `filter` key), text-mode unchanged, `--format invalid` rejected, **unknown flags still rejected** (the format addition is targeted, not a relaxation of strict-flag discipline).

## Test plan

- [x] `npm test` passes (901/901 — was 888 + 13 new)
- [x] `gate list --state pending --format json` returns envelope
- [x] `gate pending --format json` returns envelope
- [x] `gate pending --format text` unchanged
- [x] `gate pending` (no flag) defaults to text
- [x] `gate pending --format yaml` errors with structured message
- [x] `gate pending --bogus-flag-xyz x` still rejected (strict-flag discipline preserved)

## Compatibility / behavior change

Any caller using `gate pending --format json` or `gate list --state … --format json` previously errored "unknown flag"; now returns the JSON envelope. Callers using text mode (default) are unaffected.

## Out-of-scope follow-ups

- The `--format json` envelope for `list` could be promoted into a more pipe-friendly shape (e.g., bare array at top level) for shell-pipe ergonomics, but that's a separate naming/category question. This PR just closes the asymmetry by adding the supported `--format json|text` flag to both verbs.
- The bird's-eye check report mentioned this as one of three "Notable CLI behavior" items; the other two (`devil entry` severity aliases, `devil conclude` lense coverage) are correct by design — no fix needed.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_