### PR TITLE
feat(actor): .guild-actor file fallback for env-less actor resolution

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -331,6 +331,18 @@ Request IDs: `YYYY-MM-DD-NNNN`. Issue IDs: `i-YYYY-MM-DD-NNNN`.
 `GUILD_ACTOR=<name>` — default for `--from` / `--by` / `--for`.
 Explicit flags always win. `--executor` and `--auto-review` are never env-filled.
 
+If `GUILD_ACTOR` is unset, the CLI falls back to a `.guild-actor`
+file: walks up from `cwd` (same ancestor pattern as
+`guild.config.yaml`), takes the first one found, trims whitespace,
+uses its content as the actor. Empty/whitespace-only files fall
+through. **Env wins** when both are present — env is the legacy
+contract; the file is the substrate-side fallback for environments
+where shell env doesn't propagate (e.g. AI agent loops where each
+subprocess is a fresh shell). Per
+[`lore/principles/11-ai-first-human-as-projection.md`](./lore/principles/11-ai-first-human-as-projection.md),
+the file is more AI-natural than env: substrate-resident, ancestor-
+walked, the same shape as `guild.config.yaml`.
+
 `GUILD_LOCALE=<en|ja>` — prose language for `gate resume`
 `restoration_prose`. Defaults to `en`. Also settable via `--locale`.
 

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -51,8 +52,8 @@ export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
 
   const explicitFor = optionalOption(args, 'for');
   const envActor =
-    explicitFor === undefined && process.env['GUILD_ACTOR']
-      ? process.env['GUILD_ACTOR']
+    explicitFor === undefined && resolveGuildActor()
+      ? resolveGuildActor()
       : undefined;
   const forFilter = explicitFor ?? envActor;
 

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import { resolve } from 'node:path';
 import {
   ParsedArgs,
@@ -187,7 +188,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   const tailLimit = parseOptionalIntOption(args, 'tail') ?? 10;
   const personalLimit = parseOptionalIntOption(args, 'utterances') ?? 5;
 
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const actor = envActor && envActor.length > 0 ? envActor : null;
 
   // Resolve role without rejecting when GUILD_ACTOR is unset — boot

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import { resolve as resolvePath } from 'node:path';
 import { buildContainer } from '../../shared/container.js';
 import { optionalOption, ParsedArgs } from '../../shared/parseArgs.js';
@@ -57,7 +58,7 @@ export async function readStdin(): Promise<string> {
  * emitting the user-facing delegation notice.
  */
 export function deriveInvokedBy(by: string): string | undefined {
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   if (!envActor || envActor.length === 0) return undefined;
   if (envActor === by) return undefined;
   return envActor;

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   requireOption,
@@ -233,7 +234,7 @@ async function msgInboxMarkRead(c: C, args: ParsedArgs): Promise<number> {
   // both so the audit trail records "who read for whom". Fall back to
   // the inbox owner when GUILD_ACTOR is unset — same-actor self-reader
   // is the common case, and stamping `read_by: <owner>` is correct.
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const by = envActor && envActor.length > 0 ? envActor : forName;
   const result = await c.messageUC.markRead(forName, by, index);
   if (by !== forName) {

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -81,7 +82,7 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   // verdicts vs outcomes. Hidden when viewing your own voice (the
   // voter shouldn't game their own score); shown otherwise. See the
   // `computeVoiceCalibration` header in voices.ts for semantics.
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const isSelfView =
     envActor !== undefined &&
     envActor.length > 0 &&
@@ -212,7 +213,7 @@ const WHOAMI_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
 
 export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, WHOAMI_KNOWN_FLAGS, 'whoami');
-  const actor = process.env['GUILD_ACTOR'];
+  const actor = resolveGuildActor();
   if (!actor || actor.length === 0) {
     process.stderr.write(
       'GUILD_ACTOR is not set.\n' +

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   requireOption,
@@ -160,8 +161,8 @@ export async function reqList(
   const autoReviewFilter = optionalOption(args, 'auto-review');
   const explicitFor = optionalOption(args, 'for');
   const envActor =
-    explicitFor === undefined && process.env['GUILD_ACTOR']
-      ? process.env['GUILD_ACTOR']
+    explicitFor === undefined && resolveGuildActor()
+      ? resolveGuildActor()
       : undefined;
   const forFilter = explicitFor ?? envActor;
 
@@ -697,7 +698,7 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
   // `executor` may legitimately differ from `from`; when it does we
   // don't emit a second notice here — the env actor vs executor
   // mismatch is the same delegation already surfaced above.
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const invokedByExec =
     envActor && envActor.length > 0 && envActor !== executor
       ? envActor

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -109,7 +110,7 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
   }
-  const actor = process.env['GUILD_ACTOR'];
+  const actor = resolveGuildActor();
   if (!actor || actor.length === 0) {
     process.stderr.write(
       'gate resume requires GUILD_ACTOR (resume is inherently first-person).\n' +

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -153,7 +154,7 @@ function renderStatusText(s: StatusSummary): string {
 
 export async function statusCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, STATUS_KNOWN_FLAGS, 'status');
-  const actor = optionalOption(args, 'for') ?? process.env['GUILD_ACTOR'] ?? null;
+  const actor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
   const format = optionalOption(args, 'format') ?? 'json';
 
   const all = await c.requestUC.listAll();

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -41,7 +42,7 @@ export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
   }
 
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const actor = envActor && envActor.length > 0 ? envActor : null;
 
   // Role resolution mirrors bootCmd. Suggest must succeed without an

--- a/src/interface/gate/handlers/unresponded.ts
+++ b/src/interface/gate/handlers/unresponded.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -64,7 +65,7 @@ export async function unrespondedCmd(
   }
 
   const explicit = optionalOption(args, 'for');
-  const envActor = process.env['GUILD_ACTOR'];
+  const envActor = resolveGuildActor();
   const actor = explicit ?? envActor ?? '';
   if (!actor) {
     process.stderr.write(

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -1,3 +1,4 @@
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import { Request } from '../../../domain/request/Request.js';
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
@@ -212,7 +213,7 @@ export function buildWriteResponse(
   message: string,
   config: GuildConfig,
 ): WriteResponse {
-  const envActor = process.env['GUILD_ACTOR'] ?? null;
+  const envActor = resolveGuildActor() ?? null;
   return {
     ok: true,
     id: req.id.value,

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -23,6 +23,9 @@
  * value anyway, so the old misbehaviour was latent: true intent
  * dropped on the floor, positional swallowed.
  */
+
+import { resolveGuildActor } from './resolveGuildActor.js';
+
 export interface ParsedArgs {
   readonly options: Readonly<Record<string, string | boolean>>;
   readonly positional: readonly string[];
@@ -97,8 +100,8 @@ export function requireOption(
   const v = args.options[key];
   if (typeof v === 'string' && v) return v;
   if (envFallback) {
-    const envVal = process.env[envFallback];
-    if (envVal && envVal.length > 0) return envVal;
+    const fallback = resolveEnvOrActorFile(envFallback);
+    if (fallback !== undefined) return fallback;
   }
   // When the flag is present but landed as boolean, the user almost
   // certainly passed a value beginning with `--` (quoting another
@@ -122,8 +125,24 @@ export function optionalOption(
   const v = args.options[key];
   if (typeof v === 'string') return v;
   if (envFallback) {
-    const envVal = process.env[envFallback];
-    if (envVal && envVal.length > 0) return envVal;
+    const fallback = resolveEnvOrActorFile(envFallback);
+    if (fallback !== undefined) return fallback;
+  }
+  return undefined;
+}
+
+/**
+ * Read `envFallback` from process.env, falling through to the
+ * `.guild-actor` file if and only if the fallback name is `GUILD_ACTOR`.
+ * Other env-fallback names (none used today, but the parameter is open)
+ * stay env-only — the file fallback is specifically for actor identity.
+ * See `resolveGuildActor` for the file resolution rules.
+ */
+function resolveEnvOrActorFile(envFallback: string): string | undefined {
+  const envVal = process.env[envFallback];
+  if (envVal && envVal.length > 0) return envVal;
+  if (envFallback === 'GUILD_ACTOR') {
+    return resolveGuildActor();
   }
   return undefined;
 }

--- a/src/interface/shared/resolveGuildActor.ts
+++ b/src/interface/shared/resolveGuildActor.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Resolve the default actor name for `--from` / `--by` / `--for` /
+ * `--with` when no explicit flag is given. Resolution order:
+ *
+ *   1. `process.env.GUILD_ACTOR` — env vars work for shell-driven use.
+ *   2. `.guild-actor` file — first ancestor directory of `cwd` that
+ *      contains one wins. Single-line, leading/trailing whitespace
+ *      trimmed.
+ *   3. `undefined` — caller decides whether absence is an error.
+ *      (Returns `undefined` not `null` so callers can use this as a
+ *      drop-in replacement for `process.env['GUILD_ACTOR']`, which is
+ *      where the legacy code was reading.)
+ *
+ * Why both? Per
+ * `lore/principles/11-ai-first-human-as-projection.md`, env vars are a
+ * projection-layer convenience: they require a configured shell, don't
+ * survive subprocess boundaries (e.g. AI agents whose Bash tools spawn
+ * fresh shells per call), and aren't substrate. The `.guild-actor` file
+ * is substrate — committed-or-not is a per-actor choice, but it lives
+ * in the content_root tree alongside `guild.config.yaml`, and resolution
+ * follows the same ancestor-walking pattern (see `findConfig` in
+ * `infrastructure/config/GuildConfig.ts`).
+ *
+ * Env beats file. The legacy contract is "env wins"; users with
+ * `GUILD_ACTOR` set in their shell shouldn't see a quietly-different
+ * actor when a colleague drops a `.guild-actor` into the repo. The
+ * file-fallback fires only when the env is genuinely unset.
+ *
+ * Surfaced by issue i-2026-05-03-0001 from the develop-branch dogfood:
+ * the AI-agent loop using `Bash` tool calls cannot rely on shell env
+ * because each subprocess is fresh. The substrate-file fallback closes
+ * that gap without breaking anyone's existing env-based setup.
+ */
+export function resolveGuildActor(start: string = process.cwd()): string | undefined {
+  const env = process.env['GUILD_ACTOR'];
+  if (env !== undefined && env.length > 0) return env;
+  return findActorFile(start);
+}
+
+/**
+ * Walk up from `start` looking for `.guild-actor`. Returns the first
+ * file's trimmed contents or `undefined` if none found within the lookup
+ * window. Same 10-level cap as `findConfig`; cross-platform via
+ * `path.resolve('..')`.
+ */
+function findActorFile(start: string): string | undefined {
+  let dir = resolve(start);
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, '.guild-actor');
+    if (existsSync(candidate)) {
+      const raw = readFileSync(candidate, 'utf8').trim();
+      if (raw.length > 0) return raw;
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}

--- a/src/passages/agora/interface/handlers/conclude.ts
+++ b/src/passages/agora/interface/handlers/conclude.ts
@@ -55,7 +55,7 @@ export async function concludePlay(
     return 1;
   }
   const note = optionalOption(args, 'note');
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora conclude attributes the conclusion to an actor.\n',

--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -48,7 +48,7 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
     return 1;
   }
   const text = requireOption(args, 'text', '--text required');
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora move attributes the move to an actor.\n',

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -38,7 +38,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   const kind = requireOption(args, 'kind', '--kind required (quest|sandbox)');
   const title = requireOption(args, 'title', '--title required');
   const description = optionalOption(args, 'description');
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora new attributes the creation to an actor.\n',

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -43,7 +43,7 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
   rejectUnknownFlags(args, PLAY_KNOWN_FLAGS, 'play');
 
   const slug = requireOption(args, 'slug', '--slug required (game to play)');
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora play attributes the start to an actor.\n',

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -52,7 +52,7 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
     return 1;
   }
   const note = optionalOption(args, 'note');
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora resume attributes the resume to an actor.\n',

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -63,7 +63,7 @@ export async function suspendPlay(
     'invitation',
     '--invitation required (what the next opener should do, prose)',
   );
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). agora suspend attributes the suspension to an actor.\n',

--- a/src/passages/devil/interface/handlers/conclude.ts
+++ b/src/passages/devil/interface/handlers/conclude.ts
@@ -92,7 +92,7 @@ export async function concludeReview(
         .filter((s) => s.length > 0)
     : [];
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil conclude attributes the close.\n',

--- a/src/passages/devil/interface/handlers/dismiss.ts
+++ b/src/passages/devil/interface/handlers/dismiss.ts
@@ -80,7 +80,7 @@ export async function dismissEntry(
   const reason: DismissalReason = parseDismissalReason(reasonRaw);
   const note = optionalOption(args, 'note');
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil dismiss attributes the dismissal.\n',

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -106,7 +106,7 @@ export async function entryOnReview(
   );
   const text = requireOption(args, 'text', '--text required');
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil entry attributes the entry author.\n',

--- a/src/passages/devil/interface/handlers/ingest.ts
+++ b/src/passages/devil/interface/handlers/ingest.ts
@@ -193,7 +193,7 @@ export async function ingestSource(
     return 1;
   }
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil ingest attributes the ingest invocation.\n',

--- a/src/passages/devil/interface/handlers/open.ts
+++ b/src/passages/devil/interface/handlers/open.ts
@@ -62,7 +62,7 @@ export async function openReview(deps: OpenDeps, args: ParsedArgs): Promise<numb
   // bubble to the dispatcher's catch (turns into stderr error: ...).
   const type = parseTargetType(typeRaw);
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil open attributes the review opener.\n',

--- a/src/passages/devil/interface/handlers/resolve.ts
+++ b/src/passages/devil/interface/handlers/resolve.ts
@@ -71,7 +71,7 @@ export async function resolveEntry(
     return 1;
   }
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil resolve attributes the resolution.\n',

--- a/src/passages/devil/interface/handlers/resume.ts
+++ b/src/passages/devil/interface/handlers/resume.ts
@@ -67,7 +67,7 @@ export async function resumeReview(
 
   const note = optionalOption(args, 'note');
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil resume attributes the re-entry.\n',

--- a/src/passages/devil/interface/handlers/suspend.ts
+++ b/src/passages/devil/interface/handlers/suspend.ts
@@ -80,7 +80,7 @@ export async function suspendReview(
     '--invitation required (what the next opener of this thread should attempt)',
   );
 
-  const by = optionalOption(args, 'by') ?? process.env['GUILD_ACTOR'];
+  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {
     process.stderr.write(
       'error: --by required (or set GUILD_ACTOR). devil suspend attributes the pause.\n',

--- a/tests/interface/guildActorFile.test.ts
+++ b/tests/interface/guildActorFile.test.ts
@@ -1,0 +1,115 @@
+// E2E: .guild-actor file fallback works through the gate CLI surface.
+//
+// The unit test (resolveGuildActor.test.ts) covers the resolver in
+// isolation; this test pins the integration: a real `gate` subprocess
+// invocation, with no GUILD_ACTOR env, picks up the actor from a
+// `.guild-actor` file in the content_root.
+//
+// Surfaced by issue i-2026-05-03-0001 from the develop-branch
+// dogfood: env-only resolution breaks for AI agent loops where each
+// subprocess gets a fresh shell. Pinning E2E here ensures the
+// agora/devil passages and the gate verb layer all honor the
+// substrate-side fallback consistently.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-actor-file-e2e-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  envOverrides: Record<string, string | undefined>,
+): { stdout: string; stderr: string; status: number } {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  // Strip any inherited GUILD_ACTOR so the test is hermetic.
+  delete env['GUILD_ACTOR'];
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) delete env[k];
+    else env[k] = v;
+  }
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('gate boot: .guild-actor file resolves actor when GUILD_ACTOR env unset', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, '.guild-actor'), 'alice\n');
+  const r = runGate(root, ['boot', '--format', 'json'], {});
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, 'alice', 'actor must come from .guild-actor');
+});
+
+test('gate boot: env wins over .guild-actor when both set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, '.guild-actor'), 'from-file');
+  // alice is the only registered member; we'd need two for env-vs-file
+  // to produce visibly different results. Register a second.
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(join(root, '.guild-actor'), 'alice');
+  const r = runGate(root, ['boot', '--format', 'json'], { GUILD_ACTOR: 'bob' });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, 'bob', 'env GUILD_ACTOR must win over .guild-actor');
+});
+
+test('gate boot: ancestor .guild-actor found from subdir cwd', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, '.guild-actor'), 'alice');
+  const subdir = join(root, 'sub', 'deeper');
+  mkdirSync(subdir, { recursive: true });
+  const r = runGate(subdir, ['boot', '--format', 'json'], {});
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, 'alice');
+});
+
+test('gate boot: no env + no file → actor is null (not an error)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // No .guild-actor written.
+  const r = runGate(root, ['boot', '--format', 'json'], {});
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, null);
+});

--- a/tests/interface/resolveGuildActor.test.ts
+++ b/tests/interface/resolveGuildActor.test.ts
@@ -1,0 +1,164 @@
+// Cover the env → .guild-actor file → undefined resolution chain.
+//
+// Surfaced by issue i-2026-05-03-0001 (develop-branch dogfood):
+// .envrc relies on a configured shell, but Claude Code's Bash tool
+// spawns fresh subprocesses, so env never propagates. The
+// .guild-actor file fallback closes the gap without breaking
+// existing env-based shells (env still wins).
+//
+// Resolution order tested here:
+//   1. process.env.GUILD_ACTOR (legacy contract)
+//   2. .guild-actor file in cwd or any ancestor (NEW)
+//   3. undefined
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveGuildActor } from '../../src/interface/shared/resolveGuildActor.js';
+
+function withEnv(actor: string | undefined, fn: () => void): void {
+  const prev = process.env['GUILD_ACTOR'];
+  if (actor === undefined) delete process.env['GUILD_ACTOR'];
+  else process.env['GUILD_ACTOR'] = actor;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-actor-resolve-'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('env wins when set and non-empty', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv('from-env', () => {
+      assert.equal(resolveGuildActor(root), 'from-env');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('file fallback fires when env is unset', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(root), 'from-file');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('file fallback fires when env is empty string', () => {
+  // process.env stores values as strings; empty string is treated
+  // the same as unset (legacy `envVal && envVal.length > 0` guard).
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv('', () => {
+      assert.equal(resolveGuildActor(root), 'from-file');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('file content is trimmed (newlines, surrounding whitespace)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), '  alice\n');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(root), 'alice');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('empty file falls through (treated as not set)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), '');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(root), undefined);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('whitespace-only file falls through', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), '   \n  \t  ');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(root), undefined);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('ancestor walking — file in parent dir is found from child cwd', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const child = join(root, 'a', 'b', 'c');
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(root, '.guild-actor'), 'ancestral');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(child), 'ancestral');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('nearest ancestor wins when multiple .guild-actor files in path', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const child = join(root, 'a', 'b');
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(root, '.guild-actor'), 'far');
+    writeFileSync(join(root, 'a', '.guild-actor'), 'near');
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActor(child), 'near');
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('returns undefined when neither env nor any ancestor file exists', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    withEnv(undefined, () => {
+      // No .guild-actor written, no env set.
+      // Walk-up will hit root (filesystem root) and stop. tmpdir's
+      // parent chain has no .guild-actor (we hope; if a system-wide
+      // file exists this test would surface it as a real environmental
+      // contamination — which is a feature, not a bug).
+      const result = resolveGuildActor(root);
+      assert.equal(result, undefined);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('default start defaults to process.cwd() when no arg passed', () => {
+  // Smoke: just check the call doesn't throw and returns string|undefined.
+  withEnv('cwd-test', () => {
+    const result = resolveGuildActor();
+    assert.equal(result, 'cwd-test');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds substrate-side fallback (`.guild-actor` file) to actor resolution. When `GUILD_ACTOR` env is unset, the CLI walks up from `cwd` looking for a `.guild-actor` file (same ancestor pattern as `guild.config.yaml`) and uses its trimmed content. Env still wins when set.
- Closes the env-propagation gap surfaced by AI-agent loops (Claude Code's Bash tool spawns fresh subprocesses per call, so shell env never propagates) without breaking any existing env-based shell setup.
- More AI-natural per [`lore/principles/11-ai-first-human-as-projection.md`](https://github.com/eris-ths/guild-cli/blob/feat/guild-actor-file-fallback/lore/principles/11-ai-first-human-as-projection.md): the file is substrate (records outlive shell sessions, ancestor-walked, same shape as `guild.config.yaml`); env is projection.

## Resolution chain (after this PR)

1. `process.env.GUILD_ACTOR` — legacy contract, env wins.
2. `.guild-actor` file — first ancestor of cwd that contains one wins; whitespace-trimmed; empty/whitespace-only files fall through.
3. `undefined` — caller decides if absence is an error.

## Implementation

- `src/interface/shared/resolveGuildActor.ts` — new helper. 10-level ancestor walk cap (matches `findConfig`); cross-platform via `path.resolve('..')`.
- `src/interface/shared/parseArgs.ts` — `requireOption` / `optionalOption` `envFallback` path routes through the resolver when `envFallback === 'GUILD_ACTOR'`. Other env-fallback names stay env-only (none used today; the parameter is open for future).
- 14 agora/devil handlers: `optionalOption(args, 'by') ?? process.env['GUILD_ACTOR']` → `optionalOption(args, 'by', 'GUILD_ACTOR')`. One-line diff each.
- 11 gate handlers: direct `process.env['GUILD_ACTOR']` reads → `resolveGuildActor()` (drop-in `string | undefined` return).
- AGENT.md § Environment — documents the fallback and links principle 11.

## Surfaced by

- Issue `i-2026-05-03-0001` (filed during develop-branch dogfood). Candidate (d) "move actor declaration to a file the CLI reads" was the AI-natural pick of 4; this PR implements it. Issue resolved on `develop` branch (commit 7a5a328).

## Test plan

- [x] Unit tests (`tests/interface/resolveGuildActor.test.ts`, 10 cases): env wins / file fallback / empty env falls through / file content trimmed / empty file falls through / whitespace-only file falls through / ancestor walking from subdir / nearest-wins on multiple files / no env + no file → undefined / default cwd start.
- [x] E2E tests (`tests/interface/guildActorFile.test.ts`, 4 cases): real `gate boot` subprocess invocations confirming the resolution at the verb layer.
- [x] Full suite: 901 → 915 (+14 new), all passing. Typecheck clean.
- [x] **Real dogfood verified on `develop` branch** (commit 7a5a328): `.guild-actor` file with content "claude" — `gate boot`, `agora resume`, `gate issues resolve` all worked with no inline `GUILD_ACTOR=` prefix and no active env. Suspended agora play resumed correctly, surfacing closing cliff/invitation through the merge.
- [ ] CI green
- [ ] Reviewer sanity check on the 25-handler mechanical replacement (sed-driven; pattern was exact string match, verified by grep before/after — but worth a second eye)

## Behavior changes for orchestrators

None breaking. Env is still authoritative when set; nothing about the existing GUILD_ACTOR env contract changed. The fallback only fires when env is absent, which today produces a "missing actor" error — the new behavior replaces that error with successful resolution from the file. So this strictly widens the success surface.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_