### PR TITLE
fix(agora): disambiguate cross-game play-id collisions in move/suspend/resume/conclude

### DIFF
--- a/src/passages/agora/interface/handlers/conclude.ts
+++ b/src/passages/agora/interface/handlers/conclude.ts
@@ -9,11 +9,13 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { resolvePlayForVerb } from './resolvePlay.js';
 
 const CONCLUDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'note',
   'by',
   'format',
+  'game',
 ]);
 
 /**
@@ -68,7 +70,10 @@ export async function concludePlay(
     return 1;
   }
 
-  const play = await deps.plays.findById(playId);
+  const gameFilter = optionalOption(args, 'game');
+  const resolved = await resolvePlayForVerb(deps.plays, playId, gameFilter);
+  if (resolved === 'ambiguous') return 1;
+  const play = resolved;
   if (!play) {
     throw new PlayNotFound(playId);
   }

--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -11,11 +11,13 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { resolvePlayForVerb } from './resolvePlay.js';
 
 const MOVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
   'text',
   'format',
+  'game',
 ]);
 
 /**
@@ -61,7 +63,10 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
     return 1;
   }
 
-  const play = await deps.plays.findById(playId);
+  const gameFilter = optionalOption(args, 'game');
+  const resolved = await resolvePlayForVerb(deps.plays, playId, gameFilter);
+  if (resolved === 'ambiguous') return 1;
+  const play = resolved;
   if (!play) {
     throw new PlayNotFound(playId);
   }

--- a/src/passages/agora/interface/handlers/resolvePlay.ts
+++ b/src/passages/agora/interface/handlers/resolvePlay.ts
@@ -1,0 +1,52 @@
+import { Play } from '../../domain/Play.js';
+import { PlayRepository } from '../../application/PlayRepository.js';
+
+/**
+ * Resolve a `<play-id>` positional that may collide across games.
+ *
+ * Plays are sequenced **per-game-per-day**, so two games each opened
+ * on the same day both produce a `YYYY-MM-DD-001`. The repository's
+ * `findById` walks game subdirectories and returns the first match
+ * (alphabetically by game slug) — which silently mis-resolves the
+ * caller's intent when the collision is real. `agora show` already
+ * disambiguates with this pattern; this helper extracts it so
+ * `agora move` / `suspend` / `resume` / `conclude` honor the same
+ * contract.
+ *
+ * Resolution rules:
+ *   - explicit `gameFilter` → walk all matches, return the one whose
+ *     `game` slug matches; null if none.
+ *   - no `gameFilter` + 0 matches → null.
+ *   - no `gameFilter` + 1 match → that match.
+ *   - no `gameFilter` + >1 matches → write an ambiguity error to stderr
+ *     listing candidate game slugs and the `--game <slug>` escape valve;
+ *     return `'ambiguous'` so the caller exits with status 1.
+ *
+ * The ambiguity error names every candidate so the caller can pick
+ * without a separate `agora list` round-trip. Phrasing matches
+ * `agora show`'s existing message verbatim.
+ *
+ * Surfaced by issue i-2026-05-03-0002 (develop-branch dogfood,
+ * "going-inside-harness" experiment): the same-day same-id collision
+ * blocked all moves on a 2nd play of the day.
+ */
+export async function resolvePlayForVerb(
+  plays: PlayRepository,
+  playId: string,
+  gameFilter: string | undefined,
+): Promise<Play | null | 'ambiguous'> {
+  if (gameFilter) {
+    const matches = await plays.findAllById(playId);
+    return matches.find((p) => p.game === gameFilter) ?? null;
+  }
+  const matches = await plays.findAllById(playId);
+  if (matches.length > 1) {
+    const games = matches.map((p) => p.game).join(', ');
+    process.stderr.write(
+      `error: multiple games have a play with id "${playId}" (each game has its own sequence). ` +
+        `Disambiguate with --game <slug>. Candidates: ${games}\n`,
+    );
+    return 'ambiguous';
+  }
+  return matches[0] ?? null;
+}

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -10,11 +10,13 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { resolvePlayForVerb } from './resolvePlay.js';
 
 const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'note',
   'by',
   'format',
+  'game',
 ]);
 
 /**
@@ -65,7 +67,10 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
     return 1;
   }
 
-  const play = await deps.plays.findById(playId);
+  const gameFilter = optionalOption(args, 'game');
+  const resolved = await resolvePlayForVerb(deps.plays, playId, gameFilter);
+  if (resolved === 'ambiguous') return 1;
+  const play = resolved;
   if (!play) {
     throw new PlayNotFound(playId);
   }

--- a/src/passages/agora/interface/handlers/schema.ts
+++ b/src/passages/agora/interface/handlers/schema.ts
@@ -194,6 +194,10 @@ const VERBS: readonly VerbSchema[] = [
         by: strOpt('actor (defaults to GUILD_ACTOR)'),
         text: str,
         format: formatField,
+        game: strOpt(
+          'game slug (required when <play-id> matches plays in multiple games — e.g. ' +
+            'two games each have a YYYY-MM-DD-001)',
+        ),
       },
       required: ['text'],
     },
@@ -216,6 +220,7 @@ const VERBS: readonly VerbSchema[] = [
         invitation: str,
         by: strOpt('actor (defaults to GUILD_ACTOR)'),
         format: formatField,
+        game: strOpt('game slug (required for cross-game id collisions; see move)'),
       },
       required: ['cliff', 'invitation'],
     },
@@ -237,6 +242,7 @@ const VERBS: readonly VerbSchema[] = [
         note: strOpt('optional resume prose'),
         by: strOpt('actor (defaults to GUILD_ACTOR)'),
         format: formatField,
+        game: strOpt('game slug (required for cross-game id collisions; see move)'),
       },
     },
     output: writeEnvelopeBase({
@@ -260,6 +266,7 @@ const VERBS: readonly VerbSchema[] = [
         note: strOpt('optional closure prose'),
         by: strOpt('actor (defaults to GUILD_ACTOR)'),
         format: formatField,
+        game: strOpt('game slug (required for cross-game id collisions; see move)'),
       },
     },
     output: writeEnvelopeBase({

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -11,12 +11,14 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { resolvePlayForVerb } from './resolvePlay.js';
 
 const SUSPEND_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'cliff',
   'invitation',
   'by',
   'format',
+  'game',
 ]);
 
 /**
@@ -76,7 +78,10 @@ export async function suspendPlay(
     return 1;
   }
 
-  const play = await deps.plays.findById(playId);
+  const gameFilter = optionalOption(args, 'game');
+  const resolved = await resolvePlayForVerb(deps.plays, playId, gameFilter);
+  if (resolved === 'ambiguous') return 1;
+  const play = resolved;
   if (!play) {
     throw new PlayNotFound(playId);
   }

--- a/tests/passages/agora/crossGameDisambiguation.test.ts
+++ b/tests/passages/agora/crossGameDisambiguation.test.ts
@@ -1,0 +1,198 @@
+// Pin agora move/suspend/resume/conclude cross-game ID disambiguation.
+//
+// Surfaced by issue i-2026-05-03-0002 (develop dogfood, going-inside-
+// harness experiment): plays are sequenced per-game-per-day, so two
+// games each opened on the same day both produce YYYY-MM-DD-001. The
+// repository's findById walks game subdirectories and returns the
+// first match — silently mis-resolving the caller's intent when the
+// collision is real.
+//
+// agora show already disambiguates with this pattern. This test
+// covers the four state-mutating verbs that previously called
+// findById directly: move, suspend, resume, conclude.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AGORA = resolve(here, '../../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'agora-cross-game-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runAgora(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  env['GUILD_ACTOR'] = 'alice';
+  const r = spawnSync(process.execPath, [AGORA, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function seedTwoCollidingPlays(root: string): { idA: string; idB: string } {
+  // Two games, each with a play started today → both get YYYY-MM-DD-001.
+  runAgora(root, ['new', '--slug', 'aaa-game', '--kind', 'sandbox', '--title', 'A']);
+  runAgora(root, ['new', '--slug', 'bbb-game', '--kind', 'sandbox', '--title', 'B']);
+  const a = runAgora(root, ['play', '--slug', 'aaa-game']);
+  const b = runAgora(root, ['play', '--slug', 'bbb-game']);
+  // Both play_ids should match the same YYYY-MM-DD-001 shape; extract
+  // by parsing the success line.
+  const idA = (a.stdout.match(/play started: (\S+)/) ?? [])[1] ?? '';
+  const idB = (b.stdout.match(/play started: (\S+)/) ?? [])[1] ?? '';
+  assert.equal(idA, idB, 'collision setup: both plays should share id');
+  return { idA, idB };
+}
+
+// ---- move ----
+
+test('agora move: cross-game id collision is rejected with --game suggestion', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(root, ['move', idA, '--text', 'hello']);
+  assert.equal(r.status, 1, `expected exit 1 on ambiguous id; stdout: ${r.stdout}`);
+  assert.match(r.stderr, /multiple games have a play with id/);
+  assert.match(r.stderr, /--game <slug>/);
+  assert.match(r.stderr, /aaa-game/);
+  assert.match(r.stderr, /bbb-game/);
+});
+
+test('agora move --game disambiguates and lands the move on the named game', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(root, ['move', idA, '--game', 'bbb-game', '--text', 'hi-bbb']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  // Verify the move landed on bbb's play, not aaa's, by listing.
+  const list = runAgora(root, ['list', '--game', 'bbb-game']);
+  assert.match(list.stdout, /moves=1/);
+  const listA = runAgora(root, ['list', '--game', 'aaa-game']);
+  assert.match(listA.stdout, /moves=0/);
+});
+
+test('agora move --game with mismatched slug → not found', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(root, ['move', idA, '--game', 'no-such-game', '--text', 'x']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found|PlayNotFound/);
+});
+
+// ---- suspend ----
+
+test('agora suspend: cross-game collision rejected with --game hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(
+    root,
+    ['suspend', idA, '--cliff', 'c', '--invitation', 'i'],
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /multiple games have a play/);
+});
+
+test('agora suspend --game disambiguates correctly', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(
+    root,
+    ['suspend', idA, '--game', 'aaa-game', '--cliff', 'paused-aaa', '--invitation', 'next'],
+  );
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+});
+
+// ---- resume ----
+
+test('agora resume: cross-game collision rejected with --game hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  // Suspend both first so they're each in resumable state.
+  runAgora(
+    root,
+    ['suspend', idA, '--game', 'aaa-game', '--cliff', 'c', '--invitation', 'i'],
+  );
+  runAgora(
+    root,
+    ['suspend', idA, '--game', 'bbb-game', '--cliff', 'c', '--invitation', 'i'],
+  );
+  const r = runAgora(root, ['resume', idA]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /multiple games have a play/);
+});
+
+test('agora resume --game disambiguates correctly', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  runAgora(
+    root,
+    ['suspend', idA, '--game', 'bbb-game', '--cliff', 'c', '--invitation', 'i'],
+  );
+  const r = runAgora(root, ['resume', idA, '--game', 'bbb-game']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+});
+
+// ---- conclude ----
+
+test('agora conclude: cross-game collision rejected with --game hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(root, ['conclude', idA]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /multiple games have a play/);
+});
+
+test('agora conclude --game disambiguates correctly', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { idA } = seedTwoCollidingPlays(root);
+  const r = runAgora(root, ['conclude', idA, '--game', 'aaa-game', '--note', 'closing']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+});
+
+// ---- single-game (no collision) — verbs still work without --game ----
+
+test('agora move on a single-game play_id works without --game (backward compat)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(root, ['new', '--slug', 'only-game', '--kind', 'sandbox', '--title', 'O']);
+  const p = runAgora(root, ['play', '--slug', 'only-game']);
+  const id = (p.stdout.match(/play started: (\S+)/) ?? [])[1] ?? '';
+  const r = runAgora(root, ['move', id, '--text', 'hello']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+});


### PR DESCRIPTION
## Summary

- Fixes silent mis-resolution when two games each have a play with the same id (the natural per-game-per-day sequence).
- `agora move` / `suspend` / `resume` / `conclude` now refuse ambiguous ids with the same `multiple games have a play with id ...` message that `agora show` already uses; new `--game <slug>` flag resolves the ambiguity.
- Closes the dogfood blocker surfaced live during the "going-inside-harness" experiment on `develop`: a Claude instance trying to record its own work in agora couldn't make moves on a 2nd same-day play because today's earlier `develop-seed-policy 2026-05-03-001` was being resolved instead.

## Resolution rules (after this PR)

- Explicit `--game <slug>` → walk all matches, pick the one matching the slug; not-found if none match.
- No `--game`, 0 matches → not-found.
- No `--game`, 1 match → that match (unchanged from before — single-game callers don't need to update).
- No `--game`, >1 matches → exit 1 with stderr listing candidate slugs and the `--game <slug>` escape valve.

## Implementation

- `src/passages/agora/interface/handlers/resolvePlay.ts` — new `resolvePlayForVerb` helper. Returns `Play | null | 'ambiguous'`. Phrasing of the ambiguity error matches `agora show`'s existing message verbatim so agents see the same shape across read and write verbs.
- 4 handlers updated (`move` / `suspend` / `resume` / `conclude`): replace `await deps.plays.findById(playId)` with `await resolvePlayForVerb(deps.plays, playId, gameFilter)`. Each handler's `KNOWN_FLAGS` set gains `game`; the schema input gains `game: strOpt(...)` (principle 10 — schema-as-contract; `KNOWN_FLAGS`/schema drift detector test would catch the mismatch).

## Test plan

- [x] 10 new E2E tests (`tests/passages/agora/crossGameDisambiguation.test.ts`) — ambiguity rejection, `--game` disambiguation, mismatched `--game`, single-game backward compat, across all four verbs.
- [x] Full suite: 915 → 925 passing. Typecheck clean.
- [ ] CI green (4 jobs: test/test-windows × node 20/22)

## Surfaced by

- Issue [`i-2026-05-03-0002`](https://github.com/eris-ths/guild-cli/blob/develop/issues/i-2026-05-03-0002.yaml) (filed during the develop-branch "going-inside-harness" dogfood experiment).
- Promoted to gate request `2026-05-03-0001` on develop, executing during this PR's authorship; will complete when this PR lands.

## Behavior changes for orchestrators

Strictly additive. Single-game-per-id callers see no behavior change. Callers that were silently being mis-resolved (i.e., hitting cross-game collisions and getting confusing `PlayNotPlayable` errors against the wrong play) now get a clean ambiguity error pointing at the right escape valve.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_