### PR TITLE
feat(boot): cross-passage orientation via passage-registry seam

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -15,6 +15,12 @@ const BOOT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 import { collectStatus, StatusSummary } from './status.js';
 import { collectUtterances } from '../voices.js';
 import { Request } from '../../../domain/request/Request.js';
+import {
+  PassageOrientationProvider,
+  PassageOrientationSummary,
+} from '../../shared/PassageOrientation.js';
+import { agoraOrientation } from '../../../passages/agora/interface/orientation.js';
+import { devilOrientation } from '../../../passages/devil/interface/orientation.js';
 
 /**
  * Next-step hint embedded in boot. Mirrors the SuggestedNext shape
@@ -121,6 +127,25 @@ interface BootPayload {
       fix_hint: string | null;
     };
   };
+  /**
+   * Cross-passage orientation. Each registered passage that has any
+   * records under the content_root contributes a normalized summary
+   * (open count, suspended count, last-touched id/state/at). Empty
+   * passages omit their entry entirely. The map is empty when no
+   * passage besides gate has any records.
+   *
+   * Closes the substrate-side Zeigarnik continuity gap surfaced by
+   * the develop-branch dogfood (`cross-passage-orient` agora play):
+   * fresh instances that boot on a content_root with active agora
+   * plays or devil reviews previously saw nothing about them at the
+   * orientation entry point. The Zeigarnik primitive (agora's
+   * cliff/invitation) breaks if cliffs aren't surfaced where the
+   * future instance lands.
+   *
+   * Per principle 04 (records outlive writers), substrate must be
+   * findable on re-entry, not just present on disk.
+   */
+  cross_passage: Record<string, PassageOrientationSummary>;
   /**
    * Discoverability hint: what verbs are applicable right now?
    *
@@ -335,6 +360,8 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     c.config.hostNames,
   );
 
+  const crossPassage = await collectCrossPassage(c.config);
+
   const payload: BootPayload = {
     actor,
     role,
@@ -350,6 +377,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       resolved_content_root: c.config.contentRoot,
       content_root_health: contentRootHealth,
     },
+    cross_passage: crossPassage,
     suggested_next: suggestedNext,
     verbs_available_now: verbsAvailableNow,
   };
@@ -473,6 +501,45 @@ export function deriveBootSuggestedNext(
  * writeFormat.ts — same field, same semantics, exported on
  * BootSuggestedNext so consumers see one consistent shape.
  */
+/**
+ * Registry of passage orientation providers. Each passage that
+ * lives under `<content_root>/<name>/` contributes one provider;
+ * boot polls all of them at orientation time.
+ *
+ * Static array (rather than dynamic registry) because the package
+ * ships gate, agora, devil together — there's nothing to discover
+ * at runtime. The seam exists so adding a new passage is a one-
+ * line change here plus the passage's own provider, not a refactor
+ * of boot.ts. Failure of any single provider is contained: errors
+ * are logged to stderr and the rest of the registry continues.
+ */
+const PASSAGE_ORIENTATION_REGISTRY: ReadonlyArray<{
+  name: string;
+  provider: PassageOrientationProvider;
+}> = [
+  { name: 'agora', provider: agoraOrientation },
+  { name: 'devil', provider: devilOrientation },
+];
+
+async function collectCrossPassage(
+  config: C['config'],
+): Promise<Record<string, PassageOrientationSummary>> {
+  const out: Record<string, PassageOrientationSummary> = {};
+  for (const { name, provider } of PASSAGE_ORIENTATION_REGISTRY) {
+    try {
+      const summary = await provider(config);
+      if (summary !== null) out[name] = summary;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(
+        `notice: passage '${name}' orientation provider failed: ${msg} ` +
+          `(boot continues; cross_passage.${name} omitted)\n`,
+      );
+    }
+  }
+  return out;
+}
+
 function stampActorResolved(
   partial: Omit<BootSuggestedNext, 'actor_resolved'>,
   actor: string | null,
@@ -781,6 +848,23 @@ function renderBootText(p: BootPayload): string {
     }
   }
   if (p.last_activity) lines.push(`last activity: ${p.last_activity}`);
+
+  // Cross-passage summary: render only the passages with records.
+  // Empty cross_passage stays silent (voice budget — fresh roots
+  // shouldn't see "agora: 0/0/null" noise).
+  const crossEntries = Object.values(p.cross_passage);
+  if (crossEntries.length > 0) {
+    lines.push('');
+    for (const s of crossEntries) {
+      const suspendedNote =
+        s.suspended > 0 ? ` (${s.suspended} paused)` : '';
+      const lastNote =
+        s.last_id !== null
+          ? `; last ${s.last_id} [${s.last_state}]`
+          : '';
+      lines.push(`${s.passage}: ${s.open} open${suspendedNote}${lastNote}`);
+    }
+  }
 
   if (p.tail.length > 0) {
     lines.push('');

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -257,6 +257,19 @@ const VERBS: readonly VerbSchema[] = [
         your_recent: { type: 'array' },
         inbox_unread: { type: 'array' },
         last_activity: str,
+        cross_passage: {
+          type: 'object',
+          description:
+            'Cross-passage orientation. Per-passage summary keyed by ' +
+            "passage name (currently 'agora' and 'devil'). Empty when no " +
+            'passage besides gate has any records under the content_root. ' +
+            'Each entry shape: { passage, open, suspended, last_id, last_state, last_at }. ' +
+            "Surfaced so a fresh instance booting on a content_root with " +
+            "active agora plays or devil reviews sees them at the orientation " +
+            "entry point — closes the substrate-side Zeigarnik continuity " +
+            'across session boundaries (records-outlive-writers requires ' +
+            'records also be findable on re-entry).',
+        },
         suggested_next: {
           type: 'object',
           description:

--- a/src/interface/shared/PassageOrientation.ts
+++ b/src/interface/shared/PassageOrientation.ts
@@ -1,0 +1,79 @@
+import { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
+
+/**
+ * Cross-passage orientation summary surfaced at the container's
+ * primary orientation entry point (`gate boot`).
+ *
+ * Surfaced by the `cross-passage-orient` agora play
+ * (develop substrate, 2026-05-03): a fresh instance booting on a
+ * content_root with active agora plays or devil reviews previously
+ * saw only gate's own activity, breaking the substrate-side
+ * Zeigarnik continuity that agora's suspend/resume primitive
+ * relies on. The fix is a registry seam: each passage publishes a
+ * provider; gate boot polls them at runtime and presents the
+ * non-null returns under `cross_passage`.
+ *
+ * Per `lore/principles/04-records-outlive-writers.md`, records
+ * must outlive their writers. This adds the missing half: records
+ * must also be **findable on re-entry**. Substrate that exists on
+ * disk but isn't surfaced at orientation might as well be silent.
+ *
+ * Shape is intentionally normalized across passages so boot
+ * consumers iterate uniformly. Per-passage detail (e.g. agora's
+ * cliff/invitation prose) stays at each passage's own read verbs;
+ * orientation only needs the count + recency cues that point an
+ * agent at "where to look next".
+ */
+export interface PassageOrientationSummary {
+  /** Passage name. Stable identifier; orchestrators key on this. */
+  readonly passage: string;
+  /**
+   * Count of records in a non-terminal state. For agora: plays
+   * where state ∈ {playing, suspended}. For devil: reviews where
+   * state = open. Concluded / completed records do not contribute.
+   */
+  readonly open: number;
+  /**
+   * Subset of `open` that are paused awaiting re-entry. agora's
+   * suspended plays; devil's reviews with an unmatched suspension.
+   * Surfaced separately so a fresh instance immediately sees
+   * "1 thread paused with cliff/invitation waiting" without
+   * walking the records.
+   */
+  readonly suspended: number;
+  /**
+   * The most-recently-touched record's id, or null when the
+   * passage has no records at all under the content_root.
+   * "Most recent" follows each passage's own activity definition
+   * (latest move / suspension / resume / entry / etc).
+   */
+  readonly last_id: string | null;
+  /**
+   * State of the record named by `last_id`. Free-form per passage
+   * (agora: 'playing' | 'suspended' | 'concluded'; devil: 'open' |
+   * 'concluded'). Null when `last_id` is null.
+   */
+  readonly last_state: string | null;
+  /**
+   * ISO timestamp of the most recent activity reflected in
+   * `last_id`. Null when `last_id` is null.
+   */
+  readonly last_at: string | null;
+}
+
+/**
+ * Provider contract. Each passage exports exactly one of these.
+ * Boot calls every registered provider (in arbitrary order) and
+ * includes the non-null returns under `cross_passage`.
+ *
+ * Returning null means "this passage has no records under this
+ * content_root" — gate boot omits the entry. Empty passages
+ * shouldn't pollute the envelope.
+ *
+ * Errors are caught at the boot layer; a misbehaving provider
+ * does not break orientation. The contract is "best effort":
+ * an exception is logged to stderr but the rest of boot proceeds.
+ */
+export type PassageOrientationProvider = (
+  config: GuildConfig,
+) => Promise<PassageOrientationSummary | null>;

--- a/src/passages/agora/interface/orientation.ts
+++ b/src/passages/agora/interface/orientation.ts
@@ -1,0 +1,58 @@
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
+import {
+  PassageOrientationProvider,
+  PassageOrientationSummary,
+} from '../../../interface/shared/PassageOrientation.js';
+
+/**
+ * agora's orientation provider. Surfaces the count of plays in
+ * non-terminal state (playing / suspended), the suspended subset
+ * (paused with cliff/invitation awaiting re-entry), and the most-
+ * recently-touched play's id + state + activity timestamp.
+ *
+ * Returns null when `<content_root>/agora/` has no plays at all
+ * — gate boot omits the entry rather than rendering an empty
+ * "agora: 0 / 0 / null" structure.
+ *
+ * "Most recent" is computed from each play's max-timestamp across
+ * its move + suspension + resume + conclusion entries.
+ */
+export const agoraOrientation: PassageOrientationProvider = async (
+  config: GuildConfig,
+): Promise<PassageOrientationSummary | null> => {
+  const repo = new YamlPlayRepository(config);
+  const plays = await repo.listAll();
+  if (plays.length === 0) return null;
+
+  let openCount = 0;
+  let suspendedCount = 0;
+  let last: { id: string; state: string; at: string; game: string } | null = null;
+
+  for (const play of plays) {
+    if (play.state !== 'concluded') openCount += 1;
+    if (play.state === 'suspended') suspendedCount += 1;
+
+    // Latest activity timestamp on this play: max of started_at,
+    // any move/suspension/resume timestamp, conclusion timestamp.
+    const candidates: string[] = [play.started_at];
+    for (const m of play.moves) candidates.push(m.at);
+    for (const s of play.suspensions) candidates.push(s.at);
+    for (const r of play.resumes) candidates.push(r.at);
+    if (play.concluded_at) candidates.push(play.concluded_at);
+    const latest = candidates.reduce((a, b) => (a > b ? a : b));
+
+    if (last === null || latest > last.at) {
+      last = { id: play.id, state: play.state, at: latest, game: play.game };
+    }
+  }
+
+  return {
+    passage: 'agora',
+    open: openCount,
+    suspended: suspendedCount,
+    last_id: last ? last.id : null,
+    last_state: last ? last.state : null,
+    last_at: last ? last.at : null,
+  };
+};

--- a/src/passages/devil/interface/orientation.ts
+++ b/src/passages/devil/interface/orientation.ts
@@ -1,0 +1,63 @@
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
+import {
+  PassageOrientationProvider,
+  PassageOrientationSummary,
+} from '../../../interface/shared/PassageOrientation.js';
+
+/**
+ * devil's orientation provider. Surfaces the count of open reviews
+ * (state = 'open'), the subset currently paused (suspensions.length
+ * > resumes.length), and the most-recently-touched review's id +
+ * state + activity timestamp.
+ *
+ * Returns null when `<content_root>/devil/` has no reviews at all.
+ *
+ * "Most recent" is computed from each review's max-timestamp
+ * across opened_at, entry timestamps, suspension/resume entries,
+ * and conclusion timestamp.
+ *
+ * Note: devil's state machine is thinner than agora's. There is
+ * no 'suspended' state — suspend/resume on a review records re-
+ * entry context but does NOT block other entries. So the
+ * "suspended count" here is the count of reviews where the
+ * trailing suspension is unmatched by a resume; i.e. one suspend
+ * primitive is in flight even though the review itself is still
+ * accepting entries.
+ */
+export const devilOrientation: PassageOrientationProvider = async (
+  config: GuildConfig,
+): Promise<PassageOrientationSummary | null> => {
+  const repo = new YamlDevilReviewRepository(config);
+  const reviews = await repo.listAll();
+  if (reviews.length === 0) return null;
+
+  let openCount = 0;
+  let suspendedCount = 0;
+  let last: { id: string; state: string; at: string } | null = null;
+
+  for (const review of reviews) {
+    if (review.state === 'open') openCount += 1;
+    if (review.suspensions.length > review.resumes.length) suspendedCount += 1;
+
+    const candidates: string[] = [review.opened_at];
+    for (const e of review.entries) candidates.push(e.at);
+    for (const s of review.suspensions) candidates.push(s.at);
+    for (const r of review.resumes) candidates.push(r.at);
+    if (review.conclusion) candidates.push(review.conclusion.at);
+    const latest = candidates.reduce((a, b) => (a > b ? a : b));
+
+    if (last === null || latest > last.at) {
+      last = { id: review.id, state: review.state, at: latest };
+    }
+  }
+
+  return {
+    passage: 'devil',
+    open: openCount,
+    suspended: suspendedCount,
+    last_id: last ? last.id : null,
+    last_state: last ? last.state : null,
+    last_at: last ? last.at : null,
+  };
+};

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -58,6 +58,7 @@ test('gate boot: JSON top-level keys are stable', () => {
       keys,
       [
         'actor',
+        'cross_passage',
         'hints',
         'inbox_unread',
         'last_activity',

--- a/tests/interface/crossPassageBoot.test.ts
+++ b/tests/interface/crossPassageBoot.test.ts
@@ -1,0 +1,191 @@
+// gate boot: cross_passage orientation summary contract.
+//
+// Surfaced by the develop-branch dogfood (cross-passage-orient
+// agora play, 2026-05-03): a fresh instance booting on a content_root
+// with active agora plays or devil reviews previously saw nothing
+// about them at the orientation entry point. The substrate-side
+// Zeigarnik primitive (agora's cliff/invitation) breaks if the cliff
+// isn't visible to the future instance landing here.
+//
+// This test pins the registry-seam shape:
+//   - empty content_root (no agora/devil dirs) → cross_passage = {}
+//   - agora dir with plays → cross_passage.agora populated
+//   - devil dir with reviews → cross_passage.devil populated
+//   - both → both keys present
+//   - schema-as-contract: the payload type matches what schema.ts declares
+//
+// Provider failures are tested as "non-fatal" by intentionally
+// corrupting the substrate and confirming boot still returns 0.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+const DEVIL = resolve(here, '../../../bin/devil.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cross-passage-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+  envOverrides: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  delete env['GUILD_ACTOR'];
+  env['GUILD_ACTOR'] = 'alice';
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) delete env[k];
+    else env[k] = v;
+  }
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('gate boot: cross_passage is empty {} when no agora/devil records', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.cross_passage, {});
+});
+
+test('gate boot: cross_passage.agora populated when an agora play exists', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Seed an agora game + play.
+  const newR = run(AGORA, root, [
+    'new',
+    '--slug', 'topic',
+    '--kind', 'sandbox',
+    '--title', 'T',
+  ]);
+  assert.equal(newR.status, 0, `agora new stderr: ${newR.stderr}`);
+  const playR = run(AGORA, root, ['play', '--slug', 'topic']);
+  assert.equal(playR.status, 0, `agora play stderr: ${playR.stderr}`);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.cross_passage.agora, 'cross_passage.agora must exist');
+  assert.equal(payload.cross_passage.agora.passage, 'agora');
+  assert.equal(payload.cross_passage.agora.open, 1);
+  assert.equal(payload.cross_passage.agora.suspended, 0);
+  assert.match(payload.cross_passage.agora.last_id, /^\d{4}-\d{2}-\d{2}-\d{3}$/);
+  assert.equal(payload.cross_passage.agora.last_state, 'playing');
+  // No devil records → no devil entry.
+  assert.equal(payload.cross_passage.devil, undefined);
+});
+
+test('gate boot: suspended count distinguishes paused plays from playing ones', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(AGORA, root, ['new', '--slug', 't', '--kind', 'sandbox', '--title', 'T']);
+  const playR = run(AGORA, root, ['play', '--slug', 't']);
+  const playId = (playR.stdout.match(/play started: (\S+)/) ?? [])[1] ?? '';
+  run(AGORA, root, [
+    'suspend', playId,
+    '--cliff', 'paused',
+    '--invitation', 'next',
+  ]);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.cross_passage.agora.open, 1, 'suspended still counts as open');
+  assert.equal(payload.cross_passage.agora.suspended, 1);
+  assert.equal(payload.cross_passage.agora.last_state, 'suspended');
+});
+
+test('gate boot: cross_passage.devil populated when a devil review exists', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const openR = run(DEVIL, root, ['open', 'test-target', '--type', 'commit']);
+  assert.equal(openR.status, 0, `devil open stderr: ${openR.stderr}`);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.cross_passage.devil, 'cross_passage.devil must exist');
+  assert.equal(payload.cross_passage.devil.passage, 'devil');
+  assert.equal(payload.cross_passage.devil.open, 1);
+  assert.equal(payload.cross_passage.devil.suspended, 0);
+  assert.equal(payload.cross_passage.devil.last_state, 'open');
+  assert.match(
+    payload.cross_passage.devil.last_id,
+    /^rev-\d{4}-\d{2}-\d{2}-\d{3}$/,
+  );
+});
+
+test('gate boot: both passages surface independently', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(AGORA, root, ['new', '--slug', 't', '--kind', 'sandbox', '--title', 'T']);
+  run(AGORA, root, ['play', '--slug', 't']);
+  run(DEVIL, root, ['open', 'thing', '--type', 'commit']);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.cross_passage.agora, 'agora present');
+  assert.ok(payload.cross_passage.devil, 'devil present');
+});
+
+test('gate boot: a malformed devil review does not break the rest of boot', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Plant a malformed devil review file directly on disk so the
+  // provider throws on hydrate. Boot must still exit 0; cross_passage.devil
+  // is omitted (the provider error is caught and noticed on stderr).
+  mkdirSync(join(root, 'devil', 'reviews'), { recursive: true });
+  writeFileSync(
+    join(root, 'devil', 'reviews', 'rev-2026-01-01-001.yaml'),
+    'this is not valid yaml: : {] [\n',
+  );
+  // Also seed an agora play so we can confirm agora still appears.
+  run(AGORA, root, ['new', '--slug', 't', '--kind', 'sandbox', '--title', 'T']);
+  run(AGORA, root, ['play', '--slug', 't']);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  assert.equal(r.status, 0, `boot must succeed even when one provider fails; stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.cross_passage.agora, 'agora still present');
+  // devil provider failure: either the entry is omitted, OR the
+  // provider was tolerant and still returned a summary; both are
+  // acceptable as long as boot returned 0. The strong contract is
+  // "boot does not crash"; the weaker contract is "a corrupt review
+  // does not poison cross_passage.agora".
+  // We don't assert on cross_passage.devil presence here so that
+  // either tolerant or strict YAML hydration survives this test.
+});


### PR DESCRIPTION
## Summary

- `gate boot` now surfaces cross-passage activity (agora plays, devil reviews) at the orientation entry point. Closes the substrate-side Zeigarnik continuity gap: a fresh instance booting on a content_root with active agora/devil records previously saw nothing about them, breaking agora's cliff/invitation primitive across session boundaries.
- Implementation is a **registry seam**: each passage publishes a `PassageOrientationProvider`; gate boot polls registered providers at runtime. No hardcoded coupling — adding a new passage is a one-line entry in the registry array.
- Per principle 04 (records outlive writers): records must also be **findable on re-entry**, not merely present on disk.

## What boot's envelope gains

```json
{
  // ... existing keys unchanged ...
  "cross_passage": {
    "agora": { "passage": "agora", "open": 2, "suspended": 1, "last_id": "2026-05-03-001", "last_state": "suspended", "last_at": "..." },
    "devil": { "passage": "devil", "open": 1, "suspended": 0, "last_id": "rev-2026-05-03-001", "last_state": "open", "last_at": "..." }
  }
}
```

Empty `{}` when no passage besides gate has records (voice budget — fresh roots stay quiet). Per-passage entries omitted when that passage has no records on disk.

Text rendering: one line per non-empty passage, format `<name>: <open> open (<suspended> paused); last <id> [<state>]`. Suspended-count and last-id are conditional so the line stays informative without being verbose.

## Implementation

- `src/interface/shared/PassageOrientation.ts` — shared port (`PassageOrientationSummary`, `PassageOrientationProvider`). Normalized shape across passages so consumers iterate uniformly.
- `src/passages/agora/interface/orientation.ts` — agora provider. `open` = plays where state ∈ {playing, suspended}; `suspended` = the suspended subset.
- `src/passages/devil/interface/orientation.ts` — devil provider. `open` = reviews where state = open; `suspended` = reviews with trailing un-resumed suspension.
- `src/interface/gate/handlers/boot.ts` — `PASSAGE_ORIENTATION_REGISTRY` static array; `collectCrossPassage` polls each provider with per-provider try/catch (one bad provider does not break orientation).
- `src/interface/gate/handlers/schema.ts` — `cross_passage` declared on boot's output (principle 10).

## Surfaced by

- agora play [`2026-05-03-001 / cross-passage-orient`](https://github.com/eris-ths/guild-cli/blob/develop/agora/plays/cross-passage-orient/2026-05-03-001.yaml) on develop. 5 substantive moves explored 5 candidates (a-e); lean (a) + registry seam confirmed by nao.
- gate request `2026-05-03-0002` on develop, currently executing; will complete when this PR lands.

## Test plan

- [x] 6 new E2E tests (`tests/interface/crossPassageBoot.test.ts`) — empty cross_passage on fresh root; agora populated on agora play; suspended count distinguishes paused; devil populated on devil open; both passages independent; corrupt devil yaml does not break boot.
- [x] Updated `tests/interface/boot.test.ts` top-level-keys stability to include `cross_passage` (intentional addition to the contract).
- [x] Full suite: 925 → 931 passing. Typecheck clean.
- [ ] CI green

## Behavior changes for orchestrators

- **New top-level key** `cross_passage` in boot's JSON output. Existing consumers reading specific keys (`actor`, `status`, `tail`, etc.) are unaffected. Consumers that snapshot the full envelope shape need to expect the new key.
- Text rendering grows one (potentially zero) line block when passages have records. No change at all on fresh content_roots.

## Future passages

A new passage (e.g. a hypothetical `archive`) ships its own `interface/orientation.ts` exporting a `PassageOrientationProvider`, and adds one entry to `PASSAGE_ORIENTATION_REGISTRY`. No further wiring. The registry is intentionally static (the package ships gate/agora/devil together; runtime discovery isn't needed) but the seam is shaped to keep adding passages cheap.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_