### PR TITLE
fix(bin): friendly error when dist/ is missing or stale

### DIFF
--- a/bin/agora.mjs
+++ b/bin/agora.mjs
@@ -1,3 +1,16 @@
 #!/usr/bin/env node
-import { main } from '../dist/src/passages/agora/interface/index.js';
+let main;
+try {
+  ({ main } = await import('../dist/src/passages/agora/interface/index.js'));
+} catch (err) {
+  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
+    process.stderr.write(
+      'guild-cli: dist/ not built (or out of date).\n' +
+      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+      '  Or:  npm run build (rebuild after pulling source changes)\n',
+    );
+    process.exit(2);
+  }
+  throw err;
+}
 main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/bin/devil.mjs
+++ b/bin/devil.mjs
@@ -1,3 +1,16 @@
 #!/usr/bin/env node
-import { main } from '../dist/src/passages/devil/interface/index.js';
+let main;
+try {
+  ({ main } = await import('../dist/src/passages/devil/interface/index.js'));
+} catch (err) {
+  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
+    process.stderr.write(
+      'guild-cli: dist/ not built (or out of date).\n' +
+      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+      '  Or:  npm run build (rebuild after pulling source changes)\n',
+    );
+    process.exit(2);
+  }
+  throw err;
+}
 main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/bin/gate.mjs
+++ b/bin/gate.mjs
@@ -1,3 +1,16 @@
 #!/usr/bin/env node
-import { main } from '../dist/src/interface/gate/index.js';
+let main;
+try {
+  ({ main } = await import('../dist/src/interface/gate/index.js'));
+} catch (err) {
+  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
+    process.stderr.write(
+      'guild-cli: dist/ not built (or out of date).\n' +
+      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+      '  Or:  npm run build (rebuild after pulling source changes)\n',
+    );
+    process.exit(2);
+  }
+  throw err;
+}
 main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/bin/guild.mjs
+++ b/bin/guild.mjs
@@ -1,3 +1,16 @@
 #!/usr/bin/env node
-import { main } from '../dist/src/interface/guild/index.js';
+let main;
+try {
+  ({ main } = await import('../dist/src/interface/guild/index.js'));
+} catch (err) {
+  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
+    process.stderr.write(
+      'guild-cli: dist/ not built (or out of date).\n' +
+      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+      '  Or:  npm run build (rebuild after pulling source changes)\n',
+    );
+    process.exit(2);
+  }
+  throw err;
+}
 main(process.argv.slice(2)).then((code) => process.exit(code));


### PR DESCRIPTION
## Summary

- All four entry points (`gate` / `guild` / `agora` / `devil`) replaced their static dist import with a guarded dynamic import.
- When `npm install` (and thus `prepare: tsc`) hasn't run since pulling source, the entries previously died with a cryptic Node `ERR_MODULE_NOT_FOUND` stack. They now print a one-paragraph hint pointing at `npm install` / `npm run build` and exit `2`.
- Any other error is re-thrown unchanged.

## Why

A fresh agent (or any human) cloning develop and trying `npm run agora` immediately hits this trap, because the dist directory under `node_modules` reflects whatever was last built — not the current source. The new failure mode tells you exactly what to do in three lines instead of a 10-line stack.

Surfaced and explored on the `develop` dogfood substrate: `i-2026-05-04-0001` (issue) → `agora/dist-staleness-fix/2026-05-04-001` (4-move root-cause exploration; candidate A — bin entry guard — chosen over `gate doctor` extension or `postinstall` hook for tightest scope).

## Test plan

- [x] `npm run build` then verified all four entries (`gate whoami`, `agora list`, `devil list`, `guild list`) work normally on a clean main checkout.
- [x] Moved `dist/` aside and re-ran each: every entry prints the friendly hint and exits `2` instead of the ESM stack.
- [x] Existing test failures on main are unrelated (pre-existing `/private/var` symlink and JSON parse issues; unchanged by this PR).