### PR TITLE
fix(bin): harden dist-staleness guard per noir review (#139 followup)

### DIFF
--- a/bin/agora.mjs
+++ b/bin/agora.mjs
@@ -1,15 +1,32 @@
 #!/usr/bin/env node
+// Two coupled facts to remember if you change anything here:
+//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
+//      intentionally — a shared helper would itself live in dist/ and
+//      hit the same load failure (circular trap). Re-evaluate if a
+//      5th entry is added.
+//   2. The error message references `npm install` and the `prepare`
+//      script. If package.json drops `prepare: tsc`, update the message.
+const ENTRY_URL = new URL('../dist/src/passages/agora/interface/index.js', import.meta.url).href;
+
 let main;
 try {
-  ({ main } = await import('../dist/src/passages/agora/interface/index.js'));
+  ({ main } = await import(ENTRY_URL));
 } catch (err) {
-  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
-    process.stderr.write(
-      'guild-cli: dist/ not built (or out of date).\n' +
-      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
-      '  Or:  npm run build (rebuild after pulling source changes)\n',
-    );
-    process.exit(2);
+  if (err?.code === 'ERR_MODULE_NOT_FOUND') {
+    const failedUrl = typeof err.url === 'string' ? err.url : '';
+    const fromDist =
+      failedUrl.includes('/dist/') || /\/dist\//.test(err.message ?? '');
+    if (fromDist) {
+      process.stderr.write(
+        'guild-cli: dist/ not built (or out of date).\n' +
+          '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+          '  Or:  npm run build (rebuild after pulling source changes)\n',
+      );
+      if (failedUrl && failedUrl !== ENTRY_URL) {
+        process.stderr.write(`  (transitive miss: ${failedUrl})\n`);
+      }
+      process.exit(2);
+    }
   }
   throw err;
 }

--- a/bin/devil.mjs
+++ b/bin/devil.mjs
@@ -1,15 +1,32 @@
 #!/usr/bin/env node
+// Two coupled facts to remember if you change anything here:
+//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
+//      intentionally — a shared helper would itself live in dist/ and
+//      hit the same load failure (circular trap). Re-evaluate if a
+//      5th entry is added.
+//   2. The error message references `npm install` and the `prepare`
+//      script. If package.json drops `prepare: tsc`, update the message.
+const ENTRY_URL = new URL('../dist/src/passages/devil/interface/index.js', import.meta.url).href;
+
 let main;
 try {
-  ({ main } = await import('../dist/src/passages/devil/interface/index.js'));
+  ({ main } = await import(ENTRY_URL));
 } catch (err) {
-  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
-    process.stderr.write(
-      'guild-cli: dist/ not built (or out of date).\n' +
-      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
-      '  Or:  npm run build (rebuild after pulling source changes)\n',
-    );
-    process.exit(2);
+  if (err?.code === 'ERR_MODULE_NOT_FOUND') {
+    const failedUrl = typeof err.url === 'string' ? err.url : '';
+    const fromDist =
+      failedUrl.includes('/dist/') || /\/dist\//.test(err.message ?? '');
+    if (fromDist) {
+      process.stderr.write(
+        'guild-cli: dist/ not built (or out of date).\n' +
+          '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+          '  Or:  npm run build (rebuild after pulling source changes)\n',
+      );
+      if (failedUrl && failedUrl !== ENTRY_URL) {
+        process.stderr.write(`  (transitive miss: ${failedUrl})\n`);
+      }
+      process.exit(2);
+    }
   }
   throw err;
 }

--- a/bin/gate.mjs
+++ b/bin/gate.mjs
@@ -1,15 +1,38 @@
 #!/usr/bin/env node
+// Two coupled facts to remember if you change anything here:
+//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
+//      intentionally — a shared helper would itself live in dist/ and
+//      hit the same load failure (circular trap). Re-evaluate if a
+//      5th entry is added.
+//   2. The error message references `npm install` and the `prepare`
+//      script. If package.json drops `prepare: tsc`, update the message.
+const ENTRY_URL = new URL('../dist/src/interface/gate/index.js', import.meta.url).href;
+
 let main;
 try {
-  ({ main } = await import('../dist/src/interface/gate/index.js'));
+  ({ main } = await import(ENTRY_URL));
 } catch (err) {
-  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
-    process.stderr.write(
-      'guild-cli: dist/ not built (or out of date).\n' +
-      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
-      '  Or:  npm run build (rebuild after pulling source changes)\n',
-    );
-    process.exit(2);
+  if (err?.code === 'ERR_MODULE_NOT_FOUND') {
+    // Prefer err.url (stable across Node ESM-loader message tweaks);
+    // fall back to message scan for older runtimes that don't set it.
+    const failedUrl = typeof err.url === 'string' ? err.url : '';
+    const fromDist =
+      failedUrl.includes('/dist/') || /\/dist\//.test(err.message ?? '');
+    if (fromDist) {
+      process.stderr.write(
+        'guild-cli: dist/ not built (or out of date).\n' +
+          '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+          '  Or:  npm run build (rebuild after pulling source changes)\n',
+      );
+      // Transitive failure (entry loaded, but a deeper dist module is
+      // missing) suggests an incomplete or stale build rather than a
+      // never-built tree. Surface the missing path so the operator can
+      // tell the difference instead of being told to "install" twice.
+      if (failedUrl && failedUrl !== ENTRY_URL) {
+        process.stderr.write(`  (transitive miss: ${failedUrl})\n`);
+      }
+      process.exit(2);
+    }
   }
   throw err;
 }

--- a/bin/guild.mjs
+++ b/bin/guild.mjs
@@ -1,15 +1,32 @@
 #!/usr/bin/env node
+// Two coupled facts to remember if you change anything here:
+//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
+//      intentionally — a shared helper would itself live in dist/ and
+//      hit the same load failure (circular trap). Re-evaluate if a
+//      5th entry is added.
+//   2. The error message references `npm install` and the `prepare`
+//      script. If package.json drops `prepare: tsc`, update the message.
+const ENTRY_URL = new URL('../dist/src/interface/guild/index.js', import.meta.url).href;
+
 let main;
 try {
-  ({ main } = await import('../dist/src/interface/guild/index.js'));
+  ({ main } = await import(ENTRY_URL));
 } catch (err) {
-  if (err && err.code === 'ERR_MODULE_NOT_FOUND' && /\/dist\//.test(err.message ?? '')) {
-    process.stderr.write(
-      'guild-cli: dist/ not built (or out of date).\n' +
-      '  Run: npm install   (auto-builds via the `prepare` script)\n' +
-      '  Or:  npm run build (rebuild after pulling source changes)\n',
-    );
-    process.exit(2);
+  if (err?.code === 'ERR_MODULE_NOT_FOUND') {
+    const failedUrl = typeof err.url === 'string' ? err.url : '';
+    const fromDist =
+      failedUrl.includes('/dist/') || /\/dist\//.test(err.message ?? '');
+    if (fromDist) {
+      process.stderr.write(
+        'guild-cli: dist/ not built (or out of date).\n' +
+          '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+          '  Or:  npm run build (rebuild after pulling source changes)\n',
+      );
+      if (failedUrl && failedUrl !== ENTRY_URL) {
+        process.stderr.write(`  (transitive miss: ${failedUrl})\n`);
+      }
+      process.exit(2);
+    }
   }
   throw err;
 }


### PR DESCRIPTION
## Summary

Three small refinements to the guard introduced in #139, surfaced by an internal Noir code review:

1. **`err.url` over `err.message`** — Node's ESM-loader message text has shifted between major versions; `err.url` is the structured field meant for this signal. Message scan kept as a fallback for older runtimes.
2. **Distinguish transitive misses** — when the entry loads but a deeper dist module is missing, append `(transitive miss: <url>)` after the friendly hint. Distinguishes "never built" from "build is incomplete or stale" without forcing a blind re-install.
3. **Coupling notes** — each entry now carries an inline note about (a) why the guard is duplicated across all four bin entries (circular-helper avoidance), and (b) that the message text is coupled to `npm install` + the `prepare` script.

## Why

Noir review on #139 returned `verdict: ok` with one `concern` (the `err.message` brittleness) plus future-risk notes (#3, #4 above). Catching them while the change is still warm is cheaper than catching them when Node 22 silently drops the message-scan branch.

## Test plan

- [x] `npm run build` then verified all four entries (`gate whoami`, `agora list`, `devil list`, `guild list`) work normally.
- [x] Moved `dist/` aside: friendly hint prints, exit 2, no spurious `(transitive miss: ...)` line.
- [x] Removed only `dist/.../handlers/list.js` (transitive failure): friendly hint prints **plus** `(transitive miss: file://.../handlers/list.js)`, exit 2.
- [x] Existing test failures on main are pre-existing (`/private/var` symlink and JSON parse issues; unchanged by this PR).

## Substrate trace (develop)

- request `2026-05-04-0002` — promoted from Noir review intake
- gate review entry `[claude-review / devil / ok]` — Noir digest preserved as substrate-of-record