### PR TITLE
docs: close install/setup coverage gaps in README/AGENT/CONTRIBUTING

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -19,16 +19,8 @@ useful when something breaks or you want to extend the system.
 
 ## Session start
 
-> **Prerequisites.** `npm install` once in the repo root — the
-> `prepare: tsc` script auto-builds `dist/` so a separate
-> `npm run build` is not needed. `export GUILD_ACTOR=<you>` so
-> every verb defaults to your identity; without it `whoami` /
-> `resume` need explicit `--by` / `--for` and `your_recent` is
-> `null`. `gate` and `guild` are exposed as `bin` entries (use
-> `npm link` for plain `gate`/`guild` on PATH); `agora` and
-> `devil` are alpha and intentionally not in `package.json#bin`
-> — invoke as `node ./bin/agora.mjs ...` or `npm run agora -- ...`
-> (same for `devil`).
+> Prerequisites (install / `GUILD_ACTOR` / `agora`-`devil` opt-in
+> convention) are documented once in [`README.md`](./README.md#install).
 
 ```bash
 # First time in this content_root? Register yourself:

--- a/AGENT.md
+++ b/AGENT.md
@@ -19,6 +19,17 @@ useful when something breaks or you want to extend the system.
 
 ## Session start
 
+> **Prerequisites.** `npm install` once in the repo root — the
+> `prepare: tsc` script auto-builds `dist/` so a separate
+> `npm run build` is not needed. `export GUILD_ACTOR=<you>` so
+> every verb defaults to your identity; without it `whoami` /
+> `resume` need explicit `--by` / `--for` and `your_recent` is
+> `null`. `gate` and `guild` are exposed as `bin` entries (use
+> `npm link` for plain `gate`/`guild` on PATH); `agora` and
+> `devil` are alpha and intentionally not in `package.json#bin`
+> — invoke as `node ./bin/agora.mjs ...` or `npm run agora -- ...`
+> (same for `devil`).
+
 ```bash
 # First time in this content_root? Register yourself:
 gate register --name <you>              # category defaults to "professional"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,17 @@ exists to make those questions visible at the point of decision.
 - **Tests run on Node 20 and 22** — the CI matrix exercises both;
   changes that depend on Node 22-only features will fail Node 20
   jobs.
+- **Local `npm test` may show env-sensitive failures that CI does
+  not.** Two patterns to expect on macOS:
+  (a) test fixtures created via `mkdtemp` resolve through the
+  `/var/folders` ↔ `/private/var/folders` symlink, which trips
+  exact-path regex assertions in a few `agora`/handler tests;
+  (b) one schema-snapshot test JSON-parses output that contains
+  unescaped characters in certain locales. Neither reproduces in
+  the Linux CI runner. **Treat CI as the source of truth**; the
+  failures above are not regressions you introduced. If you fix
+  them, please rebase the assertions to be platform-agnostic
+  rather than masking the local failure.
 - **Lore changes follow the same write-once-then-revise discipline
   as records** — principles in `lore/principles/` are appended,
   not edited in place. Significant revisions to an existing

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,31 @@ YAMLファイルとしてディスク上に永続化され、セッションを�
 無視されたか — **熟議の過程そのもの**が残ります。ツールは知覚を
 研ぐだけで、結論を出しません。これは欠落ではなく設計選択です。
 
+## セットアップ
+
+Node.js 20 または 22 が必要。`prepare` script が `npm install` 時に
+自動で `dist/` を build するので、別途 build は不要です（ソースを
+編集した後だけ `npm run build`）。
+
+```bash
+npm install                              # prepare: tsc が dist/ を生成
+
+# content_root ごとに 1 度: 自分を actor として登録
+node ./bin/gate.mjs register --name <you>
+
+# シェルごとに 1 度: 全 verb の default actor を環境変数で固定
+export GUILD_ACTOR=<you>
+
+# セッションごとに 1 度: 1 コマンドで全コンテキスト取得
+node ./bin/gate.mjs boot                 # identity / status / tail / inbox を 1 JSON で
+```
+
+`gate` と `guild` は安定しており、`npm link` で PATH 化できます。
+`agora` と `devil` は alpha のため意図的に `package.json#bin` から
+外しており、`node ./bin/agora.mjs ...` または `npm run agora -- ...`
+で起動してください（`devil` も同様）。これは見落としではなく安定境界
+として opt-in にしてあります。
+
 ## あなたができること
 
 - `guild new` で自分や仲間をメンバー登録する
@@ -83,8 +108,9 @@ YAMLファイルとしてディスク上に永続化され、セッションを�
   [issue #117](https://github.com/eris-ths/guild-cli/issues/117)。
 - **`devil`** (`bin/devil.mjs`、 snapshot) — security-backstop の
   review passage。 **multi-persona (red-team / author-defender /
-  mirror) + lense 強制 (Claude Security の 8 category + 3 つの
-  devil 固有) + 時間延長**された review surface。 single-pass
+  mirror) + lense 強制 (Claude Security の 8 category + devil 固有
+  4 つ = 計 12 lense; composition / temporal / supply-chain /
+  coherence) + 時間延長**された review surface。 single-pass
   tool (Anthropic `/ultrareview`、 Claude Security、
   supply-chain-guard) を **置き換えるのではなく compose** する後段
   backstop として設計されています。 目的は OWASP top 10 を一度も
@@ -100,6 +126,11 @@ agora / devil 固有の records はそれぞれ `<content_root>/agora/` /
 
 ## 実例
 
-実動する典型例は [`examples/dogfood-session/`](./examples/dogfood-session/)
-にあります — このツール自身がこのツールを使って自分を拡張した
-セッションの完全な記録です。
+各ディレクトリは自己完結した `content_root` で、`cd` してそのまま
+verb を叩けます:
+
+- [`examples/quick-start/`](./examples/quick-start/) — 最小の config + members
+- [`examples/dogfood-session/`](./examples/dogfood-session/) — 多 actor の長い実セッション（このツール自身が自分を拡張した完全な記録）
+- [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON envelope を中心とした agent-driven flow
+- [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona の voice 表現
+- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil の合成例

--- a/README.md
+++ b/README.md
@@ -74,20 +74,47 @@ no DB, no network. The `content_root` you work in is the whole world.
 
 ### Install
 
-Requires Node.js 20 or 22.
+Requires Node.js 20 or 22. The `prepare` script auto-builds `dist/`
+on `npm install`, so a separate build step is not needed (run
+`npm run build` only after editing source).
 
 ```bash
-npm install
-npm run build
-node ./bin/gate.mjs --help     # request lifecycle / review / dialogue
-node ./bin/agora.mjs --help    # play / narrative (suspend/resume primitives)
-node ./bin/devil.mjs --help    # security-backstop review (alpha)
-node ./bin/guild.mjs --help    # member management
+npm install                              # auto-builds via prepare: tsc
+
+# Once per content_root: register yourself as an actor.
+node ./bin/gate.mjs register --name <you>
+
+# Once per shell: set the default actor used by every verb.
+export GUILD_ACTOR=<you>
+
+# Every session: orient with one command.
+node ./bin/gate.mjs boot                 # identity + status + tail + inbox in one JSON
 ```
 
-A worked example content_root with config, members, and a multi-actor
-session lives in [`examples/quick-start/`](./examples/quick-start/);
-a longer real session is in [`examples/dogfood-session/`](./examples/dogfood-session/).
+#### Entry points
+
+| CLI | Status | How to invoke |
+|-----|--------|----------------|
+| `gate`  | stable     | `npm link` then `gate ...`, or `node ./bin/gate.mjs ...` |
+| `guild` | stable     | `npm link` then `guild ...`, or `node ./bin/guild.mjs ...` |
+| `agora` | alpha (opt-in) | `node ./bin/agora.mjs ...` or `npm run agora -- ...` |
+| `devil` | alpha (opt-in) | `node ./bin/devil.mjs ...` or `npm run devil -- ...` |
+
+`agora` and `devil` are deliberately **not** listed in
+`package.json#bin` while they remain alpha — opt-in is the stability
+boundary, not an oversight. Add them yourself once you commit to the
+shape they hold.
+
+#### Worked examples
+
+Each directory below is a self-contained `content_root` you can `cd`
+into and run verbs against:
+
+- [`examples/quick-start/`](./examples/quick-start/) — minimal config + members
+- [`examples/dogfood-session/`](./examples/dogfood-session/) — longer multi-actor real session
+- [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON-envelope agent-driven flow
+- [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona voice rendering
+- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil composition
 
 ### Architecture: container with three passages
 
@@ -168,7 +195,12 @@ npm test
 ```
 
 CI runs the same suite on Node 20 and 22 via
-[`.github/workflows/ci.yml`](./.github/workflows/ci.yml).
+[`.github/workflows/ci.yml`](./.github/workflows/ci.yml). **CI is the
+source of truth.** A handful of tests can fail in local runs on
+macOS due to `/var/folders` ↔ `/private/var/folders` symlink
+resolution and a separate JSON-parsing edge case in the schema
+snapshot — these do not occur in CI. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the env-sensitivity notes.
 
 ### License
 


### PR DESCRIPTION
## Summary

A fresh agent (or human) reading only the **30-second to 10-minute layers** (README.md, README.ja.md, AGENT.md) was missing eight pieces of information that lived only in `docs/verbs.md` (30-minute layer) or in project-private CLAUDE.md. Triaged as gate request `2026-05-04-0003` on the develop substrate.

## Coverage closed

### `README.md`
- **Install** rewritten:
  - `GUILD_ACTOR` export shown
  - `gate boot` named as the per-session orientation verb
  - Note that `prepare: tsc` auto-builds on `npm install` (no separate `npm run build`)
  - **`agora` / `devil` are opt-in `bin` entries** — explicit table showing how to invoke each of the four CLIs
  - Worked examples listing expanded from 2 to 5
- **Test** section now names CI as source of truth and documents the macOS-local `/private/var` symlink and JSON-snapshot failures.

### `README.ja.md`
- New **セットアップ** section mirroring README.md.
- Fix lense count: ~~"Claude Security の 8 category + 3 つの devil 固有"~~ → "8 + devil 固有 4 つ = 計 12 lense" (composition / temporal / supply-chain / coherence; per `AGENT.md` L260).
- 実例 list expanded from 1 to 5.

### `AGENT.md`
- **Prerequisites** preamble inserted at the top of *Session start*: `npm install`, `GUILD_ACTOR`, the `bin` opt-in convention.

### `CONTRIBUTING.md`
- New bullet under *Other expectations* documenting env-sensitive local test failures and the "CI is the source of truth" stance.

## Test plan

- [x] `npm run build` clean.
- [x] `node --test dist/tests/interface/voiceBudget.test.js` passes (no new pedagogical-phrase trips).
- [x] `gate whoami` smoke test still works on edited tree.
- [x] Manually re-read each edited file end-to-end to check link integrity.

## Substrate trace (develop)

- request `2026-05-04-0003` (pending) — `--auto-review claude-review` set; will close after merge.