### PR TITLE
docs(lore): add principle 12 — substrate-pure module in projection ecosystem

### DIFF
--- a/lore/principles/12-substrate-pure-module-in-projection-ecosystem.md
+++ b/lore/principles/12-substrate-pure-module-in-projection-ecosystem.md
@@ -1,0 +1,117 @@
+# Substrate-pure module in a projection ecosystem
+
+**guild-cli is not a standalone harness. It is a multiply-referenced
+substrate-pure module within a larger projection ecosystem of
+sibling AI-first CLIs (yori-code, gemini-cli) and a shared GUI lens
+(projector). Its responsibility is judgment-accumulation — nothing
+more. The boundaries with adjacent modules are intentional: card
+abstraction, GUI projection, persona logic, and game construction
+all live in other modules and are not re-invented here.**
+
+## Statement
+
+Earlier principles (10 schema-as-contract, 11 ai-first-human-as-
+projection) establish that guild-cli speaks a substrate language
+intended for AI agents first. This principle names where the
+substrate ends and other ecosystem modules begin.
+
+The ecosystem, as of 2026-05-04:
+
+- **guild-cli** — judgment-accumulation substrate. Multi-actor
+  ledger, gate / agora / devil passages, lense-attributed reviews.
+- **yori-code** (with `atelier/`) — AI-first game engine. Inherits
+  gate's append-only ledger architecture and generalizes it via the
+  Card abstraction. Vendors guild-cli as a pinned submodule under
+  `external/guild-cli/`.
+- **gemini-cli** — general-purpose Gemini agent CLI; sibling, not
+  a dependency.
+- **projector** — universal CLI → GUI projection infrastructure.
+  Reads `.projection.yaml` manifests and JSON Lines event streams
+  from sibling CLIs and renders a shared GUI sandbox. Loose
+  coupling: no CLI is forked or vendored by projector.
+
+Inside guild-cli the design grammar is a five-layer composition:
+
+| Layer | Static elements | What it provides |
+|---|---|---|
+| 1. Passage | `gate` / `agora` / `devil` (+ future shapes) | the *shape* of agent activity |
+| 2. Lense | `devil`/`layer`/`cognitive`/`user` + per-content_root extensions | the *angle* of observation; target-invariant |
+| 3. Verb | per-passage action sets (`request`, `move`, `entry`, ...) | the *act* on the substrate |
+| 4. Card | borrowed from external skill systems (THS, atelier) | *enhancement* attached to the substrate |
+| 5. Infrastructure | `safeFs`, `parseYamlSafe`, `pathSafety`, passage-registry seam | *invariants* that cross every passage |
+
+Dynamic compositions arise from this static base:
+
+- **Combo** — short verb chains within or across passages
+- **Flow** — long combo chains forming a complete piece of work
+  (the bug-killing flow in [`docs/playbook.md`](../../docs/playbook.md#c4)
+  is canonical)
+- **Loop** — flows that recur (improvement loops, time-aware
+  Zeigarnik recovery via suspend/resume cliffs)
+- **Hooks** — event reactors (not yet implemented in guild-cli;
+  the harness host typically provides this layer)
+- **Cycle** — self-renewing flow shapes that arrive once a
+  reflective layer composes with the rest
+
+Three usage shapes are all first-class:
+
+1. **Standalone.** Run `gate` / `agora` / `devil` directly inside a
+   harness session.
+2. **Vendored.** Sit pinned at a SHA inside another tool's tree
+   (`yori-code/external/guild-cli/`) and serve its judgment needs.
+3. **Lensed.** Be observed through a `.projection.yaml` manifest
+   by a GUI projection layer without surrendering CLI primacy.
+
+## Why the asymmetry
+
+Three reasons the substrate stays narrow:
+
+1. **Card abstraction belongs in atelier.** atelier's eight Card
+   kinds (action, effect, rule, role, zone, lense, observer,
+   scenario) and its packs (e.g. fireworks, tictactoe, werewolf,
+   silence) are the canonical CDD implementation. Reproducing
+   even a subset inside guild-cli would create two parallel card
+   vocabularies that drift.
+2. **GUI projection belongs in projector.** A guild-cli rendering
+   layer would couple substrate evolution to GUI evolution, which
+   contradicts principle 11 — projection is downstream, not
+   upstream.
+3. **Persona logic belongs to the host harness.** guild-cli
+   records *who acted* via `--by` / `--from` / `--with`, but does
+   not model *who that actor is*. Persona shape (Yuki, Miki,
+   Eris, Noir, Asteria, ...) is host-side and arrives through
+   actor names, not through guild-cli concepts.
+
+## Consequences
+
+- **No completion-driven design.** guild-cli does not need to
+  "finish" — adjacent modules cover the gaps a standalone tool
+  would have to fill.
+- **Three ways to opt in.** Users may run guild-cli alone,
+  vendor it inside another CLI, or watch it through projector.
+  All three are intended; none is the canonical use.
+- **Responsibility orthogonality.** A change in atelier's Card
+  catalog should not require a guild-cli release. A new GUI tab
+  in projector should not require a guild-cli verb. A new persona
+  in THS should not require a guild-cli member-category change.
+  When any of these couples appear, that is a design smell to
+  investigate, not a feature to embrace.
+
+## Meta-note
+
+This principle is **descriptive** of the ecosystem state on
+2026-05-04, not **prescriptive** of how the ecosystem must be.
+The composition above will shift as `atelier`, `projector`,
+`yori-code`, and adjacent CLIs evolve. Future agreement is welcome
+to supersede this principle; supersession is the native motion of
+`lore/principles/` (per principle 04).
+
+This principle was written aware of its own gravity — once a
+record exists in `lore/principles/`, it is read later as
+inheritance. Readers who arrive at this file because grep
+surfaced it are asked to read this section before treating the
+content above as binding. The substrate ledger inside
+`substrate/agora/plays/whole-repo-review/2026-05-04-001.yaml`
+holds the three-voice conversation (eris / noir / asteria) from
+which this writing emerged; it is the trace of a specific reading
+on a specific date, not a universal claim.


### PR DESCRIPTION
## Summary

Adds `lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`. Names the boundary between guild-cli and adjacent ecosystem modules so future contributors do not re-invent abstractions that already live elsewhere.

## What it says

- guild-cli is a **multiply-referenced substrate-pure module** in a projection ecosystem (with sibling CLIs and a shared GUI lens via `projector`).
- Internal grammar is a **five-layer composition**: Passage / Lense / Verb / Card / Infrastructure, with dynamic compositions (Combo / Flow / Loop / Hooks / Cycle) emerging from it.
- **Three usage shapes** are first-class: standalone, vendored (e.g. inside `yori-code/external/guild-cli/`), or lensed (via `projector`).
- The substrate stays narrow because **card abstraction (atelier), GUI projection (projector), and persona logic (host harness)** all live in adjacent modules.

## Why now

Emerged from a three-voice agora play (eris / noir / asteria) recorded under `substrate/agora/plays/whole-repo-review/2026-05-04-001.yaml`. The five-layer grammar and the static-vs-dynamic distinction were articulated there; `principle 12` fixes the architectural read so it does not drift before being written down.

## Note on gravity

The file ends with an explicit **meta-note**: this principle is descriptive of the 2026-05-04 ecosystem state, not prescriptive law. Future agreement is welcome to supersede it (per principle 04 — records-outlive-writers, including its second meaning: gravity over what comes after). Readers arriving via grep should read the meta-note before treating the body as binding.

## Test plan

- [x] `node --test dist/tests/interface/voiceBudget.test.js` passes — no new pedagogical phrases introduced
- [x] Pure docs change; no behavior change