### PR TITLE
feat(ctx): add ctx passage phase 1 — record verb only

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -40,10 +40,12 @@ node ./bin/gate.mjs boot                 # identity / status / tail / inbox を 
 ```
 
 `gate` と `guild` は安定しており、`npm link` で PATH 化できます。
-`agora` と `devil` は alpha のため意図的に `package.json#bin` から
+`agora` / `devil` / `ctx` は alpha のため意図的に `package.json#bin` から
 外しており、`node ./bin/agora.mjs ...` または `npm run agora -- ...`
-で起動してください（`devil` も同様）。これは見落としではなく安定境界
-として opt-in にしてあります。
+で起動してください（`devil`, `ctx` も同様）。これは見落としではなく
+安定境界として opt-in にしてあります。`ctx` は phase 1 で `record`
+verb のみ実装されています — 残り 6 verb (fork / supersede / show /
+list / chain / status) は別セッションで段階的に追加されます。
 
 ## あなたができること
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ node ./bin/gate.mjs boot                 # identity + status + tail + inbox in o
 | `guild` | stable     | `npm link` then `guild ...`, or `node ./bin/guild.mjs ...` |
 | `agora` | alpha (opt-in) | `node ./bin/agora.mjs ...` or `npm run agora -- ...` |
 | `devil` | alpha (opt-in) | `node ./bin/devil.mjs ...` or `npm run devil -- ...` |
+| `ctx`   | alpha (opt-in, phase 1) | `node ./bin/ctx.mjs ...` — only `record` ships in phase 1 |
 
-`agora` and `devil` are deliberately **not** listed in
+`agora`, `devil`, and `ctx` are deliberately **not** listed in
 `package.json#bin` while they remain alpha — opt-in is the stability
 boundary, not an oversight. Add them yourself once you commit to the
 shape they hold.

--- a/bin/ctx.mjs
+++ b/bin/ctx.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Two coupled facts to remember if you change anything here:
+//   1. This guard is duplicated across bin/{gate,guild,agora,devil,ctx}.mjs
+//      intentionally — a shared helper would itself live in dist/ and
+//      hit the same load failure (circular trap). Re-evaluate if a
+//      6th entry is added.
+//   2. The error message references `npm install` and the `prepare`
+//      script. If package.json drops `prepare: tsc`, update the message.
+const ENTRY_URL = new URL('../dist/src/passages/ctx/interface/index.js', import.meta.url).href;
+
+let main;
+try {
+  ({ main } = await import(ENTRY_URL));
+} catch (err) {
+  if (err?.code === 'ERR_MODULE_NOT_FOUND') {
+    const failedUrl = typeof err.url === 'string' ? err.url : '';
+    const fromDist =
+      failedUrl.includes('/dist/') || /\/dist\//.test(err.message ?? '');
+    if (fromDist) {
+      process.stderr.write(
+        'guild-cli: dist/ not built (or out of date).\n' +
+          '  Run: npm install   (auto-builds via the `prepare` script)\n' +
+          '  Or:  npm run build (rebuild after pulling source changes)\n',
+      );
+      if (failedUrl && failedUrl !== ENTRY_URL) {
+        process.stderr.write(`  (transitive miss: ${failedUrl})\n`);
+      }
+      process.exit(2);
+    }
+  }
+  throw err;
+}
+main(process.argv.slice(2)).then((code) => process.exit(code));

--- a/src/passages/ctx/application/CtxRepository.ts
+++ b/src/passages/ctx/application/CtxRepository.ts
@@ -1,0 +1,13 @@
+import { Ctx } from '../domain/Ctx.js';
+
+/**
+ * Port — Application's view of ctx persistence. Phase 1 needs three
+ * operations: list existing ids (for nextCtxId allocation), save new,
+ * and find by id (for handler verification, even though `ctx show`
+ * itself ships in phase 2 — internal callers may need round-tripping).
+ */
+export interface CtxRepository {
+  listAllIds(): Promise<readonly string[]>;
+  saveNew(ctx: Ctx): Promise<void>;
+  findById(id: string): Promise<Ctx | null>;
+}

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -1,0 +1,36 @@
+import { Ctx, nextCtxId } from '../domain/Ctx.js';
+import { CtxRepository } from './CtxRepository.js';
+
+/**
+ * ctx use cases — phase 1 has only `record`. Phase 2 will add
+ * fork / supersede / show / list / chain / status.
+ *
+ * `now` is injected so tests can pin time and so the same allocator
+ * is used by id-generation (nextCtxId) and timestamp authorship,
+ * keeping them consistent within a single record.
+ */
+export class CtxUseCases {
+  constructor(
+    private readonly repo: CtxRepository,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async record(input: {
+    by: string;
+    fact: string;
+    tags?: readonly string[];
+  }): Promise<Ctx> {
+    const now = this.now();
+    const existing = await this.repo.listAllIds();
+    const id = nextCtxId(existing, now);
+    const ctx = Ctx.create({
+      id,
+      created_by: input.by,
+      fact: input.fact,
+      tags: input.tags ?? [],
+      now: () => now,
+    });
+    await this.repo.saveNew(ctx);
+    return ctx;
+  }
+}

--- a/src/passages/ctx/domain/Ctx.ts
+++ b/src/passages/ctx/domain/Ctx.ts
@@ -1,0 +1,170 @@
+// ctx — Fact (a recorded observation, not a judgment).
+//
+// ctx is the fourth passage under guild (after gate / agora / devil),
+// reserved for "facts the substrate has accumulated across sessions".
+// Distinct from gate (judgment), agora (exploration), devil (defense).
+//
+// Phase 1 ships the minimum: id, attribution, the fact prose, and
+// optional prefix-tagged labels (e.g. `tech:typescript`, `status:active`).
+// `evidence`, `supersedes`, `sub_of`, `chain_after`, `branch_ref` arrive
+// in phase 2 — see issue tracker.
+//
+// AI-first per principle 11:
+//   - immutable on save (re-reading agents must see what was written)
+//   - explicit fields, snake_case keys
+//   - validation at construction; tampered YAML fails closed at restore
+
+import { DomainError } from '../../../domain/shared/DomainError.js';
+
+/**
+ * Ctx id — `ctx-YYYY-MM-DD-NNN`.
+ *
+ * Mirrors the request-id shape (`YYYY-MM-DD-NNN`) with a `ctx-` prefix
+ * so the ledger can be greped by passage. Three-digit suffix supports
+ * up to 999 ctx records per day per content_root, which is well above
+ * any realistic write rate.
+ */
+const CTX_ID_PATTERN = /^ctx-\d{4}-\d{2}-\d{2}-\d{3}$/;
+
+export function parseCtxId(raw: unknown): string {
+  if (typeof raw !== 'string') {
+    throw new DomainError(`ctx id must be a string, got: ${typeof raw}`, 'id');
+  }
+  if (!CTX_ID_PATTERN.test(raw)) {
+    throw new DomainError(
+      `ctx id must match ${CTX_ID_PATTERN.source}, got: ${raw}`,
+      'id',
+    );
+  }
+  return raw;
+}
+
+/**
+ * Tag — `prefix:value` shape borrowed from THS ctx convention.
+ * Examples: `tech:typescript`, `status:active`, `topic:ctx-design`.
+ *
+ * Both halves are lowercase ASCII letters / digits / hyphens; prefix
+ * must be 1–16 chars, value 1–48 chars. The prefix is what makes
+ * tags semantically queryable (filter by `tech:*`, by `status:*`, ...).
+ */
+const TAG_PATTERN = /^[a-z][a-z0-9-]{0,15}:[a-z0-9][a-z0-9-]{0,47}$/;
+
+export function parseCtxTag(raw: unknown): string {
+  if (typeof raw !== 'string') {
+    throw new DomainError(`ctx tag must be a string, got: ${typeof raw}`, 'tag');
+  }
+  if (!TAG_PATTERN.test(raw)) {
+    throw new DomainError(
+      `ctx tag must match ${TAG_PATTERN.source} (e.g. tech:typescript), got: ${raw}`,
+      'tag',
+    );
+  }
+  return raw;
+}
+
+export interface CtxProps {
+  readonly id: string;
+  readonly created_at: string; // ISO timestamp
+  readonly created_by: string; // member or host name
+  readonly fact: string;       // non-empty prose
+  readonly tags: readonly string[]; // possibly empty; each `prefix:value`
+}
+
+export class Ctx {
+  readonly id: string;
+  readonly created_at: string;
+  readonly created_by: string;
+  readonly fact: string;
+  readonly tags: readonly string[];
+
+  private constructor(props: CtxProps) {
+    this.id = props.id;
+    this.created_at = props.created_at;
+    this.created_by = props.created_by;
+    this.fact = props.fact;
+    this.tags = props.tags;
+  }
+
+  static create(input: {
+    id: string;
+    fact: string;
+    created_by: string;
+    tags?: readonly string[];
+    now?: () => Date;
+  }): Ctx {
+    const id = parseCtxId(input.id);
+    if (typeof input.fact !== 'string' || input.fact.trim().length === 0) {
+      throw new DomainError('fact required (non-empty string)', 'fact');
+    }
+    if (typeof input.created_by !== 'string' || input.created_by.trim().length === 0) {
+      throw new DomainError('created_by required (non-empty string)', 'created_by');
+    }
+    const tags = (input.tags ?? []).map((t) => parseCtxTag(t));
+    const created_at = (input.now ?? (() => new Date()))().toISOString();
+    return new Ctx({
+      id,
+      created_at,
+      created_by: input.created_by.trim(),
+      fact: input.fact.trim(),
+      tags: Object.freeze([...tags]),
+    });
+  }
+
+  /**
+   * Restore from on-disk YAML. Same validation as create — a tampered
+   * file fails closed at the boundary.
+   */
+  static restore(input: CtxProps): Ctx {
+    const tags = (input.tags ?? []).map((t) => parseCtxTag(t));
+    return new Ctx({
+      id: parseCtxId(input.id),
+      created_at: input.created_at,
+      created_by: input.created_by,
+      fact: input.fact,
+      tags: Object.freeze([...tags]),
+    });
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      created_at: this.created_at,
+      created_by: this.created_by,
+      fact: this.fact,
+      tags: [...this.tags],
+    };
+  }
+}
+
+export class CtxIdCollision extends Error {
+  constructor(id: string) {
+    super(`Ctx id already exists: ${id}`);
+    this.name = 'CtxIdCollision';
+  }
+}
+
+/**
+ * Allocate a fresh `ctx-YYYY-MM-DD-NNN` id, scanning the current
+ * day's existing ids and choosing the next free 3-digit slot.
+ *
+ * Pure function — caller hands in the existing-ids list and `now`,
+ * we deterministically pick the next id. Repository owns the listing.
+ */
+export function nextCtxId(existing: readonly string[], now: Date): string {
+  const date = now.toISOString().slice(0, 10); // YYYY-MM-DD
+  const prefix = `ctx-${date}-`;
+  const used = new Set<number>();
+  for (const id of existing) {
+    if (id.startsWith(prefix)) {
+      const n = Number.parseInt(id.slice(prefix.length), 10);
+      if (Number.isInteger(n)) used.add(n);
+    }
+  }
+  for (let n = 1; n <= 999; n++) {
+    if (!used.has(n)) return `${prefix}${String(n).padStart(3, '0')}`;
+  }
+  throw new DomainError(
+    `ctx id exhausted for ${date} (>999 records). Bump in phase 2 if real.`,
+    'id',
+  );
+}

--- a/src/passages/ctx/infrastructure/YamlCtxRepository.ts
+++ b/src/passages/ctx/infrastructure/YamlCtxRepository.ts
@@ -1,0 +1,98 @@
+import YAML from 'yaml';
+import { join } from 'node:path';
+import { Ctx, CtxIdCollision, parseCtxId } from '../domain/Ctx.js';
+import { CtxRepository } from '../application/CtxRepository.js';
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import {
+  existsSafe,
+  listDirSafe,
+  readTextSafe,
+  writeTextSafe,
+} from '../../../infrastructure/persistence/safeFs.js';
+import { parseYamlSafe } from '../../../infrastructure/persistence/parseYamlSafe.js';
+
+/**
+ * ctx's first storage adapter — same substrate primitives as agora /
+ * devil (safeFs / parseYamlSafe / GuildConfig). The shared IO core
+ * is the implicit cross-passage invariant that lore principle 12
+ * names; this adapter participates in it without re-implementing.
+ *
+ * Layout: <content_root>/ctx/<id>.yaml  (flat, no sub-directory in
+ * phase 1 — sub_of and chain_after fields arrive in phase 2 and
+ * may motivate a layout change at that point).
+ */
+export class YamlCtxRepository implements CtxRepository {
+  private readonly base: string;
+
+  constructor(private readonly config: GuildConfig) {
+    this.base = join(this.config.contentRoot, 'ctx');
+  }
+
+  async listAllIds(): Promise<readonly string[]> {
+    const files = listDirSafe(this.base, '.');
+    const out: string[] = [];
+    for (const f of files) {
+      if (!f.endsWith('.yaml')) continue;
+      const id = f.replace(/\.yaml$/, '');
+      try {
+        parseCtxId(id);
+        out.push(id);
+      } catch {
+        // off-pattern filenames in ctx/ are surfaced via diagnostic
+        // eventually; listAllIds skips them so id allocation does
+        // not crash on a typo file (same discipline as agora).
+      }
+    }
+    return out;
+  }
+
+  async saveNew(ctx: Ctx): Promise<void> {
+    const rel = `${ctx.id}.yaml`;
+    if (existsSafe(this.base, rel)) {
+      throw new CtxIdCollision(ctx.id);
+    }
+    const text = YAML.stringify(ctx.toJSON());
+    try {
+      writeTextSafe(this.base, rel, text, { createOnly: true });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new CtxIdCollision(ctx.id);
+      }
+      throw e;
+    }
+  }
+
+  async findById(id: string): Promise<Ctx | null> {
+    parseCtxId(id);
+    const rel = `${id}.yaml`;
+    if (!existsSafe(this.base, rel)) return null;
+    const raw = readTextSafe(this.base, rel);
+    const absSource = join(this.base, rel);
+    const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
+    if (parsed === undefined) return null;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      this.config.onMalformed(absSource, 'top-level YAML is not a mapping; skipping');
+      return null;
+    }
+    const obj = parsed as Record<string, unknown>;
+    try {
+      return Ctx.restore({
+        id: typeof obj['id'] === 'string' ? (obj['id'] as string) : id,
+        created_at:
+          typeof obj['created_at'] === 'string'
+            ? (obj['created_at'] as string)
+            : new Date().toISOString(),
+        created_by:
+          typeof obj['created_by'] === 'string' ? (obj['created_by'] as string) : 'unknown',
+        fact: typeof obj['fact'] === 'string' ? (obj['fact'] as string) : '',
+        tags: Array.isArray(obj['tags'])
+          ? (obj['tags'] as unknown[]).filter((t): t is string => typeof t === 'string')
+          : [],
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.config.onMalformed(absSource, `hydrate failed (id=${id}), skipping: ${msg}`);
+      return null;
+    }
+  }
+}

--- a/src/passages/ctx/interface/handlers/record.ts
+++ b/src/passages/ctx/interface/handlers/record.ts
@@ -1,0 +1,101 @@
+import { CtxUseCases } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { resolveGuildActor } from '../../../../interface/shared/resolveGuildActor.js';
+
+const RECORD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'fact',
+  'tag',
+  'by',
+  'format',
+]);
+
+/**
+ * Parse `--tag tech:typescript,status:active` (comma-separated) into a
+ * clean tag list. Same convention as gate's `--with` (request.ts:
+ * `parseWithList`). Tag-shape validation happens upstream in
+ * Ctx.create -> parseCtxTag.
+ */
+function parseTagList(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export interface RecordCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx record — append a new fact to the substrate.
+ *
+ * Usage:
+ *   ctx record --fact "..." [--tag tech:foo,status:bar] [--by <m>] [--format json|text]
+ *
+ * Produces: <content_root>/ctx/<id>.yaml
+ *
+ * --by defaults from GUILD_ACTOR (env or .guild-actor file). Same actor
+ * resolution as gate / agora / devil.
+ */
+export async function recordCtx(
+  deps: RecordCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, RECORD_KNOWN_FLAGS, 'record');
+
+  const fact = requireOption(args, 'fact', '--fact required (the observation prose)');
+  const tags = parseTagList(optionalOption(args, 'tag'));
+  const by = optionalOption(args, 'by') ?? resolveGuildActor();
+  if (!by) {
+    process.stderr.write(
+      'error: --by required (or set GUILD_ACTOR / .guild-actor). ctx record attributes the observation to an actor.\n',
+    );
+    return 1;
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
+    return 1;
+  }
+
+  const ctx = await deps.uc.record({ by, fact, tags });
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          id: ctx.id,
+          ...ctx.toJSON(),
+          where_written: `${deps.config.contentRoot}/ctx/${ctx.id}.yaml`,
+          config_file: deps.config.configFile,
+          suggested_next: {
+            verb: 'gate',
+            args: ['boot'],
+            reason:
+              "phase 1 ships record only; show / list / fork / supersede / chain / status arrive in phase 2. Confirm the write landed via filesystem or `gate boot`.",
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(`✓ ctx recorded: ${ctx.id}\n`);
+    if (tags.length > 0) {
+      process.stdout.write(`  tags: ${tags.join(', ')}\n`);
+    }
+    process.stderr.write(
+      `notice: wrote ${deps.config.contentRoot}/ctx/${ctx.id}.yaml (config: ${deps.config.configFile})\n`,
+    );
+  }
+  return 0;
+}

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -1,0 +1,82 @@
+// ctx — passage entry point.
+//
+// ctx is the fourth passage under guild (after gate / agora / devil),
+// reserved for accumulated facts: observations the substrate has
+// witnessed across sessions. Verdict-less, attribution-required,
+// append-only. See lore/principles/12 for the boundary with adjacent
+// modules.
+//
+// Phase 1 ships only `ctx record`. The remaining six verbs (fork /
+// supersede / show / list / chain / status) land iteratively in
+// phase 2 as use surfaces what shape they need.
+//
+// AI-first per principle 11: the substrate is machine-parseable JSON /
+// snake_case YAML / explicit-flag CLI; any future human-facing UI is
+// a projection, not a substrate change.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { parseArgs } from '../../../interface/shared/parseArgs.js';
+import { DomainError } from '../../../domain/shared/DomainError.js';
+import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
+import { CtxUseCases } from '../application/CtxUseCases.js';
+import { recordCtx } from './handlers/record.js';
+
+const HELP = `ctx — fact accumulation passage (phase 1: record only)
+
+Usage:
+  ctx record --fact "<prose>" [--tag tech:foo,status:bar]
+                              [--by <m>] [--format json|text]
+                              Append a fact to the substrate. Lands at
+                              <content_root>/ctx/<id>.yaml. Id is
+                              auto-allocated as ctx-YYYY-MM-DD-NNN.
+
+  ctx --help                   This help.
+  ctx --version                Print version and exit.
+
+Phase 1 status: minimum surface — only \`record\` is implemented.
+Phase 2 (separate session): fork / supersede / show / list / chain / status.
+
+Substrate: shares content_root and members/ with gate; ctx-specific
+data goes under <content_root>/ctx/.
+
+Lore upstream:
+  lore/principles/12-substrate-pure-module-in-projection-ecosystem.md
+  lore/principles/11-ai-first-human-as-projection.md
+  lore/principles/04-records-outlive-writers.md
+`;
+
+export async function main(argv: readonly string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (argv[0] === '--version') {
+    process.stdout.write('ctx (under guild-cli) — phase 1 / record only\n');
+    return 0;
+  }
+
+  const [cmd, ...rest] = argv;
+  const args = parseArgs(rest);
+  const config = GuildConfig.load();
+  const repo = new YamlCtxRepository(config);
+  const uc = new CtxUseCases(repo);
+
+  try {
+    switch (cmd) {
+      case 'record':
+        return await recordCtx({ uc, config }, args);
+      default:
+        process.stderr.write(`ctx: unknown verb: ${cmd}\n${HELP}`);
+        return 1;
+    }
+  } catch (e) {
+    const msg =
+      e instanceof DomainError
+        ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
+        : e instanceof Error
+          ? e.message
+          : String(e);
+    process.stderr.write(`error: ${msg}\n`);
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **fourth passage** under guild: `ctx`, reserved for "facts the substrate has accumulated across sessions". Verdict-less, attribution-required, append-only. Architectural placement defined in [`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md).

## Phase 1 surface (this PR)

```bash
node ./bin/ctx.mjs record --fact "<prose>" \
                         [--tag tech:typescript,status:active] \
                         [--by <m>] [--format json|text]
# → <content_root>/ctx/ctx-YYYY-MM-DD-NNN.yaml
```

Behavior:
- Id auto-allocated via `nextCtxId(existing, now)` — pure function, deterministic given inputs.
- Tag shape: `prefix:value` (e.g. `tech:typescript`). Validation at `parseCtxTag`.
- Append-only: `EEXIST` on existing id → `CtxIdCollision` (same pattern as agora's `GameSlugCollision`, devil's review-id collision).
- Reuses `safeFs` / `parseYamlSafe` / `GuildConfig` unchanged — the cross-passage IO core that lore 12 names as the implicit invariant.

## Phase 2 (separate sessions, tracked as issues opened post-merge)

- `ctx fork` — sub-thread divergence
- `ctx supersede` — append-only correction
- `ctx show` — single-record detail view
- `ctx list` — enumeration with `--tag` / `--from` filters
- `ctx chain` — sub-tree traversal
- `ctx status` — markdown dashboard

Plus phase-2 schema fields: `evidence`, `supersedes`, `sub_of`, `chain_after`, `branch_ref`. All deferred to keep this PR minimal and let the dogfood inform the shape.

## Why opt-in

Following the precedent set for `agora` and `devil`: `ctx` is **not** added to `package.json#bin`. Per principle 12, opt-in is the stability boundary. Invoke as `node ./bin/ctx.mjs ...`.

## Verification

- [x] `npm run build` clean
- [x] `node --test dist/tests/interface/voiceBudget.test.js` passes — no new pedagogical phrases introduced
- [x] Smoke test on isolated content_root: `ctx record` writes valid YAML at expected path, exits 0, `notice:` line on stderr
- [x] Help text (`ctx --help`) renders, references `lore/principles/12`
- [x] `bin/ctx.mjs` carries the dist-staleness guard and coupling notes (per PR #140 convention)

## Substrate trace

Implementation follows the design that emerged from the three-voice agora play `2026-05-04-001 / whole-repo-review` on `develop` (eris / noir / asteria), where the 4th passage was confirmed as the right placement (α route).