### PR TITLE
fix(package.json): align scripts with README — add prepare and per-passage runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "test": "tsc && node tests/run.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "gate": "node bin/gate.mjs",
+    "guild": "node bin/guild.mjs",
+    "agora": "node bin/agora.mjs",
+    "devil": "node bin/devil.mjs",
+    "ctx": "node bin/ctx.mjs"
   },
   "dependencies": {
     "yaml": "^2.5.0"


### PR DESCRIPTION
## Summary

The README install section makes two promises that are not honored on `main`:

1. **"The `prepare` script auto-builds `dist/` on `npm install`"** — `prepare` was not defined, so fresh checkouts silently skipped the build and any `node bin/<passage>.mjs` invocation hit the dist-staleness friendly error from PR #140.
2. **`npm run agora -- ...` / `npm run devil -- ...`** — neither script existed, so `npm run` died with `invalid choice` on a fresh clone.

This PR adds the five missing entries to `scripts`:

- `prepare: tsc` — makes the README promise true
- `gate / guild / agora / devil / ctx` — per-passage convenience runners

## Why this preserves principle 12

Per [`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md), opt-in is the stability boundary, exercised at the `bin/` field of `package.json` (where only `gate` and `guild` are exposed). `scripts` is a separate convenience surface; adding `agora` / `devil` / `ctx` runners there does **not** publish them as `bin` entries, so their alpha opt-in posture is preserved.

## Verification

- [x] `npm install` triggers `prepare: tsc` (build runs without explicit `npm run build`)
- [x] `npm run agora -- --help` resolves (previously `invalid choice`)
- [x] `npm run ctx -- --help` resolves (the new ctx passage from PR #143 also reachable via `npm run`)
- [x] `node --test dist/tests/interface/voiceBudget.test.js` passes
- [x] Pure config change; no source touched