### PR TITLE
docs(readme): include ctx in the architecture section (4 passages now)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,18 +88,22 @@ list / chain / status) は別セッションで段階的に追加されます。
 
 ## guild の他の passage
 
-`gate` は guild という container の中の一つ目の passage です。
-同じ content_root を共有する別の passage が二つあります。 三 passage は
-それぞれ違う **shape の作業** を hold します:
+`gate` は guild という container の中の最初の passage です。
+同じ content_root を共有する passage が複数あり、それぞれ違う
+**shape の作業** を hold します:
 
 | passage | shape (一語) | 何をする | いつ手を伸ばすか |
 |---------|--------------|----------|-------------------|
 | `gate`  | **判断**     | request に verdict を出す | approve / deny / complete / fail / review が必要な時 |
 | `agora` | **探索**     | 結論前の思考に留まる      | Quest / Sandbox、 cliff/invitation で時間を跨ぐ思考 |
 | `devil` | **守備**     | end-user を守る           | 多角的 scrutiny が必要な変更 (security-prone change) |
+| `ctx`   | **事実**     | 観察を記録する             | session を跨いで失われない形で attribution 付きで残したい観察 (verdict 不要) |
 
-三つは AI エージェントが 「この作業はどの shape か」 で dispatch
-できる単純な分類になっています。 詳しく:
+passage 群は AI エージェントが 「この作業はどの shape か」 で dispatch
+できる単純な分類になっています。 集合は open — 詳しくは
+[`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md)
+が、追加 passage がどう既存と合成しつつ吸収されないかを名指ししています。
+個別:
 
 - **`agora`** (`bin/agora.mjs`、 alpha) — play / narrative の
   passage。 Quest と Sandbox の game-kind、 **suspend / resume を
@@ -121,10 +125,21 @@ list / chain / status) は別セッションで段階的に追加されます。
   dismiss された時にその理由が substrate に残る形で deliberation
   を honest に保つ。 設計は
   [issue #126](https://github.com/eris-ths/guild-cli/issues/126)。
+- **`ctx`** (`bin/ctx.mjs`、 alpha phase 1) — fact accumulation の
+  passage。 verdict なし、 attribution 必須、 append-only。 `gate`
+  が *判断* を、 `agora` が *動いている思考* を残すのに対し、 `ctx`
+  は *観察された事実* を残します — session を跨いで substrate が
+  目撃した出来事を、 actor 付き、 `prefix:value` 形式のタグ
+  (例: `tech:typescript`、 `status:active`) 付きで記録し、後から
+  semantic に query できる形で保持します。 phase 1 は `ctx record`
+  のみ。 `fork` / `supersede` / `show` / `list` / `chain` / `status`
+  は phase 2。 観察を session 終端で消したくないが、 判断や熟議に
+  押し上げる必要もない時に手を伸ばす passage です。
 
-3 つの passage は同じ `members/<name>.yaml` substrate を共有し、
-agora / devil 固有の records はそれぞれ `<content_root>/agora/` /
-`<content_root>/devil/` に置かれます。
+passage 群は同じ `members/<name>.yaml` substrate を共有し、
+passage 固有の records はそれぞれ `<content_root>/agora/` /
+`<content_root>/devil/` /
+`<content_root>/ctx/` に置かれます。
 
 ## 実例
 

--- a/README.md
+++ b/README.md
@@ -117,21 +117,26 @@ into and run verbs against:
 - [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona voice rendering
 - [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil composition
 
-### Architecture: container with three passages
+### Architecture: container with passages
 
 `guild` is the **container** — content_root, members, config, the
-YAML substrate records outlive sessions on. Three passages run
-through it today, each a distinct shape of agent interaction:
+YAML substrate records outlive sessions on. Passages run through it,
+each a distinct shape of agent interaction:
 
 | Passage | Shape (一語) | What you do | When to reach for it |
 |---------|------------|-------------|----------------------|
 | `gate`  | **判断 / judgment** | decide on a request | something needs a verdict (approve, deny, complete, fail, review with ok\|concern\|reject) |
 | `agora` | **探索 / exploration** | stay with a thought | something is in motion that shouldn't be forced to a verdict yet (Quest / Sandbox plays, suspend / resume cliffs) |
 | `devil` | **守備 / defense** | protect end-users | something could harm a third party if landed without scrutiny (multi-persona, lense-enforced, friction-as-feature) |
+| `ctx`   | **事実 / fact accumulation** | record an observation | something has been observed across sessions and would be lost without an attributed, append-only record (no verdict needed) |
 
 The framing is a dispatch tool, not a metaphor: gate-shaped work
 goes to `gate`, exploration-shaped to `agora`, defense-shaped to
-`devil`. AI agents can route their work by recognizing the shape.
+`devil`, fact-shaped to `ctx`. AI agents can route their work by
+recognizing the shape. The set is open — see
+[`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md)
+for how additional passages compose with these without absorbing
+into any one of them.
 
 - **`gate`** (CLI) — the request-lifecycle / review / dialogue
   passage. Decisions and the deliberation around them: file a
@@ -163,6 +168,18 @@ goes to `gate`, exploration-shaped to `agora`, defense-shaped to
   [eris-ths/supply-chain-guard](https://github.com/eris-ths/supply-chain-guard)
   whose Devil Gate framework devil-review's `supply-chain` lense
   delegates to.
+- **`ctx`** (CLI) — the fact-accumulation passage (alpha
+  phase 1, shipping under `bin/ctx.mjs`). Verdict-less,
+  attribution-required, append-only. Where `gate` records
+  *judgments* and `agora` records *thoughts in motion*, `ctx`
+  records *what has been observed* — facts the substrate has
+  witnessed across sessions, attributed to an actor, tagged
+  with `prefix:value` labels (e.g. `tech:typescript`,
+  `status:active`) for semantic query later. Phase 1 ships
+  only `ctx record`; `fork` / `supersede` / `show` / `list` /
+  `chain` / `status` arrive in phase 2. Useful when an
+  observation should outlive the session that produced it
+  without forcing a decision or a deliberation.
 
 Plus a thin operator helper:
 
@@ -170,18 +187,22 @@ Plus a thin operator helper:
   members, validate the roster, create members from outside any
   session. Small, stable, script-friendly.
 
-All four CLIs share the same content_root substrate.
+All five CLIs share the same content_root substrate.
 `gate register` and `guild new` write the same
 `members/<name>.yaml` files — two views of the same act (one from
 inside a passage, one from outside the container). agora-specific
 records live under `<content_root>/agora/` (games, plays, casts);
 devil-review records under `<content_root>/devil/` (reviews,
-custom lenses).
+custom lenses); ctx records under `<content_root>/ctx/` (one
+flat YAML per observation in phase 1).
 
 The architecture is shaped to accept additional passages —
 different shapes of agent interaction on the same substrate land
-alongside `gate`, `agora`, and `devil` without absorbing into any
-one of them.
+alongside `gate`, `agora`, `devil`, and `ctx` without absorbing
+into any one of them. Principle 12 names the boundary so future
+passages stay substrate-pure rather than re-implementing card
+abstractions, GUI projection, or persona logic that adjacent
+ecosystem modules already cover.
 
 Full surface in [`AGENT.md`](./AGENT.md); per-verb examples in
 [`docs/verbs.md`](./docs/verbs.md). Agora's own README


### PR DESCRIPTION
## Summary

PR #143 added the `ctx` passage but the README's *Architecture* section still talked about "three passages" and only described gate / agora / devil. This brings the section in line with the current four-passage state and opens it to future additions explicitly.

## Changes (README.md and README.ja.md mirrored)

- **Section title**: "container with three passages" → "container with passages"  (no fixed count, future-proof)
- **Passage table**: add `ctx` row — shape *事実 / fact accumulation*, "record an observation" / "something has been observed across sessions and would be lost without an attributed, append-only record (no verdict needed)"
- **Dispatch-tool sentence**: now includes `ctx`-shaped work
- **Per-passage block**: new `ctx` paragraph (verdict-less, attribution-required, append-only, `prefix:value` tag convention, phase 1 `record` only, phase 2 verbs listed)
- **"All four CLIs" → "All five CLIs"** (gate / guild / agora / devil / ctx)
- **content_root layout**: add `<content_root>/ctx/` line
- **Closing paragraph**: now references [`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md) as the substrate-side anchor for the open-set posture, so the "additional passages" promise has a clear boundary attached

## Test plan

- [x] `node --test dist/tests/interface/voiceBudget.test.js` passes — no new pedagogical phrases introduced
- [x] Pure docs change; no behavior or build affected
- [x] Manually re-read both files end-to-end for link integrity and tone match