### PR TITLE
docs(readme): reflect cross_passage in gate boot, fix devil status inconsistency

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@ node ./bin/gate.mjs register --name <you>
 export GUILD_ACTOR=<you>
 
 # セッションごとに 1 度: 1 コマンドで全コンテキスト取得
-node ./bin/gate.mjs boot                 # identity / status / tail / inbox を 1 JSON で
+node ./bin/gate.mjs boot                 # identity / status / tail / inbox / cross_passage を 1 JSON で
 ```
 
 `gate` と `guild` は安定しており、`npm link` で PATH 化できます。
@@ -60,8 +60,9 @@ list / chain / status) は別セッションで段階的に追加されます。
 - 小さな自己完結タスクなら `gate fast-track` で create→complete
   を一発で通し、記録だけ残して規律を緩める
 - `gate boot` でセッション開始時に全コンテキストを一発取得 —
-  identity / queues / tail / your_recent / 未読 inbox を1つの
-  JSON で。より軽い counts-only が欲しい時は `gate status`。
+  identity / queues / tail / your_recent / 未読 inbox / cross_passage
+  (agora・devil の open / suspended / 直近 activity) を 1 つの JSON
+  で。より軽い counts-only が欲しい時は `gate status`。
 - `gate resume` で前セッション終端から再開 — open loops と
   「次の一手」を restoration prompt として返す（`--locale ja` で
   日本語 prose、`GUILD_ACTOR` 必須）
@@ -112,7 +113,7 @@ passage 群は AI エージェントが 「この作業はどの shape か」 �
   を残し、 次の instance がそれを読んで再入する — substrate-side
   Zeigarnik 効果。 設計の経緯は
   [issue #117](https://github.com/eris-ths/guild-cli/issues/117)。
-- **`devil`** (`bin/devil.mjs`、 snapshot) — security-backstop の
+- **`devil`** (`bin/devil.mjs`、 alpha) — security-backstop の
   review passage。 **multi-persona (red-team / author-defender /
   mirror) + lense 強制 (Claude Security の 8 category + devil 固有
   4 つ = 計 12 lense; composition / temporal / supply-chain /

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ node ./bin/gate.mjs register --name <you>
 export GUILD_ACTOR=<you>
 
 # Every session: orient with one command.
-node ./bin/gate.mjs boot                 # identity + status + tail + inbox in one JSON
+node ./bin/gate.mjs boot                 # identity + status + tail + inbox + cross_passage in one JSON
 ```
 
 #### Entry points


### PR DESCRIPTION
## Summary

Two small README fixes surfaced when re-reading both READMEs against the current code:

1. **`gate boot` description was stale** — `cross_passage` (added in PR #138) is not mentioned anywhere. Updated en + ja.
2. **devil status inconsistent** — ja README line 115 said `snapshot` while en line 154 and ja line 44 both said `alpha`. Aligned to `alpha`.

## Changes

- `README.md` line 91: `# identity + status + tail + inbox in one JSON` → `# identity + status + tail + inbox + cross_passage in one JSON`
- `README.ja.md` line 39: same one-liner adjustment
- `README.ja.md` lines 62-64: expand the `gate boot` bullet to name what `cross_passage` carries (`agora・devil の open / suspended / 直近 activity`)
- `README.ja.md` line 115: `devil` status `snapshot` → `alpha`

## Out of scope (deferred)

While reading I also noticed three framing observations that are *not* fixed here:
- `examples/three-passages-framing/` is named for 3 passages but the README now lists 4
- ctx has no per-passage README and the navigation paragraph (en line 207-211) doesn't direct readers anywhere ctx-specific
- the headline "Built around a Two-Persona Devil Review loop" sits in slight tension with the open-set passage architecture

These are framing judgments, not concrete misses. Left for a separate decision.

## Test plan

- [x] `git diff` reviewed; only README.md and README.ja.md touched
- [x] No code changes; tests / typecheck not affected

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_