### PR TITLE
docs(agent,verbs): add ctx coverage to AGENT.md and docs/verbs.md (phase 1)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -129,18 +129,20 @@ guild validate                          # check all member YAMLs
 
 Categories: `core | professional | assignee | trial | special | host`
 
-## The three passages — a one-line dispatch shorthand
+## The four passages — a one-line dispatch shorthand
 
 | passage | shape (一語)         | the verb you do                | when to reach |
 |---------|----------------------|--------------------------------|----------------|
 | `gate`  | **判断 / judgment**  | decide on a request            | needs a verdict (approve / deny / complete / fail / review) |
 | `agora` | **探索 / exploration** | stay with a thought          | something in motion that shouldn't be forced to a verdict yet |
 | `devil` | **守備 / defense**   | protect end-users              | could harm a third party if it lands without scrutiny |
+| `ctx`   | **事実 / fact**      | record an observation          | observed across sessions; would be lost without an attributed, append-only record |
 
 This is a dispatch tool, not a metaphor. Recognize the shape of
 the work, route to the matching passage. The substrate of each
 passage is shaped by what it holds (decisions / explorations /
-multi-perspective scrutiny), not by what it talks about.
+multi-perspective scrutiny / observations), not by what it talks
+about.
 
 ## Agora (second passage — play / narrative)
 
@@ -290,6 +292,58 @@ that translate actual `/ultrareview` `bugs.json` / Claude Security
 findings / SCG verdict output into devil's strict v0 ingest JSON
 shapes are out of scope for the in-tree passage and would land as
 separate utilities (or in the source tools themselves).
+
+## ctx (fourth passage — fact accumulation, alpha phase 1)
+
+`ctx` is the fourth passage under guild — alongside `gate`, `agora`,
+and `devil`. Where gate carries decisions, agora carries narrative,
+and devil carries multi-persona scrutiny, ctx carries
+**observations that should outlive the session that produced them**
+without being forced into a verdict, a play, or a review.
+
+Verdict-less, attribution-required, append-only. Per principle 12
+(substrate-pure module in projection ecosystem), ctx is the
+substrate primitive for facts; surrounding ecosystem modules
+(persona-side `*_resume.md`, code comments, ADR docs) hold related
+prose at different layers without absorbing into one another.
+
+Phase 1 ships only `ctx record`. The remaining six verbs (`fork` /
+`supersede` / `show` / `list` / `chain` / `status`) and schema
+extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
+`branch_ref`) land in phase 2.
+
+```bash
+ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
+                            [--by <m>] [--format json|text]
+```
+
+ctx records live under `<content_root>/ctx/`:
+
+```
+<content_root>/ctx/
+  ctx-YYYY-MM-DD-NNN.yaml      # one flat YAML per observation
+                                # id sequence per content_root per day
+                                # immutable on save (re-readers see what was written)
+```
+
+Tags follow `prefix:value` shape (e.g. `tech:typescript`,
+`status:active`, `topic:ctx-design`). Both halves are validated at
+the boundary; the prefix is what makes tags semantically queryable
+later — filter by `tech:*`, `status:*`, etc. Phase 1 leaves prefix
+choice free-form; phase 2 will introduce strictness levels (0/1/2 =
+loose / middle / strict) for prefix catalogs.
+
+When to reach for ctx vs the other passages: ctx is the residence
+for prose that doesn't want closure. If the observation is heading
+toward a verdict, file it via `gate request`. If it's
+thought-in-motion across sessions, use `agora play`. If it's a
+finding that needs adversarial scrutiny, use `devil entry`. ctx is
+for what remains: pinned observation, no closure required.
+
+Status: alpha phase 1. Read-side is currently grep on
+`<content_root>/ctx/*.yaml` — `ctx list` / `ctx chain` arrive in
+phase 2 and that's the design test (junk-drawer risk vs principled
+substrate).
 
 ## Diagnostic
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1213,6 +1213,90 @@ outside the in-tree passage.
 For substrate paths and the persona/lense schema reference, see
 the `## devil-review` section of [`AGENT.md`](../AGENT.md).
 
+## ctx — the fourth passage (alpha phase 1)
+
+`ctx` is the fourth passage under guild, alongside `gate`, `agora`,
+and `devil`. Where gate carries decisions, agora carries narrative,
+and devil carries multi-persona scrutiny, ctx carries
+**observations**: facts the substrate has witnessed across sessions
+that don't fit into a verdict, a play, or a review.
+
+### When to reach for ctx vs gate vs agora vs devil
+
+- **Use `gate`** when an observation is heading to a verdict
+  (approve / complete / review). The lifecycle is the closure.
+- **Use `agora`** when an observation is *thought-in-motion* —
+  cliff/invitation across sessions, eventual conclusion expected.
+- **Use `devil`** when an observation is a *finding* that needs
+  adversarial scrutiny against a target (file / function / PR).
+- **Use `ctx`** when the observation should *not* be forced into
+  closure — pinned attribution, append-only, queryable later by
+  tag. Pre-decision design notes, principle candidates not yet
+  ripe for `lore/`, cross-session knowledge a future instance
+  should be able to grep with `created_by:` intact.
+
+### Phase 1 surface
+
+Phase 1 ships only `ctx record`. The remaining six verbs (`fork` /
+`supersede` / `show` / `list` / `chain` / `status`) and schema
+extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
+`branch_ref`) land in phase 2.
+
+```bash
+ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
+                            [--by <m>] [--format json|text]
+```
+
+### A worked record
+
+```bash
+$ ctx record \
+    --fact "main↔develop diff is PR #145 only (README ctx mention); harness layer stays develop-side per CLAUDE.md harness convention" \
+    --tag scope:develop-only,topic:branch-policy,observation:diff-analysis
+✓ ctx recorded: ctx-2026-05-04-006
+  tags: scope:develop-only, topic:branch-policy, observation:diff-analysis
+notice: wrote /abs/path/ctx/ctx-2026-05-04-006.yaml (config: ...)
+```
+
+The on-disk YAML:
+
+```yaml
+id: ctx-2026-05-04-006
+created_at: 2026-05-04T13:58:11.476Z
+created_by: claude
+fact: "main↔develop diff is PR #145 only (README ctx mention); harness layer stays develop-side per CLAUDE.md harness convention"
+tags:
+  - scope:develop-only
+  - topic:branch-policy
+  - observation:diff-analysis
+```
+
+ID is auto-allocated as `ctx-YYYY-MM-DD-NNN` (three-digit suffix
+supports up to 999 records per day per content_root). The file is
+**immutable on save** — re-reading agents see what was written;
+the equivalent of a correction in phase 2 is `ctx supersede`, not
+in-place edit.
+
+### Tag prefix convention
+
+Tags are `prefix:value` shape, both halves validated at the
+boundary. The prefix is what makes tags semantically queryable —
+filter by `tech:*`, by `status:*`, by `topic:*`, etc. Phase 1
+leaves prefix choice free-form (the substrate already in use mixes
+`tech:` / `topic:` / `observation:` / `scope:` / `status:` /
+`meta:` / `pr:` / `principle:`); phase 2 introduces strictness
+levels (0/1/2 = loose / middle / strict) for prefix catalogs.
+
+### Status (alpha phase 1)
+
+Read-side is currently grep on `<content_root>/ctx/*.yaml`.
+`ctx list` / `ctx show` / `ctx chain` (phase 2) are the design
+test — whether the substrate stays principled or drifts into a
+junk drawer at the 100-record scale.
+
+For the conceptual framing alongside the other passages, see the
+`## ctx` section of [`AGENT.md`](../AGENT.md).
+
 ---
 
 A fully worked multi-turn example — author/critic personas driving


### PR DESCRIPTION
## Summary

README #145 introduced ctx as the fourth passage in the architecture section, but the deeper docs that README points to ("Full surface in `AGENT.md`; per-verb examples in `docs/verbs.md`") still lived in the 3-passage world — **zero ctx mentions in either file** before this PR.

Closes that asymmetry for **phase 1 (record-only)**.

## Changes

### `AGENT.md`
- `## The three passages` → `## The four passages`; dispatch table gains a ctx row (事実 / fact)
- New `## ctx (fourth passage — fact accumulation, alpha phase 1)` section after `## devil-review`:
  - verb signature (`ctx record`)
  - on-disk layout (`<content_root>/ctx/ctx-YYYY-MM-DD-NNN.yaml`, immutable on save)
  - tag prefix convention (`prefix:value`, validated at boundary)
  - when-to-reach guidance (gate / agora / devil / ctx dispatch)
  - phase 2 surface deferred (`fork` / `supersede` / `show` / `list` / `chain` / `status`)

### `docs/verbs.md`
- New `## ctx — the fourth passage (alpha phase 1)` section after `## Devil-review`:
  - When-to-reach contrast against gate / agora / devil
  - Phase 1 verb surface
  - **Real worked record example** (the actual `ctx-2026-05-04-006` dogfood from this session)
  - Tag prefix convention with free-form-in-phase-1 / strict-in-phase-2 framing
  - Read-side note (grep now, `ctx list` / `ctx chain` arrives in phase 2)

## Out of scope (deferred)

- `docs/playbook.md` ctx-only patterns + ctx-inclusive combos — ctx record alone doesn't yet have multi-step patterns. Will land alongside phase 2 verbs.
- Phase 2 verbs themselves (issue i-2026-05-04-0004 in develop substrate)
- Per-passage `src/passages/ctx/README.md` — agora and devil have one, ctx doesn't yet. Phase 2 sized work.

## Test plan

- [x] `npm test` — 931 / 931 pass (no source changed, sanity only)
- [x] `git diff --stat` reviewed — only `AGENT.md` and `docs/verbs.md` touched
- [x] ctx mention count: AGENT.md 0 → 14, docs/verbs.md 0 → 18

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_