### PR TITLE
fix(cli): accept --help on every verb; drop hardcoded "gate" prefix in error messages

### DIFF
--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -1,5 +1,6 @@
 import { buildContainer } from '../shared/container.js';
-import { parseArgs, optionalOption } from '../shared/parseArgs.js';
+import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
+import { renderVerbHelp } from '../shared/verbHelp.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
@@ -389,6 +390,10 @@ export async function main(argv: readonly string[]): Promise<number> {
       }
     }
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      renderVerbHelp('gate', e);
+      return 0;
+    }
     // The `error:` prefix gives the CLI-universal "this failed" cue;
     // prepending "DomainError:" on top leaked an internal class name
     // into user-facing output without adding information. Keep the

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -148,6 +148,28 @@ function resolveEnvOrActorFile(envFallback: string): string | undefined {
 }
 
 /**
+ * Thrown by `rejectUnknownFlags` when the caller passes `--help` against
+ * a verb. Carries the verb name and known flag set so the binary's
+ * top-level catch can render verb-scoped help and return exit 0 (rather
+ * than the exit-1 path any unknown-flag error takes).
+ *
+ * Why a typed signal instead of stdout/exit inside rejectUnknownFlags:
+ * the helper is pure validation; coupling it to process.stdout / exit
+ * would make it untestable and would mean every caller imports the
+ * same side effect. A throw lets each binary decide what "help"
+ * renders to (different CLIs may want different prefixes).
+ */
+export class HelpRequested extends Error {
+  constructor(
+    public readonly verb: string,
+    public readonly knownFlags: readonly string[],
+  ) {
+    super(`help requested for verb: ${verb}`);
+    this.name = 'HelpRequested';
+  }
+}
+
+/**
  * Reject any --flag not in the verb's known set.
  *
  * The parser itself is intentionally permissive (a user may alias in
@@ -161,21 +183,30 @@ function resolveEnvOrActorFile(envFallback: string): string | undefined {
  * flags throw a usage error naming what was used and what is valid.
  * This is the strict variant each verb opts into — opting-in is how
  * existing verbs migrate without risk.
+ *
+ * `--help` is treated as universal: every verb honours it regardless
+ * of whether `help` appears in the verb's known set. The check throws
+ * `HelpRequested` so the binary's main() catch can render verb help
+ * with exit 0.
  */
 export function rejectUnknownFlags(
   args: ParsedArgs,
   known: ReadonlySet<string>,
   verb: string,
 ): void {
+  if (args.options['help'] === true) {
+    throw new HelpRequested(verb, [...known].sort());
+  }
   const unknown: string[] = [];
   for (const key of Object.keys(args.options)) {
+    if (key === 'help') continue;
     if (!known.has(key)) unknown.push(key);
   }
   if (unknown.length === 0) return;
   const knownList = [...known].sort().map((k) => `--${k}`).join(', ');
   const badList = unknown.sort().map((k) => `--${k}`).join(', ');
   throw new Error(
-    `gate ${verb}: unknown flag${unknown.length === 1 ? '' : 's'}: ${badList}\n` +
+    `${verb}: unknown flag${unknown.length === 1 ? '' : 's'}: ${badList}\n` +
       `  valid flags for '${verb}': ${knownList}`,
   );
 }

--- a/src/interface/shared/verbHelp.ts
+++ b/src/interface/shared/verbHelp.ts
@@ -1,0 +1,22 @@
+import type { HelpRequested } from './parseArgs.js';
+
+/**
+ * Render a verb's flag catalog to stdout in response to `<cli> <verb> --help`.
+ *
+ * Pairs with `HelpRequested` thrown by `rejectUnknownFlags`: each binary's
+ * main() catches it, calls this with the binary's name (`gate` / `agora` /
+ * `devil` / `ctx`), and returns exit 0. The output is intentionally terse —
+ * full verb-by-verb prose lives in the CLI's top-level HELP and in
+ * `AGENT.md` / `docs/verbs.md`. This is the "what flags can I pass" cheat
+ * sheet, not a usage essay.
+ */
+export function renderVerbHelp(cli: string, e: HelpRequested): void {
+  const flags =
+    e.knownFlags.length > 0
+      ? e.knownFlags.map((f) => `--${f}`).join(', ')
+      : '(no flags)';
+  process.stdout.write(
+    `${cli} ${e.verb}: ${flags}\n` +
+      `  see \`${cli} --help\` for the full verb catalog.\n`,
+  );
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -16,7 +16,8 @@
 // facing UI is a projection, not a substrate change.
 
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
-import { parseArgs } from '../../../interface/shared/parseArgs.js';
+import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
+import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
 import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
@@ -142,6 +143,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
     }
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      renderVerbHelp('agora', e);
+      return 0;
+    }
     const msg =
       e instanceof DomainError
         ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -15,7 +15,8 @@
 // a projection, not a substrate change.
 
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
-import { parseArgs } from '../../../interface/shared/parseArgs.js';
+import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
+import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
@@ -70,6 +71,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
     }
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      renderVerbHelp('ctx', e);
+      return 0;
+    }
     const msg =
       e instanceof DomainError
         ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -16,7 +16,8 @@
 // human-facing UI is a projection, not a substrate change.
 
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
-import { parseArgs } from '../../../interface/shared/parseArgs.js';
+import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
+import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
@@ -199,6 +200,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
     }
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      renderVerbHelp('devil', e);
+      return 0;
+    }
     const msg =
       e instanceof DomainError
         ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`

--- a/tests/interface/unknownFlagRejection.test.ts
+++ b/tests/interface/unknownFlagRejection.test.ts
@@ -186,9 +186,12 @@ for (const { verb, args } of READ_VERB_CASES) {
     runGate(root, ['register', '--name', 'alice', '--category', 'professional']);
     const r = runGate(root, [verb, ...args, '--bogus-flag-xyz']);
     assert.notEqual(r.status, 0, `${verb} should exit non-zero on unknown flag`);
+    // The error message no longer hardcodes "gate" — that prefix would
+    // misrepresent agora/devil/ctx callers of the same helper. The verb
+    // name + the user's invocation provide enough disambiguation.
     assert.match(
       r.stderr,
-      new RegExp(`gate ${verb}: unknown flag.*--bogus-flag-xyz`),
+      new RegExp(`${verb}: unknown flag.*--bogus-flag-xyz`),
       `${verb} stderr should name the verb and the bogus flag`,
     );
   });

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -1,0 +1,188 @@
+// `<cli> <verb> --help` — universal escape valve.
+//
+// Pre-fix, `--help` was rejected as an unknown flag on every verb of
+// every CLI (gate / agora / devil / ctx). Fresh agents typing `gate
+// whoami --help` to discover the verb's flag surface hit a soft error
+// instead of help. This file pins the new behaviour: rejectUnknownFlags
+// throws a typed `HelpRequested` signal carrying the verb name +
+// known flag set; each binary's main() catches it, renders verb help,
+// and exits 0.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseArgs,
+  rejectUnknownFlags,
+  HelpRequested,
+} from '../../src/interface/shared/parseArgs.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+const DEVIL = resolve(here, '../../../bin/devil.mjs');
+const CTX = resolve(here, '../../../bin/ctx.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-verb-help-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// --- unit tests for the throw-typed signal ---
+
+test('rejectUnknownFlags: --help throws HelpRequested with verb + known flags', () => {
+  const args = parseArgs(['--help']);
+  try {
+    rejectUnknownFlags(args, new Set(['limit', 'format']), 'tail');
+    assert.fail('expected HelpRequested');
+  } catch (e) {
+    assert.ok(e instanceof HelpRequested, 'should throw HelpRequested');
+    const h = e as HelpRequested;
+    assert.equal(h.verb, 'tail');
+    assert.deepEqual(h.knownFlags, ['format', 'limit'], 'flags sorted');
+  }
+});
+
+test('rejectUnknownFlags: --help short-circuits even when other flags are present', () => {
+  // --help wins over `--bogus`; the user asked for help, not an error.
+  const args = parseArgs(['--bogus', '--help']);
+  try {
+    rejectUnknownFlags(args, new Set(['limit']), 'tail');
+    assert.fail('expected HelpRequested');
+  } catch (e) {
+    assert.ok(e instanceof HelpRequested);
+  }
+});
+
+test('rejectUnknownFlags: HelpRequested carries empty array when verb has no known flags', () => {
+  const args = parseArgs(['--help']);
+  try {
+    rejectUnknownFlags(args, new Set(), 'register');
+    assert.fail('expected HelpRequested');
+  } catch (e) {
+    assert.ok(e instanceof HelpRequested);
+    assert.deepEqual((e as HelpRequested).knownFlags, []);
+  }
+});
+
+test('rejectUnknownFlags: --help is never reported as an unknown flag', () => {
+  // Sanity guard: even if a future caller forgot to handle HelpRequested,
+  // --help should not surface as "unknown flag: --help" in the error.
+  // (The throw branch is HelpRequested; the unknown-flag branch skips it.)
+  const args = parseArgs(['--help']);
+  assert.throws(
+    () => rejectUnknownFlags(args, new Set(['limit']), 'tail'),
+    (e: unknown) => e instanceof HelpRequested,
+    'should be HelpRequested, not generic Error',
+  );
+});
+
+test('rejectUnknownFlags: still throws plain Error for non-help unknown flags', () => {
+  // Regression guard for the non-help path.
+  const args = parseArgs(['--bogus']);
+  assert.throws(
+    () => rejectUnknownFlags(args, new Set(['limit']), 'tail'),
+    (e: unknown) => {
+      assert.ok(e instanceof Error);
+      assert.ok(!(e instanceof HelpRequested));
+      assert.match(e.message, /unknown flag.*--bogus/);
+      return true;
+    },
+  );
+});
+
+// --- E2E: `<cli> <verb> --help` exits 0 across all four CLIs ---
+
+test('gate <verb> --help: exits 0 and renders the flag catalog', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(GATE, root, ['whoami', '--help']);
+  assert.equal(r.status, 0, 'whoami --help should exit 0');
+  assert.match(r.stdout, /gate whoami: --limit/);
+  assert.match(r.stdout, /see `gate --help`/);
+});
+
+test('gate tail --help: works on a verb with a richer flag set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(GATE, root, ['tail', '--help']);
+  assert.equal(r.status, 0);
+  // tail accepts --limit, --format, etc. — pin two we know are documented.
+  assert.match(r.stdout, /gate tail:/);
+  assert.match(r.stdout, /--format/);
+  assert.match(r.stdout, /--limit/);
+});
+
+test('agora <verb> --help: exits 0 and uses the agora prefix', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(AGORA, root, ['list', '--help']);
+  assert.equal(r.status, 0, 'agora list --help should exit 0');
+  assert.match(r.stdout, /agora list:/);
+  assert.match(r.stdout, /see `agora --help`/);
+});
+
+test('devil <verb> --help: exits 0 and uses the devil prefix', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(DEVIL, root, ['list', '--help']);
+  assert.equal(r.status, 0, 'devil list --help should exit 0');
+  assert.match(r.stdout, /devil list:/);
+  assert.match(r.stdout, /see `devil --help`/);
+});
+
+test('ctx record --help: exits 0 and uses the ctx prefix', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(CTX, root, ['record', '--help']);
+  assert.equal(r.status, 0, 'ctx record --help should exit 0');
+  assert.match(r.stdout, /ctx record:/);
+  assert.match(r.stdout, /--fact/);
+  assert.match(r.stdout, /--tag/);
+});
+
+test('non-help unknown flag still errors with verb-only prefix (no "gate" hardcode)', (t) => {
+  // Cross-CLI sanity: agora's error message should NOT say "gate" anymore.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(AGORA, root, ['list', '--bogus-flag-xyz']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /list: unknown flag.*--bogus-flag-xyz/);
+  assert.equal(
+    /gate list: unknown flag/.test(r.stderr),
+    false,
+    'agora errors should not say "gate"',
+  );
+});


### PR DESCRIPTION
## Summary

Two touch-feel issues surfaced while dogfooding the four CLIs:

1. **`<verb> --help` was rejected as an unknown flag on every CLI.** Fresh agents typing `gate whoami --help` to discover the flag surface got a soft error ("unknown flag: --help, valid flags: ...") instead of help. Same pattern across gate / agora / devil / ctx.

2. **The error message hardcoded "gate" regardless of which CLI invoked the helper.** `agora list --bogus` printed `gate list: unknown flag`, which lies about the caller. The verb name + the user's invocation provide enough disambiguation; the CLI prefix was misleading.

## Before / after

```
# Before
$ agora list --help
error: gate list: unknown flag: --help
  valid flags for 'list': --format, --game, --state
$ echo $?
1

# After
$ agora list --help
agora list: --format, --game, --state
  see `agora --help` for the full verb catalog.
$ echo $?
0

# Bonus: error messages no longer lie
$ agora list --bogus
error: list: unknown flag: --bogus
  valid flags for 'list': --format, --game, --state
```

## Changes

### `src/interface/shared/parseArgs.ts`
- New exported `HelpRequested extends Error` carrying the verb name + sorted known-flag list
- `rejectUnknownFlags` short-circuits on `--help` (throws HelpRequested), ignores `--help` in the unknown-flag check, drops the `gate` prefix from the error message

### `src/interface/shared/verbHelp.ts` (new)
- `renderVerbHelp(cli, e)` — writes a one-line flag catalog + a pointer to `<cli> --help` for the full verb list. Pure rendering; each binary's catch calls it with its own name.

### `src/interface/gate/index.ts`, `src/passages/{agora,devil,ctx}/interface/index.ts`
- Each main()'s catch detects HelpRequested first → `renderVerbHelp(<cli>, e)` → return 0. All other catch paths unchanged.

## Tests

### `tests/interface/verbHelp.test.ts` (new, 11 tests)
- Unit: HelpRequested thrown with verb + sorted known flags
- Unit: `--help` short-circuits even when other flags accompany it
- Unit: `--help` is never reported as an unknown flag (sanity guard)
- Unit: non-help unknown flags still throw plain Error (regression guard)
- E2E: `<cli> <verb> --help` exits 0 with correct CLI prefix on all four CLIs
- E2E: `agora <verb> --bogus` does NOT say "gate" anymore (cross-CLI hardcode regression guard)

### `tests/interface/unknownFlagRejection.test.ts`
- READ_VERB_CASES regex updated: `gate ${verb}: unknown flag` → `${verb}: unknown flag` to match the dropped hardcode

**931 → 942 passing tests.**

## Test plan

- [x] `npm test` passes — 942/942
- [x] `npm run typecheck` passes
- [x] Manual smoke: `gate whoami --help` / `agora list --help` / `devil list --help` / `ctx record --help` all exit 0
- [x] Manual smoke: `agora list --bogus` no longer says "gate"
- [x] Existing unknown-flag rejection still works (regression suite green)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_