### PR TITLE
docs(readme): clarify three-passages-framing as a frozen 3-passage snapshot

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -151,4 +151,4 @@ verb を叩けます:
 - [`examples/dogfood-session/`](./examples/dogfood-session/) — 多 actor の長い実セッション（このツール自身が自分を拡張した完全な記録）
 - [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON envelope を中心とした agent-driven flow
 - [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona の voice 表現
-- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil の合成例
+- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate / agora / devil の framing arc を substrate snapshot として保存 (3-passage 当時の凍結、`ctx` は後から open set に合流)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ into and run verbs against:
 - [`examples/dogfood-session/`](./examples/dogfood-session/) — longer multi-actor real session
 - [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON-envelope agent-driven flow
 - [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona voice rendering
-- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil composition
+- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — the gate / agora / devil framing arc preserved as a substrate snapshot (frozen at the 3-passage moment; `ctx` joined the open set later)
 
 ### Architecture: container with passages
 


### PR DESCRIPTION
## Summary

`examples/three-passages-framing/` captures the moment the gate=判断 / agora=探索 / devil=守備 framing landed (PR #130). After ctx joined as the fourth passage in PR #143, the directory name reads as a 3-passage architecture claim to fresh readers — and the README's one-line description (`gate + agora + devil composition`) reinforces that read.

The example is not a current-state diagram — it's a substrate artifact preserved at the moment its arc concluded. Renaming would break links across CHANGELOG / docs / agora's README and contradict the records-outlive-writers principle (#04). **Clarify instead.**

## Changes

`README.md` line 118:
```diff
-- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil composition
++ [`examples/three-passages-framing/`](./examples/three-passages-framing/) — the gate / agora / devil framing arc preserved as a substrate snapshot (frozen at the 3-passage moment; `ctx` joined the open set later)
```

`README.ja.md` line 154:
```diff
-- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate + agora + devil の合成例
++ [`examples/three-passages-framing/`](./examples/three-passages-framing/) — gate / agora / devil の framing arc を substrate snapshot として保存 (3-passage 当時の凍結、`ctx` は後から open set に合流)
```

## Why this and not a rename

- The example's own `README.md` already explains the lifecycle correctly (frozen at conclusion, mutation requires `--addresses` to a new play, etc.). The signal was missing only at the entry-point link.
- Directory name is referenced from CHANGELOG (×2), `docs/playbook.md`, `src/passages/agora/README.md`, and the example's own README. A rename creates link rot in all 5 + breaks any external links to the `examples/` URL on GitHub.
- The records-outlive-writers principle (#04) treats committed records as substrate. The directory name reflects when the arc was concluded; rewriting it to match a later state would be revisionist.

## Test plan

- [x] `git diff --stat` reviewed — only README.md and README.ja.md touched
- [x] No code changes; tests / typecheck not affected

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_