### PR TITLE
chore(npm): add files field + prepack to harden npm publish boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,24 @@
     "guild": "./bin/guild.mjs",
     "gate": "./bin/gate.mjs"
   },
+  "files": [
+    "bin",
+    "dist/src",
+    "docs",
+    "examples",
+    "lore",
+    "AGENT.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "README.ja.md",
+    "SECURITY.md"
+  ],
   "scripts": {
     "build": "tsc",
     "prepare": "tsc",
+    "prepack": "npm run build",
     "test": "tsc && node tests/run.mjs",
     "typecheck": "tsc --noEmit",
     "gate": "node bin/gate.mjs",


### PR DESCRIPTION
## Summary

External initial-impression review flagged that the package had no `files` field, so `npm publish` would default to "everything not gitignored" — including `substrate/` dogfood YAML, `src/` TypeScript source, `tests/`, `.guild-actor`, `.envrc`, `CLAUDE.md`, etc. Fine for git, wrong for npm distribution.

This PR adds an explicit allow-list and a `prepack` script.

## Changes (`package.json`)

### `files` (new — explicit allow-list)
```json
"files": [
  "bin",
  "dist/src",
  "docs",
  "examples",
  "lore",
  "AGENT.md",
  "CHANGELOG.md",
  "CONTRIBUTING.md",
  "LICENSE",
  "README.md",
  "README.ja.md",
  "SECURITY.md"
]
```

- `bin` / `dist/src` — runtime (note: `dist/src` not `dist`, to exclude `dist/tests/` compiled test JS)
- `docs` / `examples` / `lore` — referenced extensively from README; useful at install-time
- top-level `*.md` — every README link target

### `prepack` (new script)
```json
"prepack": "npm run build"
```
Redundant with `prepare: tsc` in current npm behaviour, but makes the publish-time build intent **explicit** (matching the project's pattern of separate `build` / `test` / `typecheck` script names rather than implicit chains).

## Excluded by omission

- `substrate/` — develop-only dogfood records (the harness layer)
- `src/` — TypeScript source; `dist/src/` ships the compiled output
- `tests/` + `dist/tests/` — test code irrelevant to consumers
- `.guild-actor` / `.envrc` / `CLAUDE.md` — develop harness layer
- `tsconfig.json` — build-only

## Verification (`npm pack --dry-run`)

| | size | files |
|---|---|---|
| Before | 730.6 kB | 713 |
| With `files: [..., "dist", ...]` | 730.6 kB | 713 (dist/tests/ leaked) |
| With `files: [..., "dist/src", ...]` (this PR) | **499.2 kB** | **464** |

Confirmed develop-only files (`.guild-actor`, `.envrc`, `CLAUDE.md`, `substrate/`) all excluded after the change.

## Test plan

- [x] `npm test` — 942/942 pass
- [x] `npm run build` — typecheck + build clean
- [x] `npm pack --dry-run` — only intended files in tarball
- [x] develop-only / harness files excluded from pack

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_