### PR TITLE
ci(workflow): add npm pack --dry-run gate to verify publish artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,77 @@ jobs:
 
       - name: Test
         run: npm test
+
+  # Verify the npm publish artifact stays clean: required files present,
+  # develop-only / source-only paths absent. `package.json#files` is the
+  # public allow-list; this job pins the contract so a future PR that
+  # accidentally drops `bin/` or adds back `substrate/` fails CI.
+  # See PR #150 for the original `files` field landing.
+  package-artifact:
+    name: package artifact (dry-run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify pack contents
+        run: |
+          npm pack --dry-run --json > pack.json
+          node -e '
+            const pack = JSON.parse(require("fs").readFileSync("pack.json", "utf8"));
+            const files = pack[0].files.map(f => f.path);
+            const REQUIRED = [
+              "bin/gate.mjs",
+              "bin/guild.mjs",
+              "bin/agora.mjs",
+              "bin/devil.mjs",
+              "bin/ctx.mjs",
+              "dist/src/interface/gate/index.js",
+              "package.json",
+              "README.md",
+              "README.ja.md",
+              "LICENSE",
+              "AGENT.md",
+              "SECURITY.md",
+            ];
+            const missing = REQUIRED.filter(r => !files.includes(r));
+            if (missing.length > 0) {
+              console.error("missing from pack:", missing);
+              process.exit(1);
+            }
+            const FORBIDDEN_PREFIXES = [
+              "substrate/",
+              "src/",
+              "tests/",
+              "dist/tests/",
+            ];
+            const FORBIDDEN_FILES = [
+              ".guild-actor",
+              ".envrc",
+              "CLAUDE.md",
+              "tsconfig.json",
+              "package-lock.json",
+            ];
+            const leaked = files.filter(f =>
+              FORBIDDEN_PREFIXES.some(p => f.startsWith(p)) ||
+              FORBIDDEN_FILES.includes(f)
+            );
+            if (leaked.length > 0) {
+              console.error("leaked into pack:", leaked);
+              process.exit(1);
+            }
+            console.log("pack contents verified:", files.length, "files");
+          '


### PR DESCRIPTION
## Summary

PR #150 introduced `package.json#files` as the public allow-list for `npm publish`. This PR pins the contract via CI so a future change can't silently break it.

External deep-dive review (P0a): "今後 npm publish を強めるなら、CI に `npm pack --dry-run` を足すとさらに安心です。"

## Without this gate

A future PR could accidentally:
- Drop `bin/` from `files` → ship a non-runnable package
- Bring back `substrate/` → leak develop-only YAML to npm consumers
- Misconfigure `tsconfig` → `dist/src/` missing from the tree

## What the new job does

`package-artifact` (Linux + Node 22 only):

1. `npm ci` + `npm run build`
2. `npm pack --dry-run --json > pack.json`
3. Parse and assert:

**REQUIRED present:**
- 5 bin entries (`gate` / `guild` / `agora` / `devil` / `ctx`)
- `dist/src/interface/gate/index.js` (sentinel for dist/src/ presence)
- `package.json`, `README.md`, `README.ja.md`, `LICENSE`, `AGENT.md`, `SECURITY.md`

**FORBIDDEN absent:**
- prefixes: `substrate/`, `src/`, `tests/`, `dist/tests/`
- files: `.guild-actor`, `.envrc`, `CLAUDE.md`, `tsconfig.json`, `package-lock.json`

## Why Linux-only / Node 22-only

`npm pack` output is OS-agnostic and Node-version-agnostic. Adding it to the per-Node × per-OS test matrix would be 4 redundant runs of the same check; a single canonical run suffices.

## Test plan

- [x] Logic verified locally — `pack contents verified: 464 files` (matches `npm pack --dry-run` output from PR #150)
- [x] Failure-path sanity-tested locally (missing-required and forbidden-prefix branches both fire as expected)
- [x] Existing 4 CI jobs (test × {Linux, Windows} × {Node 20, 22}) untouched

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_