### PR TITLE
fix(domain): tighten Review.comment to require non-empty in fresh writes

### DIFF
--- a/src/domain/request/Review.ts
+++ b/src/domain/request/Review.ts
@@ -19,6 +19,21 @@ export interface ReviewProps {
 export class Review {
   private constructor(private readonly props: ReviewProps) {}
 
+  /**
+   * Create a new review at the application/domain boundary.
+   *
+   * Strict on `comment`: empty / whitespace-only is rejected. The
+   * judgment-trail principle (records outlive writers) wants every
+   * fresh review entry to carry actual prose. Bypass via `restore`
+   * only — and that path exists for hydration of pre-strictness
+   * substrate, not for new writes.
+   *
+   * Pre-2026-05 this was tolerant at the domain level and strict
+   * only at the CLI handler. That left the application API
+   * (`RequestUseCases.review`) and any future programmatic caller
+   * able to land empty comments. Tightening here makes the domain
+   * the load-bearing gate.
+   */
   static create(input: {
     by: string;
     lense: string;
@@ -28,10 +43,52 @@ export class Review {
     invokedBy?: string;
     allowedLenses?: readonly string[];
   }): Review {
+    return Review.build(input, /* strictComment */ true);
+  }
+
+  /**
+   * Re-hydrate from on-disk YAML. Tolerant of empty comments — the
+   * fallback in `YamlRequestRepository.findById` injects `''` when a
+   * historical record predates `comment`-strictness or has the field
+   * dropped. Failing hydration would erase those records from list
+   * outputs; tolerating them keeps the audit trail visible while
+   * still funneling fresh writes through the strict `create` path.
+   */
+  static restore(input: {
+    by: string;
+    lense: string;
+    verdict: string;
+    comment: string;
+    at?: string;
+    invokedBy?: string;
+    allowedLenses?: readonly string[];
+  }): Review {
+    return Review.build(input, /* strictComment */ false);
+  }
+
+  private static build(
+    input: {
+      by: string;
+      lense: string;
+      verdict: string;
+      comment: string;
+      at?: string;
+      invokedBy?: string;
+      allowedLenses?: readonly string[];
+    },
+    strictComment: boolean,
+  ): Review {
     const by = MemberName.of(input.by);
     const lense = parseLense(input.lense, input.allowedLenses);
     const verdict = parseVerdict(input.verdict);
-    const comment = sanitizeComment(input.comment);
+    const comment = sanitizeComment(input.comment, strictComment);
+    // sanitize keeps inner/leading whitespace (`trim: false` so code
+    // blocks render); domain-side strict path also rejects whitespace-
+    // only input so a programmatic caller can't bypass the CLI's
+    // `!comment.trim()` check by passing `"   "`.
+    if (strictComment && comment.trim().length === 0) {
+      throw new DomainError('comment required (cannot be blank)', 'comment');
+    }
     const at = input.at ?? new Date().toISOString();
     const props: ReviewProps = { by, lense, verdict, comment, at };
     if (input.invokedBy !== undefined && input.invokedBy !== by.value) {
@@ -76,26 +133,20 @@ export class Review {
 }
 
 /**
- * Review comments have two quirks vs other text fields:
- *   - `trim: false` — inner/trailing whitespace preserved so code blocks
- *     and indented bullets render correctly (the interface layer
- *     already stripped leading/trailing before calling create)
- *   - `requireNonEmpty: false` — empty-string comments are tolerated
- *     here at the domain level. The interface layer (handlers/review.ts)
- *     enforces "comment required" at its own boundary. This split keeps
- *     the domain permissive for programmatic callers who may have a
- *     legitimate empty-comment use (audit backfill, etc.) while still
- *     giving the CLI a UX nudge.
+ * Review comments have one quirk vs other text fields:
+ *   - `trim: false` — inner/trailing whitespace preserved so code
+ *     blocks and indented bullets render correctly (the interface
+ *     layer already stripped leading/trailing before calling create).
  *
- * Note: the second quirk is a drift that pre-dates consolidation. If it
- * turns out no caller relies on empty-comment passthrough, tighten to
- * `requireNonEmpty: true` in a later patch — consistency beats a loose
- * back-door every time.
+ * Strictness is parameterised: `Review.create` passes
+ * `requireNonEmpty: true`, `Review.restore` passes `false`. The split
+ * lets fresh writes always carry prose while letting hydration tolerate
+ * historical empty-comment records.
  */
-function sanitizeComment(raw: unknown): string {
+function sanitizeComment(raw: unknown, requireNonEmpty: boolean): string {
   return sharedSanitizeText(raw, 'comment', {
     maxLen: MAX_COMMENT_LEN,
     trim: false,
-    requireNonEmpty: false,
+    requireNonEmpty,
   });
 }

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -383,7 +383,10 @@ function hydrate(
           rc.invokedBy = ro['invoked_by'] as string;
         // Hydrate with config lenses so custom lenses in saved data are accepted
         if (allowedLenses) rc.allowedLenses = allowedLenses;
-        reviews.push(Review.create(rc));
+        // restore (not create) — tolerant of empty comment for historical
+        // records that predate the strict-comment domain invariant. Fresh
+        // writes go through Review.create and are always non-empty.
+        reviews.push(Review.restore(rc));
       }
     }
     const statusLogRaw = Array.isArray(obj['status_log'])

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -359,6 +359,64 @@ test('Review.create omits invoked_by when it equals by', () => {
   assert.equal('invoked_by' in j, false);
 });
 
+// ── Review.create vs Review.restore: comment strictness split ──
+//
+// Pre-2026-05 the domain tolerated empty comments and only the CLI
+// handler enforced "comment required". That left RequestUseCases.review
+// (the application API) and any future programmatic caller able to
+// land empty-comment reviews. The split tightens fresh-write paths
+// (Review.create) while keeping hydration (Review.restore) tolerant of
+// historical records whose `comment` field is empty or missing.
+
+test('Review.create rejects empty comment', () => {
+  assert.throws(
+    () =>
+      Review.create({
+        by: 'alice',
+        lense: 'devil',
+        verdict: 'ok',
+        comment: '',
+      }),
+    DomainError,
+  );
+});
+
+test('Review.create rejects whitespace-only comment', () => {
+  assert.throws(
+    () =>
+      Review.create({
+        by: 'alice',
+        lense: 'devil',
+        verdict: 'ok',
+        comment: '   \n\t  ',
+      }),
+    DomainError,
+  );
+});
+
+test('Review.restore tolerates empty comment (hydration path)', () => {
+  const review = Review.restore({
+    by: 'alice',
+    lense: 'devil',
+    verdict: 'ok',
+    comment: '',
+    at: '2026-05-04T00:00:00.000Z',
+  });
+  assert.equal(review.comment, '');
+  assert.equal(review.by.value, 'alice');
+});
+
+test('Review.restore preserves a non-empty comment unchanged', () => {
+  const review = Review.restore({
+    by: 'alice',
+    lense: 'devil',
+    verdict: 'ok',
+    comment: 'historical prose',
+    at: '2026-05-04T00:00:00.000Z',
+  });
+  assert.equal(review.comment, 'historical prose');
+});
+
 test('Request restore preserves invoked_by round-trip', () => {
   const r = Request.restore({
     id: RequestId.generate(d, 1),


### PR DESCRIPTION
## Summary

External deep-dive review (P0c): the domain accepted empty review comments while the CLI handler was the only enforcement layer. Programmatic callers (`RequestUseCases.review`, future application API users) bypassed the strictness — and the existing `Review.ts` docstring already flagged the drift:

> If it turns out no caller relies on empty-comment passthrough, tighten to `requireNonEmpty: true` in a later patch — consistency beats a loose back-door every time.

Caller analysis confirmed: no production or test code passes empty comment intentionally. The only legitimate empty-comment path is **hydration of historical YAML records**.

## Approach: Ctx-style `create` vs `restore` split

| Path | Strictness | Used by |
|------|-----------|---------|
| `Review.create({...})` | rejects empty AND whitespace-only | `RequestUseCases.review` — fresh writes |
| `Review.restore({...})` | tolerant of empty comment | `YamlRequestRepository.findById` — hydration |

Same internal `build(input, strictComment)` body; only the flag differs.

The whitespace-only check at the strict path mirrors `handlers/review.ts:67`'s `!comment.trim()` — the domain now rejects what the CLI rejects, so programmatic callers can't sneak `"   "` past the application boundary.

## Why hydration stays tolerant

Failing hydration on records with missing/empty `comment` would **erase those records from list outputs**. That's worse than tolerating them: the audit trail goes silent on substrate that's already on disk. `restore` keeps them visible while `create` keeps fresh writes principled.

## Tests added (4)

`tests/domain/Request.test.ts`:
- `Review.create rejects empty comment`
- `Review.create rejects whitespace-only comment` (matches CLI's `!comment.trim()`)
- `Review.restore tolerates empty comment` (hydration path)
- `Review.restore preserves a non-empty comment unchanged`

## Test plan

- [x] `npm test` passes — 942 → **946**
- [x] `npm run typecheck` passes
- [x] No existing test broken — every prior `Review.create` call passes non-empty comments (already strict, just newly enforced)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_