### PR TITLE
feat(doctor): surface plugins_loaded so plugin execution is observable at runtime

### DIFF
--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -20,6 +20,7 @@ import {
   DiagnosticArea,
   DiagnosticFinding,
   DiagnosticReport,
+  PluginLoadInfo,
   classifyMessage,
 } from '../../domain/diagnostic/DiagnosticReport.js';
 
@@ -113,7 +114,10 @@ export class DiagnosticUseCases {
     }
     const issueMalformed = findings.length - beforeIssues;
 
-    // Run doctor plugins (if any)
+    // Run doctor plugins (if any). Track each path's outcome so the
+    // doctor report can surface "what ran" at runtime — operators
+    // shouldn't have to read SECURITY.md to know a plugin executed.
+    const pluginsLoaded: PluginLoadInfo[] = [];
     if (this.pluginPaths.length > 0 && this.pluginContext) {
       for (const pluginPath of this.pluginPaths) {
         try {
@@ -122,6 +126,18 @@ export class DiagnosticUseCases {
           if (typeof fn === 'function') {
             const pluginFindings = await fn(this.pluginContext);
             findings.push(...pluginFindings);
+            pluginsLoaded.push({ path: pluginPath, status: 'loaded' });
+          } else {
+            // default export wasn't callable — surface as both a
+            // finding (with the diagnostic detail) and a plugins_loaded
+            // entry (so the path is visible in the runtime list).
+            findings.push({
+              area: 'plugin',
+              source: pluginPath,
+              kind: 'unknown',
+              message: `plugin error: default export is not a function`,
+            });
+            pluginsLoaded.push({ path: pluginPath, status: 'error' });
           }
         } catch (e) {
           // Plugin errors become findings, never crash doctor
@@ -131,6 +147,7 @@ export class DiagnosticUseCases {
             kind: 'unknown',
             message: `plugin error: ${e instanceof Error ? e.message : String(e)}`,
           });
+          pluginsLoaded.push({ path: pluginPath, status: 'error' });
         }
       }
     }
@@ -142,6 +159,7 @@ export class DiagnosticUseCases {
         issues: { total: issues.length, malformed: issueMalformed },
       },
       findings,
+      pluginsLoaded,
     );
   }
 }

--- a/src/domain/diagnostic/DiagnosticReport.ts
+++ b/src/domain/diagnostic/DiagnosticReport.ts
@@ -40,10 +40,31 @@ export interface DiagnosticSummary {
   readonly issues: DiagnosticAreaSummary;
 }
 
+/**
+ * Per-plugin load result. Surfaced in `gate doctor` output (text +
+ * JSON) so an operator can see at a glance which plugins ran in the
+ * current invocation. SECURITY.md notes that doctor plugins execute
+ * with full Node capabilities once `doctor.trusted: true`; relying on
+ * SECURITY.md disclosure alone is fragile (operators don't always
+ * read it). Runtime visibility closes that gap.
+ *
+ * `loaded` — import succeeded and the default export was a function.
+ *            (Findings the plugin produced are merged into `findings`
+ *            with area='plugin'; this entry only confirms it ran.)
+ * `error`  — import threw, or the default export wasn't callable.
+ *            The corresponding `findings` entry carries the error
+ *            message; this entry mirrors the path for visibility.
+ */
+export interface PluginLoadInfo {
+  readonly path: string;
+  readonly status: 'loaded' | 'error';
+}
+
 export class DiagnosticReport {
   constructor(
     readonly summary: DiagnosticSummary,
     readonly findings: readonly DiagnosticFinding[],
+    readonly pluginsLoaded: readonly PluginLoadInfo[] = [],
   ) {}
 
   get isClean(): boolean {
@@ -54,6 +75,7 @@ export class DiagnosticReport {
     return {
       summary: this.summary,
       findings: this.findings.map((f) => ({ ...f })),
+      plugins_loaded: this.pluginsLoaded.map((p) => ({ ...p })),
     };
   }
 }

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -93,6 +93,19 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
   writeAreaSection('members', report.summary.members, report.findings);
   writeAreaSection('requests', report.summary.requests, report.findings);
   writeAreaSection('issues', report.summary.issues, report.findings);
+  // plugins_loaded: surfaces "what ran" at runtime so an operator can
+  // see that a doctor.trusted plugin executed, even if SECURITY.md is
+  // unread. Stays quiet when no plugins were configured (the 99%
+  // normal case) — see lore/principles/09-orientation-disclosure.md.
+  if (report.pluginsLoaded.length > 0) {
+    process.stdout.write(
+      `\nplugins loaded: ${report.pluginsLoaded.length}\n`,
+    );
+    for (const p of report.pluginsLoaded) {
+      const glyph = p.status === 'loaded' ? '✓' : '✗';
+      process.stdout.write(`    ${glyph} [${p.status}] ${p.path}\n`);
+    }
+  }
   // Plugin findings (area = 'plugin')
   const pluginFindings = report.findings.filter((f) => f.area === 'plugin');
   if (pluginFindings.length > 0) {

--- a/tests/application/DiagnosticUseCases.test.ts
+++ b/tests/application/DiagnosticUseCases.test.ts
@@ -258,3 +258,100 @@ test('DiagnosticReport.toJSON: stable shape for future repair consumer', async (
   assert.equal(typeof json.findings[0]?.source, 'string');
   assert.match(json.findings[0]!.source, /\.yaml$/);
 });
+
+// ── plugins_loaded — runtime visibility into doctor plugin execution ──
+//
+// SECURITY.md notes that doctor plugins run with full Node capabilities
+// once `doctor.trusted: true`. Relying on operators to read SECURITY.md
+// is fragile; surfacing what ran at runtime is the defensive UX layer
+// that makes plugin execution observable. These tests pin that contract.
+
+test('plugins_loaded: empty when no plugin paths configured', async () => {
+  const uc = new DiagnosticUseCases(
+    makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), new FakeIssueRepo([])),
+  );
+  const report = await uc.run();
+  assert.deepEqual(report.pluginsLoaded, []);
+  const json = report.toJSON() as { plugins_loaded: unknown[] };
+  assert.deepEqual(json.plugins_loaded, []);
+});
+
+test('plugins_loaded: status=loaded when plugin imports + runs cleanly', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const dir = mkdtempSync(join(tmpdir(), 'guild-plugin-'));
+  const pluginPath = join(dir, 'plugin.mjs');
+  writeFileSync(
+    pluginPath,
+    'export default async function plugin(_ctx) { return []; }\n',
+  );
+  try {
+    const uc = new DiagnosticUseCases(
+      makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), new FakeIssueRepo([])),
+      [pluginPath],
+      { root: dir, contentRoot: dir },
+    );
+    const report = await uc.run();
+    assert.equal(report.pluginsLoaded.length, 1);
+    assert.equal(report.pluginsLoaded[0]?.path, pluginPath);
+    assert.equal(report.pluginsLoaded[0]?.status, 'loaded');
+    assert.equal(
+      report.findings.filter((f) => f.area === 'plugin').length,
+      0,
+      'a clean plugin produces no findings',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('plugins_loaded: status=error when plugin throws on import', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const dir = mkdtempSync(join(tmpdir(), 'guild-plugin-'));
+  const pluginPath = join(dir, 'broken.mjs');
+  writeFileSync(pluginPath, 'throw new Error("import time boom");\n');
+  try {
+    const uc = new DiagnosticUseCases(
+      makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), new FakeIssueRepo([])),
+      [pluginPath],
+      { root: dir, contentRoot: dir },
+    );
+    const report = await uc.run();
+    assert.equal(report.pluginsLoaded.length, 1);
+    assert.equal(report.pluginsLoaded[0]?.status, 'error');
+    // The error also surfaces as a plugin finding (existing behaviour);
+    // plugins_loaded mirrors the path so the runtime list is complete.
+    const pluginFindings = report.findings.filter((f) => f.area === 'plugin');
+    assert.equal(pluginFindings.length, 1);
+    assert.match(pluginFindings[0]!.message, /import time boom/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('plugins_loaded: status=error when default export is not callable', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const dir = mkdtempSync(join(tmpdir(), 'guild-plugin-'));
+  const pluginPath = join(dir, 'not-a-function.mjs');
+  writeFileSync(pluginPath, 'export default { not: "a function" };\n');
+  try {
+    const uc = new DiagnosticUseCases(
+      makeFactory(new FakeMemberRepo([]), new FakeRequestRepo([]), new FakeIssueRepo([])),
+      [pluginPath],
+      { root: dir, contentRoot: dir },
+    );
+    const report = await uc.run();
+    assert.equal(report.pluginsLoaded.length, 1);
+    assert.equal(report.pluginsLoaded[0]?.status, 'error');
+    const pluginFindings = report.findings.filter((f) => f.area === 'plugin');
+    assert.equal(pluginFindings.length, 1);
+    assert.match(pluginFindings[0]!.message, /not a function/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

External deep-dive review (P2.8): doctor plugins run with full Node.js capabilities once `doctor.trusted: true`. The trust gate exists, but operators don't always read `SECURITY.md`. **Runtime visibility is the defensive UX layer that closes the gap** — once a plugin runs, the doctor report names what ran.

The 99% case (no plugins configured) stays quiet; only the moment a plugin runs does the surface light up.

## Output examples

```
$ gate doctor               # text mode, plugin configured
✓ members   0 total, 0 malformed
✓ requests  0 total, 0 malformed
✓ issues    0 total, 0 malformed

plugins loaded: 1
    ✓ [loaded] /abs/path/hello-plugin.mjs

✓ clean — no malformed records detected
```

```
$ gate doctor               # text mode, no plugins
(no "plugins loaded" line — silent disclosure per principle 09)
```

```
$ gate doctor --format json # always includes (stable schema)
"plugins_loaded": []
```

## Changes

### `src/domain/diagnostic/DiagnosticReport.ts`
- New `PluginLoadInfo` type: `{ path, status: 'loaded' | 'error' }`
- `DiagnosticReport` gains `pluginsLoaded: readonly PluginLoadInfo[]` field (default `[]` — existing callers unaffected)
- `toJSON()` includes `plugins_loaded` (snake_case, JSON convention)

### `src/application/diagnostic/DiagnosticUseCases.ts`
- Plugin loop tracks each path's outcome:
  - `loaded` — import succeeded and default export was callable
  - `error` — import threw OR default export wasn't callable
- The non-callable-export branch was previously a **silent skip**; now surfaces as both a finding (existing) AND a `plugins_loaded` entry (new — closes the visibility gap for that edge case)

### `src/interface/gate/handlers/doctor.ts`
- Text: prints the `plugins loaded:` block only when `pluginsLoaded.length > 0` (silent on plugin-less repos per [`lore/principles/09-orientation-disclosure.md`](../blob/main/lore/principles/09-orientation-disclosure.md))
- JSON: always emits `plugins_loaded` (`[]` when none) for stable schema

## Tests (4 new, 946 → 950)

`tests/application/DiagnosticUseCases.test.ts`:
- `plugins_loaded empty when no plugin paths configured`
- `plugins_loaded status='loaded' when plugin imports + runs cleanly`
- `plugins_loaded status='error' when plugin throws on import`
- `plugins_loaded status='error' when default export is not callable`

Each test writes a tmpfile plugin, runs the use-case, asserts state, cleans up.

## Test plan

- [x] `npm test` passes — 950/950
- [x] `npm run typecheck` passes
- [x] Manual smoke (plugin configured): text + JSON both surface `plugins_loaded`
- [x] Manual smoke (no plugins): text stays quiet, JSON shows `[]`

## Out of scope (intentionally left)

- The "untrusted-plugins-listed-but-not-loaded" warning (currently goes to stderr at config-load time, not into the doctor report). Operators see it on every CLI run already, so doctor doesn't need to mirror it. Could add later if the stderr path proves invisible.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_