### PR TITLE
docs(security): cross-link known hardening items to their tracking issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -151,21 +151,29 @@ For full details: `src/passages/devil/README.md`,
 
 ## Known hardening items (not yet addressed)
 
-- **Error messages may leak absolute paths.** Errors from `safeFs`
-  include the resolved target. Acceptable for a local CLI; reconsider
-  before any network exposure.
-- **Prototype pollution from hostile YAML.** Modern `yaml` lib returns
-  plain objects and handles `__proto__` safely, but the hydration layer
-  does not independently guard against prototype keys.
-- **Concurrent writes.** There is no lock file. Two simultaneous
-  writes on the same record have a last-writer-wins race unless
-  optimistic-lock detection catches the second write's stale read —
-  `RequestVersionConflict`, `InboxVersionConflict`, and
-  `IssueVersionConflict` each cover their own record class. This
-  catches **most** concurrent mutations but is not a full
-  serialization barrier (the CAS window between re-read and
-  atomic-rename is non-zero). Serialize at the caller for critical
-  operations on any record.
+Each item below is tracked as a GitHub issue for visibility in the
+backlog; status here is the current load-bearing summary, status on
+the issue is the active discussion.
+
+- **Error messages may leak absolute paths**
+  ([#153](https://github.com/eris-ths/guild-cli/issues/153)).
+  Errors from `safeFs` include the resolved target. Acceptable for
+  a local CLI; reconsider before any network exposure.
+- **Prototype pollution from hostile YAML**
+  ([#154](https://github.com/eris-ths/guild-cli/issues/154)).
+  Modern `yaml` lib returns plain objects and handles `__proto__`
+  safely, but the hydration layer does not independently guard
+  against prototype keys.
+- **Concurrent writes**
+  ([#155](https://github.com/eris-ths/guild-cli/issues/155)).
+  There is no lock file. Two simultaneous writes on the same record
+  have a last-writer-wins race unless optimistic-lock detection
+  catches the second write's stale read — `RequestVersionConflict`,
+  `InboxVersionConflict`, and `IssueVersionConflict` each cover their
+  own record class. This catches **most** concurrent mutations but is
+  not a full serialization barrier (the CAS window between re-read
+  and atomic-rename is non-zero). Serialize at the caller for
+  critical operations on any record.
 
 ## Reporting
 


### PR DESCRIPTION
## Summary

`SECURITY.md § Known hardening items` had three inline notes that filed as GitHub issues during this session's deep-dive review processing:

- absolute path leak → [#153](https://github.com/eris-ths/guild-cli/issues/153)
- prototype pollution → [#154](https://github.com/eris-ths/guild-cli/issues/154)
- concurrent writes / lock file → [#155](https://github.com/eris-ths/guild-cli/issues/155)

This PR adds inline issue links so:
- SECURITY.md readers can jump to the active discussion
- The issues are findable from the doc operators typically read first
- The "doc says X / issue tracker says Y" drift can't quietly grow

## Why this and not closing the items

The items **remain open**. Filing them as issues makes them traceable; it doesn't fix them. Section heading kept as `(not yet addressed)` to match the actual state.

## Test plan

- [x] `git diff --stat` reviewed — only SECURITY.md touched, +23/-15
- [x] Issue numbers verified against the filed issues

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_