### PR TITLE
fix(doctor): convert plugin paths to file:// URLs for Windows ESM compat

### DIFF
--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -16,6 +16,7 @@ import { MemberRepository } from '../ports/MemberRepository.js';
 import { RequestRepository } from '../ports/RequestRepository.js';
 import { IssueRepository } from '../ports/IssueRepository.js';
 import { OnMalformed } from '../ports/OnMalformed.js';
+import { pathToFileURL } from 'node:url';
 import {
   DiagnosticArea,
   DiagnosticFinding,
@@ -117,11 +118,17 @@ export class DiagnosticUseCases {
     // Run doctor plugins (if any). Track each path's outcome so the
     // doctor report can surface "what ran" at runtime — operators
     // shouldn't have to read SECURITY.md to know a plugin executed.
+    //
+    // Convert filesystem paths to file:// URLs before dynamic import.
+    // Linux/Mac tolerate `await import('/abs/path.mjs')`, but Node's
+    // ESM loader on Windows rejects bare absolute paths (treats `C:`
+    // as an unknown scheme). pathToFileURL handles both platforms;
+    // the cost on Linux is one extra wrap per plugin per doctor run.
     const pluginsLoaded: PluginLoadInfo[] = [];
     if (this.pluginPaths.length > 0 && this.pluginContext) {
       for (const pluginPath of this.pluginPaths) {
         try {
-          const mod = await import(pluginPath);
+          const mod = await import(pathToFileURL(pluginPath).href);
           const fn: DoctorPluginFn = mod.default ?? mod;
           if (typeof fn === 'function') {
             const pluginFindings = await fn(this.pluginContext);


### PR DESCRIPTION
## Summary

[PR #159](https://github.com/eris-ths/guild-cli/pull/159) added 4 tests that load real plugin files via `mkdtempSync` + `await import(pluginPath)`. These passed on Linux but **exposed a latent Windows ESM bug**: Node's ESM loader on Windows rejects bare absolute paths.

```js
await import('/tmp/plugin.mjs')         // Linux: works
await import('C:\\Temp\\plugin.mjs')    // Windows: ERR_UNSUPPORTED_ESM_URL_SCHEME
                                        //         (treats "C:" as an unknown scheme)
```

## Fix

Standard cross-platform pattern — wrap path with `pathToFileURL(...).href`:

```ts
import { pathToFileURL } from 'node:url';
...
const mod = await import(pathToFileURL(pluginPath).href);
```

Linux file paths convert to `file:///abs/path` which `import` accepts; Windows paths convert correctly.

## Why this is a production fix, not just a test fix

The buggy line (`await import(pluginPath)`) was added when the doctor-plugins feature first shipped — long before this session. Actual Windows users with `doctor.plugins:` configured in `guild.config.yaml` would have hit `ERR_UNSUPPORTED_ESM_URL_SCHEME` on every `gate doctor` invocation. PR #159's tests are the first to exercise the path end-to-end with a real file, which is what made the bug visible.

## Why downstream PRs were also red

PR #160 (docs-only, SECURITY.md cross-links) inherited the failure because the test suite is the same on every PR. With this fix on main, future PRs' Windows CI returns to green.

## Test plan

- [x] `npm test` on Linux — 950/950 pass (no behavioural change for already-working platforms)
- [x] `npm run typecheck` passes
- [x] Reasoning verified: pathToFileURL is the documented Node API for this exact case ([nodejs.org docs](https://nodejs.org/api/url.html#urlpathtofileurlpath-options))

## Out of scope

- Other `await import(...)` call sites — there are no others in the codebase that take user-configured paths (verified: `git grep "await import"` shows only the doctor plugin loader uses runtime user input)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_