### PR TITLE
feat(help): show runnable usage example in `&lt;cli&gt; &lt;verb&gt; --help`

### DIFF
--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -1,0 +1,88 @@
+// Per-CLI, per-verb usage example shown by `<cli> <verb> --help`.
+//
+// Source of truth is AGENT.md / docs/verbs.md — the examples here are
+// the canonical one-liners abridged to the smallest invocation that
+// would actually run. Required flags only; optional flags belong in
+// docs. Single line per verb so the help output stays a cheat sheet,
+// not a usage essay.
+//
+// Missing entries gracefully degrade to "no example line" — adding a
+// verb here is opt-in. A new CLI can ship without touching this map;
+// the touch-feel benefit arrives when the example is added. Tests pin
+// the CLI×verb pairs that DO exist so a typo (`registr` vs `register`)
+// silently dropping the example surfaces in CI.
+
+export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
+  gate: {
+    register: 'register --name <you>',
+    request: 'request --action "<what>" --reason "<why>"',
+    approve: 'approve <id>',
+    deny: 'deny <id> --reason "<why>"',
+    execute: 'execute <id>',
+    complete: 'complete <id>',
+    fail: 'fail <id> --reason "<why>"',
+    'fast-track': 'fast-track --action "<what>" --reason "<why>"',
+    review: 'review <id> --lense layer --verdict ok --comment "<note>"',
+    thank: 'thank <to> --for <id>',
+    message: 'message --to <m> --text "<body>"',
+    broadcast: 'broadcast --text "<body>"',
+    inbox: 'inbox',
+    'inbox mark-read': 'inbox mark-read [N]',
+    'issues add': 'issues add --severity med --area <a> "<text>"',
+    'issues list': 'issues list',
+    'issues note': 'issues note <id> --text "<note>"',
+    'issues promote': 'issues promote <id>',
+    'issues resolve': 'issues resolve <id>',
+    'issues defer': 'issues defer <id>',
+    'issues start': 'issues start <id>',
+    'issues reopen': 'issues reopen <id>',
+    show: 'show <id>',
+    list: 'list --state pending',
+    board: 'board',
+    tail: 'tail [N]',
+    chain: 'chain <id>',
+    transcript: 'transcript <id>',
+    voices: 'voices <name>',
+    whoami: 'whoami',
+    boot: 'boot',
+    status: 'status',
+    suggest: 'suggest',
+    resume: 'resume',
+    summarize: 'summarize <id>',
+    why: 'why <id>',
+    unresponded: 'unresponded',
+    schema: 'schema',
+    doctor: 'doctor',
+    repair: 'repair --apply',
+  },
+  agora: {
+    new: 'new --slug <s> --kind sandbox --title "<t>"',
+    play: 'play --slug <slug>',
+    move: 'move <play-id> --text "<text>"',
+    suspend: 'suspend <play-id> --cliff "<what>" --invitation "<next>"',
+    resume: 'resume <play-id>',
+    conclude: 'conclude <play-id>',
+    list: 'list',
+    show: 'show <slug-or-play-id>',
+    schema: 'schema',
+  },
+  devil: {
+    open: 'open <target-ref> --type pr',
+    entry:
+      'entry <rev-id> --persona red-team --lense injection ' +
+      '--kind finding --text "<prose>" --severity high ' +
+      '--severity-rationale "<why>"',
+    list: 'list',
+    show: 'show <rev-id>',
+    conclude: 'conclude <rev-id> --synthesis "<prose>"',
+    dismiss: 'dismiss <rev-id> <entry-id> --reason not-applicable',
+    resolve: 'resolve <rev-id> <entry-id>',
+    suspend: 'suspend <rev-id> --cliff "<what>" --invitation "<next>"',
+    resume: 'resume <rev-id>',
+    ingest: 'ingest <rev-id> --from claude-security <input-path>',
+    schema: 'schema',
+  },
+  ctx: {
+    record: 'record --fact "<prose>" --tag prefix:value,prefix:value',
+  },
+};

--- a/src/interface/shared/verbHelp.ts
+++ b/src/interface/shared/verbHelp.ts
@@ -1,4 +1,5 @@
 import type { HelpRequested } from './parseArgs.js';
+import { VERB_EXAMPLES } from './verbExamples.js';
 
 /**
  * Render a verb's flag catalog to stdout in response to `<cli> <verb> --help`.
@@ -9,14 +10,22 @@ import type { HelpRequested } from './parseArgs.js';
  * full verb-by-verb prose lives in the CLI's top-level HELP and in
  * `AGENT.md` / `docs/verbs.md`. This is the "what flags can I pass" cheat
  * sheet, not a usage essay.
+ *
+ * When `VERB_EXAMPLES[cli][verb]` exists, an `e.g.` line follows the flag
+ * list — the canonical smallest invocation that runs. Missing verbs skip
+ * the example line silently rather than crash, so a new CLI can ship
+ * before the example map catches up.
  */
 export function renderVerbHelp(cli: string, e: HelpRequested): void {
   const flags =
     e.knownFlags.length > 0
       ? e.knownFlags.map((f) => `--${f}`).join(', ')
       : '(no flags)';
+  const example = VERB_EXAMPLES[cli]?.[e.verb];
+  const exampleLine = example !== undefined ? `  e.g. ${cli} ${example}\n` : '';
   process.stdout.write(
     `${cli} ${e.verb}: ${flags}\n` +
+      exampleLine +
       `  see \`${cli} --help\` for the full verb catalog.\n`,
   );
 }

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -20,6 +20,8 @@ import {
   rejectUnknownFlags,
   HelpRequested,
 } from '../../src/interface/shared/parseArgs.js';
+import { renderVerbHelp } from '../../src/interface/shared/verbHelp.js';
+import { VERB_EXAMPLES } from '../../src/interface/shared/verbExamples.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
@@ -103,6 +105,110 @@ test('rejectUnknownFlags: --help is never reported as an unknown flag', () => {
   );
 });
 
+// --- unit tests for the renderer + example map ---
+
+function captureStdout(fn: () => void): string {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (process.stdout as any).write = (chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = original;
+  }
+  return captured;
+}
+
+test('renderVerbHelp: prints flag list, e.g. example, and footer', () => {
+  const e = new HelpRequested('request', ['from', 'action', 'reason']);
+  const out = captureStdout(() => renderVerbHelp('gate', e));
+  assert.match(out, /^gate request: --from, --action, --reason\n/);
+  assert.match(out, /\n {2}e\.g\. gate request --action /);
+  assert.match(out, /\n {2}see `gate --help` for the full verb catalog\.\n$/);
+});
+
+test('renderVerbHelp: omits e.g. line when the verb has no example mapping', () => {
+  // Deliberately use a verb name that is NOT in VERB_EXAMPLES.gate.
+  // The renderer should still produce the flag list and footer.
+  const e = new HelpRequested('not-a-real-verb-xyz', ['flag']);
+  const out = captureStdout(() => renderVerbHelp('gate', e));
+  assert.match(out, /^gate not-a-real-verb-xyz: --flag\n/);
+  assert.equal(/e\.g\./.test(out), false, 'no example line for unknown verb');
+  assert.match(out, /see `gate --help`/);
+});
+
+test('renderVerbHelp: handles a verb with zero known flags', () => {
+  // `(no flags)` placeholder + still reaches example lookup. Example
+  // map is keyed by verb name, not flag count, so a flagless verb like
+  // `whoami` still gets its example printed.
+  const e = new HelpRequested('whoami', []);
+  const out = captureStdout(() => renderVerbHelp('gate', e));
+  assert.match(out, /^gate whoami: \(no flags\)\n/);
+  assert.match(out, /\n {2}e\.g\. gate whoami\n/);
+});
+
+// --- coverage: every (cli, verb) reachable through rejectUnknownFlags
+//     should have an example. Failure means a new verb was added without
+//     pulling its canonical example from AGENT.md / docs/verbs.md. ---
+
+test('VERB_EXAMPLES: every documented verb is mapped to a runnable example', () => {
+  // Source of truth: the verb names passed as the third arg to
+  // rejectUnknownFlags across the interface layer. Extracted here as a
+  // pinned list rather than re-grepped at test time, so a careless rename
+  // breaks the test (drawing attention) instead of silently passing.
+  const expected: Record<string, string[]> = {
+    gate: [
+      'register', 'request', 'approve', 'deny', 'execute', 'complete', 'fail',
+      'fast-track', 'review', 'thank', 'message', 'broadcast', 'inbox',
+      'inbox mark-read', 'issues add', 'issues list', 'issues note',
+      'issues promote', 'issues resolve', 'issues defer', 'issues start',
+      'issues reopen', 'show', 'list', 'board', 'tail', 'chain', 'transcript',
+      'voices', 'whoami', 'boot', 'status', 'suggest', 'resume', 'summarize',
+      'why', 'unresponded', 'schema', 'doctor', 'repair',
+    ],
+    agora: [
+      'new', 'play', 'move', 'suspend', 'resume', 'conclude',
+      'list', 'show', 'schema',
+    ],
+    devil: [
+      'open', 'entry', 'list', 'show', 'conclude', 'dismiss', 'resolve',
+      'suspend', 'resume', 'ingest', 'schema',
+    ],
+    ctx: ['record'],
+  };
+  for (const [cli, verbs] of Object.entries(expected)) {
+    const map = VERB_EXAMPLES[cli];
+    assert.ok(map, `VERB_EXAMPLES.${cli} must exist`);
+    for (const verb of verbs) {
+      assert.ok(
+        typeof map[verb] === 'string' && map[verb]!.length > 0,
+        `VERB_EXAMPLES.${cli}["${verb}"] missing or empty`,
+      );
+    }
+  }
+});
+
+test('VERB_EXAMPLES: each example begins with its own verb (catches copy/paste typos)', () => {
+  // The renderer prefixes each example with `<cli> `. If an example
+  // accidentally starts with a different verb (`register --name <you>`
+  // mapped to `request`), `<cli> request register --name <you>` would
+  // print and a copy/paster would run the wrong verb. Pin the invariant
+  // so that class of typo can't slip in.
+  for (const [cli, map] of Object.entries(VERB_EXAMPLES)) {
+    for (const [verb, example] of Object.entries(map)) {
+      assert.ok(
+        example.startsWith(verb),
+        `${cli}.${verb}: example "${example}" should start with "${verb}"`,
+      );
+    }
+  }
+});
+
 test('rejectUnknownFlags: still throws plain Error for non-help unknown flags', () => {
   // Regression guard for the non-help path.
   const args = parseArgs(['--bogus']);
@@ -129,6 +235,19 @@ test('gate <verb> --help: exits 0 and renders the flag catalog', (t) => {
   assert.match(r.stdout, /see `gate --help`/);
 });
 
+test('gate <verb> --help: includes a usage example line for documented verbs', (t) => {
+  // The example line is the touch-feel improvement on top of the flag list:
+  // a fresh agent can copy/paste a runnable invocation without bouncing to
+  // `gate --help` or AGENT.md. Missing verbs skip the line silently, so the
+  // assertion is presence (not exact prose) on a verb we know is in the map.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(GATE, root, ['request', '--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /e\.g\. gate request --action/);
+});
+
 test('gate tail --help: works on a verb with a richer flag set', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
@@ -151,6 +270,19 @@ test('agora <verb> --help: exits 0 and uses the agora prefix', (t) => {
   assert.match(r.stdout, /see `agora --help`/);
 });
 
+test('agora new --help: example uses the agora prefix (not gate)', (t) => {
+  // Same-named verbs across CLIs (`new` is agora-only, but `list` /
+  // `show` / `resume` exist in multiple); pin that the example renders
+  // with the right CLI prefix so a copy/paste from agora's help doesn't
+  // produce a `gate ...` command.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(AGORA, root, ['new', '--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /e\.g\. agora new --slug/);
+});
+
 test('devil <verb> --help: exits 0 and uses the devil prefix', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
@@ -159,6 +291,15 @@ test('devil <verb> --help: exits 0 and uses the devil prefix', (t) => {
   assert.equal(r.status, 0, 'devil list --help should exit 0');
   assert.match(r.stdout, /devil list:/);
   assert.match(r.stdout, /see `devil --help`/);
+});
+
+test('devil open --help: example shows the rev-id-shaped first arg', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+  const r = run(DEVIL, root, ['open', '--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /e\.g\. devil open .*--type pr/);
 });
 
 test('ctx record --help: exits 0 and uses the ctx prefix', (t) => {
@@ -170,6 +311,7 @@ test('ctx record --help: exits 0 and uses the ctx prefix', (t) => {
   assert.match(r.stdout, /ctx record:/);
   assert.match(r.stdout, /--fact/);
   assert.match(r.stdout, /--tag/);
+  assert.match(r.stdout, /e\.g\. ctx record --fact/);
 });
 
 test('non-help unknown flag still errors with verb-only prefix (no "gate" hardcode)', (t) => {


### PR DESCRIPTION
## Summary

PR #148 made `--help` a universal escape valve and exposed the flag list per verb; what was still missing was a **runnable invocation**. A fresh agent typing `gate request --help` got `--from, --action, --reason, ...` and had to bounce to `gate --help` or `AGENT.md` to learn the shape of a real call.

This adds a per-`(cli, verb)` example map and renders one `e.g.` line between the flag list and the footer:

```
gate request: --action, --auto-review, --executor, --format, --from, --reason, --target, --with
  e.g. gate request --action "<what>" --reason "<why>"
  see `gate --help` for the full verb catalog.
```

## Design

- Examples live in **`src/interface/shared/verbExamples.ts`**, keyed by `cli → verb → string`. Same-named verbs across CLIs (`show`, `list`, `resume`, `suspend`, `conclude`, `schema`) need CLI scoping so an `agora list --help` example never accidentally renders a `gate ...` command.
- The renderer **falls through silently** when a verb is missing — a new CLI can ship before the example map catches up. Coverage tests pin the (cli, verb) pairs that DO exist, so a typo (`registr` vs `register`) silently dropping the example surfaces in CI.
- One invariant: **each example MUST start with its own verb name**. A copy/paste typo where `request` maps to `register --name <you>` would render a wrong-verb command; `assert example.startsWith(verb)` catches that class.

Source of truth for the example prose is `AGENT.md` / `docs/verbs.md`; each entry is the smallest invocation that runs (required flags only — optional flags belong in the docs).

## Output across all four CLIs

```
gate review: --by, --comment, --dry-run, --format, --lense, --verdict
  e.g. gate review <id> --lense layer --verdict ok --comment "<note>"
  see `gate --help` for the full verb catalog.

agora new: --by, --description, --format, --kind, --slug, --title
  e.g. agora new --slug <s> --kind sandbox --title "<t>"
  see `agora --help` for the full verb catalog.

devil entry: --addresses, --by, --format, --kind, --lense, --persona, --severity, --severity-rationale, --text
  e.g. devil entry <rev-id> --persona red-team --lense injection --kind finding --text "<prose>" --severity high --severity-rationale "<why>"
  see `devil --help` for the full verb catalog.

ctx record: --by, --fact, --format, --tag
  e.g. ctx record --fact "<prose>" --tag prefix:value,prefix:value
  see `ctx --help` for the full verb catalog.
```

## Test plan

- [x] 950 → 958 passing (+8 new: 4 unit on the renderer, 4 e2e across gate / agora / devil / ctx)
- [x] Renderer omits the `e.g.` line gracefully when a verb has no mapping
- [x] Renderer handles a flagless verb (`whoami`) — `(no flags)` placeholder + example still renders
- [x] Coverage test: every documented `(cli, verb)` pair has a non-empty example
- [x] Invariant test: every example string starts with its own verb name
- [x] Manual touch-feel pass across `gate request`, `gate review`, `agora new`, `devil entry`, `ctx record`, `gate whoami`

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_