### PR TITLE
fix(guild): apply --help universal handling to guild verbs (#148 follow-up)

### DIFF
--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -1,5 +1,12 @@
 import { buildContainer } from '../shared/container.js';
-import { parseArgs, requireOption, optionalOption } from '../shared/parseArgs.js';
+import {
+  parseArgs,
+  requireOption,
+  optionalOption,
+  rejectUnknownFlags,
+  HelpRequested,
+} from '../shared/parseArgs.js';
+import { renderVerbHelp } from '../shared/verbHelp.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
 
@@ -30,6 +37,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   try {
     switch (cmd) {
       case 'list': {
+        rejectUnknownFlags(args, new Set(), 'list');
         const members = await c.memberUC.list();
         const memberNames = new Set(members.map((m) => m.name.value));
         for (const m of members) {
@@ -48,6 +56,7 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 0;
       }
       case 'show': {
+        rejectUnknownFlags(args, new Set(), 'show');
         const name = args.positional[0];
         if (!name) throw new Error('Usage: guild show <name>');
         const m = await c.memberUC.show(name);
@@ -59,6 +68,11 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 0;
       }
       case 'new': {
+        rejectUnknownFlags(
+          args,
+          new Set(['name', 'category', 'display-name']),
+          'new',
+        );
         const name = requireOption(args, 'name', '<n>');
         const category = requireOption(
           args,
@@ -73,6 +87,7 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 0;
       }
       case 'validate': {
+        rejectUnknownFlags(args, new Set(), 'validate');
         const members = await c.memberUC.list();
         const hostCount = c.config.hostNames.length;
         const hostSuffix =
@@ -87,6 +102,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
     }
   } catch (e) {
+    if (e instanceof HelpRequested) {
+      renderVerbHelp('guild', e);
+      return 0;
+    }
     const msg = e instanceof DomainError
       ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
       : e instanceof Error

--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -85,4 +85,10 @@ export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
   ctx: {
     record: 'record --fact "<prose>" --tag prefix:value,prefix:value',
   },
+  guild: {
+    list: 'list',
+    show: 'show <name>',
+    new: 'new --name <n> --category professional',
+    validate: 'validate',
+  },
 };

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -28,6 +28,7 @@ const GATE = resolve(here, '../../../bin/gate.mjs');
 const AGORA = resolve(here, '../../../bin/agora.mjs');
 const DEVIL = resolve(here, '../../../bin/devil.mjs');
 const CTX = resolve(here, '../../../bin/ctx.mjs');
+const GUILD = resolve(here, '../../../bin/guild.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
   const root = mkdtempSync(join(tmpdir(), 'guild-verb-help-'));
@@ -180,6 +181,7 @@ test('VERB_EXAMPLES: every documented verb is mapped to a runnable example', () 
       'suspend', 'resume', 'ingest', 'schema',
     ],
     ctx: ['record'],
+    guild: ['list', 'show', 'new', 'validate'],
   };
   for (const [cli, verbs] of Object.entries(expected)) {
     const map = VERB_EXAMPLES[cli];
@@ -312,6 +314,36 @@ test('ctx record --help: exits 0 and uses the ctx prefix', (t) => {
   assert.match(r.stdout, /--fact/);
   assert.match(r.stdout, /--tag/);
   assert.match(r.stdout, /e\.g\. ctx record --fact/);
+});
+
+test('guild <verb> --help: exits 0 across list / show / new / validate', (t) => {
+  // #148 rolled out the universal --help mechanism for gate / agora / devil /
+  // ctx but the operator-helper `guild` was out of scope. This pins the
+  // follow-up: all four guild verbs honour --help with the same shape.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  for (const verb of ['list', 'show', 'new', 'validate']) {
+    const r = run(GUILD, root, [verb, '--help']);
+    assert.equal(r.status, 0, `guild ${verb} --help should exit 0`);
+    assert.match(r.stdout, new RegExp(`guild ${verb}:`));
+    assert.match(r.stdout, /see `guild --help`/);
+    assert.match(r.stdout, new RegExp(`e\\.g\\. guild ${verb}`));
+  }
+});
+
+test('guild new --bogus: error message uses verb-only prefix (no "guild" hardcode)', (t) => {
+  // Mirrors the cross-CLI sanity below — the verb name + invocation are
+  // enough; the CLI prefix in the error is misleading.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(GUILD, root, ['new', '--bogus-flag-xyz']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /new: unknown flag.*--bogus-flag-xyz/);
+  assert.equal(
+    /guild new: unknown flag/.test(r.stderr),
+    false,
+    'guild errors should not say "guild" in the unknown-flag prefix',
+  );
 });
 
 test('non-help unknown flag still errors with verb-only prefix (no "gate" hardcode)', (t) => {


### PR DESCRIPTION
## Summary

PR #148 rolled out the universal \`--help\` mechanism (\`HelpRequested\` / \`rejectUnknownFlags\` / \`renderVerbHelp\`) across **gate / agora / devil / ctx** but the operator-helper \`guild\` was not in that PR's scope.

Surfaced via dogfood touch on develop:
- \`guild list --help\` silently ignored \`--help\` and ran \`list\`
- \`guild new --help\` errored with "Missing --name" before noticing \`--help\`
- \`guild new --bogus\` printed errors without the verb-only convention #148 established

This PR closes the gap. The 4 \`guild\` verbs (\`list\` / \`show\` / \`new\` / \`validate\`) now honour \`--help\` with the same shape as the four passages.

## Before / after

\`\`\`
# Before
$ guild list --help
asteria  [professional]
... # --help silently dropped
$ guild new --help
error: Missing --name. guild new --name <n> --category <c>

# After
$ guild list --help
guild list: (no flags)
  e.g. guild list
  see \`guild --help\` for the full verb catalog.
$ guild new --help
guild new: --category, --display-name, --name
  e.g. guild new --name <n> --category professional
  see \`guild --help\` for the full verb catalog.
$ guild new --bogus
error: new: unknown flag: --bogus
  valid flags for 'new': --category, --display-name, --name
\`\`\`

## Changes

- \`src/interface/guild/index.ts\` — import \`rejectUnknownFlags\` / \`HelpRequested\` / \`renderVerbHelp\`, call \`rejectUnknownFlags\` per verb (empty set for flag-less \`list\` / \`show\` / \`validate\`; full set for \`new\`), catch \`HelpRequested\` in main()
- \`src/interface/shared/verbExamples.ts\` — add \`guild\` entry with the canonical one-liner per verb
- \`tests/interface/verbHelp.test.ts\` — add \`guild\` to the coverage map + 2 new E2E tests (\`--help\` on all 4 verbs, \`--bogus\` flag error prefix)

Touch-feel parity for the 4 CLIs is now complete: every \`<cli> <verb> --help\` returns exit 0 with a flag catalog + runnable example.

Closes #165.

## Test plan

- [x] \`npm run build\`
- [x] All verbHelp tests pass (21/21 including 2 new)
- [x] Manual: \`guild {list,show,new,validate} --help\` exit 0, \`guild new --bogus\` correct error
- [ ] CI green (Linux + Windows × Node 20/22)
- [ ] Existing \`guild\` happy paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)