### PR TITLE
feat(touch-feel): state-transition next-state hint + not-found discovery line

### DIFF
--- a/src/domain/request/RequestState.ts
+++ b/src/domain/request/RequestState.ts
@@ -39,8 +39,21 @@ export function assertTransition(from: RequestState, to: RequestState): void {
   if (from === to) {
     throw new DomainError(`Request is already ${from}.`, 'state');
   }
+  // For every other illegal transition, surface the valid next states
+  // alongside the rejection. The transition map already encodes the
+  // answer; without showing it, the user is told their move was wrong
+  // but not what to do next — the "fresh agent typed `complete` on a
+  // pending request and stopped" failure mode in dogfood (P3).
+  // State names live in the domain vocabulary; verb hints (e.g. "try
+  // gate approve") belong in the interface layer and stay out of
+  // here on principle.
+  const validNext = TRANSITIONS[from];
+  const nextHint =
+    validNext.length > 0
+      ? `valid next states from ${from}: ${validNext.join(', ')}.`
+      : `${from} is terminal — no further transitions are allowed.`;
   throw new DomainError(
-    `Illegal state transition: ${from} → ${to}`,
+    `Illegal state transition: ${from} → ${to}.\n  ${nextHint}`,
     'state',
   );
 }

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -4,6 +4,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 import {
   C,
   readStdin,
@@ -226,7 +227,7 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
 
   const issue = await c.issueUC.find(id);
   if (!issue) {
-    process.stderr.write(`issue not found: ${id}\n`);
+    process.stderr.write(notFoundMessage('issue', id));
     return 1;
   }
   const j = issue.toJSON();

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -4,6 +4,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
@@ -306,7 +307,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   if (isIssueId) {
     const root = issueById.get(rootId);
     if (!root) {
-      process.stderr.write(`not found: ${rootId}\n`);
+      process.stderr.write(notFoundMessage('issue', rootId));
       return 1;
     }
     const j = root.toJSON();
@@ -317,7 +318,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   } else {
     const root = requestById.get(rootId);
     if (!root) {
-      process.stderr.write(`not found: ${rootId}\n`);
+      process.stderr.write(notFoundMessage('request', rootId));
       return 1;
     }
     const j = root.toJSON() as unknown as RequestJSON;

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -5,6 +5,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 
 // Known flags per write-verb. Silent-ignore of unknown flags (e.g.
 // `--executr noir` instead of `--executor noir`) would let a typo
@@ -272,7 +273,7 @@ export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
   }
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(`not found: ${id}\n`);
+    process.stderr.write(notFoundMessage('request', id));
     return 1;
   }
   const fields = optionalOption(args, 'fields');

--- a/src/interface/gate/handlers/summarize.ts
+++ b/src/interface/gate/handlers/summarize.ts
@@ -3,6 +3,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
 
@@ -47,7 +48,7 @@ export async function summarizeCmd(c: C, args: ParsedArgs): Promise<number> {
   }
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(`not found: ${id}\n`);
+    process.stderr.write(notFoundMessage('request', id));
     return 1;
   }
   const payload = buildSummary(r);

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -3,6 +3,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
 
@@ -64,7 +65,7 @@ export async function transcriptCmd(c: C, args: ParsedArgs): Promise<number> {
   }
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(`not found: ${id}\n`);
+    process.stderr.write(notFoundMessage('request', id));
     return 1;
   }
   const payload = buildTranscript(r);

--- a/src/interface/gate/handlers/why.ts
+++ b/src/interface/gate/handlers/why.ts
@@ -3,6 +3,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
 
@@ -60,7 +61,7 @@ export async function whyCmd(c: C, args: ParsedArgs): Promise<number> {
   }
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(`not found: ${id}\n`);
+    process.stderr.write(notFoundMessage('request', id));
     return 1;
   }
   const payload = buildWhy(r);

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -7,6 +7,7 @@ import {
   HelpRequested,
 } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
+import { notFoundMessage } from '../shared/notFoundHint.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
 
@@ -61,7 +62,7 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (!name) throw new Error('Usage: guild show <name>');
         const m = await c.memberUC.show(name);
         if (!m) {
-          process.stderr.write(`not found: ${name}\n`);
+          process.stderr.write(notFoundMessage('member', name));
           return 1;
         }
         process.stdout.write(JSON.stringify(m.toJSON(), null, 2) + '\n');

--- a/src/interface/shared/notFoundHint.ts
+++ b/src/interface/shared/notFoundHint.ts
@@ -1,0 +1,25 @@
+// Shared not-found message format with a discovery hint.
+//
+// Pre-fix: `process.stderr.write('not found: ${id}\n')` — terse, no
+// guidance on how to find a valid id. A fresh agent that mistyped a
+// request id had no signal toward `gate list` / `gate tail`.
+//
+// The hint is per-entity because the verb that lists each kind is
+// different (`gate list` for requests, `gate issues list` for issues,
+// `guild list` for members). Centralising here keeps the prose
+// consistent across call sites — the change is "every not-found
+// emission line gains one hint line" rather than "each handler
+// invents its own phrasing".
+
+export type NotFoundEntity = 'request' | 'issue' | 'member';
+
+const HINTS: Record<NotFoundEntity, string> = {
+  request: "  try 'gate list' or 'gate tail' to see existing requests.",
+  issue: "  try 'gate issues list' to see existing issues.",
+  member: "  try 'guild list' to see registered members.",
+};
+
+export function notFoundMessage(entity: NotFoundEntity, id: string): string {
+  const prefix = entity === 'issue' ? 'issue not found' : 'not found';
+  return `${prefix}: ${id}\n${HINTS[entity]}\n`;
+}

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -115,6 +115,59 @@ test('canTransition rules', () => {
   assert.throws(() => assertTransition('completed', 'failed'), DomainError);
 });
 
+test('assertTransition: illegal move surfaces the valid next states', () => {
+  // Touch-feel improvement: the user typed `complete` on a pending
+  // request and got "illegal" but no signal toward the right verb.
+  // The message now lists the valid next states from the current
+  // state — verb hints (`gate approve`) belong in the interface
+  // layer; here we only cover the domain vocabulary the transition
+  // map already carries.
+  assert.throws(
+    () => assertTransition('pending', 'completed'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /Illegal state transition: pending → completed\./);
+      assert.match(
+        e.message,
+        /valid next states from pending: approved, denied\./,
+      );
+      return true;
+    },
+  );
+});
+
+test('assertTransition: terminal states say so explicitly', () => {
+  // From completed/failed/denied there is no legal next move. Saying
+  // "valid next states from completed: " (empty) would be confusing;
+  // name the dead-end branch in plain English instead.
+  assert.throws(
+    () => assertTransition('completed', 'executing'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(
+        e.message,
+        /completed is terminal — no further transitions are allowed\./,
+      );
+      return true;
+    },
+  );
+});
+
+test('assertTransition: same-state idempotency message stays unchanged', () => {
+  // The `Request is already X` branch is the common idempotency error
+  // (approving an already-approved request). It already reads in plain
+  // English; pin that the next-states enrichment didn't accidentally
+  // bleed into it.
+  assert.throws(
+    () => assertTransition('approved', 'approved'),
+    (e: unknown) => {
+      assert.ok(e instanceof DomainError);
+      assert.match(e.message, /^Request is already approved\.$/);
+      return true;
+    },
+  );
+});
+
 test('Request rejects invalid executor name', () => {
   assert.throws(
     () =>

--- a/tests/interface/notFoundHint.test.ts
+++ b/tests/interface/notFoundHint.test.ts
@@ -1,0 +1,89 @@
+// `not found: <id>` is too terse — a fresh agent that mistyped a
+// request id had no signal toward `gate list` / `gate tail`. The
+// shared helper attaches a per-entity discovery hint so the
+// touch-feel of "I lost my id" recovers in one read.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { notFoundMessage } from '../../src/interface/shared/notFoundHint.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const GUILD = resolve(here, '../../../bin/guild.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-not-found-hint-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: []\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'alice' },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// --- unit: the helper formats per-entity ---
+
+test('notFoundMessage: request gains gate-list hint', () => {
+  const out = notFoundMessage('request', '2026-05-05-9999');
+  assert.match(out, /^not found: 2026-05-05-9999\n/);
+  assert.match(out, /try 'gate list' or 'gate tail'/);
+});
+
+test('notFoundMessage: issue uses the issue-list hint and prefix', () => {
+  const out = notFoundMessage('issue', 'i-2026-05-05-0001');
+  // Issue keeps the historical "issue not found:" prefix so any
+  // operator grepping for it across runbooks still matches.
+  assert.match(out, /^issue not found: i-2026-05-05-0001\n/);
+  assert.match(out, /try 'gate issues list'/);
+});
+
+test('notFoundMessage: member uses the guild-list hint', () => {
+  const out = notFoundMessage('member', 'ghost');
+  assert.match(out, /^not found: ghost\n/);
+  assert.match(out, /try 'guild list'/);
+});
+
+// --- e2e: the helper is wired into the user-facing read paths ---
+
+test('gate show <bad-id>: emits the discovery hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['show', '2026-05-05-9999']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found: 2026-05-05-9999/);
+  assert.match(r.stderr, /try 'gate list' or 'gate tail'/);
+});
+
+test('guild show <bad-name>: emits the member discovery hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GUILD, root, ['show', 'ghost']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found: ghost/);
+  assert.match(r.stderr, /try 'guild list'/);
+});


### PR DESCRIPTION
## Summary

Two mid-flow touch-feel gaps caught in P3 dogfood — both surfaced as **"the user knows something is wrong but not what to do next."**

## (1) `assertTransition` lists valid next states inline

```
before: error: Illegal state transition: pending → completed (state)
after:  error: Illegal state transition: pending → completed.
          valid next states from pending: approved, denied. (state)
```

For terminal states (`completed`/`failed`/`denied`), the message reads `"X is terminal — no further transitions are allowed"` instead of `"valid next: "` (empty), which would have been more confusing than the rejection itself.

State names are the only domain vocabulary added — verb hints (`gate approve`) belong in the interface layer and intentionally stay out of `RequestState.ts`.

## (2) `not found: <id>` gains a per-entity discovery hint

```
before: not found: 2026-05-05-9999
after:  not found: 2026-05-05-9999
          try 'gate list' or 'gate tail' to see existing requests.
```

Centralised in `notFoundMessage(entity, id)`. Three call shapes:

| entity  | hint |
|---------|------|
| request | `try 'gate list' or 'gate tail'` |
| issue   | `try 'gate issues list'` (preserves `issue not found:` prefix so existing operator-side greps keep matching) |
| member  | `try 'guild list'` |

Wired into the user-facing read paths: `gate show`, `summarize`, `transcript`, `why`, `chain` (read.ts), `issues note`, `guild show`.

### Out of scope (noted, not chased)

Application-layer `loadOrThrow` paths (e.g. `gate issues note <bad-id>` → `DomainError("Issue not found")`) still flow through the dispatcher's `error: ${msg}` prefix and don't get the hint. Adding it would require either domain-layer coupling to CLI vocabulary or a dispatcher-level catch — separate design decision.

## Test plan

- [x] 3 new domain tests pinning `assertTransition`'s next-state surface (illegal move, terminal state, same-state idempotency unchanged)
- [x] 5 new interface tests on `notFoundMessage` (3 unit per-entity, 2 e2e for `gate show` and `guild show`)
- [x] 961 → 969 passing
- [x] Manual touch-feel verified across `gate complete <pending>`, `gate show <bad-id>`, `guild show <bad-name>`

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_