### PR TITLE
feat(execute): notice when --executor was set and actor differs (#168)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -61,6 +61,13 @@ gate fast-track --from <m> --action "..." --reason "..."   # one-shot create→c
 gate thank <to> --for <id> [--by <m>] [--reason <s>]       # gratitude (no verdict, no calibration)
 ```
 
+`--executor <m>` records **intent**, not access — anyone with substrate
+access may run `gate execute`. When the actor differs from the assignee
+the substrate captures both, and `gate execute` emits a `notice:` so
+the mismatch is visible at the surface that did it. See
+[issue #168](https://github.com/eris-ths/guild-cli/issues/168) for the
+design rationale.
+
 ## Review (Two-Persona Devil)
 
 ```bash

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -560,6 +560,20 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
     return 0;
   }
   const r = await c.requestUC.execute(id, by, note, invokedBy);
+  // `--executor` is informational, not access control: the substrate
+  // records both the assignment and the actual actor, but does not
+  // refuse a mismatched execute. Surface a notice so a fresh agent
+  // who reads `--executor bob` doesn't silently interpret it as a
+  // gate. See issue #168 for the design rationale ("anyone may
+  // execute; the audit trail captures who did"). Mirrors the shape
+  // of the self-approve notice on `gate approve`.
+  const assignedExecutor = r.executor?.value;
+  if (assignedExecutor !== undefined && assignedExecutor !== by) {
+    process.stderr.write(
+      `notice: ${by} executed request ${id} (assigned to ` +
+        `${assignedExecutor}); --executor records intent, not access.\n`,
+    );
+  }
   emitWriteResponse(parseFormat(args), r, `✓ executing: ${id}`, c.config);
   return 0;
 }

--- a/tests/interface/executorMismatchNotice.test.ts
+++ b/tests/interface/executorMismatchNotice.test.ts
@@ -1,0 +1,104 @@
+// `gate execute` emits a notice when --executor was set on the
+// request but the executing actor differs. Per issue #168, --executor
+// is informational (not access control) — anyone may execute. The
+// notice keeps the mismatch visible at the surface that did it,
+// mirroring the self-approve notice on `gate approve`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-executor-mismatch-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: []\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+  actor?: string,
+): { stdout: string; stderr: string; status: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (actor !== undefined) env['GUILD_ACTOR'] = actor;
+  else delete env['GUILD_ACTOR'];
+  const r = spawnSync(process.execPath, [bin, ...args], { cwd, env, encoding: 'utf8' });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function setupAliceBobRequest(root: string, opts: { withExecutor?: 'bob' | undefined }): string {
+  run(GATE, root, ['register', '--name', 'alice']);
+  run(GATE, root, ['register', '--name', 'bob']);
+  const requestArgs = ['request', '--action', 'do x', '--reason', 'for y', '--format', 'json'];
+  if (opts.withExecutor) requestArgs.push('--executor', opts.withExecutor);
+  const r = run(GATE, root, requestArgs, 'alice');
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+  // approve before execute
+  const ar = run(GATE, root, ['approve', id], 'alice');
+  assert.equal(ar.status, 0, `approve failed: ${ar.stderr}`);
+  return id;
+}
+
+test('gate execute: notice fires when --executor was set and actor differs', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = setupAliceBobRequest(root, { withExecutor: 'bob' });
+
+  // alice (≠ bob) executes — notice should appear on stderr.
+  const r = run(GATE, root, ['execute', id], 'alice');
+  assert.equal(r.status, 0, `execute failed: ${r.stderr}`);
+  assert.match(r.stdout, /✓ executing/);
+  assert.match(
+    r.stderr,
+    /notice: alice executed request .* \(assigned to bob\); --executor records intent, not access\./,
+  );
+});
+
+test('gate execute: notice silent when --executor matches the actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = setupAliceBobRequest(root, { withExecutor: 'bob' });
+
+  // bob (== bob) executes — no mismatch notice.
+  const r = run(GATE, root, ['execute', id], 'bob');
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ executing/);
+  assert.equal(
+    /notice:.*--executor/.test(r.stderr),
+    false,
+    'no mismatch notice when actor === executor',
+  );
+});
+
+test('gate execute: notice silent when --executor was never set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // No --executor on the request — there is nothing to mismatch against.
+  const id = setupAliceBobRequest(root, { withExecutor: undefined });
+
+  const r = run(GATE, root, ['execute', id], 'alice');
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ executing/);
+  assert.equal(
+    /notice:.*--executor/.test(r.stderr),
+    false,
+    'no notice when executor was never assigned',
+  );
+});


### PR DESCRIPTION
## Summary

Per issue #168, `--executor` records **intent** (not access control) — anyone with substrate access may run `gate execute`. Pre-fix, a fresh agent who saw `--executor bob` on the request reasonably interpreted it as a gate; when alice ran `execute` on bob's assignment the substrate captured both but the surface gave no signal that something off-pattern had happened.

This adds a `notice:` that mirrors the shape of the self-approve notice on `gate approve`:

```
notice: alice approved their own request 2026-05-05-0001 (no second reviewer; ...)
notice: alice executed request 2026-05-05-0001 (assigned to bob); --executor records intent, not access.
```

## Three states, only one produces the notice

| state | behaviour |
|-------|-----------|
| `--executor` never set | silent (nothing to mismatch) |
| `--executor` matches actor | silent (no surprise) |
| `--executor` set and differs | notice on stderr |

The check uses the returned `Request`'s `executor` field — no extra round-trip to the substrate.

## AGENT.md clarification

Added under the request-lifecycle table:

> `--executor <m>` records **intent**, not access — anyone with substrate access may run `gate execute`. When the actor differs from the assignee the substrate captures both, and `gate execute` emits a `notice:` so the mismatch is visible at the surface that did it. See [issue #168](https://github.com/eris-ths/guild-cli/issues/168) for the design rationale.

## Test plan

- [x] 3 new tests pinning all three states (mismatch fires, matched-executor silent, no-executor silent)
- [x] 950 → 953 pass on this branch (PR #167's 8 new tests will compose at merge time)
- [x] Manual touch-feel verified: alice executing bob's assignment fires notice; bob executing his own assignment is silent

## Related

- Closes / addresses #168 with the (A) interpretation nao confirmed: "誰でもexecuteしていい。ただ工夫はしたい。"
- Sibling to PR #167 (mid-flow touch-feel: state-transition + not-found hints)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_