### PR TITLE
feat(touch-feel): gate list --state all sugar + drop error noise

### DIFF
--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -162,7 +162,16 @@ export async function reqList(
       : undefined;
   const forFilter = explicitFor ?? envActor;
 
-  let items = await c.requestUC.listByState(state);
+  // `--state all` is sugar for "every state, no filter" — parity with
+  // `gate issues list --state all`. Implemented at the interface layer
+  // because `all` is a CLI-level affordance, not a domain state;
+  // parseRequestState rejects it. The asymmetry where one list verb
+  // accepted the sugar and the other errored was the touch-feel gap
+  // surfaced in P3 dogfood.
+  let items =
+    state === 'all'
+      ? await c.requestUC.listAll()
+      : await c.requestUC.listByState(state);
   if (fromFilter !== undefined) {
     items = items.filter((r) => r.from.value === fromFilter);
   }

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -313,9 +313,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         const state = optionalOption(args, 'state');
         if (state === undefined) {
           process.stderr.write(
-            `gate list needs --state <s> (${REQUEST_STATES.join(' | ')}).\n` +
+            `gate list needs --state <s> (${REQUEST_STATES.join(' | ')} | all).\n` +
               '  For counts across every state:  gate status\n' +
-              '  For the contents of one state:  gate list --state <s>\n',
+              '  For the contents of one state:  gate list --state <s>\n' +
+              '  For every state at once:        gate list --state all\n',
           );
           return 1;
         }
@@ -396,14 +397,13 @@ export async function main(argv: readonly string[]): Promise<number> {
     }
     // The `error:` prefix gives the CLI-universal "this failed" cue;
     // prepending "DomainError:" on top leaked an internal class name
-    // into user-facing output without adding information. Keep the
-    // field suffix (`(id)`, `(from)`, etc.) — that actually names
-    // which flag was bad.
-    const msg = e instanceof DomainError
-      ? `${e.message}${e.field ? ` (${e.field})` : ''}`
-      : e instanceof Error
-        ? e.message
-        : String(e);
+    // into user-facing output without adding information. The trailing
+    // `(field)` suffix used to echo which flag was bad — but for
+    // domain-internal fields (`state`, `sequence`) it read as debug
+    // noise, and for user-typed flags the message already names the
+    // field in prose. JSON envelope retains `error.field` for
+    // programmatic consumers (P3 dogfood C/A cleanup).
+    const msg = e instanceof Error ? e.message : String(e);
     // When the caller asked for JSON output, mirror the error on
     // stderr as a JSON envelope so a tool layer doesn't have to run
     // two parsers (one on stdout JSON, one on stderr text). The

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -107,11 +107,11 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('guild', e);
       return 0;
     }
-    const msg = e instanceof DomainError
-      ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
-      : e instanceof Error
-        ? e.message
-        : String(e);
+    // Mirror gate's catch shape: `error:` prefix carries the failure
+    // signal; the `DomainError:` prefix and `(field)` trailing tag
+    // were debug noise, not touch-feel signal (P3 dogfood C/A
+    // cleanup).
+    const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -147,12 +147,12 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('agora', e);
       return 0;
     }
-    const msg =
-      e instanceof DomainError
-        ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
-        : e instanceof Error
-          ? e.message
-          : String(e);
+    // Mirror gate's catch shape: `error:` prefix carries the failure
+    // signal; the `DomainError:` prefix and `(field)` trailing tag
+    // were debug noise, not touch-feel signal (P3 dogfood C/A
+    // cleanup). DomainError still flows out as a typed object for
+    // any downstream JSON envelope.
+    const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -75,12 +75,11 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('ctx', e);
       return 0;
     }
-    const msg =
-      e instanceof DomainError
-        ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
-        : e instanceof Error
-          ? e.message
-          : String(e);
+    // Mirror gate's catch shape: `error:` prefix carries the failure
+    // signal; the `DomainError:` prefix and `(field)` trailing tag
+    // were debug noise, not touch-feel signal (P3 dogfood C/A
+    // cleanup).
+    const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -204,12 +204,11 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('devil', e);
       return 0;
     }
-    const msg =
-      e instanceof DomainError
-        ? `DomainError: ${e.message}${e.field ? ` (${e.field})` : ''}`
-        : e instanceof Error
-          ? e.message
-          : String(e);
+    // Mirror gate's catch shape: `error:` prefix carries the failure
+    // signal; the `DomainError:` prefix and `(field)` trailing tag
+    // were debug noise, not touch-feel signal (P3 dogfood C/A
+    // cleanup).
+    const msg = e instanceof Error ? e.message : String(e);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/tests/interface/touchFeelCleanup.test.ts
+++ b/tests/interface/touchFeelCleanup.test.ts
@@ -1,0 +1,192 @@
+// Touch-feel cleanups from P3 dogfood C/A:
+//
+// 1. `gate list --state all` is sugar for "every state, no filter" —
+//    parity with `gate issues list --state all`. Pre-fix this errored
+//    `Invalid state: all`, breaking muscle memory between the two
+//    sibling list verbs.
+//
+// 2. The trailing `(field)` tag on DomainError messages
+//    (`error: Invalid lense: "bogus" ... (lense)`) is dropped from the
+//    human-readable output. For domain-internal fields it read as
+//    debug noise; for user-typed fields the message already names the
+//    flag in prose. JSON envelope retains `error.field` so
+//    programmatic consumers don't lose the structured info.
+//
+// 3. The `DomainError:` class-name prefix is removed from agora /
+//    devil / ctx / guild dispatchers (gate had already dropped it);
+//    it leaked an internal class name into user-facing output.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-touchfeel-cleanup-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: []\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function setupActorAndRequests(root: string): void {
+  run(GATE, root, ['register', '--name', 'alice']);
+  run(GATE, root, ['register', '--name', 'bob']);
+  // One pending, one approved, one denied — three states for --state all.
+  run(GATE, root, ['request', '--action', 'a1', '--reason', 'r1'], { GUILD_ACTOR: 'alice' });
+  run(GATE, root, ['request', '--action', 'a2', '--reason', 'r2'], { GUILD_ACTOR: 'alice' });
+  run(GATE, root, ['request', '--action', 'a3', '--reason', 'r3'], { GUILD_ACTOR: 'alice' });
+  // Approve the second, deny the third — leaves a mix.
+  run(GATE, root, ['approve', '2026-05-05-0002'], { GUILD_ACTOR: 'alice' });
+  run(GATE, root, ['deny', '2026-05-05-0003', '--reason', 'no'], { GUILD_ACTOR: 'alice' });
+}
+
+// --- (1) `gate list --state all` sugar ---
+
+test('gate list --state all: returns requests across every state (text)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setupActorAndRequests(root);
+
+  const r = run(GATE, root, ['list', '--state', 'all'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr=${r.stderr}`);
+  // All three requests should appear, regardless of state.
+  assert.match(r.stdout, /2026-05-05-0001/);
+  assert.match(r.stdout, /2026-05-05-0002/);
+  assert.match(r.stdout, /2026-05-05-0003/);
+});
+
+test('gate list --state all: works in --format json (sugar handled at interface)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setupActorAndRequests(root);
+
+  const r = run(GATE, root, ['list', '--state', 'all', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout) as {
+    requests: Array<{ id: string; state: string }>;
+    _meta: { state: string; verb: string };
+  };
+  assert.equal(payload.requests.length, 3);
+  assert.equal(payload._meta.state, 'all');
+  // The set of states should include at least two distinct values
+  // (we created one of each: pending, approved, denied — but the
+  // deny may move 0003 to denied; just check we got mixed states).
+  const states = new Set(payload.requests.map((r) => r.state));
+  assert.ok(states.size >= 2, `expected mixed states, got: ${[...states].join(',')}`);
+});
+
+test('gate list (no --state): hint mentions --state all as an option', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+
+  const r = run(GATE, root, ['list'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /\| all\)/);
+  assert.match(r.stderr, /gate list --state all/);
+});
+
+// --- (2) Trailing (field) tag dropped from human-readable errors ---
+
+test('error message: trailing (field) tag is dropped (gate)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setupActorAndRequests(root);
+
+  const r = run(
+    GATE,
+    root,
+    ['review', '2026-05-05-0001', '--lense', 'bogus', '--verdict', 'ok', '--comment', 'x'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Invalid lense: "bogus"/);
+  // Pre-fix the error ended `... (lense)\n`. The cleanup drops it.
+  assert.equal(
+    / \(lense\)\n/.test(r.stderr),
+    false,
+    `expected no '(lense)' debug tag, got stderr:\n${r.stderr}`,
+  );
+});
+
+test('error message: trailing (field) tag is dropped (agora)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+
+  // Bad `--kind` triggers a DomainError with field set internally.
+  const r = run(
+    AGORA,
+    root,
+    ['new', '--slug', 't', '--kind', 'invalid', '--title', 'x'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  // No DomainError prefix anymore.
+  assert.equal(/^error: DomainError:/m.test(r.stderr), false);
+  // No trailing `(<field>)` debug tag.
+  assert.equal(/ \([a-z_]+\)\n/.test(r.stderr), false);
+});
+
+// --- (3) JSON envelope still carries error.field ---
+
+test('error JSON envelope: error.field preserved when dropped from text', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setupActorAndRequests(root);
+
+  const r = run(
+    GATE,
+    root,
+    [
+      'review', '2026-05-05-0001',
+      '--lense', 'bogus',
+      '--verdict', 'ok',
+      '--comment', 'x',
+      '--format', 'json',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  // Stderr has TWO lines: a JSON envelope first, then `error: ...` prose.
+  // Parse only the first line as JSON.
+  const firstLine = r.stderr.split('\n').find((l) => l.startsWith('{'));
+  assert.ok(firstLine, 'expected a JSON envelope on stderr');
+  const payload = JSON.parse(firstLine!) as {
+    ok: boolean;
+    error: { message: string; field?: string };
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error.field, 'lense');
+  assert.match(payload.error.message, /Invalid lense/);
+});


### PR DESCRIPTION
## Summary

Two cleanups from P3 dogfood pass C/A — both touch-feel finishes around the work that landed in #163 / #164 / #167 / #169.

## (1) `gate list --state all` now works as sugar

Pre-fix:

```
$ gate list --state all
error: Invalid state: all (state)
$ gate issues list --state all
# (works — already supported)
```

A user who learned the issues sugar hit a wall as soon as they reached for the same muscle memory on requests. Two-line dispatch in `reqList` (interface layer; `all` is a CLI-level affordance, not a domain state — `parseRequestState` still rejects it). The hint shown when `--state` is omitted now mentions `| all` and includes a `gate list --state all` example line.

## (2) Error noise dropped: trailing `(field)` tag and `DomainError:` prefix

The trailing `(field)` suffix on every DomainError-rendered message (`error: Invalid lense: "bogus" ... (lense)`) was design intent at one point ("name which flag was bad") but read as **redundant** for flag-aligned fields (message already names them in prose) and as **debug noise** for domain-internal fields (`(state)`, `(sequence)`).

Before / after:

```
before: error: Invalid lense: "bogus" ... (lense)
after:  error: Invalid lense: "bogus" ...

before: error: Illegal state transition: pending → completed. ... (state)
after:  error: Illegal state transition: pending → completed. ...

before: error: DomainError: kind must be one of quest, sandbox ... (kind)
after:  error: kind must be one of quest, sandbox ...
```

Dropped from human-readable output across all five dispatchers (gate / agora / devil / ctx / guild). Same dispatchers also drop the `DomainError:` class-name prefix that gate had already removed but the four passage dispatchers still leaked. Aligns the catch shape across all five binaries.

**JSON envelope unchanged**: `error.field` still surfaced in `--format json` output, so orchestrators / tool layers keep the structured info.

```
$ gate review <id> --lense bogus --format json
{"ok":false,"error":{"message":"Invalid lense: ...","field":"lense","code":"validation_error"}}
error: Invalid lense: ...
```

## Test plan

- [x] 6 new tests in `tests/interface/touchFeelCleanup.test.ts`:
  - 3 for `--state all` (text output, JSON envelope, hint mentions `--state all`)
  - 2 for trailing `(field)` tag absence (gate review bad lense, agora new bad kind)
  - 1 for JSON envelope `error.field` preservation
- [x] 962 → 968 passing
- [x] Manual touch-feel verified across `gate list --state all`, bad lense / verdict / state transition / recipient / `--by` errors, agora bad kind, JSON envelope shape

## Closes the P3 dogfood loop

This is the last touch-feel cleanup from the P3 mid-flow dogfood that started at #167. Cumulative effect (verified by re-dogfooding the cold-start → discovery → mid-flow flow): fresh-agent friction at every error / not-found / state-mismatch / list-shape touch point now answers "what next?" inline.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_