### PR TITLE
fix(security): sanitize absolute paths in CLI error messages (#153)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -157,8 +157,15 @@ the issue is the active discussion.
 
 - **Error messages may leak absolute paths**
   ([#153](https://github.com/eris-ths/guild-cli/issues/153)).
-  Errors from `safeFs` include the resolved target. Acceptable for
-  a local CLI; reconsider before any network exposure.
+  Mitigated as of v1-prep #153 (boundary sanitize): each CLI's
+  top-level `catch` rewrites occurrences of the configured
+  `contentRoot` prefix to the literal token `<content_root>`
+  before writing to stderr (`src/interface/shared/sanitizeError.ts`).
+  The structural tail (`<content_root>/requests/pending/foo.yaml`)
+  is preserved so debugging is not impaired. Paths outside
+  `contentRoot` (e.g. `/etc`, `/tmp`, accidental absolute paths in
+  user input) are *not* sanitized — boundary sanitize only collapses
+  the host-specific prefix that `safeFs` resolves into.
 - **Prototype pollution from hostile YAML**
   ([#154](https://github.com/eris-ths/guild-cli/issues/154)).
   Modern `yaml` lib returns plain objects and handles `__proto__`

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -4,6 +4,7 @@ import { renderVerbHelp } from '../shared/verbHelp.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
+import { sanitizeError } from '../shared/sanitizeError.js';
 import {
   reqCreate,
   reqList,
@@ -403,7 +404,10 @@ export async function main(argv: readonly string[]): Promise<number> {
     // noise, and for user-typed flags the message already names the
     // field in prose. JSON envelope retains `error.field` for
     // programmatic consumers (P3 dogfood C/A cleanup).
-    const msg = e instanceof Error ? e.message : String(e);
+    const rawMsg = e instanceof Error ? e.message : String(e);
+    // Strip absolute contentRoot prefix from any safeFs-style paths
+    // before they reach stderr (issue #153, Direction 1).
+    const msg = sanitizeError(rawMsg, c.config.contentRoot);
     // When the caller asked for JSON output, mirror the error on
     // stderr as a JSON envelope so a tool layer doesn't have to run
     // two parsers (one on stdout JSON, one on stderr text). The
@@ -415,7 +419,9 @@ export async function main(argv: readonly string[]): Promise<number> {
         ok: false,
         error: {
           message:
-            e instanceof DomainError ? e.message : msg,
+            e instanceof DomainError
+              ? sanitizeError(e.message, c.config.contentRoot)
+              : msg,
         },
       };
       const errObj = payload['error'] as Record<string, unknown>;

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -10,6 +10,7 @@ import { renderVerbHelp } from '../shared/verbHelp.js';
 import { notFoundMessage } from '../shared/notFoundHint.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
+import { sanitizeError } from '../shared/sanitizeError.js';
 
 const HELP = `guild — member management CLI
 
@@ -111,7 +112,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     // signal; the `DomainError:` prefix and `(field)` trailing tag
     // were debug noise, not touch-feel signal (P3 dogfood C/A
     // cleanup).
-    const msg = e instanceof Error ? e.message : String(e);
+    const rawMsg = e instanceof Error ? e.message : String(e);
+    // Strip absolute contentRoot prefix (issue #153).
+    const msg = sanitizeError(rawMsg, c.config.contentRoot);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/interface/shared/sanitizeError.ts
+++ b/src/interface/shared/sanitizeError.ts
@@ -1,0 +1,44 @@
+/**
+ * Boundary-side absolute path sanitization for CLI error messages.
+ *
+ * Errors raised from `safeFs` and other infrastructure code carry the
+ * fully-resolved absolute path (e.g.
+ * `/Users/alice/work/proj/substrate/requests/pending/foo.yaml`). For a
+ * single-user, trusted-environment CLI (see SECURITY.md threat model)
+ * this is acceptable, but it incidentally leaks home-directory and
+ * checkout-location info into logs, screenshots, and bug reports.
+ *
+ * Mitigation (issue #153, Direction 1 — "sanitize at the boundary"):
+ * each CLI's top-level `catch` rewrites occurrences of the configured
+ * `contentRoot` prefix to the literal token `<content_root>`. The
+ * structural tail (`<content_root>/requests/pending/foo.yaml`) is
+ * preserved so debugging is not impaired — only the host-specific
+ * prefix collapses.
+ *
+ * Pure function, no I/O. Lives in `interface/shared/` because it is
+ * called from every CLI's `main()` and has no domain-layer dependency.
+ */
+export function sanitizeError(msg: string, contentRoot: string): string {
+  // Defensive no-op for degenerate inputs. An empty or root-only
+  // contentRoot would replace far too aggressively if applied
+  // literally — better to leave the message untouched than to
+  // corrupt it. In practice GuildConfig.load() always returns a
+  // multi-segment absolute path.
+  if (!contentRoot || contentRoot === '/' || contentRoot.length < 2) {
+    return msg;
+  }
+
+  // Strip a single trailing slash so `/foo/bar` and `/foo/bar/`
+  // both match the same prefix in the message. We do not try to
+  // normalize internal `..` / `.` segments — GuildConfig already
+  // resolves to a canonical absolute path before we see it.
+  const root = contentRoot.endsWith('/')
+    ? contentRoot.slice(0, -1)
+    : contentRoot;
+
+  // String-level replaceAll. The path is treated as a literal — no
+  // regex, no escaping concerns. Multiple occurrences in one
+  // message (e.g. "cannot move A to B" with both inside the root)
+  // are all collapsed.
+  return msg.split(root).join('<content_root>');
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -18,6 +18,7 @@
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
+import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
 import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
@@ -152,7 +153,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     // were debug noise, not touch-feel signal (P3 dogfood C/A
     // cleanup). DomainError still flows out as a typed object for
     // any downstream JSON envelope.
-    const msg = e instanceof Error ? e.message : String(e);
+    const rawMsg = e instanceof Error ? e.message : String(e);
+    // Strip absolute contentRoot prefix (issue #153).
+    const msg = sanitizeError(rawMsg, config.contentRoot);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -17,6 +17,7 @@
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
+import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
@@ -79,7 +80,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     // signal; the `DomainError:` prefix and `(field)` trailing tag
     // were debug noise, not touch-feel signal (P3 dogfood C/A
     // cleanup).
-    const msg = e instanceof Error ? e.message : String(e);
+    const rawMsg = e instanceof Error ? e.message : String(e);
+    // Strip absolute contentRoot prefix (issue #153).
+    const msg = sanitizeError(rawMsg, config.contentRoot);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -18,6 +18,7 @@
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
+import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
@@ -208,7 +209,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     // signal; the `DomainError:` prefix and `(field)` trailing tag
     // were debug noise, not touch-feel signal (P3 dogfood C/A
     // cleanup).
-    const msg = e instanceof Error ? e.message : String(e);
+    const rawMsg = e instanceof Error ? e.message : String(e);
+    // Strip absolute contentRoot prefix (issue #153).
+    const msg = sanitizeError(rawMsg, config.contentRoot);
     process.stderr.write(`error: ${msg}\n`);
     return 1;
   }

--- a/tests/interface/sanitizeError.test.ts
+++ b/tests/interface/sanitizeError.test.ts
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeError } from '../../src/interface/shared/sanitizeError.js';
+
+test('sanitizeError: replaces contentRoot prefix with <content_root>', () => {
+  assert.equal(
+    sanitizeError(
+      'failed to write /Users/alice/proj/substrate/requests/pending/x.yaml',
+      '/Users/alice/proj/substrate',
+    ),
+    'failed to write <content_root>/requests/pending/x.yaml',
+  );
+});
+
+test('sanitizeError: handles trailing slash on contentRoot', () => {
+  assert.equal(
+    sanitizeError(
+      'cannot read /Users/alice/proj/substrate/members/foo.yaml',
+      '/Users/alice/proj/substrate/',
+    ),
+    'cannot read <content_root>/members/foo.yaml',
+  );
+});
+
+test('sanitizeError: replaces multiple occurrences in one message', () => {
+  assert.equal(
+    sanitizeError(
+      'cannot move /home/u/r/issues/a.yaml to /home/u/r/issues/closed/a.yaml',
+      '/home/u/r',
+    ),
+    'cannot move <content_root>/issues/a.yaml to <content_root>/issues/closed/a.yaml',
+  );
+});
+
+test('sanitizeError: leaves messages with no contentRoot prefix untouched', () => {
+  assert.equal(
+    sanitizeError('member not found: alice', '/Users/alice/proj/substrate'),
+    'member not found: alice',
+  );
+});
+
+test('sanitizeError: leaves paths outside contentRoot untouched', () => {
+  // A leaked /tmp or /etc path is not in scope for this issue —
+  // boundary sanitize only knows about contentRoot.
+  assert.equal(
+    sanitizeError(
+      'cannot read /etc/passwd while in /Users/alice/proj/substrate/foo',
+      '/Users/alice/proj/substrate',
+    ),
+    'cannot read /etc/passwd while in <content_root>/foo',
+  );
+});
+
+test('sanitizeError: no-op when contentRoot is empty', () => {
+  assert.equal(
+    sanitizeError('failed to write /tmp/foo', ''),
+    'failed to write /tmp/foo',
+  );
+});
+
+test('sanitizeError: no-op when contentRoot is just "/"', () => {
+  // Replacing "/" everywhere would mangle every path.
+  assert.equal(
+    sanitizeError('failed at /usr/local/bin', '/'),
+    'failed at /usr/local/bin',
+  );
+});
+
+test('sanitizeError: contentRoot appearing as substring inside a longer path is also replaced', () => {
+  // Documents current behavior: simple string replace, no
+  // path-segment awareness. Acceptable because contentRoot is
+  // always a deep absolute path in practice (GuildConfig
+  // resolves it before storing) and structural tail is preserved.
+  assert.equal(
+    sanitizeError(
+      '/Users/alice/proj/substrate-backup/foo',
+      '/Users/alice/proj/substrate',
+    ),
+    '<content_root>-backup/foo',
+  );
+});


### PR DESCRIPTION
## Summary

Closes #153 (v1-prep hardening: error messages may leak absolute paths). Implements **Direction 1** from the issue: sanitize at the boundary in each CLI's top-level `catch`. Errors from `safeFs` and friends carry full resolved paths (e.g. \`/Users/alice/work/proj/substrate/requests/pending/foo.yaml\`) which incidentally leak home-directory and checkout-location info into logs / screenshots / bug reports.

After this PR, the host-specific prefix collapses to the literal token \`<content_root>\` while the structural tail is preserved (debugging is not impaired).

## Approach (Direction 1, per issue)

Pure function in \`src/interface/shared/sanitizeError.ts\` invoked by every CLI's main() catch block. **No infrastructure-layer change** (vs Direction 2), so existing safeFs error semantics are unchanged.

## Before / after

\`\`\`
# Before
$ guild show ghost
not found: ghost
  try 'guild list' to see registered members.
# (no path leak in this case, but errors that DO carry paths look like:)
$ gate request --action "x" --reason "y" --auto-review nonexistent
error: member not found: /Users/alice/work/proj/substrate/members/nonexistent.yaml

# After
$ gate request --action "x" --reason "y" --auto-review nonexistent
error: member not found: <content_root>/members/nonexistent.yaml
\`\`\`

## Changes

| File | Change |
|------|--------|
| \`src/interface/shared/sanitizeError.ts\` (new, 44 LOC) | Pure function; degenerate-input guard (\`length<2\` no-op); trailing-slash normalize; literal string replaceAll |
| \`src/interface/{gate,guild}/index.ts\` | catch block sanitizes \`rawMsg\` via \`c.config.contentRoot\`. gate also sanitizes JSON envelope \`error.message\` (text + JSON double-protect) |
| \`src/passages/{agora,devil,ctx}/interface/index.ts\` | Same catch-block sanitize pattern, 5 CLI parity |
| \`tests/interface/sanitizeError.test.ts\` (new, 81 LOC, 8 tests) | Pure-function unit tests: prefix replacement, trailing slash variants, multiple occurrences, no-op for unrelated strings, degenerate inputs |
| \`SECURITY.md\` | "Error messages may leak absolute paths" updated to "Mitigated as of v1-prep #153"; explicitly notes paths outside contentRoot (\`/etc\`, \`/tmp\`, user-input absolute paths) are *not* sanitized |

\`\`\`
8 files changed, 158 insertions(+), 8 deletions(-)
\`\`\`

## Trade-offs / explicit non-goals

- **Paths outside contentRoot are not sanitized** (intentional). \`/etc\`, \`/tmp\`, user-input absolute paths pass through unchanged. Boundary sanitize collapses only the host-specific prefix that \`safeFs\` resolves into. Documented in SECURITY.md.
- **Normal-path \`process.stderr.write\` (e.g. register success notice) is not touched** — Issue #153 Direction 1 scope is "error messages". Other path emissions belong to a separate decision.
- **Direction 2/3 deferred** (per Issue): Direction 2 (sanitize in safeFs) keeps coupling tighter but would require touching every \`Yaml*Repository\`. Direction 3 (doc-only) does not actually mitigate. Direction 1 is the minimum-diff effective fix.

## Test plan

- [x] \`npm run build\`
- [x] New sanitizeError tests: 8/8 pass
- [x] Full suite: 950 pass / 20 fail. The 20 failures are **identical to main** (verified via fresh clone): pre-existing macOS \`/var\` vs \`/private/var\` symlink issues + JSON snapshot edge case, per CONTRIBUTING.md. **Net new failures: 0**
- [ ] CI green (Linux + Windows × Node 20/22 + package artifact)
- [ ] Touch on a content_root with intentional bad invocation to verify the tail is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)