### PR TITLE
feat(touch-feel): port did-you-mean to agora/ctx/devil + drop agora 'v0 skeleton' label

### DIFF
--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -1,6 +1,7 @@
 import { buildContainer } from '../shared/container.js';
 import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
+import { nearestCommand } from '../shared/nearestCommand.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
@@ -245,47 +246,6 @@ const KNOWN_COMMANDS = [
   'unresponded',
 ] as const;
 
-function levenshtein(a: string, b: string): number {
-  if (a === b) return 0;
-  const m = a.length;
-  const n = b.length;
-  if (m === 0) return n;
-  if (n === 0) return m;
-  let prev = Array.from({ length: n + 1 }, (_, i) => i);
-  const cur = new Array(n + 1).fill(0);
-  for (let i = 1; i <= m; i++) {
-    cur[0] = i;
-    for (let j = 1; j <= n; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      cur[j] = Math.min(
-        cur[j - 1] + 1,
-        prev[j]! + 1,
-        prev[j - 1]! + cost,
-      );
-    }
-    prev = cur.slice();
-  }
-  return prev[n]!;
-}
-
-function nearestCommand(input: string): string | null {
-  let best: string | null = null;
-  let bestDist = Infinity;
-  // Cap distance at 2 so genuinely unrelated typos ("foo") don't draw
-  // a confident-but-wrong suggestion ("did you mean: doctor?"). Two
-  // edits covers single-letter typos AND transpositions ("requst" /
-  // "rqeuest" / "approveee").
-  const max = Math.min(2, Math.floor(input.length / 2) + 1);
-  for (const cmd of KNOWN_COMMANDS) {
-    const d = levenshtein(input.toLowerCase(), cmd);
-    if (d < bestDist && d <= max) {
-      bestDist = d;
-      best = cmd;
-    }
-  }
-  return best;
-}
-
 export async function main(argv: readonly string[]): Promise<number> {
   if (isVersionFlag(argv)) {
     process.stdout.write(`guild-cli ${getPackageVersion()}\n`);
@@ -382,7 +342,7 @@ export async function main(argv: readonly string[]): Promise<number> {
       case 'unresponded':
         return await unrespondedCmd(c, args);
       default: {
-        const hint = nearestCommand(cmd);
+        const hint = nearestCommand(cmd, KNOWN_COMMANDS);
         const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';
         process.stderr.write(
           `unknown command: ${cmd}${suggest}\n` +

--- a/src/interface/shared/nearestCommand.ts
+++ b/src/interface/shared/nearestCommand.ts
@@ -1,0 +1,61 @@
+// Shared "did you mean?" helper for unknown-verb errors across all
+// passage CLIs. gate had a local implementation; agora / ctx / devil
+// silently fell back to a HELP dump when the user mistyped a verb,
+// missing the same friction-reduction. This file lifts it out so
+// every passage gets the same touch-feel.
+//
+// Design notes:
+// - Distance cap is `min(2, floor(input.length / 2) + 1)`. Two edits
+//   covers single-letter typos and transpositions ("requst", "rqeuest")
+//   without producing a confident-but-wrong suggestion on genuinely
+//   unrelated input ("foo" → "doctor"?).
+// - Comparison is case-insensitive on the input only. The known list
+//   is the canonical lowercase shape — that's what gets suggested.
+// - Returns the closest match as-is. Caller decides how to render
+//   (each CLI prefixes its own binary name: "did you mean: gate
+//   approve?" vs "agora new?").
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  const cur = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(
+        cur[j - 1] + 1,
+        prev[j]! + 1,
+        prev[j - 1]! + cost,
+      );
+    }
+    prev = cur.slice();
+  }
+  return prev[n]!;
+}
+
+export function nearestCommand(
+  input: string | undefined,
+  knownCommands: readonly string[],
+): string | null {
+  // Accept undefined so callers don't have to non-null-assert at the
+  // dispatcher: the unknown-verb branch is reachable with empty argv
+  // through some entry shapes, and "no input → no suggestion" is the
+  // safe default.
+  if (!input) return null;
+  let best: string | null = null;
+  let bestDist = Infinity;
+  const max = Math.min(2, Math.floor(input.length / 2) + 1);
+  for (const cmd of knownCommands) {
+    const d = levenshtein(input.toLowerCase(), cmd);
+    if (d < bestDist && d <= max) {
+      bestDist = d;
+      best = cmd;
+    }
+  }
+  return best;
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -6,10 +6,11 @@
 // games designed for AI-first interaction with suspend/resume as
 // a first-class primitive (per design issue #117).
 //
-// This is the v0 skeleton. Only `agora new` is implemented; `play`,
-// `move`, `suspend`, `resume`, `list`, `show` will land iteratively
-// as the prototype surfaces what shape they need (per the pull-
-// driven extraction strategy chosen at design time).
+// v1 alpha: full surface implemented (new / play / move / suspend /
+// resume / conclude / list / show / schema). The pull-driven
+// extraction strategy chosen at design time has converged; later
+// changes will be enhancements (cross-passage anchoring, ingest
+// shapes), not core verb additions.
 //
 // AI-first per principle 11: the substrate is machine-parseable
 // JSON / snake_case YAML / explicit-flag CLI; any future human-
@@ -19,6 +20,7 @@ import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
 import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
@@ -32,7 +34,7 @@ import { listAgora } from './handlers/list.js';
 import { showAgora } from './handlers/show.js';
 import { schemaCmd } from './handlers/schema.js';
 
-const HELP = `agora — game / play passage (v0 skeleton)
+const HELP = `agora — play / narrative passage (alpha, 9 verbs)
 
 Usage:
   agora new --slug <s> --kind <quest|sandbox> --title "<t>" [--by <m>]
@@ -91,7 +93,8 @@ Usage:
   agora --help                 This help.
   agora --version              Print version and exit.
 
-Passage status: v0 skeleton. Verbs landing iteratively per design issue #117.
+Passage status: alpha. Full v1 surface (new / play / move / suspend /
+resume / conclude / list / show / schema) per design issue #117.
 Substrate: shares content_root and members/ with gate; agora-specific data
 goes under <content_root>/agora/.
 
@@ -101,6 +104,14 @@ Lore upstream:
   lore/principles/04-records-outlive-writers.md       (records persist across sessions)
 `;
 
+// Mirror of the switch below for did-you-mean suggestions. Same
+// "obvious-when-broken" rule as gate's KNOWN_COMMANDS: a verb
+// forgotten here loses its typo hint, doesn't crash anything.
+const AGORA_COMMANDS = [
+  'new', 'play', 'move', 'suspend', 'resume', 'conclude',
+  'list', 'show', 'schema',
+] as const;
+
 export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
     process.stdout.write(HELP);
@@ -108,8 +119,9 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
   if (argv[0] === '--version') {
     // Single-binary version reuse — agora ships under guild-cli's
-    // package.json. No separate version surface for v0.
-    process.stdout.write('agora (under guild-cli) — snapshot/agora\n');
+    // package.json. No separate version surface; the alpha label is
+    // carried by HELP and per-passage README.
+    process.stdout.write('agora (under guild-cli) — alpha\n');
     return 0;
   }
 
@@ -139,9 +151,15 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await showAgora({ games, plays, config }, args);
       case 'schema':
         return await schemaCmd(args);
-      default:
-        process.stderr.write(`agora: unknown verb: ${cmd}\n${HELP}`);
+      default: {
+        const hint = nearestCommand(cmd, AGORA_COMMANDS);
+        const suggest = hint ? `\n  did you mean: agora ${hint}?` : '';
+        process.stderr.write(
+          `agora: unknown verb: ${cmd}${suggest}\n` +
+            `  see 'agora --help' for the full verb catalog.\n`,
+        );
         return 1;
+      }
     }
   } catch (e) {
     if (e instanceof HelpRequested) {

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -18,6 +18,7 @@ import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
@@ -47,6 +48,12 @@ Lore upstream:
   lore/principles/04-records-outlive-writers.md
 `;
 
+// Mirror of the switch below for did-you-mean suggestions. Phase 1
+// has only `record`; phase 2 will add fork / supersede / show /
+// list / chain / status. A new verb forgotten here loses its typo
+// hint, doesn't crash anything.
+const CTX_COMMANDS = ['record'] as const;
+
 export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
     process.stdout.write(HELP);
@@ -67,9 +74,19 @@ export async function main(argv: readonly string[]): Promise<number> {
     switch (cmd) {
       case 'record':
         return await recordCtx({ uc, config }, args);
-      default:
-        process.stderr.write(`ctx: unknown verb: ${cmd}\n${HELP}`);
+      default: {
+        // Phase 2 will add fork / supersede / show / list / chain /
+        // status; the catalog grows as those land. For now, `record`
+        // is the only valid verb — typos like `recor` should still
+        // get suggested rather than dumping the full HELP.
+        const hint = nearestCommand(cmd, CTX_COMMANDS);
+        const suggest = hint ? `\n  did you mean: ctx ${hint}?` : '';
+        process.stderr.write(
+          `ctx: unknown verb: ${cmd}${suggest}\n` +
+            `  see 'ctx --help' for the full verb catalog (phase 1: record only).\n`,
+        );
         return 1;
+      }
     }
   } catch (e) {
     if (e instanceof HelpRequested) {

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -19,6 +19,7 @@ import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
@@ -152,6 +153,14 @@ Design issue: https://github.com/eris-ths/guild-cli/issues/126
 Sister project: https://github.com/eris-ths/supply-chain-guard
 `;
 
+// Mirror of the switch below for did-you-mean suggestions. A verb
+// forgotten here loses its typo hint, doesn't crash anything.
+const DEVIL_COMMANDS = [
+  'open', 'entry', 'list', 'show', 'dismiss', 'resolve',
+  'suspend', 'resume', 'ingest', 'conclude', 'schema',
+] as const;
+
+
 export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
     process.stdout.write(HELP);
@@ -193,12 +202,16 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await ingestSource({ reviews, lenses, personas, config }, args);
       case 'conclude':
         return await concludeReview({ reviews, lenses, config }, args);
-      default:
+      default: {
+        const hint = nearestCommand(cmd, DEVIL_COMMANDS);
+        const suggest = hint ? `\n  did you mean: devil ${hint}?` : '';
         process.stderr.write(
-          `devil: unknown verb: ${cmd}\n` +
-            `(v1 surface from #126: open / entry / list / show / dismiss / resolve / suspend / resume / ingest / conclude / schema)\n`,
+          `devil: unknown verb: ${cmd}${suggest}\n` +
+            `  v1 surface (#126): open / entry / list / show / dismiss / resolve / ` +
+            `suspend / resume / ingest / conclude / schema.\n`,
         );
         return 1;
+      }
     }
   } catch (e) {
     if (e instanceof HelpRequested) {

--- a/tests/interface/nearestCommand.test.ts
+++ b/tests/interface/nearestCommand.test.ts
@@ -1,0 +1,143 @@
+// Did-you-mean port: agora / ctx / devil now use the same shared
+// `nearestCommand` helper that gate had locally. Pre-fix, only gate
+// suggested a near match; the other passages dumped HELP without a
+// hint, breaking the cross-passage discoverability parity.
+//
+// This file pins the unit shape of `nearestCommand` (distance cap,
+// case-insensitive, gracefully nullable input) and the e2e behaviour
+// for each passage's unknown-verb branch.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { nearestCommand } from '../../src/interface/shared/nearestCommand.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+const CTX = resolve(here, '../../../bin/ctx.mjs');
+const DEVIL = resolve(here, '../../../bin/devil.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-nearest-cmd-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: []\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'alice' },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// --- unit ---
+
+test('nearestCommand: returns the closest within distance cap', () => {
+  const known = ['approve', 'deny', 'execute', 'complete'];
+  assert.equal(nearestCommand('aprove', known), 'approve');
+  assert.equal(nearestCommand('exectue', known), 'execute');
+  assert.equal(nearestCommand('complte', known), 'complete');
+});
+
+test('nearestCommand: case-insensitive on input', () => {
+  assert.equal(nearestCommand('APROVE', ['approve']), 'approve');
+});
+
+test('nearestCommand: refuses to suggest when distance exceeds cap', () => {
+  // "foo" is 3 edits from any common verb — too far. Cap is
+  // min(2, floor(len/2)+1) = min(2, 2) = 2 for "foo", but no real
+  // verb is within 2 edits of "foo".
+  assert.equal(nearestCommand('foo', ['approve', 'deny', 'execute']), null);
+});
+
+test('nearestCommand: short input gets a tighter cap', () => {
+  // For input "a" (length 1), cap = min(2, floor(1/2)+1) = min(2, 1) = 1.
+  // "approve" is 6 edits away — too far. Should refuse rather than
+  // suggest a wildly different verb.
+  assert.equal(nearestCommand('a', ['approve', 'deny']), null);
+});
+
+test('nearestCommand: undefined input returns null (safe default)', () => {
+  // When the dispatcher has no cmd to suggest against, "no suggestion"
+  // is the right answer — not a crash.
+  assert.equal(nearestCommand(undefined, ['approve']), null);
+});
+
+test('nearestCommand: empty string returns null', () => {
+  assert.equal(nearestCommand('', ['approve']), null);
+});
+
+// --- e2e: each passage's unknown-verb branch suggests its own catalog ---
+
+test('agora <typo>: suggests agora-prefixed verb', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(AGORA, root, ['nuw']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown verb: nuw/);
+  assert.match(r.stderr, /did you mean: agora new\?/);
+});
+
+test('agora <unrelated>: refuses to suggest when nothing close', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(AGORA, root, ['absolutely-not-a-verb']);
+  assert.equal(r.status, 1);
+  assert.equal(/did you mean/.test(r.stderr), false);
+  assert.match(r.stderr, /agora --help/);
+});
+
+test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(CTX, root, ['recor']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown verb: recor/);
+  assert.match(r.stderr, /did you mean: ctx record\?/);
+  // Phase-1 callout — flag the constraint at the surface that hit it,
+  // since fork / supersede / show / list / chain / status are not yet
+  // implemented and a typo for any of those would refuse to suggest.
+  assert.match(r.stderr, /phase 1: record only/);
+});
+
+test('devil <typo>: suggests devil-prefixed verb', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(DEVIL, root, ['oepn']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown verb: oepn/);
+  assert.match(r.stderr, /did you mean: devil open\?/);
+});
+
+test('agora --help: no longer says "v0 skeleton"', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(AGORA, root, ['--help']);
+  assert.equal(r.status, 0);
+  assert.equal(/v0 skeleton/.test(r.stdout), false, 'stale label removed');
+  assert.match(r.stdout, /alpha/);
+});

--- a/tests/passages/devil/cliBoot.test.ts
+++ b/tests/passages/devil/cliBoot.test.ts
@@ -118,7 +118,13 @@ test('devil <unknown-verb> surfaces v1 surface error naming the catalog', (t) =>
   const r = runDevil(root, ['nonsense']);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /unknown verb: nonsense/);
-  assert.match(r.stderr, /v1 surface from #126/);
+  // The catalog hint is preserved across the did-you-mean refactor;
+  // exact prose is `v1 surface (#126): open / entry / ...`. Pin only
+  // the parts a fresh agent reading the error would actually scan
+  // (the issue ref + a couple of verbs from the catalog).
+  assert.match(r.stderr, /v1 surface .*#126/);
+  assert.match(r.stderr, /open/);
+  assert.match(r.stderr, /conclude/);
 });
 
 test('devil schema rejects unknown flag', (t) => {


### PR DESCRIPTION
## Summary

Two passage-parity finishes from the P3 dogfood pass B (cross-passage / discoverability).

### (1) Did-you-mean port

`gate` had a local levenshtein + `nearestCommand` that suggested the closest verb on a typo. `agora` / `ctx` / `devil` dumped HELP without a hint — the same friction-reduction missing in three places.

Lifted the helper to **`src/interface/shared/nearestCommand.ts`**. All four CLIs now suggest from their own catalog:

```
$ agora nuw
agora: unknown verb: nuw
  did you mean: agora new?
  see 'agora --help' for the full verb catalog.

$ ctx recor
ctx: unknown verb: recor
  did you mean: ctx record?
  see 'ctx --help' for the full verb catalog (phase 1: record only).

$ devil oepn
devil: unknown verb: oepn
  did you mean: devil open?
  v1 surface (#126): open / entry / list / show / dismiss / resolve / suspend / resume / ingest / conclude / schema.
```

Each catalog is an `as const` array next to the dispatcher's switch — same **obvious-when-broken** rule gate already used: a new verb forgotten in the array silently loses its typo hint, doesn't crash anything. ctx phase-1 catalog has only `record`; the unknown-verb prose flags the constraint at the surface that hit it (`phase 1: record only`).

The helper accepts `string | undefined` so dispatchers don't have to non-null-assert at the call site.

### (2) Drop stale 'v0 skeleton' label from agora

```
before: agora — game / play passage (v0 skeleton)
after:  agora — play / narrative passage (alpha, 9 verbs)
```

PR #128's post-merge cleanup pass was supposed to remove these, but `agora/interface/index.ts` had **three holdouts** (HELP header, source comment line 9, "Passage status" footer line 93) plus a `--version` string of `'snapshot/agora'`. All four updated to the alpha framing already used by devil's HELP and the per-passage README.

## Test plan

- [x] **11 new tests** in `tests/interface/nearestCommand.test.ts`:
  - 6 unit (distance cap, case-insensitivity, undefined / empty input, short input gets tighter cap, unrelated input refuses)
  - 4 e2e per-passage (agora typo / agora unrelated / ctx typo / devil typo)
  - 1 e2e for the agora 'v0 skeleton' label removal
- [x] 1 regression-fix in `tests/passages/devil/cliBoot.test.ts`: the unknown-verb prose moved from `v1 surface from #126` → `v1 surface (#126)`. Test pinned to a looser regex that survives the prose tweak.
- [x] 968 → 979 passing (+11 new, 0 net regressions)
- [x] Manual touch-feel verified across all four CLIs

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_