### PR TITLE
feat(touch-feel): unify --version across passages + agora new next-step ordering

### DIFF
--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -95,10 +95,13 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
           where_written,
           config_file: deps.config.configFile,
           suggested_next: {
-            verb: 'list',
-            args: {},
+            verb: 'play',
+            args: { slug: game.slug },
             reason:
-              'New game definition saved. `agora list` shows every game and play in the content root; `agora play --slug <slug>` starts a session against this definition.',
+              'New game definition saved. `agora play --slug ' +
+              `${game.slug}\` starts a session against this ` +
+              'definition; `agora list` shows every game and play if ' +
+              'you want to confirm before playing.',
           },
         },
         null,
@@ -108,7 +111,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   } else {
     process.stdout.write(
       `✓ created game: ${game.slug} [${game.kind}] — ${game.title}\n` +
-        `  next: agora list  (or agora play --slug ${game.slug} to start a session)\n`,
+        `  next: agora play --slug ${game.slug}  (or agora list to see all games)\n`,
     );
   }
   // Stderr notice mirrors gate register's path-disclosure line shape

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -21,6 +21,7 @@ import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
+import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
 import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
@@ -117,11 +118,14 @@ export async function main(argv: readonly string[]): Promise<number> {
     process.stdout.write(HELP);
     return 0;
   }
-  if (argv[0] === '--version') {
+  if (isVersionFlag(argv)) {
     // Single-binary version reuse — agora ships under guild-cli's
-    // package.json. No separate version surface; the alpha label is
-    // carried by HELP and per-passage README.
-    process.stdout.write('agora (under guild-cli) — alpha\n');
+    // package.json, so the version number is shared. The status
+    // phrase ("alpha, 9 verbs") is per-passage and rides alongside
+    // so a reader sees both lineage and surface maturity in one line.
+    process.stdout.write(
+      `agora (under guild-cli ${getPackageVersion()}) — alpha, 9 verbs\n`,
+    );
     return 0;
   }
 

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -19,6 +19,7 @@ import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
+import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
@@ -59,8 +60,10 @@ export async function main(argv: readonly string[]): Promise<number> {
     process.stdout.write(HELP);
     return 0;
   }
-  if (argv[0] === '--version') {
-    process.stdout.write('ctx (under guild-cli) — phase 1 / record only\n');
+  if (isVersionFlag(argv)) {
+    process.stdout.write(
+      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record only)\n`,
+    );
     return 0;
   }
 

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -20,6 +20,7 @@ import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
+import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
@@ -166,8 +167,10 @@ export async function main(argv: readonly string[]): Promise<number> {
     process.stdout.write(HELP);
     return 0;
   }
-  if (argv[0] === '--version') {
-    process.stdout.write('devil-review (under guild-cli) — alpha (v1 complete, #126)\n');
+  if (isVersionFlag(argv)) {
+    process.stdout.write(
+      `devil-review (under guild-cli ${getPackageVersion()}) — alpha (v1 complete, #126)\n`,
+    );
     return 0;
   }
 

--- a/tests/interface/passageVersion.test.ts
+++ b/tests/interface/passageVersion.test.ts
@@ -1,0 +1,79 @@
+// E2E version surface across all four CLIs (gate / agora / devil / ctx).
+//
+// Pre-fix, the three passage binaries hardcoded their version strings
+// (no package version, no `-v` flag). gate alone used the shared
+// `getPackageVersion` + `isVersionFlag` helpers. The three passages now
+// share the helper, so:
+//   - every binary accepts both `--version` and `-v`
+//   - the package version flows through, not a stale literal
+//   - the per-passage status phrase ("alpha, 9 verbs", "v1 complete")
+//     stays alongside so a reader sees lineage and surface maturity at
+//     once
+//
+// This file pins the e2e shape on each binary so a future rename of
+// the version helpers can't silently regress one passage.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+const DEVIL = resolve(here, '../../../bin/devil.mjs');
+const CTX = resolve(here, '../../../bin/ctx.mjs');
+const GUILD = resolve(here, '../../../bin/guild.mjs');
+
+function run(bin: string, args: string[]): string {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+  return r.stdout;
+}
+
+const SEMVER = /\d+\.\d+\.\d+/;
+
+test('gate --version: prints package version', () => {
+  assert.match(run(GATE, ['--version']), new RegExp(`^guild-cli ${SEMVER.source}`));
+});
+
+test('gate -v: same as --version', () => {
+  assert.equal(run(GATE, ['-v']), run(GATE, ['--version']));
+});
+
+test('guild --version: prints package version', () => {
+  assert.match(run(GUILD, ['--version']), new RegExp(`^guild-cli ${SEMVER.source}`));
+});
+
+test('agora --version: includes package version + alpha status', () => {
+  const out = run(AGORA, ['--version']);
+  assert.match(out, new RegExp(`agora \\(under guild-cli ${SEMVER.source}\\)`));
+  assert.match(out, /alpha/);
+});
+
+test('agora -v: same as --version', () => {
+  assert.equal(run(AGORA, ['-v']), run(AGORA, ['--version']));
+});
+
+test('devil --version: includes package version + v1 status', () => {
+  const out = run(DEVIL, ['--version']);
+  assert.match(out, new RegExp(`devil-review \\(under guild-cli ${SEMVER.source}\\)`));
+  assert.match(out, /v1 complete/);
+});
+
+test('devil -v: same as --version', () => {
+  assert.equal(run(DEVIL, ['-v']), run(DEVIL, ['--version']));
+});
+
+test('ctx --version: includes package version + phase 1 status', () => {
+  const out = run(CTX, ['--version']);
+  assert.match(out, new RegExp(`ctx \\(under guild-cli ${SEMVER.source}\\)`));
+  assert.match(out, /alpha phase 1/);
+});
+
+test('ctx -v: same as --version', () => {
+  assert.equal(run(CTX, ['-v']), run(CTX, ['--version']));
+});

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -127,7 +127,12 @@ test('agora new: JSON mode emits snake_case envelope with where_written + config
   );
   assert.equal(payload.config_file, join(root, 'guild.config.yaml'));
   assert.equal(typeof payload.suggested_next, 'object');
-  assert.equal(payload.suggested_next.verb, 'list');
+  // Post-dogfood: the natural next-step after `agora new` is `agora
+  // play --slug <slug>`. Previously this emitted `verb: 'list'` (a
+  // safer no-arg call), but text mode and JSON now agree: play first,
+  // list as the alternative path named in `reason`.
+  assert.equal(payload.suggested_next.verb, 'play');
+  assert.equal(payload.suggested_next.args.slug, 'sandbox-one');
   // No camelCase keys in the envelope (principle 11 + PR #109).
   for (const key of Object.keys(payload)) {
     assert.ok(!/[A-Z]/.test(key), `envelope key "${key}" must be snake_case`);

--- a/tests/passages/agora/suggestedNextContract.test.ts
+++ b/tests/passages/agora/suggestedNextContract.test.ts
@@ -359,9 +359,12 @@ test('agora suspend / resume: suggested_next.args does NOT carry by', (t) => {
   assert.equal(res.suggested_next.args.by, undefined);
 });
 
-test('agora new: suggested_next.args is empty (no policy, no recommendations)', (t) => {
-  // For new, there's no play_id yet to recommend. args is just {}.
-  // Pin to confirm we don't accidentally start adding args here either.
+test('agora new: suggested_next pins the just-created slug for the next play', (t) => {
+  // Post-dogfood update: `agora new` now suggests `agora play --slug
+  // <just-created>` as the next call (text and JSON agree). The args
+  // carry the slug so an orchestrator can dispatch the next call
+  // without parsing the success message. play_id and other downstream
+  // identifiers still don't exist yet — only the slug is in scope.
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   const r = runAgora(
@@ -370,5 +373,6 @@ test('agora new: suggested_next.args is empty (no policy, no recommendations)', 
     { GUILD_ACTOR: 'alice' },
   );
   const payload = JSON.parse(r.stdout);
-  assert.deepEqual(payload.suggested_next.args, {});
+  assert.equal(payload.suggested_next.verb, 'play');
+  assert.deepEqual(payload.suggested_next.args, { slug: 'g' });
 });


### PR DESCRIPTION
## Summary

Three small finishes from the post-P3 dogfood pass — all caught by re-touching the surface with fresh-agent eyes after the campaign landed.

### (1) `--version` flow unified across all passages

```
before:                                          after:
─────────────────────────────────────────        ─────────────────────────────────────────
gate --version    guild-cli 0.4.0                gate --version    guild-cli 0.4.0
agora --version   agora (under guild-cli)        agora --version   agora (under guild-cli 0.4.0) — alpha, 9 verbs
                  — alpha                        agora -v          (same as --version)
agora -v          (unknown verb)                  
devil --version   devil-review (...) — alpha     devil --version   devil-review (under guild-cli 0.4.0) — alpha (v1 complete, #126)
                  (v1 complete, #126)            devil -v          (same as --version)
ctx --version     ctx (...) — phase 1 /          ctx --version     ctx (under guild-cli 0.4.0) — alpha phase 1 (record only)
                  record only                    ctx -v            (same as --version)
```

agora / devil / ctx hardcoded their version strings — no package number, no `-v` shorthand. gate alone used `getPackageVersion()` / `isVersionFlag()`. Three passages now share the helpers, gaining both the version number and the `-v` alias.

Per-passage status phrase preserved alongside the version so a reader sees both lineage and surface maturity in one line.

### (2) `agora new` next-step demoted `agora play` to the parenthetical

```
before: next: agora list  (or agora play --slug <s> to start a session)
after:  next: agora play --slug <s>  (or agora list to see all games)
```

After creating a game, the natural follow-up is to **play** it — `list` is for "what's around" discovery, but the user just made the thing, so they already know what's around. Reordered so the primary suggestion is what the user almost certainly wants.

JSON envelope follows: `suggested_next.verb` was `'list'`, now `'play'` with `args: { slug: <just-created> }`. Text and JSON now agree; an orchestrator dispatching `suggested_next` directly lands on the right next call without re-parsing the success line.

## Test plan

- [x] 9 new e2e tests in `tests/interface/passageVersion.test.ts`: pin every binary's `--version` + `-v` output shape (gate / agora / devil / ctx / guild)
- [x] 1 existing test updated (`suggestedNextContract.test.ts`): the agora new contract pin now asserts `verb: 'play'` with the slug in args
- [x] 1 existing test updated (`new.test.ts`): JSON envelope shape matches the reordered suggested_next
- [x] 987 → 996 passing
- [x] Manual: all three passage `--version` outputs include the package version; `-v` alias works; `agora new` next-line plays first

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_