### PR TITLE
fix(security): close #153 sanitizer hole in agora new collision error

### DIFF
--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -2,6 +2,7 @@ import { Game, GameSlugCollision } from '../../domain/Game.js';
 import { GameRepository } from '../../application/GameRepository.js';
 import { ParsedArgs, optionalOption, requireOption, rejectUnknownFlags } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { sanitizeError } from '../../../../interface/shared/sanitizeError.js';
 
 const NEW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'slug',
@@ -75,9 +76,15 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
     await deps.repo.saveNew(game);
   } catch (e) {
     if (e instanceof GameSlugCollision) {
+      // The collision error returns 1 from this handler instead of
+      // throwing; that bypasses the binary's main() catch where #153's
+      // sanitizer normally runs. Apply sanitizeError directly here so
+      // `<content_root>/...` collapses the host-specific prefix in this
+      // path, matching the contract for all other error-path emissions.
+      const at = sanitizeError(where_written, deps.config.contentRoot);
       process.stderr.write(
         `error: Game slug "${game.slug}" already exists.\n` +
-          `  At: ${where_written}\n` +
+          `  At: ${at}\n` +
           `  Pick a different --slug, or edit the existing file directly.\n`,
       );
       return 1;

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -203,6 +203,39 @@ test('agora new: slug collision fails closed (no overwrite)', (t) => {
   assert.equal(after, original);
 });
 
+test('agora new: collision error sanitizes the absolute path (#153 follow-up)', (t) => {
+  // The collision branch returns 1 from the handler instead of throwing,
+  // bypassing main()'s catch where #153's sanitizer normally runs. Pin
+  // that the `At:` line collapses contentRoot to `<content_root>` so
+  // home-directory and checkout-location info doesn't leak through this
+  // alternate egress path. Mirrors the contract sanitizeError holds for
+  // every other error-path emission across the four CLIs.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'leak', '--kind', 'sandbox', '--title', 'first'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const second = runAgora(
+    root,
+    ['new', '--slug', 'leak', '--kind', 'sandbox', '--title', 'second'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(second.status, 0);
+  assert.match(second.stderr, /already exists/);
+  assert.match(
+    second.stderr,
+    /At: <content_root>\/agora\/games\/leak\.yaml/,
+    'collision error should report the relative <content_root> form',
+  );
+  assert.equal(
+    second.stderr.includes(root),
+    false,
+    `collision error must not leak the absolute root path (${root})`,
+  );
+});
+
 test('agora new: invalid slug rejected at domain boundary', (t) => {
   // Uppercase, leading digit, special chars — same class of typo
   // gate's member registration would reject. The boundary fails

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -224,9 +224,15 @@ test('agora new: collision error sanitizes the absolute path (#153 follow-up)', 
   );
   assert.notEqual(second.status, 0);
   assert.match(second.stderr, /already exists/);
+  // sanitizeError replaces only the host-specific contentRoot prefix;
+  // the suffix is whatever path.join produced, so build the expected
+  // string with join() too to keep the assertion cross-platform
+  // (Windows backslash vs POSIX forward slash). Mirrors the
+  // escapeRegex(join(...)) pattern the notice-line tests already use.
+  const expectedAt = `At: ${join('<content_root>', 'agora', 'games', 'leak.yaml')}`;
   assert.match(
     second.stderr,
-    /At: <content_root>\/agora\/games\/leak\.yaml/,
+    new RegExp(escapeRegex(expectedAt)),
     'collision error should report the relative <content_root> form',
   );
   assert.equal(


### PR DESCRIPTION
## Summary

#153 closed the absolute-path leak from CLI errors by sanitizing in each binary's main() catch. Dogfood touch surfaced one remaining hole: the \`agora new\` collision branch returns 1 directly from the handler instead of throwing, so its \`At: <path>\` line bypasses the sanitizer.

## Before / after

\`\`\`
# Before (on current main)
$ agora new --slug test-game --kind sandbox --title "second"
error: Game slug "test-game" already exists.
  At: /private/tmp/bug-b-test/agora/games/test-game.yaml   ← absolute path leak
  Pick a different --slug, or edit the existing file directly.

# After
$ agora new --slug test-game --kind sandbox --title "second"
error: Game slug "test-game" already exists.
  At: <content_root>/agora/games/test-game.yaml             ← collapsed
  Pick a different --slug, or edit the existing file directly.
\`\`\`

## Why this PR (and not a rework of #153)

#153 chose Direction 1 ("sanitize at the boundary"), which is the right shape *if* the boundary is the only egress point. The \`agora new\` collision branch is the only handler-level direct \`process.stderr.write\` that includes a content-root path on an error path — verified via grep across all 5 CLIs. Happy-path notices (\`notice: wrote /abs/path\`) are explicitly out of #153 scope per the issue, and unchanged here.

A wider refactor (have all handlers throw, sanitize only in main) would be cleaner architecturally but would touch 9+ handlers for one observed leak. This PR closes the actual hole with a 6-line fix.

## Changes

| File | Change |
|------|--------|
| \`src/passages/agora/interface/handlers/new.ts\` | Import \`sanitizeError\`, apply to \`where_written\` in the GameSlugCollision branch (+ inline rationale comment) |
| \`tests/passages/agora/new.test.ts\` | New test pins (a) \`<content_root>/agora/games/<slug>.yaml\` form appears, (b) the absolute root never appears in stderr |

\`\`\`
2 files changed, 47 insertions(+), 2 deletions(-)
\`\`\`

## Test plan

- [x] \`npm run build\`
- [x] New collision-sanitize test passes
- [x] Full suite: 980 pass / 17 fail. Fail count identical to main (945 pass / 17 fail on main; +35 on this branch = nao's #173/#174 + my +1). **Net new failures: 0**
- [ ] CI green (Linux + Windows × Node 20/22 + package artifact)
- [ ] Manual: trigger collision in a fresh content_root and confirm \`<content_root>\` form

## Out of scope (consistent with #153 boundary)

- Happy-path \`notice: wrote /abs/path\` lines (explicit non-goal of #153)
- A general "all handlers must throw, never write to stderr" refactor (separate design issue if pursued)

🤖 Generated with [Claude Code](https://claude.com/claude-code)