### PR TITLE
feat(agora): default new flags + drop move's repeating next-hint

### DIFF
--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -113,10 +113,18 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
       ) + '\n',
     );
   } else {
+    // Text-mode: success line only. The `next:` hint that used to
+    // print here was redundant (agora play / resume already named
+    // move + suspend as the branches) and broke immersion when a
+    // user wrote three or four moves in a row — the same hint
+    // re-asserting itself on every flow-shaped verb. Per the
+    // post-#174 dogfood reviewer observation: "move 003 で書いたら、
+    // その応答にもまさにそのhintが出てきて、再帰的に証明された."
+    // suggested_next stays in the JSON envelope above for
+    // orchestrators; humans in flow get the success line and
+    // nothing else.
     process.stdout.write(
-      `✓ move ${move.id} appended to ${play.id} on game=${play.game} by ${by}\n` +
-        `  next: agora move ${play.id} --by ${by} "<text>"  (continue)\n` +
-        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (leave a cliff)\n`,
+      `✓ move ${move.id} appended to ${play.id} on game=${play.game} by ${by}\n`,
     );
   }
   return 0;

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -35,8 +35,15 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   rejectUnknownFlags(args, NEW_KNOWN_FLAGS, 'new');
 
   const slug = requireOption(args, 'slug', '<slug>');
-  const kind = requireOption(args, 'kind', '<quest|sandbox>');
-  const title = requireOption(args, 'title', '"..."');
+  // `--kind` and `--title` defaulted post-dogfood (#173 reviewer
+  // observation): four required flags at the entry verb fight agora's
+  // "exploration" character — a fresh agent with "ちょっと遊んでみるか"
+  // tension hits friction at the door. Defaults pick the playful
+  // shape (sandbox over quest) and reuse the slug as title so
+  // `agora new --slug today` is a one-flag entry. Full-spec form
+  // still works for callers who want to be explicit.
+  const kind = optionalOption(args, 'kind') ?? 'sandbox';
+  const title = optionalOption(args, 'title') ?? slug;
   const description = optionalOption(args, 'description');
   const by = optionalOption(args, 'by', 'GUILD_ACTOR');
   if (!by) {

--- a/tests/passages/agora/flowTouchFeel.test.ts
+++ b/tests/passages/agora/flowTouchFeel.test.ts
@@ -1,0 +1,167 @@
+// Two touch-feel finishes from the post-#174 dogfood reviewer pass:
+//
+// (A) `agora new` defaults --kind to sandbox and --title to slug.
+//     Pre-fix, four flags were required at the entry verb — friction
+//     for a fresh agent in playful "ちょっと遊んでみるか" mode. Defaults
+//     reduce the entry shape to one flag (`agora new --slug today`)
+//     while preserving the full-spec form for callers who want it.
+//
+// (B) `agora move` text mode no longer prints the `next:` hint.
+//     Reviewer observation: "move 003 で書いたら、その応答にもまさに
+//     そのhintが出てきて、再帰的に証明された." The hint that helps
+//     gate's lifecycle verbs (each step is a deliberation point)
+//     hurts agora's flow-shaped move (the hint re-asserts itself
+//     every move and breaks immersion). suggested_next stays in the
+//     JSON envelope so orchestrators don't lose the contract.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-agora-flow-touchfeel-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: []\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function setup(root: string): void {
+  run(GATE, root, ['register', '--name', 'alice']);
+}
+
+// --- (A) agora new defaults ---
+
+test('agora new: --slug only succeeds, kind defaults to sandbox, title defaults to slug', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  const r = run(AGORA, root, ['new', '--slug', 'today'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`);
+  assert.match(r.stdout, /✓ created game: today \[sandbox\] — today/);
+});
+
+test('agora new: explicit --kind quest still works', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  const r = run(
+    AGORA,
+    root,
+    ['new', '--slug', 'campaign', '--kind', 'quest'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[quest\]/);
+  // Title still defaults to slug when omitted.
+  assert.match(r.stdout, /— campaign/);
+});
+
+test('agora new: explicit --title overrides the slug-as-title default', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  const r = run(
+    AGORA,
+    root,
+    ['new', '--slug', 'today', '--title', 'an explicit title'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /— an explicit title/);
+});
+
+test('agora new: invalid --kind still rejected (defaults do not bypass validation)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  const r = run(
+    AGORA,
+    root,
+    ['new', '--slug', 't', '--kind', 'invalid'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /kind must be one of/);
+});
+
+// --- (B) agora move text mode drops the next: hint ---
+
+test('agora move (text): success line only, no next: hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  run(AGORA, root, ['new', '--slug', 'flow'], { GUILD_ACTOR: 'alice' });
+  run(AGORA, root, ['play', '--slug', 'flow'], { GUILD_ACTOR: 'alice' });
+  // Find the play id (single play under games/flow/).
+  const playId = readdirSync(join(root, 'agora', 'plays', 'flow'))[0]!.replace(/\.yaml$/, '');
+
+  const r = run(
+    AGORA,
+    root,
+    ['move', playId, '--text', 'first move'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ move 001 appended to/);
+  // The pre-fix hint lines are gone — pin both branches that used to
+  // appear so a reintroduction would surface immediately.
+  assert.equal(/next: agora move/.test(r.stdout), false, 'no next: move hint');
+  assert.equal(
+    /or agora suspend/.test(r.stdout),
+    false,
+    'no or-suspend hint',
+  );
+});
+
+test('agora move (json): suggested_next stays for orchestrators', (t) => {
+  // The text-mode hint is gone; the JSON envelope is unchanged so any
+  // tool layer dispatching on `suggested_next` keeps working.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  setup(root);
+  run(AGORA, root, ['new', '--slug', 'flow2'], { GUILD_ACTOR: 'alice' });
+  run(AGORA, root, ['play', '--slug', 'flow2'], { GUILD_ACTOR: 'alice' });
+  const playId = readdirSync(join(root, 'agora', 'plays', 'flow2'))[0]!.replace(/\.yaml$/, '');
+
+  const r = run(
+    AGORA,
+    root,
+    ['move', playId, '--text', 'first move', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout) as {
+    suggested_next: { verb: string; args: { play_id: string } };
+  };
+  assert.equal(payload.suggested_next.verb, 'move');
+  assert.equal(payload.suggested_next.args.play_id, playId);
+});


### PR DESCRIPTION
## Summary

Two finishes from a post-#174 dogfood reviewer pass — both diagnoses sharper than mine, both about agora's "exploration / flow" character clashing with affordances inherited from gate's lifecycle pattern.

### (1) `agora new` defaults `--kind` to sandbox and `--title` to slug

Pre-fix:

```
$ agora new
error: Missing --slug <slug>.
$ agora new --slug today
error: Missing --kind <quest|sandbox>.
$ agora new --slug today --kind sandbox
error: Missing --title "...".
```

Three rounds of friction at the entry verb. Reviewer (a fellow AI agent):

> 私はAIだからコピペできるしretryも痛くない。でも人間が「ちょっと遊んでみるか」のテンションで来た時、これは入口で躓く。**起動コストとagora的な没入の相性が悪い。** 探索したい時に「タイトルを決めろ」と言われる感じ。

Defaults pick the playful shape (`sandbox` over `quest`) and reuse the slug as title:

```
$ agora new --slug today
✓ created game: today [sandbox] — today
```

Full-spec form unchanged: `--kind` / `--title` still accepted and override the defaults. Domain validation untouched: `--kind invalid` still rejects.

### (2) `agora move` text mode no longer prints the `next:` hint

The reviewer's recursive proof:

> moveを打つたびに「次はmove or suspend」が応答に出る。AIには有用、でも人間が書く流れに乗ってる時、視界に毎回チラつく。**没入を守る設計のはずが、UI出力が没入を邪魔する瞬間がある。矛盾してる。** **move 003で書いたら、その応答にもまさにそのhintが出てきて、再帰的に証明された。**

The same `next:` line that helps gate's lifecycle verbs (each step is a deliberation point) hurts agora `move` (every move is flow). Worse, the hint that the reviewer was complaining about — the move they wrote to capture the observation — re-printed itself on move 003.

```
before:
  ✓ move 003 appended to 2026-05-05-001 on game=today by claude
    next: agora move 2026-05-05-001 --by claude "<text>"  (continue)
          or agora suspend 2026-05-05-001 --cliff "..." --invitation "..."  (leave a cliff)

after:
  ✓ move 003 appended to 2026-05-05-001 on game=today by claude
```

Orientation cost was already paid: `agora play` and `agora resume` both name move + suspend in their success lines. After that, move is flow. JSON envelope's `suggested_next` stays — orchestrators dispatching on it keep working.

## Test plan

- [x] 6 new tests in `tests/passages/agora/flowTouchFeel.test.ts`:
  - 4 for the new defaults (slug-only succeeds; explicit `--kind quest`; explicit `--title` overrides; invalid `--kind` still rejected)
  - 2 for move (text drops next-hint; JSON envelope keeps `suggested_next`)
- [x] 996 → 1002 passing
- [x] Manual: `agora new --slug today` is 1-flag entry; `agora move × 3` emits success lines only

## Related

Filed [#176](https://github.com/eris-ths/guild-cli/issues/176) for the **principled rule** behind this decision: lifecycle vs flow verbs — when does the `next:` hint help? `agora move` dropping the hint is the right local fix; the systemic question (when should ANY verb show a next-hint) is design judgment for a separate session.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_