### PR TITLE
docs: reflect 4-passage architecture and recent PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,67 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
   shown when `--state` is omitted now mentions `| all` and includes
   a `gate list --state all` example line.
 
+- **`guild` verbs honour `--help` like every other CLI.**
+  ([#166](https://github.com/eris-ths/guild-cli/pull/166))
+  PR #148 rolled out the universal `HelpRequested` /
+  `rejectUnknownFlags` / `renderVerbHelp` mechanism across gate /
+  agora / devil / ctx, but the operator-helper `guild` was out of
+  scope. The 4 `guild` verbs (`list` / `show` / `new` / `validate`)
+  now honour `--help` with the same shape and `guild new --bogus`
+  no longer hardcodes `guild` in the unknown-flag error prefix.
+
+- **`agora` / `ctx` / `devil` get the same did-you-mean as `gate`.**
+  ([#173](https://github.com/eris-ths/guild-cli/pull/173))
+  Typo'd verbs across the three passages now surface the closest
+  matches inline rather than dumping the full HELP. Same Levenshtein
+  shape gate already used. Also drops the `agora — v0 skeleton`
+  label from agora's HELP block (alpha v1 has shipped).
+
+- **`--version` reports a parseable version across all 5 CLIs.**
+  ([#174](https://github.com/eris-ths/guild-cli/pull/174))
+  Pre-fix, `gate --version` and `guild --version` printed
+  `guild-cli <X.Y.Z>` while `agora` / `ctx` / `devil --version`
+  printed status strings without a version number — a shell that
+  did `agora --version | grep <version>` was silently broken. Each
+  passage now prints `<cli> (under guild-cli <X.Y.Z>) — <status>`
+  so the version is grep-able and the status remains visible.
+  Also: `agora new` `suggested_next` points at `play` (the natural
+  next step) instead of `list`.
+
+- **`agora new` defaults `--kind sandbox` and `--title` to the slug;**
+  **`agora move`'s next-hint stops repeating on every move.**
+  ([#177](https://github.com/eris-ths/guild-cli/pull/177))
+  `agora new --slug <s>` now works without `--kind` or `--title`,
+  matching the most common opening shape (Sandbox plays without
+  ceremony). And the `next: agora move ... | agora suspend ...`
+  block that previously printed after every successful move was
+  noise once a play got going — `move` is now a quiet `✓` line.
+
+### Security
+
+- **Sanitize absolute paths in CLI error messages.**
+  ([#172](https://github.com/eris-ths/guild-cli/pull/172),
+  closes [#153](https://github.com/eris-ths/guild-cli/issues/153))
+  Errors from `safeFs` and friends carried the full resolved path
+  (e.g. `/Users/alice/work/proj/substrate/requests/pending/foo.yaml`),
+  incidentally leaking home-directory and checkout-location info
+  into logs / screenshots / bug reports. Each CLI's main() catch
+  now collapses the configured `contentRoot` prefix to the literal
+  `<content_root>` token via `sanitizeError` (new pure function in
+  `src/interface/shared/sanitizeError.ts`). The structural tail is
+  preserved so debugging is not impaired. Paths outside contentRoot
+  (`/etc`, `/tmp`, user-input absolute paths) are intentionally not
+  sanitized — the threat model is single-user, trusted-environment.
+
+- **Close `agora new` collision-error sanitizer hole.**
+  ([#175](https://github.com/eris-ths/guild-cli/pull/175))
+  Follow-up to #172. The `GameSlugCollision` branch returned 1
+  directly from the handler instead of throwing, bypassing main()'s
+  catch where `sanitizeError` runs — so its `At: <path>` line still
+  leaked the absolute substrate path. Apply `sanitizeError` at the
+  handler level so this alternate egress matches the contract every
+  other error-path emission already holds.
+
 ### Changed
 
 - **DomainError trailing `(field)` tag and `DomainError:` prefix

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -16,9 +16,9 @@ It is **not** a task tracker. It is not for doing things. It is for
 deciding, recording the why, and keeping the dialogue visible so
 the next session — or the next agent — can pick up where you left off.
 
-## Three passages, three shapes of work
+## Four passages, four shapes of work
 
-Guild has three passages on top of one shared substrate. Each
+Guild has four passages on top of one shared substrate. Each
 passage holds a different **shape** of agent activity:
 
 - **`gate` — 判断 (judgment).** "Decide on a request." Verdict-shaped:
@@ -27,9 +27,13 @@ passage holds a different **shape** of agent activity:
   Quest and Sandbox plays, suspend/resume cliffs, moves accumulating.
 - **`devil` — 守備 (defense).** "Protect end-users." Floor-shaped:
   multi-persona, lense-enforced, friction is the feature.
+- **`ctx` — 事実 (fact).** "Pin an observation." Verdict-less,
+  thread-less, target-less append. Phase 1 ships only `record`;
+  more verbs (fork / supersede / show / list / chain / status)
+  arrive in phase 2 as the use surface fills in.
 
 If you're new to guild-cli, start with `gate` — the rest of this
-document is gate-rooted. The other two passages have their own
+document is gate-rooted. The other three passages have their own
 sections in [`AGENT.md`](../AGENT.md) and worked examples in
 [`docs/verbs.md`](./verbs.md).
 

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -1,8 +1,8 @@
 # guild playbook — patterns, combos, recipes
 
-Practical guide for using `gate` / `agora` / `devil` together. Each
-section is a recipe — *when* to reach for *what*, with concrete
-verb sequences.
+Practical guide for using `gate` / `agora` / `devil` / `ctx`
+together. Each section is a recipe — *when* to reach for *what*,
+with concrete verb sequences.
 
 > **Audience.** Primarily AI agents who will be doing the work.
 > Per [`lore/principles/11-ai-first-human-as-projection.md`](../lore/principles/11-ai-first-human-as-projection.md),
@@ -10,9 +10,9 @@ verb sequences.
 > Recipes are command sequences; the rationale lives alongside
 > for cross-context memory.
 
-If you don't yet know what the three passages *are*, start with
+If you don't yet know what the passages *are*, start with
 [`../README.md`](../README.md) § "Architecture: container with
-three passages". This doc assumes you know each passage's shape;
+passages". This doc assumes you know each passage's shape;
 it covers *combos* and *workflow*.
 
 ## Dispatch in one breath
@@ -22,10 +22,12 @@ it covers *combos* and *workflow*.
 | `gate`  | **判断 / judgment**     | decide on a request    | needs a verdict (approve / deny / complete / fail / review) |
 | `agora` | **探索 / exploration**  | stay with a thought    | open question; can't / shouldn't conclude yet |
 | `devil` | **守備 / defense**      | protect end-users      | could harm a third party if it lands without scrutiny |
+| `ctx`   | **事実 / fact**         | record an observation  | something happened that future-you should remember (no verdict, no scrutiny — just a fact) |
 
 **Heuristic when uncertain:** *"Could a verdict close this?"*
 Yes → gate. No, but I want to keep going → agora. No, and
-something downstream could break badly → devil.
+something downstream could break badly → devil. No, and there's
+nothing to *do* — only something to *remember* — → ctx.
 
 ---
 
@@ -236,6 +238,57 @@ by this actor, at this time." Re-dismissing a dismissed entry
 is refused — substrate stays append-only at the contest level
 (file a new entry that `--addresses` the disputed one if you
 disagree).
+
+---
+
+## ctx-only patterns
+
+> **Phase 1 status.** ctx ships only `record` today; the remaining
+> six verbs (`fork` / `supersede` / `show` / `list` / `chain` /
+> `status`) land iteratively in phase 2. So the patterns here are
+> intentionally narrow — more recipes appear as the verb surface
+> fills in. Substrate written today is forward-compatible with the
+> phase-2 verbs (id shape, tag prefix discipline).
+
+### X1: pin a fact future-you needs
+
+```bash
+ctx record --fact "<one prose paragraph>" \
+  --tag prefix:value,prefix:value
+```
+
+**Shape**: an observation worth remembering across sessions but
+without a verdict (gate-shape) or open thread (agora-shape) or
+defense scope (devil-shape). Examples: "noir's review of #154
+called direction 1 minimal", "git lock collision observed during
+worktree concurrent commit", "main has been quiet for 3 iters of
+the watch loop".
+
+The `--tag` shape is `prefix:value` (lowercase, kebab-case).
+Shared tag prefixes — `topic:`, `scope:`, `iter:`, `observation:`
+— make later filtering tractable when phase-2 `ctx list` and
+`ctx chain` arrive. Plan tags as if they will be queried.
+
+Distinct from a `gate request` because there is no action
+implied. Distinct from an `agora move` because there is no
+ongoing thread. Distinct from a `devil entry` because there is
+no target under review. ctx is the verdict-less, thread-less,
+target-less append.
+
+### X2: cross-passage breadcrumb
+
+ctx is also the right place to leave a substrate breadcrumb when
+the action lives in another passage. Example: during a long
+`agora` play, you notice a fact that *could* matter to a future
+gate decision but isn't part of this thread. Drop a `ctx record`
+mentioning the play id and tag it `cross-passage:agora` — the
+fact accumulates outside the play's scope, queryable later when
+phase-2 `ctx list` lands.
+
+This pattern keeps the agora play focused on its own thread
+without losing the side-observation, and avoids inflating the
+play's `moves[]` with material the next opener doesn't need to
+re-read.
 
 ---
 

--- a/src/passages/agora/README.md
+++ b/src/passages/agora/README.md
@@ -14,7 +14,9 @@ plays close with prose, not with `ok|concern|reject`.
 
 If your work is decision-shaped, use `gate`. If it's
 defense-shaped (security review against a code change), use
-`devil`. If it's exploration-shaped, agora.
+`devil`. If it's a verdict-less, thread-less observation that
+future-you should remember, use `ctx`. If it's
+exploration-shaped, agora.
 
 ## Lore upstream
 

--- a/src/passages/devil/README.md
+++ b/src/passages/devil/README.md
@@ -19,7 +19,8 @@ how the substrate raises the floor.
 
 If your work is decision-shaped, use `gate`. If it's
 exploration-shaped (open-ended thinking), use `agora`. If it's
-defense-shaped, devil.
+a verdict-less, thread-less observation worth pinning for
+future-you, use `ctx`. If it's defense-shaped, devil.
 
 ## Lore upstream
 


### PR DESCRIPTION
## Summary

Doc audit triggered by a README link sweep surfaced **4-passage staleness** in 4 docs and **5 PRs missing from CHANGELOG**. All 22 README links were healthy (no broken targets); the staleness is content-level, not link-level.

## Changes

### 4-passage staleness fixes (functional — misled readers)

**`docs/playbook.md`**
- "three passages" → "the passages"; broken anchor reference fixed (README section is now "container with passages", not "container with three passages")
- New row in **Dispatch in one breath** table for ctx (事実 / fact)
- New **ctx-only patterns** section (X1: pin a fact future-you needs / X2: cross-passage breadcrumb) — phase 1 status disclosed inline
- Updated **Heuristic when uncertain** to fork four ways

**`docs/concepts-for-newcomers.md`**
- "## Three passages, three shapes of work" → "## Four passages, four shapes of work"
- Added ctx bullet with phase 1 caveat ("only \`record\` today; phase 2 verbs land iteratively")
- "the other two passages" → "the other three passages"

**`src/passages/agora/README.md`**, **`src/passages/devil/README.md`**
- Sibling-list line ("If your work is X, use Y") gains a ctx clause without disturbing the existing decision/exploration/defense framing

### CHANGELOG sweep (5 PRs missing from Unreleased)

Added entries for:

- **#166** — guild verbs honour \`--help\` like every other CLI (#148 follow-up)
- **#173** — did-you-mean port to agora / ctx / devil
- **#174** — \`--version\` parseable across all 5 CLIs
- **#177** — \`agora new\` defaults + \`agora move\` quiet hint

New **Security** section in [Unreleased]:

- **#172** — sanitize absolute paths in CLI error messages (closes #153)
- **#175** — close \`agora new\` collision-error sanitizer hole (#153 follow-up)

The original "Touch-feel campaign" intro paragraph is left intact (it's a narrative about the P3 dogfood, not a strict count).

## Out of scope (intentionally)

- **\`examples/three-passages-framing/\`** — #149 froze this as a 3-passage snapshot. The example is a dated artefact, not a live doc, so its "three passages" framing is correct for that frozen state.
- **\`CLAUDE.md\`** — develop-branch-only doc; can be updated separately in develop's dogfood substrate without main-repo PR review.

## Test plan

- [x] \`npm run typecheck\` — no source changes, just sanity
- [x] All 22 README relative links verified to exist on disk
- [ ] CI green (only doc-side smoke from build + lint, no functional tests touched)
- [ ] \`docs/playbook.md\` rendered as markdown looks coherent
- [ ] CHANGELOG entries match the merged PR titles + numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)