### PR TITLE
feat(agora): add `last` and `cliff` sugar verbs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -174,6 +174,8 @@ agora resume <play-id> [--note "<resume prose>"] [--by <m>]
 agora conclude <play-id> [--note "<closure prose>"] [--by <m>]
 agora list [--game <slug>] [--state <playing|suspended|concluded>]
 agora show <slug-or-play-id> [--game <slug>]   # auto-disambiguates by pattern
+agora last [--by <m>] [--state <s>] [--include-concluded]   # "which play am I in?"
+agora cliff <play-id> [--game <slug>]          # peek closing cliff/invitation, no state change
 agora schema [--verb <name>]                   # principle 10 contract
 ```
 

--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -64,6 +64,8 @@ export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
     conclude: 'conclude <play-id>',
     list: 'list',
     show: 'show <slug-or-play-id>',
+    last: 'last',
+    cliff: 'cliff <play-id>',
     schema: 'schema',
   },
   devil: {

--- a/src/passages/agora/README.md
+++ b/src/passages/agora/README.md
@@ -80,7 +80,7 @@ agora-specific records live under `<content_root>/agora/`:
     plays/<game>/<play-id>.yaml     # play sessions (sequence per game per day)
 ```
 
-## Verbs (v1, complete)
+## Verbs (v1 core, complete)
 
 - `agora new` — create a Game definition (Quest or Sandbox)
 - `agora play` — start a play session against a Game
@@ -95,6 +95,23 @@ agora-specific records live under `<content_root>/agora/`:
 - `agora show <slug-or-play-id>` — detail view with full move +
   suspension/resume history paired by index
 - `agora schema` — agent dispatch contract per principle 10
+
+## Sugar verbs (read-only affordances)
+
+These layer on top of the v1 core; pure read affordances that
+answer the daily-use questions without making the actor
+remember play ids:
+
+- `agora last` — "which play am I in?" Returns the actor's
+  most recent play; defaults to open (playing|suspended).
+  Surfaces the closing cliff/invitation when state=suspended,
+  so a re-entering instance reads the resume-context without
+  even calling `agora cliff`.
+- `agora cliff <play-id>` — "what was I about to do?" Peeks
+  the closing cliff/invitation without transitioning state.
+  Distinguishes active (next-resume-closes-it) vs historical
+  (already-resumed) cliffs, so the reader doesn't mistake
+  a stale cliff for an open one.
 
 The substrate-side Zeigarnik (issue #117) is in place: every
 suspend records `cliff` (what just happened) and `invitation`

--- a/src/passages/agora/interface/handlers/cliff.ts
+++ b/src/passages/agora/interface/handlers/cliff.ts
@@ -1,0 +1,170 @@
+import { PlayRepository } from '../../application/PlayRepository.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { resolvePlayForVerb } from './resolvePlay.js';
+import { parsePlayId } from '../../domain/Play.js';
+
+const CLIFF_KNOWN_FLAGS: ReadonlySet<string> = new Set(['game', 'format']);
+
+/**
+ * agora cliff <play-id> — peek the closing cliff/invitation
+ * without transitioning state.
+ *
+ * Usage:
+ *   agora cliff <play-id> [--game <slug>] [--format json|text]
+ *
+ * Answers the daily-use question "what was I about to do here?"
+ * without committing to `agora resume` (which transitions
+ * suspended → playing). Useful when:
+ *   - the actor is deciding whether this play is the right one
+ *     to re-enter
+ *   - a different actor wants to read the substrate-side context
+ *     before opening the play themselves
+ *   - the play has already been resumed and the actor wants to
+ *     re-read the most recent historical cliff
+ *
+ * Cross-state behaviour:
+ *   - suspended: the closing cliff is "active" (the next resume
+ *     will close this very pair). Marked accordingly.
+ *   - playing with prior suspensions: the most recent cliff has
+ *     already been resumed; output names the resume time so the
+ *     reader doesn't mistake it for an active cliff.
+ *   - playing with no suspensions: returns nothing meaningful;
+ *     exit 1 with a helpful message ("never suspended").
+ *   - concluded with prior suspensions: the cliff is historical;
+ *     marked as part of a closed thread.
+ *
+ * Read-only verb. Output shape per principle 11.
+ */
+export interface CliffDeps {
+  readonly plays: PlayRepository;
+  readonly config: GuildConfig;
+}
+
+export async function cliffOf(deps: CliffDeps, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, CLIFF_KNOWN_FLAGS, 'cliff');
+
+  const positional = args.positional[0];
+  if (!positional) {
+    process.stderr.write(
+      `error: agora cliff requires a play-id positional. e.g. agora cliff 2026-05-05-001\n`,
+    );
+    return 1;
+  }
+  // parsePlayId throws DomainError on bad shape — caller's main()
+  // catch sanitizes & exits 1. Same contract as agora show.
+  const playId = parsePlayId(positional);
+
+  const gameFilter = optionalOption(args, 'game');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
+    return 1;
+  }
+
+  const resolved = await resolvePlayForVerb(deps.plays, playId, gameFilter);
+  if (resolved === 'ambiguous') return 1; // resolvePlayForVerb already wrote stderr
+  if (resolved === null) {
+    process.stderr.write(
+      `error: play ${playId} not found${gameFilter ? ` in game=${gameFilter}` : ''}.\n`,
+    );
+    return 1;
+  }
+  const play = resolved;
+
+  const lastSuspension = play.suspensions[play.suspensions.length - 1];
+
+  if (!lastSuspension) {
+    // No suspension has ever happened on this play — nothing to peek.
+    if (format === 'json') {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            ok: true,
+            play_id: play.id,
+            game: play.game,
+            state: play.state,
+            cliff: null,
+            invitation: null,
+            note: 'play has never been suspended; no cliff to peek',
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+      return 0;
+    }
+    process.stdout.write(
+      `play ${play.id}  [${play.state}]  game=${play.game}\n` +
+        `  (never suspended — no cliff to peek)\n`,
+    );
+    return 0;
+  }
+
+  // The most recent suspension may be active (still pending a
+  // resume) or historical (already resumed since). The
+  // state-derivation invariant from Play.ts:
+  //   suspensions.length === resumes.length + 1 → suspended (active cliff)
+  //   suspensions.length === resumes.length     → playing/concluded (historical)
+  const active = play.suspensions.length === play.resumes.length + 1;
+  const correspondingResume = active
+    ? null
+    : play.resumes[play.resumes.length - 1] ?? null;
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          play_id: play.id,
+          game: play.game,
+          state: play.state,
+          cliff: lastSuspension.cliff,
+          invitation: lastSuspension.invitation,
+          suspended_at: lastSuspension.at,
+          suspended_by: lastSuspension.by,
+          active,
+          ...(correspondingResume
+            ? {
+                resumed_at: correspondingResume.at,
+                resumed_by: correspondingResume.by,
+              }
+            : {}),
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+
+  // text rendering
+  const stateTag =
+    play.state === 'suspended'
+      ? `[${play.state} ↺]`
+      : play.state === 'concluded'
+        ? `[${play.state} ✓]`
+        : `[${play.state}]`;
+  process.stdout.write(
+    `play ${play.id}  ${stateTag}  game=${play.game}\n`,
+  );
+  if (active) {
+    process.stdout.write(
+      `last suspension: ${lastSuspension.at} by ${lastSuspension.by} (active — not yet resumed)\n`,
+    );
+  } else {
+    const r = correspondingResume!;
+    process.stdout.write(
+      `last suspension: ${lastSuspension.at} by ${lastSuspension.by} (resumed at ${r.at} by ${r.by})\n`,
+    );
+  }
+  process.stdout.write(
+    `cliff:      ${lastSuspension.cliff}\n` +
+      `invitation: ${lastSuspension.invitation}\n`,
+  );
+  return 0;
+}

--- a/src/passages/agora/interface/handlers/last.ts
+++ b/src/passages/agora/interface/handlers/last.ts
@@ -1,0 +1,165 @@
+import { Play } from '../../domain/Play.js';
+import { PlayRepository } from '../../application/PlayRepository.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { resolveGuildActor } from '../../../../interface/shared/resolveGuildActor.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+
+const LAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'state',
+  'include-concluded',
+  'format',
+]);
+
+/**
+ * agora last — return the actor's most recent play.
+ *
+ * Usage:
+ *   agora last [--by <m>] [--state playing|suspended|concluded]
+ *              [--include-concluded] [--format json|text]
+ *
+ * Answers the daily-use question "which play am I in?" without
+ * making the actor `agora list` and copy a play-id. Defaults:
+ *   - actor:  --by, else GUILD_ACTOR
+ *   - state:  any of playing|suspended (concluded plays excluded
+ *             unless --include-concluded or --state concluded)
+ *   - sort:   most recently started_at first
+ *
+ * The "most recent open play" framing matches the touch-feel use
+ * case: an actor returning to work asks "what was I in?" — and
+ * concluded plays are by definition closed work, not the answer.
+ * --include-concluded surfaces them when the question is "what
+ * have I ever done?" instead.
+ *
+ * Output shape per principle 11: JSON envelope is the agent
+ * contract; text is the projection. Empty result is exit 0 with
+ * an empty payload (json: `{ ok: true, play: null }`) — orchestrators
+ * branch on `play === null`, no error noise required.
+ */
+export interface LastDeps {
+  readonly plays: PlayRepository;
+  readonly config: GuildConfig;
+}
+
+export async function lastPlay(deps: LastDeps, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, LAST_KNOWN_FLAGS, 'last');
+
+  const by = optionalOption(args, 'by') ?? resolveGuildActor();
+  if (!by) {
+    process.stderr.write(
+      'error: --by required (or set GUILD_ACTOR). agora last is per-actor — it asks "which play am I in?"\n',
+    );
+    return 1;
+  }
+
+  const stateFilter = optionalOption(args, 'state');
+  if (
+    stateFilter !== undefined &&
+    stateFilter !== 'playing' &&
+    stateFilter !== 'suspended' &&
+    stateFilter !== 'concluded'
+  ) {
+    process.stderr.write(
+      `error: --state must be one of playing|suspended|concluded, got: ${stateFilter}\n`,
+    );
+    return 1;
+  }
+
+  const includeConcluded = args.options['include-concluded'] === true;
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
+    return 1;
+  }
+
+  let plays: Play[] = await deps.plays.listAll();
+  // started_by is the canonical "whose play is this" field.
+  // Future: when an actor's contribution is move-only (didn't start
+  // it), a follow-up could expand the filter to "any actor who has
+  // moved here". For v1 of this verb, started_by keeps the question
+  // crisp.
+  plays = plays.filter((p) => p.started_by === by);
+
+  if (stateFilter) {
+    plays = plays.filter((p) => p.state === stateFilter);
+  } else if (!includeConcluded) {
+    plays = plays.filter((p) => p.state !== 'concluded');
+  }
+
+  // Most recently started first. Lexicographic sort works because
+  // started_at is ISO-8601 with consistent precision.
+  plays.sort((a, b) => b.started_at.localeCompare(a.started_at));
+
+  const last = plays[0];
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          play: last
+            ? {
+                id: last.id,
+                game: last.game,
+                state: last.state,
+                started_at: last.started_at,
+                started_by: last.started_by,
+                move_count: last.moves.length,
+                suspension_count: last.suspensions.length,
+                resume_count: last.resumes.length,
+                // Surface the closing cliff/invitation when the
+                // play is currently suspended — the resume-time
+                // peek without committing to resume.
+                ...(last.state === 'suspended' && last.suspensions.length > 0
+                  ? {
+                      closing_cliff:
+                        last.suspensions[last.suspensions.length - 1]!.cliff,
+                      closing_invitation:
+                        last.suspensions[last.suspensions.length - 1]!.invitation,
+                    }
+                  : {}),
+              }
+            : null,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+
+  // text rendering
+  if (!last) {
+    const scope = stateFilter
+      ? `state=${stateFilter}`
+      : includeConcluded
+        ? 'any state'
+        : 'open (playing|suspended)';
+    process.stdout.write(
+      `(no ${scope} plays for ${by} — start one with 'agora play --slug <game-slug>')\n`,
+    );
+    return 0;
+  }
+  const tag =
+    last.state === 'suspended'
+      ? `[${last.state} ↺]`
+      : last.state === 'concluded'
+        ? `[${last.state} ✓]`
+        : `[${last.state}]`;
+  process.stdout.write(
+    `${last.id}  ${tag.padEnd(15)} game=${last.game}  moves=${last.moves.length}  ` +
+      `(started ${last.started_at} by ${last.started_by})\n`,
+  );
+  if (last.state === 'suspended' && last.suspensions.length > 0) {
+    const closing = last.suspensions[last.suspensions.length - 1]!;
+    process.stdout.write(
+      `  closing cliff:      ${closing.cliff}\n` +
+        `  closing invitation: ${closing.invitation}\n`,
+    );
+  }
+  return 0;
+}

--- a/src/passages/agora/interface/handlers/schema.ts
+++ b/src/passages/agora/interface/handlers/schema.ts
@@ -344,6 +344,86 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'last',
+    category: 'read',
+    summary:
+      "the actor's most recent play — answers 'which play am I in?' without copying a play id from `agora list`. " +
+      'Defaults to open (playing|suspended); --include-concluded broadens to any state.',
+    input: {
+      type: 'object',
+      properties: {
+        by: strOpt('actor (defaults to GUILD_ACTOR)'),
+        state: {
+          type: 'string',
+          enum: ['playing', 'suspended', 'concluded'],
+          description: 'narrow to a single state (omit for the default open-only behaviour)',
+        },
+        'include-concluded': {
+          type: 'boolean',
+          description: 'include concluded plays in the search (default false)',
+        },
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        play: {
+          description: 'most recent matching play, or null if none',
+          type: 'object',
+          properties: {
+            id: str,
+            game: str,
+            state: { type: 'string', enum: ['playing', 'suspended', 'concluded'] },
+            started_at: str,
+            started_by: str,
+            move_count: str,
+            suspension_count: str,
+            resume_count: str,
+            closing_cliff: strOpt('present when state=suspended'),
+            closing_invitation: strOpt('present when state=suspended'),
+          },
+        },
+      },
+      required: ['ok', 'play'],
+    },
+  },
+  {
+    name: 'cliff',
+    category: 'read',
+    summary:
+      'peek the closing cliff/invitation of a play without transitioning state. ' +
+      "Answers 'what was I about to do?' without committing to resume.",
+    input: {
+      type: 'object',
+      properties: {
+        play_id: { type: 'string', description: 'positional; play id (YYYY-MM-DD-NNN)' },
+        game: strOpt('disambiguate cross-game play-id collisions'),
+        format: formatField,
+      },
+      required: ['play_id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        play_id: str,
+        game: str,
+        state: { type: 'string', enum: ['playing', 'suspended', 'concluded'] },
+        cliff: strOpt('null if play was never suspended'),
+        invitation: strOpt('null if play was never suspended'),
+        suspended_at: strOpt('present when there is a last suspension'),
+        suspended_by: strOpt('present when there is a last suspension'),
+        active: { type: 'boolean', description: 'true when this cliff awaits a resume; false when historical' },
+        resumed_at: strOpt('present when active=false'),
+        resumed_by: strOpt('present when active=false'),
+        note: strOpt('helpful note when no cliff exists'),
+      },
+      required: ['ok', 'play_id', 'game', 'state'],
+    },
+  },
+  {
     name: 'schema',
     category: 'meta',
     summary: 'this introspection payload — the agent dispatch contract',

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -33,9 +33,11 @@ import { resumePlay } from './handlers/resume.js';
 import { concludePlay } from './handlers/conclude.js';
 import { listAgora } from './handlers/list.js';
 import { showAgora } from './handlers/show.js';
+import { lastPlay } from './handlers/last.js';
+import { cliffOf } from './handlers/cliff.js';
 import { schemaCmd } from './handlers/schema.js';
 
-const HELP = `agora — play / narrative passage (alpha, 9 verbs)
+const HELP = `agora — play / narrative passage (alpha, 11 verbs)
 
 Usage:
   agora new --slug <s> --kind <quest|sandbox> --title "<t>" [--by <m>]
@@ -91,11 +93,27 @@ Usage:
                               --game disambiguates cross-game id collisions
                               for plays.
 
+  agora last [--by <m>] [--state playing|suspended|concluded]
+             [--include-concluded] [--format json|text]
+                              "Which play am I in?" — return the actor's
+                              most recent play. Defaults to open
+                              (playing|suspended); concluded excluded
+                              unless --include-concluded or --state given.
+
+  agora cliff <play-id> [--game <slug>] [--format json|text]
+                              Peek the closing cliff/invitation without
+                              transitioning state. "What was I about to
+                              do here?" without committing to resume.
+                              Surfaces whether the cliff is active
+                              (next resume closes it) or historical
+                              (already resumed since).
+
   agora --help                 This help.
   agora --version              Print version and exit.
 
-Passage status: alpha. Full v1 surface (new / play / move / suspend /
-resume / conclude / list / show / schema) per design issue #117.
+Passage status: alpha. Core v1 surface (new / play / move / suspend /
+resume / conclude / list / show / schema) per design issue #117. Sugar
+verbs (last / cliff) layer on top — pure read affordances.
 Substrate: shares content_root and members/ with gate; agora-specific data
 goes under <content_root>/agora/.
 
@@ -110,7 +128,7 @@ Lore upstream:
 // forgotten here loses its typo hint, doesn't crash anything.
 const AGORA_COMMANDS = [
   'new', 'play', 'move', 'suspend', 'resume', 'conclude',
-  'list', 'show', 'schema',
+  'list', 'show', 'last', 'cliff', 'schema',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -124,7 +142,7 @@ export async function main(argv: readonly string[]): Promise<number> {
     // phrase ("alpha, 9 verbs") is per-passage and rides alongside
     // so a reader sees both lineage and surface maturity in one line.
     process.stdout.write(
-      `agora (under guild-cli ${getPackageVersion()}) — alpha, 9 verbs\n`,
+      `agora (under guild-cli ${getPackageVersion()}) — alpha, 11 verbs\n`,
     );
     return 0;
   }
@@ -153,6 +171,10 @@ export async function main(argv: readonly string[]): Promise<number> {
         return await listAgora({ games, plays, config }, args);
       case 'show':
         return await showAgora({ games, plays, config }, args);
+      case 'last':
+        return await lastPlay({ plays, config }, args);
+      case 'cliff':
+        return await cliffOf({ plays, config }, args);
       case 'schema':
         return await schemaCmd(args);
       default: {

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -174,7 +174,7 @@ test('VERB_EXAMPLES: every documented verb is mapped to a runnable example', () 
     ],
     agora: [
       'new', 'play', 'move', 'suspend', 'resume', 'conclude',
-      'list', 'show', 'schema',
+      'list', 'show', 'last', 'cliff', 'schema',
     ],
     devil: [
       'open', 'entry', 'list', 'show', 'conclude', 'dismiss', 'resolve',

--- a/tests/passages/agora/lastAndCliff.test.ts
+++ b/tests/passages/agora/lastAndCliff.test.ts
@@ -1,0 +1,292 @@
+// agora last + agora cliff — sugar verbs that answer the daily-use
+// questions "which play am I in?" and "what was I about to do?".
+//
+// Pins the contract:
+//   - last: actor scoped, defaults to open (playing|suspended), sorts by
+//     started_at desc, exits 0 with a null payload when nothing matches
+//   - cliff: read-only peek of the closing cliff/invitation, distinguishes
+//     active (next-resume-closes-it) vs historical (already-resumed)
+//   - both verbs match agora's JSON envelope conventions: snake_case,
+//     ok-flag, no surprise stdout in failure paths
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AGORA = resolve(here, '../../../../bin/agora.mjs');
+const GATE = resolve(here, '../../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'agora-sugar-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  bin: string,
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function seedAlice(root: string): void {
+  run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
+}
+
+// --- agora last ---
+
+test('agora last: empty content_root returns null payload (no error)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  const r = run(AGORA, root, ['last', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.play, null);
+});
+
+test('agora last: returns the most recently started open play for the actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  // Two plays in the same game; the second is the most recent.
+  run(AGORA, root, ['new', '--slug', 'g1', '--kind', 'sandbox', '--title', 'g1'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const first = run(AGORA, root, ['play', '--slug', 'g1', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const firstPayload = JSON.parse(first.stdout);
+  // Sleep a millisecond to guarantee different started_at.
+  // Tiny but enough; agora plays are sequenced per-game-per-day so
+  // the id collides — we need started_at to differ for the sort.
+  const wait = run(process.execPath, root, [
+    '-e',
+    'setTimeout(()=>{},10); require("fs").writeFileSync("/dev/null","x")',
+  ]);
+  void wait;
+  const r = run(AGORA, root, ['last', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.play.id, firstPayload.play_id);
+  assert.equal(payload.play.game, 'g1');
+  assert.equal(payload.play.state, 'playing');
+  assert.equal(payload.play.started_by, 'alice');
+});
+
+test('agora last: surfaces closing cliff/invitation when state=suspended', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'g2', '--kind', 'sandbox', '--title', 'g2'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'g2', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, [
+    'suspend', play.play_id, '--by', 'alice',
+    '--cliff', 'paused mid-thought',
+    '--invitation', 'pick up from the contradiction',
+  ]);
+  const r = run(AGORA, root, ['last', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.play.state, 'suspended');
+  assert.equal(payload.play.closing_cliff, 'paused mid-thought');
+  assert.equal(payload.play.closing_invitation, 'pick up from the contradiction');
+});
+
+test('agora last: excludes concluded plays by default; --include-concluded surfaces them', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'g3', '--kind', 'sandbox', '--title', 'g3'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'g3', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, ['conclude', play.play_id, '--by', 'alice', '--note', 'done']);
+
+  // Default: no open play exists → null
+  const r1 = run(AGORA, root, ['last', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+  assert.equal(JSON.parse(r1.stdout).play, null);
+
+  // --include-concluded: surfaces the concluded play
+  const r2 = run(
+    AGORA,
+    root,
+    ['last', '--include-concluded', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const p = JSON.parse(r2.stdout).play;
+  assert.equal(p.state, 'concluded');
+  assert.equal(p.id, play.play_id);
+});
+
+test('agora last: --by overrides GUILD_ACTOR; missing actor errors clearly', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(GATE, root, ['register', '--name', 'bob', '--category', 'professional']);
+  run(AGORA, root, ['new', '--slug', 'gb', '--kind', 'sandbox', '--title', 'gb'], {
+    GUILD_ACTOR: 'bob',
+  });
+  run(AGORA, root, ['play', '--slug', 'gb'], { GUILD_ACTOR: 'bob' });
+
+  // --by bob picks up bob's play even though caller is alice
+  const r = run(AGORA, root, ['last', '--by', 'bob', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(JSON.parse(r.stdout).play.started_by, 'bob');
+
+  // No --by, no GUILD_ACTOR → error
+  const r2 = run(AGORA, root, ['last']);
+  assert.notEqual(r2.status, 0);
+  assert.match(r2.stderr, /--by required/);
+});
+
+test('agora last: text mode renders one-line summary + cliff lines when suspended', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'gt', '--kind', 'sandbox', '--title', 'gt'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'gt', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, [
+    'suspend', play.play_id, '--by', 'alice',
+    '--cliff', 'C', '--invitation', 'I',
+  ]);
+  const r = run(AGORA, root, ['last'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[suspended ↺\]/);
+  assert.match(r.stdout, /closing cliff:/);
+  assert.match(r.stdout, /closing invitation:/);
+});
+
+// --- agora cliff ---
+
+test('agora cliff: never-suspended play returns helpful "no cliff" message', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'gc1', '--kind', 'sandbox', '--title', 'gc1'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'gc1', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  const r = run(AGORA, root, ['cliff', play.play_id, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.cliff, null);
+  assert.equal(payload.invitation, null);
+  assert.match(payload.note, /never been suspended/);
+});
+
+test('agora cliff: suspended play surfaces active=true with cliff/invitation/timestamps', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'gc2', '--kind', 'sandbox', '--title', 'gc2'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'gc2', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, [
+    'suspend', play.play_id, '--by', 'alice',
+    '--cliff', 'C2', '--invitation', 'I2',
+  ]);
+  const r = run(AGORA, root, ['cliff', play.play_id, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.cliff, 'C2');
+  assert.equal(payload.invitation, 'I2');
+  assert.equal(payload.active, true);
+  assert.equal(typeof payload.suspended_at, 'string');
+  assert.equal(payload.suspended_by, 'alice');
+  assert.equal(payload.resumed_at, undefined, 'no resume yet');
+});
+
+test('agora cliff: resumed play surfaces active=false with both timestamps', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'gc3', '--kind', 'sandbox', '--title', 'gc3'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const play = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'gc3', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, [
+    'suspend', play.play_id, '--by', 'alice',
+    '--cliff', 'C3', '--invitation', 'I3',
+  ]);
+  run(AGORA, root, ['resume', play.play_id, '--by', 'alice']);
+
+  const r = run(AGORA, root, ['cliff', play.play_id, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.cliff, 'C3');
+  assert.equal(payload.active, false);
+  assert.equal(typeof payload.resumed_at, 'string');
+  assert.equal(payload.resumed_by, 'alice');
+});
+
+test('agora cliff: missing positional surfaces a clear error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  const r = run(AGORA, root, ['cliff']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /requires a play-id positional/);
+});
+
+test('agora cliff: unknown play-id errors with not-found', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  const r = run(AGORA, root, ['cliff', '2099-01-01-001']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /not found/);
+});

--- a/tests/passages/agora/schema.test.ts
+++ b/tests/passages/agora/schema.test.ts
@@ -1,8 +1,8 @@
 // agora schema — agent dispatch contract for the second passage.
 //
 // Pins the principle 10 obligations specifically for agora:
-//   - schema lists all 9 verbs (new/play/move/suspend/resume/
-//     conclude/list/show/schema)
+//   - schema lists all 11 verbs (new/play/move/suspend/resume/
+//     conclude/list/show/last/cliff/schema)
 //   - JSON envelope shape: {$schema, passage: "agora", version, verbs}
 //   - --verb filter narrows to one verb
 //   - input completeness: every flag the runtime accepts via
@@ -59,7 +59,7 @@ test('agora schema: JSON envelope contains every verb', (t) => {
   assert.equal(payload.$schema, 'http://json-schema.org/draft-07/schema#');
   const names = (payload.verbs as Array<{ name: string }>).map((v) => v.name).sort();
   assert.deepEqual(names, [
-    'conclude', 'list', 'move', 'new', 'play',
+    'cliff', 'conclude', 'last', 'list', 'move', 'new', 'play',
     'resume', 'schema', 'show', 'suspend',
   ]);
 });
@@ -94,7 +94,7 @@ test('agora schema: text mode renders one summary per verb', (t) => {
   t.after(cleanup);
   const r = runAgora(root, ['schema', '--format', 'text'], { GUILD_ACTOR: 'alice' });
   assert.equal(r.status, 0);
-  assert.match(r.stdout, /agora — 9 verb\(s\):/);
+  assert.match(r.stdout, /agora — 11 verb\(s\):/);
   assert.match(r.stdout, /^new\s+\[write\]/m);
   assert.match(r.stdout, /^suspend\s+\[write\]/m);
   assert.match(r.stdout, /^schema\s+\[meta\]/m);


### PR DESCRIPTION
## Summary

Two read-only sugar verbs on top of the v1 core, closing the daily-use gap surfaced during the wave7-main-watch dogfood loop on develop:

- **\`agora last\`** — "which play am I in?" Returns the actor's most recent play without copying a play-id from \`agora list\`. Defaults to open (playing|suspended); concluded excluded unless \`--include-concluded\` or \`--state concluded\` given. Surfaces the closing cliff/invitation inline when state=suspended.

- **\`agora cliff <play-id>\`** — "what was I about to do?" Peeks the closing cliff/invitation **without transitioning state**. Distinguishes **active** (next-resume-closes-it) vs **historical** (already-resumed) cliffs so the reader doesn't mistake a stale cliff for an open one.

## Why these two

The wave7-main-watch loop (12 iterations on develop) repeatedly needed "what was I in?" + "what was the cliff?" without re-resuming. Today's workflow forces the actor to:

1. \`agora list --format json\` and parse for their play
2. \`agora resume <play-id>\` (committing to a state transition) just to read the cliff

Neither is hostile, but both are friction points the substrate-side Zeigarnik (issue #117) was supposed to eliminate. The data was already there — only the read affordances were missing.

## Examples

\`\`\`
$ agora last
2026-05-05-001  [suspended ↺]   game=wave7-main-watch  moves=17  (started 2026-05-05T01:52:22.103Z by eris)
  closing cliff:      Iter 12: PR #178 merged。3 PR 連続 ship 完了 (#172 / #175 / #178)。loop idle 状態。
  closing invitation: Iter 13: git fetch のみ、main 動きあれば touch、無ければ 1200s 延長 or なお報告 'loop 終わって良い?' 打診。

$ agora cliff 2026-05-05-001
play 2026-05-05-001  [suspended ↺]  game=wave7-main-watch
last suspension: 2026-05-05T05:30:00.000Z by eris (active — not yet resumed)
cliff:      ...
invitation: ...

# After resume:
$ agora cliff 2026-05-05-001
play 2026-05-05-001  [playing]  game=wave7-main-watch
last suspension: 2026-05-05T03:00:00.000Z by eris (resumed at 2026-05-05T03:01:00.000Z by eris)
cliff:      ...
invitation: ...
\`\`\`

## Changes

| File | Change |
|------|--------|
| \`src/passages/agora/interface/handlers/last.ts\` | NEW (~150 LOC) — \`agora last\` handler |
| \`src/passages/agora/interface/handlers/cliff.ts\` | NEW (~140 LOC) — \`agora cliff\` handler |
| \`src/passages/agora/interface/index.ts\` | Wire into HELP, dispatcher switch, AGORA_COMMANDS, version status (9 → 11 verbs) |
| \`src/passages/agora/interface/handlers/schema.ts\` | Add \`last\` + \`cliff\` schema entries (principle 10) |
| \`src/passages/agora/README.md\` | Add "Sugar verbs (read-only affordances)" section |
| \`AGENT.md\` | Append \`agora last\` and \`agora cliff\` to verb cheat sheet |
| \`src/interface/shared/verbExamples.ts\` | \`agora.last\` + \`agora.cliff\` runnable examples |
| \`tests/passages/agora/lastAndCliff.test.ts\` | NEW (~210 LOC, 11 tests) pinning the contract |
| \`tests/passages/agora/schema.test.ts\` | Update verb count assertion (9 → 11) |
| \`tests/interface/verbHelp.test.ts\` | Add \`last\` + \`cliff\` to coverage map |

\`\`\`
10 files changed, ~510 insertions(+), ~11 deletions(-)
\`\`\`

## Out of scope

- **\`agora suggest\` cousin to \`gate suggest\`** — considered as the third sugar verb but kept for a separate decision; \`last\` already returns the open play (which orchestrators can derive next from), so \`suggest\` would mostly duplicate.
- **No state transitions, no new domain shapes** — these are pure read affordances. The Game/Play YAML and the v1 core verbs are untouched.
- **#176 lifecycle/flow/bootstrap/boundary principle** — separate design decision; these new verbs follow the existing pattern (\`last\` is bootstrap-shaped, \`cliff\` is read-shaped).

## Test plan

- [x] \`npm run build\`
- [x] 11 new tests pass: empty/null payload, state filter behaviour, cliff active-vs-historical, positional/flag validation, json/text symmetry, --by / GUILD_ACTOR / missing-actor error
- [x] \`agora schema\` verb count updated 9 → 11; verb-help coverage map includes both
- [x] Full suite: 997 pass / 17 fail. Failures identical to main (pre-existing macOS \`/var\` symlink + JSON snapshot edge case per CONTRIBUTING.md). **Net new failures: 0**
- [ ] CI green (Linux + Windows × Node 20/22 + package artifact)

## Related

- Surfaces from the wave7-main-watch dogfood loop on develop (12 iterations, 17 moves, 13 suspend/resume cycles — exactly the use case these verbs solve)
- Issue #117 (Zeigarnik design) — the substrate was already there; this PR adds the missing read affordances
- Closes nothing (no GitHub issue tracks these specifically; surfaced and closed in one shot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)