### PR TITLE
fix(gate): lean boot default tail 10→5 (principle 13)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -210,7 +210,14 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
   }
-  const tailLimit = parseOptionalIntOption(args, 'tail') ?? 10;
+  // Default tail=5 (was 10) to keep `gate boot` lean — agents call
+  // boot at every session start, so the orientation payload is on the
+  // hot path. 5 covers "what just happened" without flooding the JSON
+  // (each utterance entry is ~6-8 lines pretty-printed). Callers that
+  // want deeper history pass `--tail <N>` explicitly. Per principle 13:
+  // bootstrap-shape verbs tolerate noise less than they look (high
+  // frequency × full context = death by a thousand cuts).
+  const tailLimit = parseOptionalIntOption(args, 'tail') ?? 5;
   const personalLimit = parseOptionalIntOption(args, 'utterances') ?? 5;
 
   const envActor = resolveGuildActor();

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -183,6 +183,9 @@ Status:
                        Returns identity + status + tail + your recent
                        utterances + inbox unread as one JSON payload.
                        GUILD_ACTOR optional (global view if unset).
+                       Defaults: --tail 5 --utterances 5 (lean for
+                       hot-path session start; pass higher N for deeper
+                       history).
   gate suggest [--format json|text]
                        Tight-loop sibling of boot: returns ONLY the
                        suggested_next triple (verb/args/reason) or

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -443,6 +443,57 @@ test('gate boot text: misconfigured_cwd block suppresses content_root disclosure
   }
 });
 
+// Default tail size pin. Bumped 10→5 with principle 13 in mind:
+// boot is bootstrap-shape, called every session start, so the
+// orientation payload sits on the hot path. Smaller default keeps
+// JSON lean (~200 vs ~250 lines pretty-printed); callers that want
+// deeper history pass `--tail <N>` explicitly. If this test fails
+// because the default moved again, update both this assertion AND
+// the rationale comment in src/interface/gate/handlers/boot.ts.
+test('gate boot: default tail returns 5 entries (lean default)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Seed 8 requests so a default of 5 (or 10) is observable.
+    for (let i = 0; i < 8; i++) {
+      const { status } = runGate(
+        root,
+        ['request', '--action', `seed ${i}`, '--reason', 'tail-default pin'],
+        { GUILD_ACTOR: 'alice' },
+      );
+      assert.equal(status, 0, `seed ${i} failed`);
+    }
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.equal(
+      payload.tail.length,
+      5,
+      'gate boot default tail size — change requires updating boot.ts rationale comment',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: --tail <N> overrides the default', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    for (let i = 0; i < 8; i++) {
+      runGate(
+        root,
+        ['request', '--action', `seed ${i}`, '--reason', 'override pin'],
+        { GUILD_ACTOR: 'alice' },
+      );
+    }
+    const { stdout } = runGate(root, ['boot', '--tail', '8'], {
+      GUILD_ACTOR: 'alice',
+    });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.tail.length, 8, '--tail <N> override broken');
+  } finally {
+    cleanup();
+  }
+});
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Summary

- \`gate boot\` is **bootstrap-shape** — called every session start, hot path
- Default \`--tail 10\` produced ~250-line JSON; lowered to 5 (~200 lines, **20% reduction**)
- Override via \`--tail <N>\` works as before — deeper history still one flag away
- Two new pin tests: default size + override path (regression net for both directions)

## Why

Per [principle 13](./lore/principles/13-affordance-density-by-verb-shape.md): bootstrap-shape verbs tolerate noise less than they look. High frequency × full context = death by a thousand cuts. \`gate boot\` lands at every session start; saving ~50 lines of JSON scroll per call is real ergonomic budget.

This was caught during Wave 7 dogfood — \"毎セッション頭で読み流してる\" was the surface signal, the underlying issue was that 10 utterance entries × ~7 lines each dominated the payload.

## Test plan

- [x] \`gate boot\` JSON is 197 lines (was 247) on dogfood content_root
- [x] \`gate boot --tail 10\` returns 247 lines (override unchanged)
- [x] \`gate boot --format text\` unchanged at 25 lines (text render already capped at 5)
- [x] New tests pin default=5 and override=8
- [x] Full suite: 996/1016 pass, 20 fail = pre-existing macOS/JSON-snapshot baseline (zero regression vs main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)