### PR TITLE
feat(gate): surface ctx in boot cross_passage (4th passage orientation)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -20,6 +20,7 @@ import {
   PassageOrientationSummary,
 } from '../../shared/PassageOrientation.js';
 import { agoraOrientation } from '../../../passages/agora/interface/orientation.js';
+import { ctxOrientation } from '../../../passages/ctx/interface/orientation.js';
 import { devilOrientation } from '../../../passages/devil/interface/orientation.js';
 
 /**
@@ -526,6 +527,7 @@ const PASSAGE_ORIENTATION_REGISTRY: ReadonlyArray<{
 }> = [
   { name: 'agora', provider: agoraOrientation },
   { name: 'devil', provider: devilOrientation },
+  { name: 'ctx', provider: ctxOrientation },
 ];
 
 async function collectCrossPassage(

--- a/src/passages/ctx/interface/orientation.ts
+++ b/src/passages/ctx/interface/orientation.ts
@@ -1,0 +1,59 @@
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
+import {
+  PassageOrientationProvider,
+  PassageOrientationSummary,
+} from '../../../interface/shared/PassageOrientation.js';
+
+/**
+ * ctx's orientation provider. Surfaces the count of recorded facts
+ * and the most-recently-created id + timestamp.
+ *
+ * ctx has no state machine in phase 1 — it is record-only. So
+ * `open` is the total count, `suspended` is always 0, and
+ * `last_state` is the literal string `'recorded'` (the only state
+ * a ctx record can be in). This keeps the cross-passage shape
+ * uniform for boot consumers without forcing ctx to invent a
+ * lifecycle it doesn't have.
+ *
+ * Returns null when `<content_root>/ctx/` has no records at all
+ * — gate boot omits the entry rather than rendering an empty
+ * "ctx: 0 / 0 / null" structure (voice budget; principle 13).
+ *
+ * Closes the orientation gap surfaced during Wave 7 dogfood: ctx
+ * records existed on the substrate but `gate boot` cross_passage
+ * showed only agora/devil — the registry hadn't been updated when
+ * ctx (the fourth passage) joined the family.
+ */
+export const ctxOrientation: PassageOrientationProvider = async (
+  config: GuildConfig,
+): Promise<PassageOrientationSummary | null> => {
+  const repo = new YamlCtxRepository(config);
+  const ids = await repo.listAllIds();
+  if (ids.length === 0) return null;
+
+  // ctx ids embed the date (ctx-YYYY-MM-DD-NNN). Lexicographic
+  // descending sort puts the newest id first — same trick agora's
+  // play ids use, no need to hydrate every record just to find
+  // the latest. The actual created_at lives inside each YAML, but
+  // for orientation the id-derived ordering is sufficient and
+  // avoids reading N files on every boot.
+  const sorted = [...ids].sort((a, b) => (a < b ? 1 : a > b ? -1 : 0));
+  const latestId = sorted[0]!;
+
+  // Hydrate just the latest to surface its created_at — boot's
+  // contract names `last_at` as the activity timestamp, and an
+  // id-derived date wouldn't carry the H:M:S precision the other
+  // providers do.
+  const latest = await repo.findById(latestId);
+  const lastAt = latest?.created_at ?? null;
+
+  return {
+    passage: 'ctx',
+    open: ids.length,
+    suspended: 0,
+    last_id: latestId,
+    last_state: 'recorded',
+    last_at: lastAt,
+  };
+};

--- a/tests/interface/crossPassageBoot.test.ts
+++ b/tests/interface/crossPassageBoot.test.ts
@@ -29,6 +29,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 const AGORA = resolve(here, '../../../bin/agora.mjs');
 const DEVIL = resolve(here, '../../../bin/devil.mjs');
+const CTX = resolve(here, '../../../bin/ctx.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
   const root = mkdtempSync(join(tmpdir(), 'guild-cross-passage-'));
@@ -160,6 +161,46 @@ test('gate boot: both passages surface independently', (t) => {
   const payload = JSON.parse(r.stdout);
   assert.ok(payload.cross_passage.agora, 'agora present');
   assert.ok(payload.cross_passage.devil, 'devil present');
+});
+
+test('gate boot: cross_passage.ctx populated when ctx records exist', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r1 = run(CTX, root, ['record', '--fact', 'first fact']);
+  assert.equal(r1.status, 0, `ctx record stderr: ${r1.stderr}`);
+  const r2 = run(CTX, root, ['record', '--fact', 'second fact']);
+  assert.equal(r2.status, 0, `ctx record stderr: ${r2.stderr}`);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  // ctx has no state machine in phase 1: open=count, suspended=0,
+  // last_state='recorded'. Pin all four so a future "let's add a
+  // lifecycle to ctx" change has to update this contract explicitly.
+  assert.equal(payload.cross_passage.ctx.passage, 'ctx');
+  assert.equal(payload.cross_passage.ctx.open, 2);
+  assert.equal(payload.cross_passage.ctx.suspended, 0);
+  assert.equal(payload.cross_passage.ctx.last_state, 'recorded');
+  assert.match(payload.cross_passage.ctx.last_id, /^ctx-\d{4}-\d{2}-\d{2}-\d{3}$/);
+  assert.ok(payload.cross_passage.ctx.last_at, 'last_at set');
+});
+
+test('gate boot: cross_passage omits ctx when no ctx records exist', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Seed agora only — confirms ctx provider returns null (omitted)
+  // rather than appearing as an empty stub.
+  run(AGORA, root, ['new', '--slug', 't', '--kind', 'sandbox', '--title', 'T']);
+  run(AGORA, root, ['play', '--slug', 't']);
+
+  const r = run(GATE, root, ['boot', '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.cross_passage.agora, 'agora present');
+  assert.equal(
+    payload.cross_passage.ctx,
+    undefined,
+    'ctx absent when no records — voice budget',
+  );
 });
 
 test('gate boot: a malformed devil review does not break the rest of boot', (t) => {


### PR DESCRIPTION
## Summary

- ctx records existed on the substrate but \`gate boot\` cross_passage only surfaced agora/devil
- Add \`ctxOrientation\` provider + register it in \`PASSAGE_ORIENTATION_REGISTRY\`
- ctx is record-only in phase 1: \`open\` = count, \`suspended\` = 0, \`last_state\` = \`'recorded'\`
- Provider hydrates only the latest record (id-derived sort) — boot stays cheap as ctx grows

## Why

Wave 7 dogfood surface signal (Eris): on dogfood substrate with **11 ctx records**, \`gate boot\` showed:

\`\`\`
agora: 1 open (1 paused); last 2026-05-05-001 [suspended]
devil: 0 open; last rev-2026-05-04-001 [concluded]
\`\`\`

ctx invisible. With this PR:

\`\`\`
agora: 1 open (1 paused); last 2026-05-05-001 [suspended]
devil: 0 open; last rev-2026-05-04-001 [concluded]
ctx: 11 open; last ctx-2026-05-05-004 [recorded]
\`\`\`

Per [principle 04](./lore/principles/04-records-outlive-writers.md): substrate must be **findable on re-entry**, not just present on disk. The cross-passage registry was the seam #cross-passage-orient established for exactly this — adding ctx is a one-line registry change + a small provider, not a refactor of boot.

Per [principle 13](./lore/principles/13-affordance-density-by-verb-shape.md): provider returns \`null\` when ctx has no records → boot omits the entry. No \"ctx: 0 open\" noise on fresh roots.

## Test plan

- [x] New test: cross_passage.ctx populated (open=2, suspended=0, last_state='recorded')
- [x] New test: cross_passage omits ctx when no records (voice budget)
- [x] Full suite: 1000/1020 pass, 20 fail = pre-existing macOS baseline (zero regression)
- [x] Manual: dogfood content_root with 11 ctx records → \`gate boot --format text\` shows the new line

🤖 Generated with [Claude Code](https://claude.com/claude-code)