### PR TITLE
feat(devil): include catalog + did-you-mean hint on lense/persona miss

### DIFF
--- a/src/passages/devil/domain/Lense.ts
+++ b/src/passages/devil/domain/Lense.ts
@@ -142,9 +142,23 @@ export class Lense {
 }
 
 export class LenseNotFound extends Error {
-  constructor(name: string) {
+  /**
+   * `available` carries the catalog at the time of the failure so
+   * the interface layer can render a did-you-mean hint without having
+   * to round-trip back through the LenseCatalog. The domain layer
+   * is the source of truth on which lenses exist; pushing the list
+   * up via the error means error messages always reflect *what was
+   * looked at*, not what the renderer thinks should exist.
+   *
+   * Empty `available` is allowed (catalog could legitimately be
+   * empty in a malformed config) — the interface renders without
+   * the suggestion line in that case.
+   */
+  readonly available: readonly string[];
+  constructor(name: string, available: readonly string[] = []) {
     super(`Lense not found in catalog: ${name}`);
     this.name = 'LenseNotFound';
+    this.available = available;
   }
 }
 

--- a/src/passages/devil/domain/Persona.ts
+++ b/src/passages/devil/domain/Persona.ts
@@ -112,9 +112,18 @@ export class Persona {
 }
 
 export class PersonaNotFound extends Error {
-  constructor(name: string) {
+  /**
+   * Mirror of LenseNotFound.available — the catalog at failure time,
+   * surfaced so the interface layer can render did-you-mean hints
+   * uniformly across the two unknown-name failures `devil entry` can
+   * trip on. Empty list is legal (malformed config) and renders
+   * without a suggestion.
+   */
+  readonly available: readonly string[];
+  constructor(name: string, available: readonly string[] = []) {
     super(`Persona not found in catalog: ${name}`);
     this.name = 'PersonaNotFound';
+    this.available = available;
   }
 }
 

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -122,11 +122,11 @@ export async function entryOnReview(
   // Catalog resolution. Throw structured errors so the dispatcher
   // surfaces them as named failures rather than generic message text.
   const persona = deps.personas.find(personaName);
-  if (!persona) throw new PersonaNotFound(personaName);
+  if (!persona) throw new PersonaNotFound(personaName, deps.personas.names());
   if (persona.ingest_only) throw new PersonaIsIngestOnly(personaName);
 
   const lense = deps.lenses.find(lenseName);
-  if (!lense) throw new LenseNotFound(lenseName);
+  if (!lense) throw new LenseNotFound(lenseName, deps.lenses.names());
 
   // Kind handling. `gate` is reserved for ingest paths.
   const kind: EntryKind = parseEntryKind(kindRaw);

--- a/src/passages/devil/interface/handlers/ingest.ts
+++ b/src/passages/devil/interface/handlers/ingest.ts
@@ -242,7 +242,7 @@ export async function ingestSource(
 
   const personaName = SOURCE_TO_PERSONA[source];
   const persona = deps.personas.find(personaName);
-  if (!persona) throw new PersonaNotFound(personaName);
+  if (!persona) throw new PersonaNotFound(personaName, deps.personas.names());
   if (!persona.ingest_only) {
     // Defensive — if the catalog ever gets reshaped so the source's
     // persona isn't ingest-only, refuse rather than silently
@@ -489,7 +489,7 @@ function requireKnownLense(
     throw new DomainError(`${ctx}: 'lense' required (non-empty string)`, 'lense');
   }
   if (!lenses.find(raw)) {
-    throw new LenseNotFound(raw);
+    throw new LenseNotFound(raw, lenses.names());
   }
   return raw;
 }

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -22,6 +22,8 @@ import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
+import { LenseNotFound } from '../domain/Lense.js';
+import { PersonaNotFound } from '../domain/Persona.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
 import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
@@ -229,6 +231,29 @@ export async function main(argv: readonly string[]): Promise<number> {
     // Strip absolute contentRoot prefix (issue #153).
     const msg = sanitizeError(rawMsg, config.contentRoot);
     process.stderr.write(`error: ${msg}\n`);
+    // For catalog-miss failures, render the catalog + did-you-mean
+    // hint so the caller doesn't have to round-trip through `devil
+    // schema` to recover. 12 lenses + 6 personas are too many to
+    // hold in agent working memory; surfacing them at the failure
+    // site is the same affordance gate's `nearestCommand` already
+    // provides for unknown verbs (CLAUDE.md: "Skills that *open*
+    // something → agora; that *protect* something → devil"). The
+    // hint is on stderr so JSON parsers reading stdout aren't
+    // affected. Empty `available` (malformed config) renders no
+    // hint — same shape as gate's nearestCommand-returns-null.
+    if (e instanceof LenseNotFound || e instanceof PersonaNotFound) {
+      const kind = e instanceof LenseNotFound ? 'lense' : 'persona';
+      const tried = e.message.split(': ').pop() ?? '';
+      if (e.available.length > 0) {
+        const hint = nearestCommand(tried, e.available);
+        if (hint) {
+          process.stderr.write(`  did you mean: --${kind} ${hint}?\n`);
+        }
+        process.stderr.write(
+          `  available ${kind}s: ${e.available.join(', ')}\n`,
+        );
+      }
+    }
     return 1;
   }
 }

--- a/tests/passages/devil/entryVerb.test.ts
+++ b/tests/passages/devil/entryVerb.test.ts
@@ -216,6 +216,51 @@ test('entry: unknown lense surfaces LenseNotFound', (t) => {
   assert.match(r.stderr, /Lense not found in catalog: made-up/);
 });
 
+test('entry: unknown lense includes catalog + did-you-mean for typos', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const reviewId = openReview(root);
+  // One-edit typo: "injecton" → "injection". The hint should fire.
+  const r = runDevil(
+    root,
+    [
+      'entry', reviewId,
+      '--persona', 'red-team',
+      '--lense', 'injecton',
+      '--kind', 'resistance',
+      '--text', 'x',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Lense not found in catalog: injecton/);
+  assert.match(r.stderr, /did you mean: --lense injection\?/);
+  // Catalog list — pin a few canonical names so a future catalog
+  // shape change has to update this test explicitly.
+  assert.match(r.stderr, /available lenses:.*injection.*supply-chain/);
+});
+
+test('entry: unknown persona includes catalog + did-you-mean for typos', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const reviewId = openReview(root);
+  const r = runDevil(
+    root,
+    [
+      'entry', reviewId,
+      '--persona', 'redteam',
+      '--lense', 'injection',
+      '--kind', 'resistance',
+      '--text', 'x',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Persona not found in catalog: redteam/);
+  assert.match(r.stderr, /did you mean: --persona red-team\?/);
+  assert.match(r.stderr, /available personas:.*red-team.*mirror/);
+});
+
 test('entry: review not found returns DevilReviewNotFound', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);


### PR DESCRIPTION
## Summary

- \`devil entry --lense bogus\` now lists the **12 available lenses** + a Levenshtein \"did you mean: --lense X?\" hint on near-matches
- Same treatment for \`--persona\` (6 personas)
- Hint on stderr → JSON consumers reading stdout unaffected
- Empty \`available\` (malformed config) renders no hint — parallels gate's \`nearestCommand\`-returns-null

## Why

Wave 7 dogfood surface signal (Eris): \"devil の lense 12 個、毎回手で覚えてられない（schema 引けばいいが flow 中断）\".

Before:
\`\`\`
$ devil entry rev-x --lense injecton --kind resistance --text x
error: Lense not found in catalog: injecton
\`\`\`

After:
\`\`\`
error: Lense not found in catalog: injecton
  did you mean: --lense injection?
  available lenses: injection, injection-parser, path-network, auth-access, memory-safety, crypto, deserialization, protocol-encoding, supply-chain, composition, temporal, coherence
\`\`\`

The same shape gate's [nearestCommand](./src/interface/shared/nearestCommand.ts) already provides for unknown verbs. CLAUDE.md frames this as devil's affordance: \"Skills that *protect* something → devil\". Recovery ergonomics extend that — devil should help you reach for the right lense, not just refuse the wrong one.

## Mechanics

- \`LenseNotFound\` / \`PersonaNotFound\` carry a new \`available: readonly string[]\` field, populated at throw sites from \`catalog.names()\` (already on the catalog port).
- Interface-layer catch in \`src/passages/devil/interface/index.ts\` checks instance type, runs \`nearestCommand\` for the hint, and writes both the suggestion (when present) and the full catalog list to stderr.
- Tests pin: typo near-match fires \`did you mean\` + lists catalog (existing \"unknown lense\" test still asserts the original message → backward-compatible).

## Test plan

- [x] \`devil entry --lense injecton\` → did-you-mean injection + 12-lense list
- [x] \`devil entry --persona redteam\` → did-you-mean red-team + 6-persona list
- [x] Genuinely unrelated input (no near match) → catalog list only, no hint line
- [x] Existing \`unknown lense\` / \`unknown persona\` tests still pass (message backward-compatible)
- [x] Full suite: 1002/1022 pass, 20 fail = pre-existing macOS baseline (zero regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)