### PR TITLE
feat(agora): qualify last next-hint with --game; surface suspension at in list

### DIFF
--- a/src/passages/agora/interface/handlers/last.ts
+++ b/src/passages/agora/interface/handlers/last.ts
@@ -161,5 +161,21 @@ export async function lastPlay(deps: LastDeps, args: ParsedArgs): Promise<number
         `  closing invitation: ${closing.invitation}\n`,
     );
   }
+  // Next-hint: include `--game <slug>` so the id is usable as-is. Play
+  // ids are per-game sequences, so a bare id collides across games and
+  // every downstream verb (move/suspend/cliff/resume) errors with a
+  // "Disambiguate with --game" message. last is an orientation verb
+  // — its job isn't done until the next call works.
+  if (last.state === 'playing') {
+    process.stdout.write(
+      `  next: agora move ${last.id} --game ${last.game} --text "..."\n` +
+        `        or agora suspend ${last.id} --game ${last.game} --cliff "..." --invitation "..."\n`,
+    );
+  } else if (last.state === 'suspended') {
+    process.stdout.write(
+      `  next: agora resume ${last.id} --game ${last.game}\n` +
+        `        or agora cliff ${last.id} --game ${last.game}  (peek without resuming)\n`,
+    );
+  }
   return 0;
 }

--- a/src/passages/agora/interface/handlers/list.ts
+++ b/src/passages/agora/interface/handlers/list.ts
@@ -145,8 +145,14 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
           : p.state === 'concluded'
             ? `[${p.state} ✓]`
             : `[${p.state}]`;
+      // For --state suspended, surface the suspension timestamp so the
+      // caller can see the sort axis (#182 sorts by most-recent suspension,
+      // but without the timestamp on screen the ordering is opaque).
+      const suspendedAt =
+        stateFilter === 'suspended' ? p.suspensions.at(-1)?.at : undefined;
+      const trailer = suspendedAt ? ` (suspended ${suspendedAt})` : '';
       process.stdout.write(
-        `  ${p.id}  ${tag.padEnd(15)} game=${p.game.padEnd(20)} moves=${moves} by ${p.started_by}\n`,
+        `  ${p.id}  ${tag.padEnd(15)} game=${p.game.padEnd(20)} moves=${moves} by ${p.started_by}${trailer}\n`,
       );
     }
   }

--- a/tests/passages/agora/lastAndCliff.test.ts
+++ b/tests/passages/agora/lastAndCliff.test.ts
@@ -196,6 +196,51 @@ test('agora last: text mode renders one-line summary + cliff lines when suspende
   assert.match(r.stdout, /closing invitation:/);
 });
 
+test('agora last: text next-hint includes --game so the id is usable as-is', (t) => {
+  // Touch-feel: bare play-ids collide across games; downstream verbs
+  // (move/suspend/cliff/resume) error with "Disambiguate with --game".
+  // last is an orientation verb — the next call must work without the
+  // caller hand-pasting the slug they just read off the same line.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedAlice(root);
+  run(AGORA, root, ['new', '--slug', 'gh-play', '--kind', 'sandbox', '--title', 'g'], {
+    GUILD_ACTOR: 'alice',
+  });
+  run(AGORA, root, ['play', '--slug', 'gh-play'], { GUILD_ACTOR: 'alice' });
+  const playing = run(AGORA, root, ['last'], { GUILD_ACTOR: 'alice' });
+  assert.equal(playing.status, 0);
+  assert.match(playing.stdout, /next: agora move .+ --game gh-play --text/);
+  assert.match(playing.stdout, /agora suspend .+ --game gh-play --cliff/);
+
+  // suspended state → resume + cliff hints, both --game-qualified
+  run(AGORA, root, ['new', '--slug', 'gh-susp', '--kind', 'sandbox', '--title', 'g'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const susp = JSON.parse(
+    run(AGORA, root, ['play', '--slug', 'gh-susp', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    }).stdout,
+  );
+  run(AGORA, root, [
+    'suspend', susp.play_id, '--game', 'gh-susp', '--by', 'alice',
+    '--cliff', 'c', '--invitation', 'i',
+  ]);
+  const suspended = run(AGORA, root, ['last'], { GUILD_ACTOR: 'alice' });
+  assert.equal(suspended.status, 0);
+  assert.match(suspended.stdout, /next: agora resume .+ --game gh-susp/);
+  assert.match(suspended.stdout, /agora cliff .+ --game gh-susp/);
+
+  // JSON envelope is unchanged — orchestrators rebuild qualified args
+  // from id+game already; the hint is a text-only affordance.
+  const json = JSON.parse(
+    run(AGORA, root, ['last', '--format', 'json'], { GUILD_ACTOR: 'alice' }).stdout,
+  );
+  assert.equal(json.ok, true);
+  assert.ok(typeof json.play.id === 'string');
+  assert.ok(typeof json.play.game === 'string');
+});
+
 // --- agora cliff ---
 
 test('agora cliff: never-suspended play returns helpful "no cliff" message', (t) => {

--- a/tests/passages/agora/list.test.ts
+++ b/tests/passages/agora/list.test.ts
@@ -297,6 +297,42 @@ test('agora list: --state playing keeps substrate id-desc sort (no re-sort)', (t
   );
 });
 
+test('agora list: --state suspended text output surfaces suspension timestamp', (t) => {
+  // Pairs with the sort: #182 ordered suspended plays by most-recent
+  // suspension, but the text view didn't show the timestamp — so the
+  // sort axis was invisible. Surface the `at` of the latest suspension
+  // so a human reader can see why the order is what it is.
+  // Other states (playing/concluded) and the no-filter case stay clean.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+  const today = new Date().toISOString().slice(0, 10);
+  runAgora(
+    root,
+    ['suspend', `${today}-001`, '--cliff', 'c', '--invitation', 'i'],
+    { GUILD_ACTOR: 'alice' },
+  );
+
+  const r = runAgora(root, ['list', '--state', 'suspended'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  // Match the trailing "(suspended <iso8601>)" — proves the timestamp
+  // is present without pinning the exact value.
+  assert.match(r.stdout, /\(suspended \d{4}-\d{2}-\d{2}T[\d:.]+Z\)/);
+
+  // Negative: --state playing should NOT carry a (suspended ...) trailer.
+  const playing = runAgora(root, ['list', '--state', 'playing'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(playing.status, 0);
+  assert.doesNotMatch(playing.stdout, /\(suspended /);
+});
+
 test('agora list: rejects unknown flag (principle 10 input contract)', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);


### PR DESCRIPTION
## Summary

Two touch-feel friction points from a 2026-05-05 main-merge dogfood pass.

- **`agora last` ↔ cross-game id collision**: `last` returned a bare id (`2026-05-05-001`) but downstream verbs errored with "Disambiguate with --game". Now the text mode emits a `next:` hint that's already `--game`-qualified — playing → move/suspend, suspended → resume/cliff, concluded → no hint. JSON envelope unchanged.
- **`agora list --state suspended` opaque sort**: PR #182 added the most-recent-suspension sort, but the text view didn't show the timestamp so the sort axis was invisible. Trailer `(suspended <ts>)` now appears only for `--state suspended`; other states keep the clean line.

Both follow principle 13 (affordance density follows verb shape): `last` is an orientation verb, hints belong; `list --state suspended` is asking *when* something paused, surface the answer.

## Test plan

- [x] `tests/passages/agora/lastAndCliff.test.ts`: new test pins `next:` hint with `--game` for playing + suspended; JSON envelope unchanged.
- [x] `tests/passages/agora/list.test.ts`: new test pins suspended trailer present + absent on `--state playing`.
- [x] 1022 → 1024 tests; 17 pre-existing failures unchanged (macOS realpath /var vs /private/var, unrelated to this PR — same on main).
- [x] Manual dogfood: `agora new` → `play` → `suspend` → `last` (both states) → `list --state suspended` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)