### PR TITLE
fix(agora): extend --game qualifier to play/suspend/resume next-hints (#186 follow-up)

### DIFF
--- a/src/passages/agora/interface/handlers/last.ts
+++ b/src/passages/agora/interface/handlers/last.ts
@@ -166,6 +166,11 @@ export async function lastPlay(deps: LastDeps, args: ParsedArgs): Promise<number
   // every downstream verb (move/suspend/cliff/resume) errors with a
   // "Disambiguate with --game" message. last is an orientation verb
   // — its job isn't done until the next call works.
+  //
+  // `concluded` is intentionally absent: terminal state, no further
+  // moves/suspensions/resumes are valid (mirrors conclude.ts which
+  // sets `suggested_next: null`). Surfacing a hint here would invite
+  // a call that always errors.
   if (last.state === 'playing') {
     process.stdout.write(
       `  next: agora move ${last.id} --game ${last.game} --text "..."\n` +

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -105,8 +105,8 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
   } else {
     process.stdout.write(
       `✓ play started: ${play.id} [${play.state}] on game=${play.game}\n` +
-        `  next: agora move ${play.id} --by ${by} "<text>"\n` +
-        `        or agora suspend ${play.id} --cliff "..." --invitation "..."  (leave a cliff)\n`,
+        `  next: agora move ${play.id} --game ${play.game} --by ${by} "<text>"\n` +
+        `        or agora suspend ${play.id} --game ${play.game} --cliff "..." --invitation "..."  (leave a cliff)\n`,
     );
   }
   const configSegment =

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -135,7 +135,7 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
       );
     }
     process.stdout.write(
-      `  next: agora move ${play.id} --by ${by} "<text addressing the invitation>"\n`,
+      `  next: agora move ${play.id} --game ${play.game} --by ${by} "<text addressing the invitation>"\n`,
     );
   }
   return 0;

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -127,7 +127,7 @@ export async function suspendPlay(
       `✓ play suspended: ${play.id} [playing → suspended] by ${by}\n` +
         `  cliff:      ${cliff}\n` +
         `  invitation: ${invitation}\n` +
-        `  next: agora resume ${play.id} --by <m>  (when re-entering)\n`,
+        `  next: agora resume ${play.id} --game ${play.game} --by <m>  (when re-entering)\n`,
     );
   }
   return 0;

--- a/tests/interface/parseArgs.test.ts
+++ b/tests/interface/parseArgs.test.ts
@@ -24,6 +24,16 @@ import {
  * via the explicit `start` parameter; what's missing is honest
  * isolation in tests that go through requireOption / optionalOption,
  * since those don't expose `start`.
+ *
+ * IMPORTANT — concurrency safety: process.chdir() is global state.
+ * This helper is safe today because (a) node:test runs each *.test.js
+ * file in a child process via tests/run.mjs, so chdir cannot leak
+ * across files, and (b) within one file, tests run serially by
+ * default. If a future change adds `test.concurrency > 1` to this
+ * file or imports `withCleanCwd` into another test that runs in
+ * parallel within the same process, two tests could race on cwd
+ * and silent-fail on either side. Promote to a per-call DI seam
+ * before parallelizing.
  */
 function withCleanCwd(fn: () => void): void {
   const cwdBefore = process.cwd();

--- a/tests/passages/agora/play.test.ts
+++ b/tests/passages/agora/play.test.ts
@@ -201,6 +201,20 @@ test('agora play: rejects unknown flag (principle 10 input contract)', (t) => {
   assert.match(r.stderr, /unknown flag.*--bogus/);
 });
 
+test('agora play: text next-hint includes --game so the id is usable as-is', (t) => {
+  // Same touch-feel contract as agora last (PR #186): play ids are
+  // per-game sequences, so a bare id collides across games. The
+  // success-line next-hint must already include --game or the user's
+  // first follow-up call errors with "Disambiguate with --game".
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedGame(root, 'g-hint');
+  const r = runAgora(root, ['play', '--slug', 'g-hint'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /next: agora move .+ --game g-hint --by alice/);
+  assert.match(r.stdout, /agora suspend .+ --game g-hint --cliff/);
+});
+
 test('agora play: yaml file directory layout matches passage convention', (t) => {
   // Pin the structural decision: plays live under
   // <content_root>/agora/plays/<game-slug>/<play-id>.yaml.

--- a/tests/passages/agora/suspendResume.test.ts
+++ b/tests/passages/agora/suspendResume.test.ts
@@ -310,6 +310,28 @@ test('agora resume: JSON envelope surfaces resumed_suspension struct', (t) => {
   assert.equal(payload.suggested_next.verb, 'move');
 });
 
+test('agora suspend / resume: text next-hint includes --game so the id is usable as-is', (t) => {
+  // Same touch-feel contract as agora last + agora play (PR #186):
+  // play ids are per-game sequences. The success-line next-hint must
+  // already include --game or the user's first follow-up call errors
+  // with "Disambiguate with --game".
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const playId = seedPlayingPlay(root);
+
+  const susp = runAgora(
+    root,
+    ['suspend', playId, '--cliff', 'c', '--invitation', 'i'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(susp.status, 0);
+  assert.match(susp.stdout, /next: agora resume .+ --game pivot-game --by/);
+
+  const resumed = runAgora(root, ['resume', playId], { GUILD_ACTOR: 'alice' });
+  assert.equal(resumed.status, 0);
+  assert.match(resumed.stdout, /next: agora move .+ --game pivot-game --by alice/);
+});
+
 test('agora suspend: nonexistent play fails closed', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);


### PR DESCRIPTION
Follow-up to PR #186 / #187, addressing devil-review (noir) findings on both.

## Summary

**(1) Consistency: --game qualifier across all four next-hint emitters.** PR #186 added `--game <slug>` to `agora last`'s next-hint but left the same hint unqualified in `agora play` / `suspend` / `resume`. The justification — "ids are per-game sequences, so a bare id collides; orientation verbs must produce calls that work" — applies identically to all four. Half-fixed, the success line of `agora play` told you to `agora move <id> --by alice "<text>"` and that exact call errored on the very next line. Now consistent.

**(2) Comment: why concluded state has no next-hint in last.ts.** noir flagged that the if/else covers playing + suspended but not concluded, with no comment explaining intent. Added one — terminal state, mirrors `conclude.ts`'s `suggested_next: null`.

**(3) Docstring: withCleanCwd's serial-execution dependency.** noir flagged that `process.chdir()` inside `withCleanCwd` is global state, safe today only because node:test spawns a child process per file and tests within a file run serially. Future `test.concurrency > 1` would silent-fail. Tripwire added.

## Files

- `src/passages/agora/interface/handlers/play.ts` / `suspend.ts` / `resume.ts` — each next-hint now embeds `--game <slug>`
- `src/passages/agora/interface/handlers/last.ts` — concluded-state intent comment
- `tests/passages/agora/play.test.ts` — pin play's next-hint shape
- `tests/passages/agora/suspendResume.test.ts` — pin suspend + resume next-hint shape
- `tests/interface/parseArgs.test.ts` — withCleanCwd docstring

## Test plan

- [x] 1024 → 1027 tests; identical 17 pre-existing failures (macOS realpath /var vs /private/var, unrelated).
- [x] Manual dogfood end-to-end: every success line is now copy-paste ready under the multi-game id-collision case.

## Devil findings deferred

- **MINOR (#187)**: third use of `.guild-actor` isolation pattern → promote to `tests/_helpers/cleanCwd.ts`. Tracking in ctx; ship when third callsite emerges.
- **MINOR (#186)**: 2-line next-hint × 2 states is denser than other verbs; consider moving the `or` line to `agora help last`. Open question for the next agora touch-feel pass — not blocking.
- **MINOR (#186)**: `suspensions[].at` ISO-8601 format dependency in `list.ts` — tests pin via `\d{4}-\d{2}-\d{2}T...` regex, so format change would break tests; acceptable contract today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)