### PR TITLE
feat(security): defense-in-depth prototype-pollution guard in parseYamlSafe (#154)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -168,9 +168,18 @@ the issue is the active discussion.
   the host-specific prefix that `safeFs` resolves into.
 - **Prototype pollution from hostile YAML**
   ([#154](https://github.com/eris-ths/guild-cli/issues/154)).
-  Modern `yaml` lib returns plain objects and handles `__proto__`
-  safely, but the hydration layer does not independently guard
-  against prototype keys.
+  Mitigated as of v1-prep #154 (defense-in-depth): `parseYamlSafe`
+  passes the parsed tree through `stripPrototypeKeys` before
+  returning. The walker rebuilds plain objects via
+  `Object.create(null)`, dropping `__proto__` / `constructor` /
+  `prototype` literal keys at every nesting level. Defence is now
+  layered: (1) `MemberName` rejects the three names at the domain
+  boundary, (2) the `yaml` library returns plain objects (upstream
+  guarantee), and (3) parseYamlSafe strips them independently
+  regardless of what the lib does. Class instances pass through
+  unchanged so YAML custom tags that produce e.g. `Date` carriers
+  are unaffected. Tests:
+  `tests/infrastructure/parseYamlSafe.test.ts`.
 - **Concurrent writes**
   ([#155](https://github.com/eris-ths/guild-cli/issues/155)).
   There is no lock file. Two simultaneous writes on the same record

--- a/src/infrastructure/persistence/parseYamlSafe.ts
+++ b/src/infrastructure/persistence/parseYamlSafe.ts
@@ -16,9 +16,65 @@
 // prefix is matched by DiagnosticReport.classifyMessage which maps
 // it to the `yaml_parse_error` DiagnosticKind, and RepairPlan in
 // turn routes that kind to quarantine.
+//
+// Defense-in-depth: prototype-key stripping (issue #154). The
+// `yaml` library returns plain Maps/objects with `__proto__` set
+// as a literal key (not via the prototype slot), but that guarantee
+// is upstream. We add an independent guard here so the safety of
+// the hydrate layer doesn't rest on the lib's internal behaviour
+// alone. Every parsed object/array passes through `stripPrototypeKeys`
+// before returning, walking the tree and dropping `__proto__` /
+// `constructor` / `prototype` literal keys at every level. The
+// `Object.create(null)` rebuild ensures the returned tree has no
+// prototype chain at all — domain restore code reads bracket-indexed
+// keys (`obj['action']` etc.) so this is invisible to callers, but
+// closes the gap where a future yaml-lib version, a YAML-spec corner
+// case (merge keys, anchors, custom tags), or a downstream
+// `Object.assign` could reintroduce pollution.
 
 import YAML from 'yaml';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
+
+const DANGEROUS_KEYS: ReadonlySet<string> = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+/**
+ * Recursively rebuild `value` with prototype-poisoning keys removed.
+ *
+ * - Plain objects → new prototype-less object via `Object.create(null)`.
+ *   Dangerous keys are dropped; remaining keys are recursed.
+ * - Arrays → new array with each element recursed.
+ * - Primitives, null, undefined → returned as-is.
+ * - Class instances (Date, Map, etc.) → returned as-is. The yaml lib
+ *   returns plain objects/arrays for normal documents, so this branch
+ *   is for safety on hostile inputs that shape into other carriers
+ *   via custom tags (`!!js/regexp`, etc.) — passing them through
+ *   unchanged is correct because they're not the JSON-shaped tree
+ *   we walk in hydrate.
+ *
+ * Why three names: `__proto__` is the historical pollution vector,
+ * `constructor` lets an attacker reach `Function` and arbitrary code
+ * via `obj.constructor.constructor('...')`, `prototype` rounds out
+ * the trio used in defensive guards across the npm ecosystem
+ * (see e.g. `lodash._baseSet`, `qs.parse`, `mongoose`).
+ */
+function stripPrototypeKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(stripPrototypeKeys);
+  // Only recurse into plain objects. Class instances pass through
+  // unchanged (see comment above).
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
+  const cleaned = Object.create(null) as Record<string, unknown>;
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.has(k)) continue;
+    cleaned[k] = stripPrototypeKeys(v);
+  }
+  return cleaned;
+}
 
 /**
  * Parse YAML text, returning `undefined` on lexer/parser failure
@@ -32,14 +88,18 @@ import { OnMalformed } from '../../application/ports/OnMalformed.js';
  * turn every empty file into a silently-dropped "parse failed" event.
  * The 6 call sites in the Yaml*Repository hydrate paths follow this
  * rule; tests in `tests/infrastructure/parseYamlSafe.test.ts` pin it.
+ *
+ * The returned tree is sanitized against prototype pollution
+ * (issue #154 defense-in-depth). See `stripPrototypeKeys` above.
  */
 export function parseYamlSafe(
   raw: string,
   source: string,
   onMalformed: OnMalformed,
 ): unknown {
+  let parsed: unknown;
   try {
-    return YAML.parse(raw);
+    parsed = YAML.parse(raw);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     // Flatten newlines only, preserving intentional horizontal
@@ -52,4 +112,5 @@ export function parseYamlSafe(
     onMalformed(source, `yaml parse failed: ${oneLine}`);
     return undefined;
   }
+  return stripPrototypeKeys(parsed);
 }

--- a/tests/infrastructure/parseYamlSafe.test.ts
+++ b/tests/infrastructure/parseYamlSafe.test.ts
@@ -16,8 +16,19 @@ function makeCollector(): { calls: Call[]; onMalformed: (s: string, m: string) =
 
 test('parseYamlSafe: returns parsed value for valid YAML (mapping)', () => {
   const { calls, onMalformed } = makeCollector();
-  const result = parseYamlSafe('name: kiri\ncategory: core\n', '/tmp/x.yaml', onMalformed);
-  assert.deepEqual(result, { name: 'kiri', category: 'core' });
+  const result = parseYamlSafe(
+    'name: kiri\ncategory: core\n',
+    '/tmp/x.yaml',
+    onMalformed,
+  ) as Record<string, unknown>;
+  // Compare keys + values rather than `deepEqual({ ... })` because the
+  // post-#154 helper rebuilds objects via Object.create(null) for
+  // prototype-pollution defense; deepStrictEqual (the strict-mode
+  // alias) compares prototypes, so a literal `{ ... }` expected value
+  // wouldn't match. The shape contract — keys + values — still holds.
+  assert.equal(result['name'], 'kiri');
+  assert.equal(result['category'], 'core');
+  assert.deepEqual(Object.keys(result).sort(), ['category', 'name']);
   assert.equal(calls.length, 0, 'valid YAML should not trigger onMalformed');
 });
 
@@ -139,4 +150,114 @@ test('parseYamlSafe: message prefix matches classifier expectation', () => {
     calls[0]!.msg.toLowerCase().startsWith('yaml parse failed'),
     'prefix must start with "yaml parse failed" so classifyMessage routes to yaml_parse_error',
   );
+});
+
+// ── Prototype-pollution defense-in-depth (issue #154) ──
+//
+// The current `yaml` library returns plain objects with `__proto__`
+// as a literal key (no actual prototype-slot pollution), but the
+// hydrate layer doesn't independently guard. parseYamlSafe now
+// strips `__proto__` / `constructor` / `prototype` literal keys at
+// every nesting level before returning, so the safety isn't load-
+// bearing on the upstream lib alone.
+
+test('parseYamlSafe: strips __proto__ literal key at top level', () => {
+  const { onMalformed } = makeCollector();
+  const yaml = '__proto__:\n  polluted: true\nname: alice\n';
+  const result = parseYamlSafe(yaml, '/x', onMalformed) as Record<string, unknown>;
+  assert.equal(result['name'], 'alice');
+  assert.equal(result['__proto__'], undefined);
+  // Object.prototype globally uncontaminated
+  const probe: Record<string, unknown> = {};
+  assert.equal(probe['polluted'], undefined);
+});
+
+test('parseYamlSafe: strips constructor and prototype literal keys', () => {
+  const { onMalformed } = makeCollector();
+  const yaml = 'constructor: evil\nprototype: also-evil\nlegit: kept\n';
+  const result = parseYamlSafe(yaml, '/x', onMalformed) as Record<string, unknown>;
+  assert.equal(result['legit'], 'kept');
+  assert.equal(result['constructor'], undefined);
+  assert.equal(result['prototype'], undefined);
+});
+
+test('parseYamlSafe: strips dangerous keys at nested levels (recursive)', () => {
+  const { onMalformed } = makeCollector();
+  const yaml = `
+top:
+  ok: yes
+  __proto__:
+    polluted: nested
+  inner:
+    constructor: also-evil
+    legit: deep
+list:
+  - prototype: in-array-element
+    name: a
+  - name: b
+`;
+  const result = parseYamlSafe(yaml, '/x', onMalformed) as Record<string, unknown>;
+  const top = result['top'] as Record<string, unknown>;
+  assert.equal(top['ok'], 'yes');
+  assert.equal(top['__proto__'], undefined);
+  const inner = top['inner'] as Record<string, unknown>;
+  assert.equal(inner['legit'], 'deep');
+  assert.equal(inner['constructor'], undefined);
+  const list = result['list'] as Array<Record<string, unknown>>;
+  assert.equal(list.length, 2);
+  assert.equal(list[0]!['name'], 'a');
+  assert.equal(list[0]!['prototype'], undefined);
+  assert.equal(list[1]!['name'], 'b');
+});
+
+test('parseYamlSafe: dangerous-name-prefixed keys are NOT stripped (only exact matches)', () => {
+  // The defense targets the three exact names that participate in
+  // prototype pollution. Other keys that happen to share a prefix
+  // are application data and must pass through unchanged.
+  const { onMalformed } = makeCollector();
+  const yaml = `
+__internal__: ok
+constructor_name: also-ok
+__proto_: this-is-just-data
+my_prototype: still-data
+`;
+  const result = parseYamlSafe(yaml, '/x', onMalformed) as Record<string, unknown>;
+  assert.equal(result['__internal__'], 'ok');
+  assert.equal(result['constructor_name'], 'also-ok');
+  assert.equal(result['__proto_'], 'this-is-just-data');
+  assert.equal(result['my_prototype'], 'still-data');
+});
+
+test('parseYamlSafe: cleaned objects have no prototype (Object.create(null))', () => {
+  const { onMalformed } = makeCollector();
+  const result = parseYamlSafe('a: 1\nb: 2\n', '/x', onMalformed) as object;
+  assert.equal(Object.getPrototypeOf(result), null);
+  // Bracket-indexed reads (the pattern hydrate code uses) keep
+  // working transparently — that's the whole point.
+  assert.equal((result as Record<string, unknown>)['a'], 1);
+});
+
+test('parseYamlSafe: arrays of primitives pass through unchanged', () => {
+  const { onMalformed } = makeCollector();
+  const result = parseYamlSafe('tags:\n  - a\n  - b\n  - c\n', '/x', onMalformed) as Record<string, unknown>;
+  assert.deepEqual(result['tags'], ['a', 'b', 'c']);
+});
+
+test('parseYamlSafe: scalar documents pass through unchanged', () => {
+  const { onMalformed } = makeCollector();
+  assert.equal(parseYamlSafe('42', '/x', onMalformed), 42);
+  assert.equal(parseYamlSafe('"hello"', '/x', onMalformed), 'hello');
+  assert.equal(parseYamlSafe('true', '/x', onMalformed), true);
+});
+
+test('parseYamlSafe: Object.prototype is uncontaminated after hostile parses', () => {
+  // The strongest test: if any prior parse leaked into Object.prototype,
+  // a fresh empty object would inherit the pollution. Run hostile
+  // parses and then probe a fresh object — must remain pristine.
+  const { onMalformed } = makeCollector();
+  parseYamlSafe('__proto__:\n  isAdmin: true\n', '/x', onMalformed);
+  parseYamlSafe('constructor:\n  prototype:\n    isAdmin: true\n', '/x', onMalformed);
+  const probe: Record<string, unknown> = {};
+  assert.equal(probe['isAdmin'], undefined);
+  assert.ok(!('isAdmin' in probe), 'isAdmin must not appear via prototype chain');
 });


### PR DESCRIPTION
Closes #154.

## Summary

Hydrate layer was leaning on `yaml`-lib's promise that `__proto__` lands as a literal key (no prototype-slot pollution). Add an independent guard at the `parseYamlSafe` chokepoint so that guarantee is no longer load-bearing on the upstream library alone.

`stripPrototypeKeys(value)` walks the parsed tree and rebuilds plain objects via `Object.create(null)`, dropping `__proto__` / `constructor` / `prototype` literal keys at every nesting level. Class instances (Date, Map, custom-tag carriers) pass through unchanged.

## Why the chokepoint approach

Every `Yaml*Repository` in the codebase already routes hydrate input through `parseYamlSafe` — one sanitization site means no per-caller follow-up. Repositories read fields via bracket indexing (`obj['action']`), so the prototype-less rebuild is invisible at read time.

## Defense layers (post-#154)

1. `MemberName.of` rejects the three names at the domain boundary
2. `yaml` library returns plain objects (upstream guarantee)
3. `parseYamlSafe` drops them independently via `stripPrototypeKeys` (**this PR**)
4. Repositories receive `Object.create(null)`-based objects — `obj.constructor` returns `undefined` rather than reaching `Function`

## Test plan

- [x] 8 new tests in `tests/infrastructure/parseYamlSafe.test.ts` pinning: top-level / nested / array-element strip, prefix-only false positives ruled out, `Object.create(null)` rebuild, scalars + primitive arrays unchanged, global `Object.prototype` uncontaminated after hostile parses.
- [x] 1 existing test updated (`deepEqual` of plain object → key/value comparisons; `deepStrictEqual` rejects prototype mismatch for a contract-equivalent shape).
- [x] 1027 → 1035 tests, 17 pre-existing failures unchanged.
- [x] No `Yaml*Repository.ts` changes needed — bracket-index reads work transparently.

## SECURITY.md

The known-hardening item is now marked **mitigated**, sibling shape to the #153 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)