### PR TITLE
feat(lock): introduce withGuildLock + 4-entry middleware (#155 PR-A)

### DIFF
--- a/src/infrastructure/lock/guildLock.ts
+++ b/src/infrastructure/lock/guildLock.ts
@@ -1,0 +1,290 @@
+// guildLock — content-root-wide single-writer lock primitive.
+//
+// Design lineage: issue #155 (Noir/Devil ratified). Acts as a coarse
+// write-side mutex for write-classified verbs across all four passage
+// entries (gate / agora / devil / ctx) so that two concurrently
+// invoked CLIs cannot interleave writes onto the same content root.
+//
+// Mechanism: O_CREAT|O_EXCL ('wx') on `${contentRoot}/.guild-lock`.
+// Holder writes JSON metadata into the file, runs `fn`, and unlinks
+// in `finally`. A competing acquire fails with EEXIST and surfaces
+// as `LockBusyError` (DomainError subclass → `lock_busy` JSON code).
+//
+// Stale reclaim (minimal, PR-A scope): on EEXIST we try once to
+// rescue an obviously-dead lock by reading the file's metadata and
+// auto-unlinking when EITHER:
+//   1. `kill(pid, 0)` reports ESRCH (the recorded process is gone), OR
+//   2. `GUILD_LOCK_MAX_AGE_MS` env is set and `started_at` exceeds it.
+//
+// We deliberately refuse to reclaim a lock whose pid is our own
+// process or our parent — that's ancestor territory and reclaiming
+// it would silently corrupt a legitimate concurrent flow within the
+// same process tree. boottime-aware reclaim is PR-B work.
+//
+// Lock metadata is treated as UNTRUSTED input: another writer (or a
+// hand-edited file) may put arbitrary strings in `actor` / `verb` /
+// `passage`. We never interpolate them into shell or filesystem
+// paths; user-facing surfaces JSON-stringify before display.
+
+import { openSync, writeSync, closeSync, unlinkSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { hostname } from 'node:os';
+import { DomainError } from '../../domain/shared/DomainError.js';
+import { getPackageVersion } from '../../interface/shared/version.js';
+
+/**
+ * Thrown when the content-root lock is held by another process and
+ * cannot be reclaimed as stale. Subclass of `DomainError` so the
+ * existing entry-point catch path handles it uniformly; the JSON
+ * envelope branch in `deriveErrorCode` maps it to `lock_busy`.
+ *
+ * `holder` carries the lock metadata that was on disk at the time
+ * we tried to acquire — useful for diagnostics, but treat as
+ * untrusted (it came from another writer's serialization).
+ */
+export class LockBusyError extends DomainError {
+  public readonly holder: LockMetadata | null;
+  public readonly lockPath: string;
+  constructor(lockPath: string, holder: LockMetadata | null) {
+    const who = holder
+      ? `pid=${String(holder.pid)} actor=${JSON.stringify(holder.actor)} verb=${JSON.stringify(holder.verb)}`
+      : '(unreadable holder metadata)';
+    super(
+      `another guild-cli write is in flight (lock: ${lockPath}); holder: ${who}`,
+    );
+    this.name = 'LockBusyError';
+    this.holder = holder;
+    this.lockPath = lockPath;
+  }
+}
+
+/**
+ * Persisted shape of the lock file. New optional fields can be
+ * appended without breaking older holders since we only `read` the
+ * fields we explicitly inspect during reclaim.
+ */
+export interface LockMetadata {
+  pid: number;
+  ppid: number;
+  started_at: string; // ISO 8601
+  verb: string;
+  actor: string;
+  host: string;
+  cwd: string;
+  passage: string;
+  guild_cli_version: string;
+}
+
+export interface GuildLockMeta {
+  passage: string;
+  verb: string;
+  actor: string;
+}
+
+export interface GuildLockOpts {
+  /**
+   * Override the lock filename within `contentRoot`. Tests use this
+   * to isolate concurrent runs; production always uses the default.
+   */
+  lockFile?: string;
+}
+
+interface ConfigLike {
+  contentRoot: string;
+}
+
+const DEFAULT_LOCK_FILE = '.guild-lock';
+
+/**
+ * Acquire the content-root lock, run `fn`, release in `finally`.
+ *
+ * Returns whatever `fn` returns. If `fn` throws, the error
+ * propagates AFTER the lock is released. If acquisition itself
+ * fails (other holder, not stale), throws `LockBusyError`.
+ */
+export async function withGuildLock<T>(
+  config: ConfigLike,
+  meta: GuildLockMeta,
+  fn: () => Promise<T>,
+  opts: GuildLockOpts = {},
+): Promise<T> {
+  const lockPath = join(config.contentRoot, opts.lockFile ?? DEFAULT_LOCK_FILE);
+  const fd = acquire(lockPath, meta);
+  try {
+    return await fn();
+  } finally {
+    release(lockPath, fd);
+  }
+}
+
+/**
+ * Attempt to create the lock file exclusively. On EEXIST, peek the
+ * existing metadata and either reclaim (one retry) or throw
+ * `LockBusyError`. Returns the held file descriptor.
+ */
+function acquire(lockPath: string, meta: GuildLockMeta): number {
+  try {
+    return openExclusive(lockPath, meta);
+  } catch (err) {
+    if (!isEexist(err)) throw err;
+    // EEXIST path — read holder, decide whether to reclaim.
+    const holder = readHolder(lockPath);
+    if (holder && isReclaimable(holder)) {
+      // Best-effort unlink; if it disappears between our read and
+      // unlink that's fine — the next openExclusive will succeed.
+      try {
+        unlinkSync(lockPath);
+      } catch (e) {
+        if (!isEnoent(e)) throw e;
+      }
+      try {
+        return openExclusive(lockPath, meta);
+      } catch (retryErr) {
+        if (!isEexist(retryErr)) throw retryErr;
+        // Lost the race: someone else acquired between our unlink
+        // and retry. Surface that as busy with the *new* holder.
+        throw new LockBusyError(lockPath, readHolder(lockPath));
+      }
+    }
+    throw new LockBusyError(lockPath, holder);
+  }
+}
+
+function release(lockPath: string, fd: number): void {
+  // Close first so platforms that hold a delete-lock on open fds
+  // (e.g. Windows) can complete the unlink. Errors during release
+  // are swallowed — a leaked .guild-lock will be reclaimed by the
+  // next caller via the staleness check; throwing here would mask
+  // a real `fn` error in the caller's catch.
+  try {
+    closeSync(fd);
+  } catch {
+    // ignore
+  }
+  try {
+    unlinkSync(lockPath);
+  } catch (e) {
+    if (!isEnoent(e)) {
+      // We deliberately do not rethrow. The lock is process-bound
+      // and the next caller's reclaim will handle a stuck file.
+    }
+  }
+}
+
+function openExclusive(lockPath: string, meta: GuildLockMeta): number {
+  const fd = openSync(lockPath, 'wx');
+  try {
+    const payload: LockMetadata = {
+      pid: process.pid,
+      ppid: typeof process.ppid === 'number' ? process.ppid : 0,
+      started_at: new Date().toISOString(),
+      verb: meta.verb,
+      actor: meta.actor,
+      host: hostname(),
+      cwd: process.cwd(),
+      passage: meta.passage,
+      guild_cli_version: safeVersion(),
+    };
+    writeSync(fd, JSON.stringify(payload, null, 2) + '\n');
+    return fd;
+  } catch (e) {
+    // If we crashed mid-write, leaving an empty/garbage file would
+    // wedge subsequent runs. Best-effort cleanup before rethrow.
+    try { closeSync(fd); } catch { /* ignore */ }
+    try { unlinkSync(lockPath); } catch { /* ignore */ }
+    throw e;
+  }
+}
+
+function readHolder(lockPath: string): LockMetadata | null {
+  let raw: string;
+  try {
+    raw = readFileSync(lockPath, 'utf8');
+  } catch (e) {
+    if (isEnoent(e)) return null;
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const o = parsed as Record<string, unknown>;
+    if (typeof o['pid'] !== 'number') return null;
+    return {
+      pid: o['pid'] as number,
+      ppid: typeof o['ppid'] === 'number' ? (o['ppid'] as number) : 0,
+      started_at: typeof o['started_at'] === 'string' ? (o['started_at'] as string) : '',
+      verb: typeof o['verb'] === 'string' ? (o['verb'] as string) : '',
+      actor: typeof o['actor'] === 'string' ? (o['actor'] as string) : '',
+      host: typeof o['host'] === 'string' ? (o['host'] as string) : '',
+      cwd: typeof o['cwd'] === 'string' ? (o['cwd'] as string) : '',
+      passage: typeof o['passage'] === 'string' ? (o['passage'] as string) : '',
+      guild_cli_version:
+        typeof o['guild_cli_version'] === 'string' ? (o['guild_cli_version'] as string) : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether an existing lock can be safely auto-unlinked.
+ * Conservative: refuses to touch our own pid or our parent, since
+ * those are ancestors and reclaiming them would corrupt a legitimate
+ * in-flight call within the same process tree.
+ */
+function isReclaimable(holder: LockMetadata): boolean {
+  // Safety valve: never reclaim ancestor pids.
+  if (holder.pid === process.pid) return false;
+  if (typeof process.ppid === 'number' && holder.pid === process.ppid) return false;
+
+  // Dead-process check: kill(pid, 0) → ESRCH means the process is gone.
+  // EPERM means the process exists but we can't signal it (different
+  // user) — treat as alive (don't reclaim). Other errors: also treat
+  // as alive (conservative).
+  if (isPidDead(holder.pid)) return true;
+
+  // Age-based reclaim, opt-in via env. The env path is intended for
+  // operators who know their workflow's max sane duration; the
+  // default (env unset) leaves stale locks alone unless the pid is
+  // demonstrably dead.
+  const maxAgeRaw = process.env['GUILD_LOCK_MAX_AGE_MS'];
+  if (maxAgeRaw !== undefined && maxAgeRaw.length > 0) {
+    const maxAge = Number(maxAgeRaw);
+    if (Number.isFinite(maxAge) && maxAge > 0 && holder.started_at !== '') {
+      const startedMs = Date.parse(holder.started_at);
+      if (Number.isFinite(startedMs)) {
+        const age = Date.now() - startedMs;
+        if (age > maxAge) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isPidDead(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return false; // signal accepted → process is alive
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return true; // no such process
+    return false; // EPERM or other → assume alive (conservative)
+  }
+}
+
+function isEexist(e: unknown): boolean {
+  return !!e && typeof e === 'object' && (e as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function isEnoent(e: unknown): boolean {
+  return !!e && typeof e === 'object' && (e as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function safeVersion(): string {
+  try {
+    return getPackageVersion();
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/infrastructure/lock/guildLock.ts
+++ b/src/infrastructure/lock/guildLock.ts
@@ -10,25 +10,33 @@
 // in `finally`. A competing acquire fails with EEXIST and surfaces
 // as `LockBusyError` (DomainError subclass → `lock_busy` JSON code).
 //
-// Stale reclaim (minimal, PR-A scope): on EEXIST we try once to
-// rescue an obviously-dead lock by reading the file's metadata and
-// auto-unlinking when EITHER:
-//   1. `kill(pid, 0)` reports ESRCH (the recorded process is gone), OR
-//   2. `GUILD_LOCK_MAX_AGE_MS` env is set and `started_at` exceeds it.
+// Stale reclaim (PR-A + PR-B): on EEXIST we try once to rescue an
+// obviously-dead lock by reading the file's metadata and
+// auto-unlinking when ANY of:
+//   1. `lock.started_at` predates the current OS boot (reboot
+//      crossed → the recorded pid cannot be the same process as
+//      the holder, even if a fresh pid happens to collide), OR
+//   2. `kill(pid, 0)` reports ESRCH (the recorded process is gone)
+//      AND the pid is not our own / not our parent, OR
+//   3. `GUILD_LOCK_MAX_AGE_MS` env is set and `started_at` exceeds it.
 //
 // We deliberately refuse to reclaim a lock whose pid is our own
 // process or our parent — that's ancestor territory and reclaiming
 // it would silently corrupt a legitimate concurrent flow within the
-// same process tree. boottime-aware reclaim is PR-B work.
+// same process tree. We do NOT walk further up the ancestor chain:
+// a portable Node API for that does not exist (Linux-only /proc is
+// out of scope), and reboot-crossing PID collisions on the
+// grandparent boundary fall under "acceptable false-reclaim" — the
+// boottime check (1) catches the common reboot case anyway.
 //
 // Lock metadata is treated as UNTRUSTED input: another writer (or a
 // hand-edited file) may put arbitrary strings in `actor` / `verb` /
 // `passage`. We never interpolate them into shell or filesystem
 // paths; user-facing surfaces JSON-stringify before display.
 
-import { openSync, writeSync, closeSync, unlinkSync, readFileSync } from 'node:fs';
+import { openSync, writeSync, closeSync, unlinkSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { hostname } from 'node:os';
+import { hostname, uptime as osUptime } from 'node:os';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion } from '../../interface/shared/version.js';
 
@@ -123,6 +131,16 @@ export async function withGuildLock<T>(
  * `LockBusyError`. Returns the held file descriptor.
  */
 function acquire(lockPath: string, meta: GuildLockMeta): number {
+  // Test-only synchronization barrier. When GUILD_LOCK_TEST_BARRIER
+  // is set to a path, block (busy-poll) until that path exists
+  // before attempting `openExclusive`. The cross-passage race E2E
+  // suite uses this to make N spawned children all enter the
+  // open-O_EXCL race in the same kernel-scheduling window — without
+  // it, child N starts so much later than child 1 that child 1 has
+  // already finished and released, and the suite cannot observe a
+  // real race. Production callers never set this env, so the cost
+  // is one cheap getenv per acquire.
+  awaitTestBarrier();
   try {
     return openExclusive(lockPath, meta);
   } catch (err) {
@@ -233,14 +251,44 @@ function readHolder(lockPath: string): LockMetadata | null {
  * in-flight call within the same process tree.
  */
 function isReclaimable(holder: LockMetadata): boolean {
-  // Safety valve: never reclaim ancestor pids.
+  // Boottime check first — if started_at predates OS boot, the
+  // recorded pid cannot belong to the original holder regardless
+  // of whether the same pid is alive now (reboots reset the pid
+  // namespace). This rescues a legitimate stale lock left over by
+  // a hard crash that rebooted the machine.
+  //
+  // Strict `<` (not `<=`): the reboot-second boundary is too coarse
+  // to make a confident call from boottime alone; the kill-0 ESRCH
+  // OR the GUILD_LOCK_MAX_AGE_MS path will pick up that one-second
+  // edge case if it actually matters.
+  //
+  // os.uptime() is whole-second precision on macOS / Linux but the
+  // returned value is a Number; multiply by 1000 to compare against
+  // Date.now() in ms.
+  if (holder.started_at !== '') {
+    const startedMs = Date.parse(holder.started_at);
+    if (Number.isFinite(startedMs)) {
+      const bootMs = Date.now() - osUptime() * 1000;
+      if (startedMs < bootMs) return true;
+    }
+  }
+
+  // Safety valve: never reclaim ancestor pids via the kill-0 branch.
+  // Note: a lock surviving a reboot WILL pass through here above
+  // (boottime branch) before hitting this guard — that's intentional
+  // because post-reboot a colliding pid is by definition not our
+  // ancestor. We only refuse to reclaim ancestors in the "machine
+  // hasn't rebooted" case.
   if (holder.pid === process.pid) return false;
   if (typeof process.ppid === 'number' && holder.pid === process.ppid) return false;
 
   // Dead-process check: kill(pid, 0) → ESRCH means the process is gone.
   // EPERM means the process exists but we can't signal it (different
   // user) — treat as alive (don't reclaim). Other errors: also treat
-  // as alive (conservative).
+  // as alive (conservative). Ancestor-walk beyond pid/ppid is not
+  // portable in Node, so reboot-crossing pid collisions further up
+  // the tree fall under acceptable risk; the boottime branch above
+  // covers the common reboot case.
   if (isPidDead(holder.pid)) return true;
 
   // Age-based reclaim, opt-in via env. The env path is intended for
@@ -259,6 +307,37 @@ function isReclaimable(holder: LockMetadata): boolean {
     }
   }
   return false;
+}
+
+/**
+ * If `GUILD_LOCK_TEST_BARRIER` is set, busy-wait until the named
+ * file exists. No-op when the env is unset (the production case).
+ *
+ * Uses a tight sync poll with `existsSync` rather than fs.watch so
+ * the wait is deterministic across platforms (fs.watch semantics on
+ * macOS are different enough from Linux that test flake is real).
+ * Bounded at ~10s so a misconfigured test fails fast instead of
+ * hanging the runner indefinitely.
+ */
+function awaitTestBarrier(): void {
+  const barrier = process.env['GUILD_LOCK_TEST_BARRIER'];
+  if (barrier === undefined || barrier.length === 0) return;
+  const deadline = Date.now() + 10_000;
+  // Atomics + SharedArrayBuffer would let us sleep without burn,
+  // but pulling that in for a test-only path isn't worth the
+  // complexity. A 5ms granularity keeps CPU use trivial.
+  while (!existsSync(barrier)) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `GUILD_LOCK_TEST_BARRIER timeout: ${barrier} did not appear within 10s`,
+      );
+    }
+    // Synchronous tight loop with Atomics.wait on a dummy buffer
+    // to yield the thread without spinning hot. 5ms is well below
+    // any meaningful test timeout but well above the kernel's
+    // wakeup granularity.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+  }
 }
 
 function isPidDead(pid: number): boolean {

--- a/src/infrastructure/lock/withEntryLock.ts
+++ b/src/infrastructure/lock/withEntryLock.ts
@@ -1,0 +1,40 @@
+// withEntryLock — thin per-entry middleware that decides whether
+// to engage `withGuildLock` for a given verb.
+//
+// Decision order (fail-safe by design):
+//   1. EXEMPT  → run `fn` directly, no lock.        (e.g. doctor / repair)
+//   2. READ    → run `fn` directly, no lock.
+//   3. WRITE   → acquire lock, run `fn`, release.
+//   4. unknown → acquire lock (treat as write).     ← fail-safe
+//
+// "unknown" should never happen in practice — the verbs-consistency
+// test pins each entry's switch cases to the union READ ∪ WRITE ∪
+// EXEMPT — but if a new verb is added without updating verbs.ts, we
+// prefer over-locking (slight contention) to under-locking (silent
+// concurrent corruption).
+
+import { withGuildLock } from './guildLock.js';
+
+export interface VerbSets {
+  READ_VERBS: ReadonlySet<string>;
+  WRITE_VERBS: ReadonlySet<string>;
+  LOCK_EXEMPT_VERBS: ReadonlySet<string>;
+}
+
+interface ConfigLike {
+  contentRoot: string;
+}
+
+export async function withEntryLock<T>(
+  config: ConfigLike,
+  passage: string,
+  cmd: string,
+  verbs: VerbSets,
+  actor: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (verbs.LOCK_EXEMPT_VERBS.has(cmd)) return fn();
+  if (verbs.READ_VERBS.has(cmd)) return fn();
+  // WRITE_VERBS or unknown → lock (fail-safe).
+  return withGuildLock(config, { passage, verb: cmd, actor }, fn);
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -44,6 +44,12 @@ import { transcriptCmd } from './handlers/transcript.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
+import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
+import { LockBusyError } from '../../infrastructure/lock/guildLock.js';
+import { resolveGuildActor } from '../shared/resolveGuildActor.js';
+import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
+import type { Container } from '../shared/container.js';
+import type { ParsedArgs } from '../shared/parseArgs.js';
 
 // Re-export for test backward-compat (tests/interface/reviewMarkers.test.ts).
 // formatReviewMarkers and computeReviewMarkerWidth live in handlers/request.ts
@@ -262,121 +268,22 @@ export async function main(argv: readonly string[]): Promise<number> {
   const args = parseArgs(rest);
   const c = buildContainer();
   try {
-    switch (cmd) {
-      case 'request':
-        return await reqCreate(c, args);
-      case 'pending':
-        return await reqList(c, 'pending', args, 'pending');
-      case 'board':
-        return await boardCmd(c, args);
-      case 'list': {
-        // `gate list` without --state is a common first-try ("show me
-        // everything"). Rather than just erroring on the missing flag,
-        // spell out the list vs status distinction — the question most
-        // first-time users actually have is "which verb do I want?"
-        const state = optionalOption(args, 'state');
-        if (state === undefined) {
-          process.stderr.write(
-            `gate list needs --state <s> (${REQUEST_STATES.join(' | ')} | all).\n` +
-              '  For counts across every state:  gate status\n' +
-              '  For the contents of one state:  gate list --state <s>\n' +
-              '  For every state at once:        gate list --state all\n',
-          );
-          return 1;
-        }
-        return await reqList(c, state, args, 'list');
-      }
-      case 'show':
-        return await reqShow(c, args);
-      case 'voices':
-        return await reqVoices(c, args);
-      case 'tail':
-        return await reqTail(c, args);
-      case 'whoami':
-        return await reqWhoami(c, args);
-      case 'register':
-        return await reqRegister(c, args);
-      case 'chain':
-        return await reqChain(c, args);
-      case 'approve':
-        return await reqApprove(c, args);
-      case 'deny':
-        return await reqDeny(c, args);
-      case 'execute':
-        return await reqExecute(c, args);
-      case 'complete':
-        return await reqComplete(c, args);
-      case 'fail':
-        return await reqFail(c, args);
-      case 'review':
-        return await reqReview(c, args);
-      case 'thank':
-        return await reqThank(c, args);
-      case 'fast-track':
-        return await reqFastTrack(c, args);
-      case 'issues':
-        return await issuesCmd(c, args);
-      case 'message':
-        return await msgSend(c, args);
-      case 'broadcast':
-        return await msgBroadcast(c, args);
-      case 'inbox':
-        return await msgInbox(c, args);
-      case 'doctor':
-        return await doctorCmd(c, args);
-      case 'repair':
-        return await repairCmd(c, args);
-      case 'status':
-        return await statusCmd(c, args);
-      case 'boot':
-        return await bootCmd(c, args);
-      case 'suggest':
-        return await suggestCmd(c, args);
-      case 'transcript':
-        return await transcriptCmd(c, args);
-      case 'summarize':
-        return await summarizeCmd(c, args);
-      case 'why':
-        return await whyCmd(c, args);
-      case 'resume':
-        return await resumeCmd(c, args);
-      case 'schema':
-        return await schemaCmd(c, args);
-      case 'unresponded':
-        return await unrespondedCmd(c, args);
-      default: {
-        const hint = nearestCommand(cmd, KNOWN_COMMANDS);
-        const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';
-        process.stderr.write(
-          `unknown command: ${cmd}${suggest}\n` +
-            `  see 'gate --help' for the full command list.\n`,
-        );
-        return 1;
-      }
-    }
+    const actor = resolveGuildActor() ?? '';
+    return await withEntryLock(
+      c.config,
+      'gate',
+      cmd,
+      { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS },
+      actor,
+      () => dispatch(cmd, c, args),
+    );
   } catch (e) {
     if (e instanceof HelpRequested) {
       renderVerbHelp('gate', e);
       return 0;
     }
-    // The `error:` prefix gives the CLI-universal "this failed" cue;
-    // prepending "DomainError:" on top leaked an internal class name
-    // into user-facing output without adding information. The trailing
-    // `(field)` suffix used to echo which flag was bad — but for
-    // domain-internal fields (`state`, `sequence`) it read as debug
-    // noise, and for user-typed flags the message already names the
-    // field in prose. JSON envelope retains `error.field` for
-    // programmatic consumers (P3 dogfood C/A cleanup).
     const rawMsg = e instanceof Error ? e.message : String(e);
-    // Strip absolute contentRoot prefix from any safeFs-style paths
-    // before they reach stderr (issue #153, Direction 1).
     const msg = sanitizeError(rawMsg, c.config.contentRoot);
-    // When the caller asked for JSON output, mirror the error on
-    // stderr as a JSON envelope so a tool layer doesn't have to run
-    // two parsers (one on stdout JSON, one on stderr text). The
-    // human-readable `error: …` line still goes out too — pipelines
-    // that ignore stderr keep working, and humans reading the
-    // terminal still get a scannable message at the top.
     if (args.options['format'] === 'json') {
       const payload: Record<string, unknown> = {
         ok: false,
@@ -398,6 +305,105 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
 }
 
+async function dispatch(
+  cmd: string,
+  c: Container,
+  args: ParsedArgs,
+): Promise<number> {
+  switch (cmd) {
+    case 'request':
+      return await reqCreate(c, args);
+    case 'pending':
+      return await reqList(c, 'pending', args, 'pending');
+    case 'board':
+      return await boardCmd(c, args);
+    case 'list': {
+      // `gate list` without --state is a common first-try ("show me
+      // everything"). Rather than just erroring on the missing flag,
+      // spell out the list vs status distinction — the question most
+      // first-time users actually have is "which verb do I want?"
+      const state = optionalOption(args, 'state');
+      if (state === undefined) {
+        process.stderr.write(
+          `gate list needs --state <s> (${REQUEST_STATES.join(' | ')} | all).\n` +
+            '  For counts across every state:  gate status\n' +
+            '  For the contents of one state:  gate list --state <s>\n' +
+            '  For every state at once:        gate list --state all\n',
+        );
+        return 1;
+      }
+      return await reqList(c, state, args, 'list');
+    }
+    case 'show':
+      return await reqShow(c, args);
+    case 'voices':
+      return await reqVoices(c, args);
+    case 'tail':
+      return await reqTail(c, args);
+    case 'whoami':
+      return await reqWhoami(c, args);
+    case 'register':
+      return await reqRegister(c, args);
+    case 'chain':
+      return await reqChain(c, args);
+    case 'approve':
+      return await reqApprove(c, args);
+    case 'deny':
+      return await reqDeny(c, args);
+    case 'execute':
+      return await reqExecute(c, args);
+    case 'complete':
+      return await reqComplete(c, args);
+    case 'fail':
+      return await reqFail(c, args);
+    case 'review':
+      return await reqReview(c, args);
+    case 'thank':
+      return await reqThank(c, args);
+    case 'fast-track':
+      return await reqFastTrack(c, args);
+    case 'issues':
+      return await issuesCmd(c, args);
+    case 'message':
+      return await msgSend(c, args);
+    case 'broadcast':
+      return await msgBroadcast(c, args);
+    case 'inbox':
+      return await msgInbox(c, args);
+    case 'doctor':
+      return await doctorCmd(c, args);
+    case 'repair':
+      return await repairCmd(c, args);
+    case 'status':
+      return await statusCmd(c, args);
+    case 'boot':
+      return await bootCmd(c, args);
+    case 'suggest':
+      return await suggestCmd(c, args);
+    case 'transcript':
+      return await transcriptCmd(c, args);
+    case 'summarize':
+      return await summarizeCmd(c, args);
+    case 'why':
+      return await whyCmd(c, args);
+    case 'resume':
+      return await resumeCmd(c, args);
+    case 'schema':
+      return await schemaCmd(c, args);
+    case 'unresponded':
+      return await unrespondedCmd(c, args);
+    default: {
+      const hint = nearestCommand(cmd, KNOWN_COMMANDS);
+      const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';
+      process.stderr.write(
+        `unknown command: ${cmd}${suggest}\n` +
+          `  see 'gate --help' for the full command list.\n`,
+      );
+      return 1;
+    }
+  }
+}
+
 /**
  * Macro-level error classification for the JSON envelope. Patterns
  * match the current set of `DomainError` messages so a tool layer
@@ -414,6 +420,12 @@ export async function main(argv: readonly string[]): Promise<number> {
  */
 function deriveErrorCode(e: unknown): string | null {
   if (!(e instanceof Error)) return null;
+  // LockBusyError check is first: it's a DomainError subclass, so the
+  // generic `validation_error` fallback below would otherwise shadow
+  // the more-specific `lock_busy` code. Tools branching on this need
+  // to distinguish "retry-after-backoff" (lock busy) from
+  // "fix-input-and-resubmit" (validation).
+  if (e instanceof LockBusyError) return 'lock_busy';
   const m = e.message;
   if (/\bnot found\b/i.test(m)) return 'not_found';
   if (/\bis already \w+\.?/i.test(m)) return 'already_in_state';

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -1,0 +1,61 @@
+// gate verbs — read/write/exempt classification for entry middleware.
+//
+// This file is the authoritative classification of every verb the
+// `gate` entry dispatches. The verbs-consistency test pins the union
+// (READ ∪ WRITE ∪ LOCK_EXEMPT) to the actual switch cases in
+// `index.ts`, so adding a new verb without updating this file fails
+// CI loud rather than silently bypassing or over-locking.
+//
+// Classification rule of thumb:
+//   READ   — verb's handler only reads YAML / does not mutate state.
+//   WRITE  — verb's handler appends or transitions persisted records.
+//   EXEMPT — verb intentionally orthogonal to the lock (doctor /
+//            repair are the maintenance pair; locking them would
+//            deadlock if the lock itself were the corruption).
+//
+// `gate inbox` is classified WRITE because the verb dispatcher branches
+// into `inbox mark-read`, which transitions inbox file state. The
+// classification is at verb-name granularity, not subverb, so the
+// conservative call wins.
+
+export const READ_VERBS: ReadonlySet<string> = new Set([
+  'pending',
+  'board',
+  'list',
+  'show',
+  'voices',
+  'tail',
+  'whoami',
+  'chain',
+  'status',
+  'boot',
+  'suggest',
+  'transcript',
+  'summarize',
+  'why',
+  'resume',
+  'schema',
+  'unresponded',
+]);
+
+export const WRITE_VERBS: ReadonlySet<string> = new Set([
+  'request',
+  'approve',
+  'deny',
+  'execute',
+  'complete',
+  'fail',
+  'review',
+  'thank',
+  'fast-track',
+  'register',
+  'issues',
+  'message',
+  'broadcast',
+  'inbox',
+]);
+
+export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set([
+  'doctor',
+  'repair',
+]);

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -11,6 +11,18 @@ import { notFoundMessage } from '../shared/notFoundHint.js';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
 import { sanitizeError } from '../shared/sanitizeError.js';
+import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
+import { resolveGuildActor } from '../shared/resolveGuildActor.js';
+
+// Per-entry verb classification. `guild new` writes a member YAML;
+// list/show/validate are read-only. No EXEMPT verbs at this entry.
+const GUILD_READ_VERBS: ReadonlySet<string> = new Set([
+  'list',
+  'show',
+  'validate',
+]);
+const GUILD_WRITE_VERBS: ReadonlySet<string> = new Set(['new']);
+const GUILD_EXEMPT_VERBS: ReadonlySet<string> = new Set();
 
 const HELP = `guild — member management CLI
 
@@ -36,7 +48,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
   const args = parseArgs(rest);
   const c = buildContainer();
-  try {
+  const dispatch = async (): Promise<number> => {
     switch (cmd) {
       case 'list': {
         rejectUnknownFlags(args, new Set(), 'list');
@@ -103,6 +115,21 @@ export async function main(argv: readonly string[]): Promise<number> {
         process.stderr.write(`unknown command: ${cmd}\n${HELP}`);
         return 1;
     }
+  };
+  try {
+    const actor = resolveGuildActor() ?? '';
+    return await withEntryLock(
+      c.config,
+      'guild',
+      cmd,
+      {
+        READ_VERBS: GUILD_READ_VERBS,
+        WRITE_VERBS: GUILD_WRITE_VERBS,
+        LOCK_EXEMPT_VERBS: GUILD_EXEMPT_VERBS,
+      },
+      actor,
+      dispatch,
+    );
   } catch (e) {
     if (e instanceof HelpRequested) {
       renderVerbHelp('guild', e);

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -28,8 +28,17 @@ export interface Container {
   unrespondedConcernsQ: UnrespondedConcernsQuery;
 }
 
-export function buildContainer(): Container {
-  const config = GuildConfig.load();
+export interface BuildContainerOpts {
+  /**
+   * Override `cwd` for `GuildConfig.load`. Tests pass a freshly
+   * `mkdtemp`-ed directory to verify the builder is side-effect-free
+   * (issue #155 PR-B pin test); production never sets this.
+   */
+  cwd?: string;
+}
+
+export function buildContainer(opts: BuildContainerOpts = {}): Container {
+  const config = GuildConfig.load(opts.cwd);
   const members = new YamlMemberRepository(config);
   const requests = new YamlRequestRepository(config);
   const issues = new YamlIssueRepository(config);
@@ -39,7 +48,7 @@ export function buildContainer(): Container {
   // onMalformed callback isn't shared with the stderr-emitting
   // default that the rest of the CLI uses.
   const buildDiagRepos = (om: OnMalformed): DiagnosticRepoBundle => {
-    const cfg = GuildConfig.load(process.cwd(), om);
+    const cfg = GuildConfig.load(opts.cwd ?? process.cwd(), om);
     return {
       members: new YamlMemberRepository(cfg),
       requests: new YamlRequestRepository(cfg),

--- a/src/passages/agora/interface/container.ts
+++ b/src/passages/agora/interface/container.ts
@@ -1,0 +1,43 @@
+// agora — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape (src/interface/shared/container.ts):
+// a single pure factory that loads config and constructs the Yaml*
+// repositories used by every handler in this passage. Extracted from
+// `main()` so the cross-process lock invariant test (issue #155 PR-B)
+// can verify the builder is side-effect-free — i.e. it does not write
+// anything to `contentRoot` BEFORE `withGuildLock` would have a chance
+// to serialize concurrent writers.
+//
+// Why the invariant matters: the lock middleware acquires AFTER
+// buildContainer. If a future change introduces write side-effects in
+// buildContainer (e.g. a config-migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. A pin test asserts the
+// directory snapshot before/after this call is byte-identical.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
+import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
+
+export interface AgoraContainer {
+  config: GuildConfig;
+  games: YamlGameRepository;
+  plays: YamlPlayRepository;
+}
+
+export interface BuildAgoraContainerOpts {
+  /**
+   * Override `cwd` for `GuildConfig.load`. Tests pass a freshly
+   * `mkdtemp`-ed directory; production never sets this.
+   */
+  cwd?: string;
+}
+
+export function buildAgoraContainer(
+  opts: BuildAgoraContainerOpts = {},
+): AgoraContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const games = new YamlGameRepository(config);
+  const plays = new YamlPlayRepository(config);
+  return { config, games, plays };
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -36,6 +36,9 @@ import { showAgora } from './handlers/show.js';
 import { lastPlay, LAST_BOOLEAN_FLAGS } from './handlers/last.js';
 import { cliffOf } from './handlers/cliff.js';
 import { schemaCmd } from './handlers/schema.js';
+import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
+import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
+import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
 const HELP = `agora — play / narrative passage (alpha, 11 verbs)
 
@@ -161,7 +164,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   const games = new YamlGameRepository(config);
   const plays = new YamlPlayRepository(config);
 
-  try {
+  const dispatch = async (): Promise<number> => {
     switch (cmd) {
       case 'new':
         return await newGame({ repo: games, config }, args);
@@ -195,6 +198,18 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
       }
     }
+  };
+
+  try {
+    const actor = resolveGuildActor() ?? '';
+    return await withEntryLock(
+      config,
+      'agora',
+      cmd ?? '',
+      { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS },
+      actor,
+      dispatch,
+    );
   } catch (e) {
     if (e instanceof HelpRequested) {
       renderVerbHelp('agora', e);

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -16,15 +16,13 @@
 // JSON / snake_case YAML / explicit-flag CLI; any future human-
 // facing UI is a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
-import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
-import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
+import { buildAgoraContainer } from './container.js';
 import { newGame } from './handlers/new.js';
 import { startPlay } from './handlers/play.js';
 import { moveOnPlay } from './handlers/move.js';
@@ -160,9 +158,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   ]);
   const verbBooleans = cmd ? VERB_BOOLEAN_FLAGS.get(cmd) : undefined;
   const args = parseArgs(rest, verbBooleans ? { booleanFlags: verbBooleans } : {});
-  const config = GuildConfig.load();
-  const games = new YamlGameRepository(config);
-  const plays = new YamlPlayRepository(config);
+  const { config, games, plays } = buildAgoraContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/src/passages/agora/interface/verbs.ts
+++ b/src/passages/agora/interface/verbs.ts
@@ -1,0 +1,25 @@
+// agora verbs — read/write/exempt classification for entry middleware.
+//
+// See gate's verbs.ts header for the rule-of-thumb classification.
+// agora has no maintenance verb pair yet, so LOCK_EXEMPT_VERBS is
+// empty (kept as an exported constant so the middleware signature
+// is uniform across passages).
+
+export const READ_VERBS: ReadonlySet<string> = new Set([
+  'list',
+  'show',
+  'last',
+  'cliff',
+  'schema',
+]);
+
+export const WRITE_VERBS: ReadonlySet<string> = new Set([
+  'new',
+  'play',
+  'move',
+  'suspend',
+  'resume',
+  'conclude',
+]);
+
+export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set();

--- a/src/passages/ctx/interface/container.ts
+++ b/src/passages/ctx/interface/container.ts
@@ -1,0 +1,31 @@
+// ctx — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape. Extracted from `main()` so
+// the buildContainer-invariant pin test (issue #155 PR-B) can assert
+// no on-disk writes happen here. The lock middleware acquires AFTER
+// this call; any future write side-effect introduced inside the
+// builder would silently break the cross-process serialization
+// guarantee. The pin test exists to catch that regression.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
+import { CtxUseCases } from '../application/CtxUseCases.js';
+
+export interface CtxContainer {
+  config: GuildConfig;
+  repo: YamlCtxRepository;
+  uc: CtxUseCases;
+}
+
+export interface BuildCtxContainerOpts {
+  cwd?: string;
+}
+
+export function buildCtxContainer(
+  opts: BuildCtxContainerOpts = {},
+): CtxContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const repo = new YamlCtxRepository(config);
+  const uc = new CtxUseCases(repo);
+  return { config, repo, uc };
+}

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -24,6 +24,9 @@ import { DomainError } from '../../../domain/shared/DomainError.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
 import { recordCtx } from './handlers/record.js';
+import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
+import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
+import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
 const HELP = `ctx — fact accumulation passage (phase 1: record only)
 
@@ -73,7 +76,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   const repo = new YamlCtxRepository(config);
   const uc = new CtxUseCases(repo);
 
-  try {
+  const dispatch = async (): Promise<number> => {
     switch (cmd) {
       case 'record':
         return await recordCtx({ uc, config }, args);
@@ -91,6 +94,18 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
       }
     }
+  };
+
+  try {
+    const actor = resolveGuildActor() ?? '';
+    return await withEntryLock(
+      config,
+      'ctx',
+      cmd ?? '',
+      { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS },
+      actor,
+      dispatch,
+    );
   } catch (e) {
     if (e instanceof HelpRequested) {
       renderVerbHelp('ctx', e);

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -14,15 +14,13 @@
 // snake_case YAML / explicit-flag CLI; any future human-facing UI is
 // a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
-import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
-import { CtxUseCases } from '../application/CtxUseCases.js';
+import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
@@ -72,9 +70,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const [cmd, ...rest] = argv;
   const args = parseArgs(rest);
-  const config = GuildConfig.load();
-  const repo = new YamlCtxRepository(config);
-  const uc = new CtxUseCases(repo);
+  const { config, uc } = buildCtxContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/src/passages/ctx/interface/verbs.ts
+++ b/src/passages/ctx/interface/verbs.ts
@@ -1,0 +1,12 @@
+// ctx verbs — read/write/exempt classification for entry middleware.
+//
+// See gate's verbs.ts header for the rule-of-thumb classification.
+// Phase 1 surface is just `record` (write). Phase 2 will add fork /
+// supersede / show / list / chain / status; this file grows as those
+// land.
+
+export const READ_VERBS: ReadonlySet<string> = new Set();
+
+export const WRITE_VERBS: ReadonlySet<string> = new Set(['record']);
+
+export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set();

--- a/src/passages/devil/interface/container.ts
+++ b/src/passages/devil/interface/container.ts
@@ -1,0 +1,34 @@
+// devil-review — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape. Extracted from `main()` so
+// the buildContainer-invariant pin test (issue #155 PR-B) can assert
+// no on-disk writes happen here. The lock middleware acquires AFTER
+// this call; any future write side-effect introduced inside the
+// builder would silently break the cross-process serialization
+// guarantee. The pin test exists to catch that regression.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
+import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
+import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
+
+export interface DevilContainer {
+  config: GuildConfig;
+  reviews: YamlDevilReviewRepository;
+  lenses: BundledLenseCatalog;
+  personas: BundledPersonaCatalog;
+}
+
+export interface BuildDevilContainerOpts {
+  cwd?: string;
+}
+
+export function buildDevilContainer(
+  opts: BuildDevilContainerOpts = {},
+): DevilContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const reviews = new YamlDevilReviewRepository(config);
+  const lenses = new BundledLenseCatalog();
+  const personas = new BundledPersonaCatalog();
+  return { config, reviews, lenses, personas };
+}

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -38,6 +38,9 @@ import { resolveEntry } from './handlers/resolve.js';
 import { suspendReview } from './handlers/suspend.js';
 import { resumeReview } from './handlers/resume.js';
 import { ingestSource } from './handlers/ingest.js';
+import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
+import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
+import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
 const HELP = `devil-review — security-backstop review passage (alpha, 11 verbs)
 
@@ -183,7 +186,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   const lenses = new BundledLenseCatalog();
   const personas = new BundledPersonaCatalog();
 
-  try {
+  const dispatch = async (): Promise<number> => {
     switch (cmd) {
       case 'schema':
         return await schemaCmd(args);
@@ -218,6 +221,18 @@ export async function main(argv: readonly string[]): Promise<number> {
         return 1;
       }
     }
+  };
+
+  try {
+    const actor = resolveGuildActor() ?? '';
+    return await withEntryLock(
+      config,
+      'devil',
+      cmd ?? '',
+      { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS },
+      actor,
+      dispatch,
+    );
   } catch (e) {
     if (e instanceof HelpRequested) {
       renderVerbHelp('devil', e);

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -15,7 +15,6 @@
 // JSON / snake_case YAML / explicit-flag CLI. Any future
 // human-facing UI is a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
@@ -24,9 +23,7 @@ import { getPackageVersion, isVersionFlag } from '../../../interface/shared/vers
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { LenseNotFound } from '../domain/Lense.js';
 import { PersonaNotFound } from '../domain/Persona.js';
-import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
-import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
-import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
+import { buildDevilContainer } from './container.js';
 import { schemaCmd } from './handlers/schema.js';
 import { openReview } from './handlers/open.js';
 import { entryOnReview } from './handlers/entry.js';
@@ -181,10 +178,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const [cmd, ...rest] = argv;
   const args = parseArgs(rest);
-  const config = GuildConfig.load();
-  const reviews = new YamlDevilReviewRepository(config);
-  const lenses = new BundledLenseCatalog();
-  const personas = new BundledPersonaCatalog();
+  const { config, reviews, lenses, personas } = buildDevilContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/src/passages/devil/interface/verbs.ts
+++ b/src/passages/devil/interface/verbs.ts
@@ -1,0 +1,24 @@
+// devil verbs — read/write/exempt classification for entry middleware.
+//
+// See gate's verbs.ts header for the rule-of-thumb classification.
+// devil-review's `ingest` is WRITE: it appends entries from automated
+// sources into the review record.
+
+export const READ_VERBS: ReadonlySet<string> = new Set([
+  'list',
+  'show',
+  'schema',
+]);
+
+export const WRITE_VERBS: ReadonlySet<string> = new Set([
+  'open',
+  'entry',
+  'dismiss',
+  'resolve',
+  'suspend',
+  'resume',
+  'ingest',
+  'conclude',
+]);
+
+export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set();

--- a/tests/infrastructure/agoraContainer.test.ts
+++ b/tests/infrastructure/agoraContainer.test.ts
@@ -1,0 +1,56 @@
+// agoraContainer.test.ts — buildAgoraContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildAgoraContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildAgoraContainer } from '../../src/passages/agora/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildAgoraContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agora-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildAgoraContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildAgoraContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/ctxContainer.test.ts
+++ b/tests/infrastructure/ctxContainer.test.ts
@@ -1,0 +1,56 @@
+// ctxContainer.test.ts — buildCtxContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildCtxContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildCtxContainer } from '../../src/passages/ctx/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildCtxContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildCtxContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildCtxContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/devilContainer.test.ts
+++ b/tests/infrastructure/devilContainer.test.ts
@@ -1,0 +1,56 @@
+// devilContainer.test.ts — buildDevilContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildDevilContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildDevilContainer } from '../../src/passages/devil/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildDevilContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'devil-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildDevilContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildDevilContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/gateContainer.test.ts
+++ b/tests/infrastructure/gateContainer.test.ts
@@ -1,0 +1,65 @@
+// gateContainer.test.ts — buildContainer invariant pin (issue #155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildContainer. If a future change introduces write side-effects in
+// buildContainer (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+//
+// Strategy: snapshot the directory tree before and after the
+// builder runs. Any new file, deleted file, or size change fails
+// the test with a clear diff.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildContainer } from '../../src/interface/shared/container.js';
+
+interface Snapshot {
+  [relPath: string]: number; // size in bytes
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        const rel = relative(root, full);
+        out[rel] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildContainer (gate) does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gate-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(
+      after,
+      before,
+      'buildContainer must not write to contentRoot — see test header',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/lock/guildLock.test.ts
+++ b/tests/infrastructure/lock/guildLock.test.ts
@@ -193,6 +193,101 @@ test('withGuildLock: GUILD_LOCK_MAX_AGE_MS triggers age-based reclaim', async ()
   }
 });
 
+test('withGuildLock: reclaims a lock whose started_at predates OS boot', async () => {
+  // Boottime branch (PR-B): if a lock file's started_at is older
+  // than the current OS uptime, the recorded pid by definition
+  // cannot be the original holder regardless of whether a colliding
+  // pid happens to be alive now. This test plants a lock with a
+  // started_at far in the past (epoch + 1s) and a pid that *is*
+  // alive (our own ppid). Without the boottime branch, the
+  // ancestor-safety valve would refuse to reclaim. With it, the
+  // pre-boot timestamp short-circuits the ancestor check.
+  const { root, cleanup } = makeRoot();
+  try {
+    // Pid we know is alive AND would normally be refused by the
+    // ancestor guard — pick our parent. This proves the boottime
+    // branch fires BEFORE the ancestor check.
+    const livePid = process.ppid;
+    const ancientHolder = {
+      pid: livePid,
+      ppid: 1,
+      // 1970-01-01T00:00:01Z — guaranteed predates any plausible
+      // current boot time.
+      started_at: new Date(1000).toISOString(),
+      verb: 'old',
+      actor: 'ghost',
+      host: 'pre-boot',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(ancientHolder, null, 2) + '\n',
+      'utf8',
+    );
+    const result = await withGuildLock(
+      { contentRoot: root },
+      META,
+      async () => 'reclaimed-via-boottime',
+    );
+    assert.equal(result, 'reclaimed-via-boottime');
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: does NOT reclaim when started_at is post-boot and pid is alive', async () => {
+  // Inverse of the boottime test: a lock with a recent (post-boot)
+  // timestamp and an alive pid (our own ppid) must NOT be reclaimed.
+  // This pins the boottime branch so it doesn't accidentally green-
+  // light reclaim of legitimate in-flight locks within the same
+  // process tree.
+  const { root, cleanup } = makeRoot();
+  const prev = process.env['GUILD_LOCK_MAX_AGE_MS'];
+  try {
+    delete process.env['GUILD_LOCK_MAX_AGE_MS']; // disable age branch
+    const liveAncestorHolder = {
+      pid: process.ppid,
+      ppid: 1,
+      started_at: new Date().toISOString(), // post-boot
+      verb: 'live',
+      actor: 'parent',
+      host: 'h',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(liveAncestorHolder, null, 2) + '\n',
+      'utf8',
+    );
+    let caught: unknown = null;
+    try {
+      await withGuildLock(
+        { contentRoot: root },
+        META,
+        async () => 'should-not-run',
+      );
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(
+      caught instanceof LockBusyError,
+      `expected LockBusyError, got ${String(caught)}`,
+    );
+    // Lock file must still be on disk (we did NOT reclaim it).
+    assert.equal(existsSync(join(root, '.guild-lock')), true);
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_LOCK_MAX_AGE_MS'];
+    else process.env['GUILD_LOCK_MAX_AGE_MS'] = prev;
+    // Manually clean since we left the lock in place.
+    cleanup();
+  }
+});
+
 test('withGuildLock: writes metadata with the expected shape', async () => {
   const { root, cleanup } = makeRoot();
   try {

--- a/tests/infrastructure/lock/guildLock.test.ts
+++ b/tests/infrastructure/lock/guildLock.test.ts
@@ -1,0 +1,237 @@
+// guildLock — infrastructure tests.
+//
+// Verifies the lock primitive's contract:
+//   1. competing acquire while held → LockBusyError
+//   2. successful run unlinks the lock in `finally` (success path)
+//   3. throwing fn unlinks the lock in `finally` (failure path)
+//   4. dead-pid stale lock is reclaimed automatically
+//   5. GUILD_LOCK_MAX_AGE_MS expiry triggers age-based reclaim
+//   6. lock metadata JSON has the expected shape
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  withGuildLock,
+  LockBusyError,
+} from '../../../src/infrastructure/lock/guildLock.js';
+
+function makeRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-lock-'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+const META = { passage: 'gate', verb: 'request', actor: 'eris' };
+
+test('withGuildLock: competing acquire throws LockBusyError', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    let inner: unknown = null;
+    await withGuildLock(
+      { contentRoot: root },
+      META,
+      async () => {
+        // While holding the lock, a second acquire on the same path
+        // must surface as LockBusyError. We intentionally use a verb
+        // distinct from the outer holder so the holder metadata
+        // returned in the error is distinguishable.
+        try {
+          await withGuildLock(
+            { contentRoot: root },
+            { passage: 'gate', verb: 'approve', actor: 'noir' },
+            async () => 'should-not-run',
+          );
+        } catch (e) {
+          inner = e;
+        }
+      },
+    );
+    assert.ok(
+      inner instanceof LockBusyError,
+      `expected LockBusyError, got ${String(inner)}`,
+    );
+    if (inner instanceof LockBusyError) {
+      assert.equal(inner.holder?.verb, 'request');
+      assert.equal(inner.holder?.actor, 'eris');
+      assert.equal(inner.holder?.passage, 'gate');
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: unlinks on success', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const result = await withGuildLock({ contentRoot: root }, META, async () => 42);
+    assert.equal(result, 42);
+    assert.equal(
+      existsSync(join(root, '.guild-lock')),
+      false,
+      'lock should be released after fn completes',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: unlinks on fn failure', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    let caught: unknown = null;
+    try {
+      await withGuildLock({ contentRoot: root }, META, async () => {
+        throw new Error('boom');
+      });
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught instanceof Error);
+    assert.equal((caught as Error).message, 'boom');
+    assert.equal(
+      existsSync(join(root, '.guild-lock')),
+      false,
+      'lock should be released even when fn throws',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: reclaims a dead-pid stale lock', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // Pre-write a lock owned by an obviously-dead pid. We pick a
+    // value sufficiently far above the typical pid range that
+    // kill(pid, 0) will reliably return ESRCH on every supported OS.
+    // (The reclaim safety valve refuses to touch our pid or ppid;
+    // adding 999_999 puts us well outside that ancestry.)
+    const deadPid = process.pid + 999_999;
+    const fakeHolder = {
+      pid: deadPid,
+      ppid: 1,
+      started_at: new Date().toISOString(),
+      verb: 'stale',
+      actor: 'ghost',
+      host: 'old-host',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(fakeHolder, null, 2) + '\n',
+      'utf8',
+    );
+    // Acquisition should reclaim the stale lock and run fn cleanly.
+    const result = await withGuildLock(
+      { contentRoot: root },
+      META,
+      async () => 'reclaimed',
+    );
+    assert.equal(result, 'reclaimed');
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: GUILD_LOCK_MAX_AGE_MS triggers age-based reclaim', async () => {
+  const { root, cleanup } = makeRoot();
+  const prev = process.env['GUILD_LOCK_MAX_AGE_MS'];
+  try {
+    process.env['GUILD_LOCK_MAX_AGE_MS'] = '100';
+    // Simulate a 200ms-old lock owned by some pid that *is* alive
+    // (we use a pid near our own — but not our own and not ppid —
+    // by picking process.pid + 2). The age branch should still
+    // reclaim it because age > MAX_AGE_MS.
+    //
+    // Subtle: if process.pid + 2 happens to be a real live process,
+    // isPidDead returns false and the only path to reclaim is the
+    // age branch — which is exactly what this test exercises.
+    const livePid = process.pid + 2;
+    const stale = {
+      pid: livePid,
+      ppid: 1,
+      started_at: new Date(Date.now() - 200).toISOString(),
+      verb: 'old',
+      actor: 'ghost',
+      host: 'h',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(stale, null, 2) + '\n',
+      'utf8',
+    );
+    const result = await withGuildLock(
+      { contentRoot: root },
+      META,
+      async () => 'aged-out',
+    );
+    assert.equal(result, 'aged-out');
+  } finally {
+    if (prev === undefined) {
+      delete process.env['GUILD_LOCK_MAX_AGE_MS'];
+    } else {
+      process.env['GUILD_LOCK_MAX_AGE_MS'] = prev;
+    }
+    cleanup();
+  }
+});
+
+test('withGuildLock: writes metadata with the expected shape', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    let snapshot: Record<string, unknown> | null = null;
+    await withGuildLock(
+      { contentRoot: root },
+      { passage: 'devil', verb: 'open', actor: 'miki' },
+      async () => {
+        const raw = readFileSync(join(root, '.guild-lock'), 'utf8');
+        snapshot = JSON.parse(raw) as Record<string, unknown>;
+      },
+    );
+    assert.ok(snapshot, 'metadata should have been read inside fn');
+    const expected = [
+      'pid',
+      'ppid',
+      'started_at',
+      'verb',
+      'actor',
+      'host',
+      'cwd',
+      'passage',
+      'guild_cli_version',
+    ];
+    for (const key of expected) {
+      assert.ok(
+        snapshot !== null && key in snapshot,
+        `lock metadata missing field: ${key}`,
+      );
+    }
+    assert.equal((snapshot as Record<string, unknown>)['verb'], 'open');
+    assert.equal((snapshot as Record<string, unknown>)['actor'], 'miki');
+    assert.equal((snapshot as Record<string, unknown>)['passage'], 'devil');
+    assert.equal(
+      (snapshot as Record<string, unknown>)['pid'],
+      process.pid,
+      'pid should be our own',
+    );
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/integration/lock/_lockChild.ts
+++ b/tests/integration/lock/_lockChild.ts
@@ -1,0 +1,69 @@
+// _lockChild.ts — helper subprocess for the cross-passage race
+// E2E suite. Parent spawns this with the following env:
+//
+//   CHILD_ROOT          contentRoot for withGuildLock
+//   CHILD_BARRIER       barrier path (also passed as GUILD_LOCK_TEST_BARRIER)
+//   CHILD_READY         ready-marker path; we touch it just before
+//                       calling withGuildLock so the parent can
+//                       wait for "all children at the gate" before
+//                       releasing the barrier
+//   CHILD_PASSAGE       cosmetic; recorded in lock metadata
+//   CHILD_VERB          cosmetic; recorded in lock metadata
+//   CHILD_HOLD_MS       how long the winner sleeps inside fn
+//                       (gives losers time to retry/fail observably)
+//
+// Exit codes:
+//   0 → acquired, ran fn, released cleanly
+//   2 → LockBusyError (the loser path)
+//   1 → unexpected error
+//
+// stderr carries the error message (parent asserts on it).
+
+import { writeFileSync } from 'node:fs';
+import {
+  withGuildLock,
+  LockBusyError,
+} from '../../../src/infrastructure/lock/guildLock.js';
+
+function env(name: string): string {
+  const v = process.env[name];
+  if (v === undefined || v.length === 0) {
+    process.stderr.write(`_lockChild: missing env ${name}\n`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main(): Promise<void> {
+  const root = env('CHILD_ROOT');
+  const ready = env('CHILD_READY');
+  const passage = env('CHILD_PASSAGE');
+  const verb = env('CHILD_VERB');
+  const holdMs = Number(process.env['CHILD_HOLD_MS'] ?? '50');
+
+  // Signal "I'm at the barrier" — parent waits for this file
+  // (per child) before touching the barrier file.
+  writeFileSync(ready, '1', 'utf8');
+
+  try {
+    await withGuildLock(
+      { contentRoot: root },
+      { passage, verb, actor: 'race-test' },
+      async () => {
+        // Hold briefly so a contending acquire can race and lose.
+        await new Promise<void>((r) => setTimeout(r, holdMs));
+        return null;
+      },
+    );
+    process.exit(0);
+  } catch (e) {
+    if (e instanceof LockBusyError) {
+      process.stderr.write(`lock_busy: ${e.message}\n`);
+      process.exit(2);
+    }
+    process.stderr.write(`unexpected: ${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/integration/lock/cross-passage-race.test.ts
+++ b/tests/integration/lock/cross-passage-race.test.ts
@@ -1,0 +1,215 @@
+// cross-passage-race.test.ts — issue #155 PR-B.
+//
+// Verifies the content-root lock actually serializes concurrent
+// writes ACROSS PROCESSES, not just within one Node event loop.
+//
+// Why this can't be done with Promise.all in-process: a single Node
+// process holds the file descriptor across the entire `withGuildLock`
+// call, so an in-process `Promise.all` of two `withGuildLock` calls
+// observes nothing surprising — the second call sees an EEXIST and
+// throws LockBusyError; that path is already covered by the unit
+// test in tests/infrastructure/lock/guildLock.test.ts. The thing
+// that's NOT covered there — and the thing that actually fails if
+// the lock is buggy — is a cross-process race where each process
+// independently hits `openSync(path, 'wx')` in the same kernel
+// scheduling window. That's what this suite spawns.
+//
+// Synchronization strategy: each child first touches its own ready
+// file, then calls withGuildLock. The acquire path inside
+// guildLock.ts honors GUILD_LOCK_TEST_BARRIER by busy-polling for
+// a barrier file before attempting `openExclusive`. The parent
+// waits for all children's ready files to appear, then `touch`es
+// the barrier — every child unblocks within a 5ms poll quantum and
+// they enter the open-O_EXCL race nearly simultaneously. Exactly
+// one child observes EEXIST → LockBusyError → exit 2; the rest
+// (one) acquires → exits 0.
+//
+// Note: this is a *probabilistic* race — on a heavily loaded host
+// the kernel might schedule child N so much later that child 1 has
+// already finished. The barrier dramatically reduces that window
+// but doesn't eliminate it. The hold time (CHILD_HOLD_MS=300) is
+// generous enough that we have not observed flakes locally.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  unlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+interface ChildOutcome {
+  exitCode: number | null;
+  stderr: string;
+}
+
+interface ChildSpec {
+  passage: string;
+  verb: string;
+}
+
+const CHILD_SCRIPT = resolve('dist/tests/integration/lock/_lockChild.js');
+const HOLD_MS = '300';
+const READY_TIMEOUT_MS = 8_000;
+
+function makeRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-race-'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`waitFor timeout: ${label}`);
+    }
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+}
+
+async function runRace(
+  root: string,
+  specs: readonly ChildSpec[],
+): Promise<ChildOutcome[]> {
+  const barrier = join(root, '.barrier');
+  const readyPaths = specs.map((_, i) => join(root, `.ready-${String(i)}`));
+
+  // Spawn all children. Each waits for the barrier before attempting
+  // openExclusive, so order of spawn doesn't materially affect the
+  // race outcome.
+  const children = specs.map((spec, i) => {
+    const child = spawn(process.execPath, [CHILD_SCRIPT], {
+      env: {
+        ...process.env,
+        CHILD_ROOT: root,
+        CHILD_BARRIER: barrier,
+        CHILD_READY: readyPaths[i] ?? '',
+        CHILD_PASSAGE: spec.passage,
+        CHILD_VERB: spec.verb,
+        CHILD_HOLD_MS: HOLD_MS,
+        GUILD_LOCK_TEST_BARRIER: barrier,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    const done = new Promise<ChildOutcome>((res) => {
+      child.on('exit', (code) => res({ exitCode: code, stderr }));
+    });
+    return { child, done };
+  });
+
+  // Wait for all children to be at the barrier (ready files present).
+  await waitFor(
+    () => readyPaths.every((p) => existsSync(p)),
+    READY_TIMEOUT_MS,
+    'children-ready',
+  );
+
+  // Release the barrier. All children unblock within ~5ms (the
+  // Atomics.wait quantum inside awaitTestBarrier) and race.
+  writeFileSync(barrier, '1', 'utf8');
+
+  const outcomes = await Promise.all(children.map((c) => c.done));
+
+  // Best-effort cleanup of barrier (lock file is unlinked by the
+  // winner's release path; ready files live under root and will
+  // be removed by the cleanup() rm -rf).
+  try {
+    unlinkSync(barrier);
+  } catch {
+    // ignore
+  }
+  return outcomes;
+}
+
+function summarize(outcomes: readonly ChildOutcome[]): {
+  winners: number;
+  busy: number;
+  unexpected: ChildOutcome[];
+} {
+  let winners = 0;
+  let busy = 0;
+  const unexpected: ChildOutcome[] = [];
+  for (const o of outcomes) {
+    if (o.exitCode === 0) winners += 1;
+    else if (o.exitCode === 2) busy += 1;
+    else unexpected.push(o);
+  }
+  return { winners, busy, unexpected };
+}
+
+test('cross-passage race: same-entry duo → 1 winner, 1 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'request' },
+      { passage: 'gate', verb: 'request' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(
+      s.unexpected.length,
+      0,
+      `unexpected exit codes: ${JSON.stringify(s.unexpected)}`,
+    );
+    assert.equal(s.winners, 1, `expected exactly 1 winner, got ${String(s.winners)}`);
+    assert.equal(s.busy, 1, `expected exactly 1 busy, got ${String(s.busy)}`);
+    // Lock file must be cleaned up after the winner releases.
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('cross-passage race: gate vs agora → 1 winner, 1 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'approve' },
+      { passage: 'agora', verb: 'move' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(s.unexpected.length, 0);
+    assert.equal(s.winners, 1);
+    assert.equal(s.busy, 1);
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('cross-passage race: three-way (gate/agora/devil) → 1 winner, 2 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'request' },
+      { passage: 'agora', verb: 'play' },
+      { passage: 'devil', verb: 'open' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(
+      s.unexpected.length,
+      0,
+      `unexpected exit codes: ${JSON.stringify(s.unexpected)}`,
+    );
+    assert.equal(s.winners, 1);
+    assert.equal(s.busy, 2);
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -1,0 +1,116 @@
+// verbs-consistency — pin each entry's READ/WRITE/EXEMPT verb sets
+// against the verbs the dispatcher actually accepts.
+//
+// Why this exists: the entry middleware (`withEntryLock`) treats any
+// verb not in READ/EXEMPT as WRITE (fail-safe). That means a forgotten
+// entry in verbs.ts would silently over-lock in the safe direction —
+// no incident, but slow. Conversely, a forgotten verb in the switch
+// would silently slip through. This test pins both sides so a new
+// verb either lands in verbs.ts or fails CI loud.
+//
+// We use a hand-curated ALL_VERBS per passage (mirrored against the
+// switch / KNOWN_COMMANDS arrays in each index.ts). AST-walking would
+// be more clever but brittle; hand enumeration is obvious-when-broken
+// in the same spirit as the index-level KNOWN_COMMANDS arrays.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as gateVerbs from '../../src/interface/gate/verbs.js';
+import * as agoraVerbs from '../../src/passages/agora/interface/verbs.js';
+import * as devilVerbs from '../../src/passages/devil/interface/verbs.js';
+import * as ctxVerbs from '../../src/passages/ctx/interface/verbs.js';
+
+interface VerbSets {
+  READ_VERBS: ReadonlySet<string>;
+  WRITE_VERBS: ReadonlySet<string>;
+  LOCK_EXEMPT_VERBS: ReadonlySet<string>;
+}
+
+interface Case {
+  passage: string;
+  verbs: VerbSets;
+  all: readonly string[];
+}
+
+// Mirrors of the switch cases in each entry's index.ts. If a new verb
+// lands, add it here too — the test will fail loud at CI otherwise.
+const GATE_ALL = [
+  'request', 'pending', 'board', 'list', 'show', 'voices', 'tail',
+  'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
+  'complete', 'fail', 'review', 'thank', 'fast-track', 'issues',
+  'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
+  'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
+  'schema', 'unresponded',
+] as const;
+
+const AGORA_ALL = [
+  'new', 'play', 'move', 'suspend', 'resume', 'conclude',
+  'list', 'show', 'last', 'cliff', 'schema',
+] as const;
+
+const DEVIL_ALL = [
+  'open', 'entry', 'list', 'show', 'dismiss', 'resolve',
+  'suspend', 'resume', 'ingest', 'conclude', 'schema',
+] as const;
+
+const CTX_ALL = ['record'] as const;
+
+const CASES: Case[] = [
+  { passage: 'gate', verbs: gateVerbs, all: GATE_ALL },
+  { passage: 'agora', verbs: agoraVerbs, all: AGORA_ALL },
+  { passage: 'devil', verbs: devilVerbs, all: DEVIL_ALL },
+  { passage: 'ctx', verbs: ctxVerbs, all: CTX_ALL },
+];
+
+for (const c of CASES) {
+  test(`${c.passage} verbs: union equals ALL_VERBS`, () => {
+    const union = new Set<string>([
+      ...c.verbs.READ_VERBS,
+      ...c.verbs.WRITE_VERBS,
+      ...c.verbs.LOCK_EXEMPT_VERBS,
+    ]);
+    const all = new Set<string>(c.all);
+    const missingFromVerbs = [...all].filter((v) => !union.has(v)).sort();
+    const extraInVerbs = [...union].filter((v) => !all.has(v)).sort();
+    assert.deepEqual(
+      missingFromVerbs,
+      [],
+      `${c.passage}: verbs in dispatcher but absent from verbs.ts: ${missingFromVerbs.join(', ')}`,
+    );
+    assert.deepEqual(
+      extraInVerbs,
+      [],
+      `${c.passage}: verbs in verbs.ts not in dispatcher: ${extraInVerbs.join(', ')}`,
+    );
+  });
+
+  test(`${c.passage} verbs: READ ∩ WRITE = ∅`, () => {
+    const overlap = [...c.verbs.READ_VERBS].filter((v) =>
+      c.verbs.WRITE_VERBS.has(v),
+    );
+    assert.deepEqual(overlap, [], `${c.passage}: READ ∩ WRITE: ${overlap.join(', ')}`);
+  });
+
+  test(`${c.passage} verbs: READ ∩ EXEMPT = ∅`, () => {
+    const overlap = [...c.verbs.READ_VERBS].filter((v) =>
+      c.verbs.LOCK_EXEMPT_VERBS.has(v),
+    );
+    assert.deepEqual(
+      overlap,
+      [],
+      `${c.passage}: READ ∩ EXEMPT: ${overlap.join(', ')}`,
+    );
+  });
+
+  test(`${c.passage} verbs: WRITE ∩ EXEMPT = ∅`, () => {
+    const overlap = [...c.verbs.WRITE_VERBS].filter((v) =>
+      c.verbs.LOCK_EXEMPT_VERBS.has(v),
+    );
+    assert.deepEqual(
+      overlap,
+      [],
+      `${c.passage}: WRITE ∩ EXEMPT: ${overlap.join(', ')}`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

PR-A of the #155 lock-file landing. Introduces the cross-process write serialization primitive and wraps all four (potentially five) write-bearing CLI entries.

Design discussion: #155 (Eris + Noir + Devil convergence — all five ship-blockers from devil-review accepted).

## Scope

### New
- `src/infrastructure/lock/guildLock.ts` — primitive (`withGuildLock`, `LockBusyError`, minimal stale reclaim)
- `src/infrastructure/lock/withEntryLock.ts` — middleware (EXEMPT → READ → lock decision order)
- Per-passage `verbs.ts` exporting `READ_VERBS / WRITE_VERBS / LOCK_EXEMPT_VERBS` (gate / agora / devil / ctx / guild)
- `tests/infrastructure/lock/guildLock.test.ts` (6 tests: busy, unlink success/fail, dead-pid reclaim, age reclaim, metadata shape)
- `tests/interface/verbs-consistency.test.ts` (4 passages × 4 properties = 16 tests: union covers all switch cases, three sets pairwise disjoint)

### Modified
- 5 entry `main()` bodies wrap dispatch in `withEntryLock` (`gate`, `agora`, `devil`, `ctx`, `guild`)
- `gate/index.ts` adds `lock_busy` code to `deriveErrorCode`
- `bin/guild.mjs` itself is a thin loader (no write side-effects); the middleware sits in `src/interface/guild/index.ts` because `guild new` is a write verb

### Out of scope (deferred)
- **PR-B**: boottime-based stale reclaim, `GUILD_LOCK_MAX_AGE_MS` (env handling already in PR-A as a CI safety valve), cross-passage race E2E (spawn + barrier per devil's N-4), `buildContainer` invariant pin tests × 4
- **PR-C**: `SECURITY.md` rewrite, `docs/storage-format.md` `.guild-lock` contract, CHANGELOG

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — no regression vs `main` (22 pre-existing failures match exactly; PR-A introduces zero)
- [x] 6 lock primitive tests pass
- [x] 16 verbs-consistency tests pass
- [ ] Real-machine concurrent-execution validation (asteria, follow-up commit on this branch if anything surfaces)

## Notes for reviewer
- Per devil hand-off (N-1): boottime precision is left to PR-B; PR-A's stale reclaim relies on `kill 0 → ESRCH` and the optional `GUILD_LOCK_MAX_AGE_MS` env.
- Per devil hand-off (N-2): ancestor-pid guard is `pid !== process.pid && pid !== process.ppid` only (portable surface).
- Per devil hand-off (N-3): minimal stale reclaim is in PR-A so `main` is self-recoverable from this PR onward.
- `LockBusyError` extends `DomainError`; `format=json` envelopes carry `code: "lock_busy"` automatically.
- Existing `YamlRequestRepository` CAS preserved as in-process safety net (intentional, see comment + test).

Draft until asteria's real-machine validation completes.