### PR TITLE
feat(lock): boottime reclaim + cross-passage race E2E + container invariants (#155 PR-B)

### DIFF
--- a/src/infrastructure/lock/guildLock.ts
+++ b/src/infrastructure/lock/guildLock.ts
@@ -10,25 +10,33 @@
 // in `finally`. A competing acquire fails with EEXIST and surfaces
 // as `LockBusyError` (DomainError subclass → `lock_busy` JSON code).
 //
-// Stale reclaim (minimal, PR-A scope): on EEXIST we try once to
-// rescue an obviously-dead lock by reading the file's metadata and
-// auto-unlinking when EITHER:
-//   1. `kill(pid, 0)` reports ESRCH (the recorded process is gone), OR
-//   2. `GUILD_LOCK_MAX_AGE_MS` env is set and `started_at` exceeds it.
+// Stale reclaim (PR-A + PR-B): on EEXIST we try once to rescue an
+// obviously-dead lock by reading the file's metadata and
+// auto-unlinking when ANY of:
+//   1. `lock.started_at` predates the current OS boot (reboot
+//      crossed → the recorded pid cannot be the same process as
+//      the holder, even if a fresh pid happens to collide), OR
+//   2. `kill(pid, 0)` reports ESRCH (the recorded process is gone)
+//      AND the pid is not our own / not our parent, OR
+//   3. `GUILD_LOCK_MAX_AGE_MS` env is set and `started_at` exceeds it.
 //
 // We deliberately refuse to reclaim a lock whose pid is our own
 // process or our parent — that's ancestor territory and reclaiming
 // it would silently corrupt a legitimate concurrent flow within the
-// same process tree. boottime-aware reclaim is PR-B work.
+// same process tree. We do NOT walk further up the ancestor chain:
+// a portable Node API for that does not exist (Linux-only /proc is
+// out of scope), and reboot-crossing PID collisions on the
+// grandparent boundary fall under "acceptable false-reclaim" — the
+// boottime check (1) catches the common reboot case anyway.
 //
 // Lock metadata is treated as UNTRUSTED input: another writer (or a
 // hand-edited file) may put arbitrary strings in `actor` / `verb` /
 // `passage`. We never interpolate them into shell or filesystem
 // paths; user-facing surfaces JSON-stringify before display.
 
-import { openSync, writeSync, closeSync, unlinkSync, readFileSync } from 'node:fs';
+import { openSync, writeSync, closeSync, unlinkSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { hostname } from 'node:os';
+import { hostname, uptime as osUptime } from 'node:os';
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { getPackageVersion } from '../../interface/shared/version.js';
 
@@ -123,6 +131,16 @@ export async function withGuildLock<T>(
  * `LockBusyError`. Returns the held file descriptor.
  */
 function acquire(lockPath: string, meta: GuildLockMeta): number {
+  // Test-only synchronization barrier. When GUILD_LOCK_TEST_BARRIER
+  // is set to a path, block (busy-poll) until that path exists
+  // before attempting `openExclusive`. The cross-passage race E2E
+  // suite uses this to make N spawned children all enter the
+  // open-O_EXCL race in the same kernel-scheduling window — without
+  // it, child N starts so much later than child 1 that child 1 has
+  // already finished and released, and the suite cannot observe a
+  // real race. Production callers never set this env, so the cost
+  // is one cheap getenv per acquire.
+  awaitTestBarrier();
   try {
     return openExclusive(lockPath, meta);
   } catch (err) {
@@ -233,14 +251,44 @@ function readHolder(lockPath: string): LockMetadata | null {
  * in-flight call within the same process tree.
  */
 function isReclaimable(holder: LockMetadata): boolean {
-  // Safety valve: never reclaim ancestor pids.
+  // Boottime check first — if started_at predates OS boot, the
+  // recorded pid cannot belong to the original holder regardless
+  // of whether the same pid is alive now (reboots reset the pid
+  // namespace). This rescues a legitimate stale lock left over by
+  // a hard crash that rebooted the machine.
+  //
+  // Strict `<` (not `<=`): the reboot-second boundary is too coarse
+  // to make a confident call from boottime alone; the kill-0 ESRCH
+  // OR the GUILD_LOCK_MAX_AGE_MS path will pick up that one-second
+  // edge case if it actually matters.
+  //
+  // os.uptime() is whole-second precision on macOS / Linux but the
+  // returned value is a Number; multiply by 1000 to compare against
+  // Date.now() in ms.
+  if (holder.started_at !== '') {
+    const startedMs = Date.parse(holder.started_at);
+    if (Number.isFinite(startedMs)) {
+      const bootMs = Date.now() - osUptime() * 1000;
+      if (startedMs < bootMs) return true;
+    }
+  }
+
+  // Safety valve: never reclaim ancestor pids via the kill-0 branch.
+  // Note: a lock surviving a reboot WILL pass through here above
+  // (boottime branch) before hitting this guard — that's intentional
+  // because post-reboot a colliding pid is by definition not our
+  // ancestor. We only refuse to reclaim ancestors in the "machine
+  // hasn't rebooted" case.
   if (holder.pid === process.pid) return false;
   if (typeof process.ppid === 'number' && holder.pid === process.ppid) return false;
 
   // Dead-process check: kill(pid, 0) → ESRCH means the process is gone.
   // EPERM means the process exists but we can't signal it (different
   // user) — treat as alive (don't reclaim). Other errors: also treat
-  // as alive (conservative).
+  // as alive (conservative). Ancestor-walk beyond pid/ppid is not
+  // portable in Node, so reboot-crossing pid collisions further up
+  // the tree fall under acceptable risk; the boottime branch above
+  // covers the common reboot case.
   if (isPidDead(holder.pid)) return true;
 
   // Age-based reclaim, opt-in via env. The env path is intended for
@@ -259,6 +307,37 @@ function isReclaimable(holder: LockMetadata): boolean {
     }
   }
   return false;
+}
+
+/**
+ * If `GUILD_LOCK_TEST_BARRIER` is set, busy-wait until the named
+ * file exists. No-op when the env is unset (the production case).
+ *
+ * Uses a tight sync poll with `existsSync` rather than fs.watch so
+ * the wait is deterministic across platforms (fs.watch semantics on
+ * macOS are different enough from Linux that test flake is real).
+ * Bounded at ~10s so a misconfigured test fails fast instead of
+ * hanging the runner indefinitely.
+ */
+function awaitTestBarrier(): void {
+  const barrier = process.env['GUILD_LOCK_TEST_BARRIER'];
+  if (barrier === undefined || barrier.length === 0) return;
+  const deadline = Date.now() + 10_000;
+  // Atomics + SharedArrayBuffer would let us sleep without burn,
+  // but pulling that in for a test-only path isn't worth the
+  // complexity. A 5ms granularity keeps CPU use trivial.
+  while (!existsSync(barrier)) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `GUILD_LOCK_TEST_BARRIER timeout: ${barrier} did not appear within 10s`,
+      );
+    }
+    // Synchronous tight loop with Atomics.wait on a dummy buffer
+    // to yield the thread without spinning hot. 5ms is well below
+    // any meaningful test timeout but well above the kernel's
+    // wakeup granularity.
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+  }
 }
 
 function isPidDead(pid: number): boolean {

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -28,8 +28,17 @@ export interface Container {
   unrespondedConcernsQ: UnrespondedConcernsQuery;
 }
 
-export function buildContainer(): Container {
-  const config = GuildConfig.load();
+export interface BuildContainerOpts {
+  /**
+   * Override `cwd` for `GuildConfig.load`. Tests pass a freshly
+   * `mkdtemp`-ed directory to verify the builder is side-effect-free
+   * (issue #155 PR-B pin test); production never sets this.
+   */
+  cwd?: string;
+}
+
+export function buildContainer(opts: BuildContainerOpts = {}): Container {
+  const config = GuildConfig.load(opts.cwd);
   const members = new YamlMemberRepository(config);
   const requests = new YamlRequestRepository(config);
   const issues = new YamlIssueRepository(config);
@@ -39,7 +48,7 @@ export function buildContainer(): Container {
   // onMalformed callback isn't shared with the stderr-emitting
   // default that the rest of the CLI uses.
   const buildDiagRepos = (om: OnMalformed): DiagnosticRepoBundle => {
-    const cfg = GuildConfig.load(process.cwd(), om);
+    const cfg = GuildConfig.load(opts.cwd ?? process.cwd(), om);
     return {
       members: new YamlMemberRepository(cfg),
       requests: new YamlRequestRepository(cfg),

--- a/src/passages/agora/interface/container.ts
+++ b/src/passages/agora/interface/container.ts
@@ -1,0 +1,43 @@
+// agora — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape (src/interface/shared/container.ts):
+// a single pure factory that loads config and constructs the Yaml*
+// repositories used by every handler in this passage. Extracted from
+// `main()` so the cross-process lock invariant test (issue #155 PR-B)
+// can verify the builder is side-effect-free — i.e. it does not write
+// anything to `contentRoot` BEFORE `withGuildLock` would have a chance
+// to serialize concurrent writers.
+//
+// Why the invariant matters: the lock middleware acquires AFTER
+// buildContainer. If a future change introduces write side-effects in
+// buildContainer (e.g. a config-migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. A pin test asserts the
+// directory snapshot before/after this call is byte-identical.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
+import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
+
+export interface AgoraContainer {
+  config: GuildConfig;
+  games: YamlGameRepository;
+  plays: YamlPlayRepository;
+}
+
+export interface BuildAgoraContainerOpts {
+  /**
+   * Override `cwd` for `GuildConfig.load`. Tests pass a freshly
+   * `mkdtemp`-ed directory; production never sets this.
+   */
+  cwd?: string;
+}
+
+export function buildAgoraContainer(
+  opts: BuildAgoraContainerOpts = {},
+): AgoraContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const games = new YamlGameRepository(config);
+  const plays = new YamlPlayRepository(config);
+  return { config, games, plays };
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -16,15 +16,13 @@
 // JSON / snake_case YAML / explicit-flag CLI; any future human-
 // facing UI is a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
-import { YamlGameRepository } from '../infrastructure/YamlGameRepository.js';
-import { YamlPlayRepository } from '../infrastructure/YamlPlayRepository.js';
+import { buildAgoraContainer } from './container.js';
 import { newGame } from './handlers/new.js';
 import { startPlay } from './handlers/play.js';
 import { moveOnPlay } from './handlers/move.js';
@@ -160,9 +158,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   ]);
   const verbBooleans = cmd ? VERB_BOOLEAN_FLAGS.get(cmd) : undefined;
   const args = parseArgs(rest, verbBooleans ? { booleanFlags: verbBooleans } : {});
-  const config = GuildConfig.load();
-  const games = new YamlGameRepository(config);
-  const plays = new YamlPlayRepository(config);
+  const { config, games, plays } = buildAgoraContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/src/passages/ctx/interface/container.ts
+++ b/src/passages/ctx/interface/container.ts
@@ -1,0 +1,31 @@
+// ctx — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape. Extracted from `main()` so
+// the buildContainer-invariant pin test (issue #155 PR-B) can assert
+// no on-disk writes happen here. The lock middleware acquires AFTER
+// this call; any future write side-effect introduced inside the
+// builder would silently break the cross-process serialization
+// guarantee. The pin test exists to catch that regression.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
+import { CtxUseCases } from '../application/CtxUseCases.js';
+
+export interface CtxContainer {
+  config: GuildConfig;
+  repo: YamlCtxRepository;
+  uc: CtxUseCases;
+}
+
+export interface BuildCtxContainerOpts {
+  cwd?: string;
+}
+
+export function buildCtxContainer(
+  opts: BuildCtxContainerOpts = {},
+): CtxContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const repo = new YamlCtxRepository(config);
+  const uc = new CtxUseCases(repo);
+  return { config, repo, uc };
+}

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -14,15 +14,13 @@
 // snake_case YAML / explicit-flag CLI; any future human-facing UI is
 // a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
-import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
-import { CtxUseCases } from '../application/CtxUseCases.js';
+import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
@@ -72,9 +70,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const [cmd, ...rest] = argv;
   const args = parseArgs(rest);
-  const config = GuildConfig.load();
-  const repo = new YamlCtxRepository(config);
-  const uc = new CtxUseCases(repo);
+  const { config, uc } = buildCtxContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/src/passages/devil/interface/container.ts
+++ b/src/passages/devil/interface/container.ts
@@ -1,0 +1,34 @@
+// devil-review — passage container builder.
+//
+// Mirrors gate's `buildContainer` shape. Extracted from `main()` so
+// the buildContainer-invariant pin test (issue #155 PR-B) can assert
+// no on-disk writes happen here. The lock middleware acquires AFTER
+// this call; any future write side-effect introduced inside the
+// builder would silently break the cross-process serialization
+// guarantee. The pin test exists to catch that regression.
+
+import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
+import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
+import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
+import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
+
+export interface DevilContainer {
+  config: GuildConfig;
+  reviews: YamlDevilReviewRepository;
+  lenses: BundledLenseCatalog;
+  personas: BundledPersonaCatalog;
+}
+
+export interface BuildDevilContainerOpts {
+  cwd?: string;
+}
+
+export function buildDevilContainer(
+  opts: BuildDevilContainerOpts = {},
+): DevilContainer {
+  const config = GuildConfig.load(opts.cwd);
+  const reviews = new YamlDevilReviewRepository(config);
+  const lenses = new BundledLenseCatalog();
+  const personas = new BundledPersonaCatalog();
+  return { config, reviews, lenses, personas };
+}

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -15,7 +15,6 @@
 // JSON / snake_case YAML / explicit-flag CLI. Any future
 // human-facing UI is a projection, not a substrate change.
 
-import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
 import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
@@ -24,9 +23,7 @@ import { getPackageVersion, isVersionFlag } from '../../../interface/shared/vers
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { LenseNotFound } from '../domain/Lense.js';
 import { PersonaNotFound } from '../domain/Persona.js';
-import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
-import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
-import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
+import { buildDevilContainer } from './container.js';
 import { schemaCmd } from './handlers/schema.js';
 import { openReview } from './handlers/open.js';
 import { entryOnReview } from './handlers/entry.js';
@@ -181,10 +178,7 @@ export async function main(argv: readonly string[]): Promise<number> {
 
   const [cmd, ...rest] = argv;
   const args = parseArgs(rest);
-  const config = GuildConfig.load();
-  const reviews = new YamlDevilReviewRepository(config);
-  const lenses = new BundledLenseCatalog();
-  const personas = new BundledPersonaCatalog();
+  const { config, reviews, lenses, personas } = buildDevilContainer();
 
   const dispatch = async (): Promise<number> => {
     switch (cmd) {

--- a/tests/infrastructure/agoraContainer.test.ts
+++ b/tests/infrastructure/agoraContainer.test.ts
@@ -1,0 +1,56 @@
+// agoraContainer.test.ts — buildAgoraContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildAgoraContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildAgoraContainer } from '../../src/passages/agora/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildAgoraContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'agora-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildAgoraContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildAgoraContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/ctxContainer.test.ts
+++ b/tests/infrastructure/ctxContainer.test.ts
@@ -1,0 +1,56 @@
+// ctxContainer.test.ts — buildCtxContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildCtxContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildCtxContainer } from '../../src/passages/ctx/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildCtxContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildCtxContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildCtxContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/devilContainer.test.ts
+++ b/tests/infrastructure/devilContainer.test.ts
@@ -1,0 +1,56 @@
+// devilContainer.test.ts — buildDevilContainer invariant pin (#155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildDevilContainer. If a future change introduces write side-effects
+// in the builder (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildDevilContainer } from '../../src/passages/devil/interface/container.js';
+
+interface Snapshot {
+  [relPath: string]: number;
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out[relative(root, full)] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildDevilContainer does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'devil-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildDevilContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(after, before, 'buildDevilContainer must not write to contentRoot');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/gateContainer.test.ts
+++ b/tests/infrastructure/gateContainer.test.ts
@@ -1,0 +1,65 @@
+// gateContainer.test.ts — buildContainer invariant pin (issue #155 PR-B).
+//
+// Why this invariant matters: the lock middleware acquires AFTER
+// buildContainer. If a future change introduces write side-effects in
+// buildContainer (e.g. config migration auto-run in a constructor),
+// those writes happen BEFORE the lock, silently breaking the
+// cross-process serialization guarantee. This test exists to catch
+// that regression at the unit-test level.
+//
+// Strategy: snapshot the directory tree before and after the
+// builder runs. Any new file, deleted file, or size change fails
+// the test with a clear diff.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { buildContainer } from '../../src/interface/shared/container.js';
+
+interface Snapshot {
+  [relPath: string]: number; // size in bytes
+}
+
+function snapshot(root: string): Snapshot {
+  const out: Snapshot = {};
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        const rel = relative(root, full);
+        out[rel] = statSync(full).size;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+test('buildContainer (gate) does not write to contentRoot', () => {
+  const root = mkdtempSync(join(tmpdir(), 'gate-container-pin-'));
+  try {
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\n',
+    );
+    const before = snapshot(root);
+    buildContainer({ cwd: root });
+    const after = snapshot(root);
+    assert.deepEqual(
+      after,
+      before,
+      'buildContainer must not write to contentRoot — see test header',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/infrastructure/lock/guildLock.test.ts
+++ b/tests/infrastructure/lock/guildLock.test.ts
@@ -193,6 +193,101 @@ test('withGuildLock: GUILD_LOCK_MAX_AGE_MS triggers age-based reclaim', async ()
   }
 });
 
+test('withGuildLock: reclaims a lock whose started_at predates OS boot', async () => {
+  // Boottime branch (PR-B): if a lock file's started_at is older
+  // than the current OS uptime, the recorded pid by definition
+  // cannot be the original holder regardless of whether a colliding
+  // pid happens to be alive now. This test plants a lock with a
+  // started_at far in the past (epoch + 1s) and a pid that *is*
+  // alive (our own ppid). Without the boottime branch, the
+  // ancestor-safety valve would refuse to reclaim. With it, the
+  // pre-boot timestamp short-circuits the ancestor check.
+  const { root, cleanup } = makeRoot();
+  try {
+    // Pid we know is alive AND would normally be refused by the
+    // ancestor guard — pick our parent. This proves the boottime
+    // branch fires BEFORE the ancestor check.
+    const livePid = process.ppid;
+    const ancientHolder = {
+      pid: livePid,
+      ppid: 1,
+      // 1970-01-01T00:00:01Z — guaranteed predates any plausible
+      // current boot time.
+      started_at: new Date(1000).toISOString(),
+      verb: 'old',
+      actor: 'ghost',
+      host: 'pre-boot',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(ancientHolder, null, 2) + '\n',
+      'utf8',
+    );
+    const result = await withGuildLock(
+      { contentRoot: root },
+      META,
+      async () => 'reclaimed-via-boottime',
+    );
+    assert.equal(result, 'reclaimed-via-boottime');
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('withGuildLock: does NOT reclaim when started_at is post-boot and pid is alive', async () => {
+  // Inverse of the boottime test: a lock with a recent (post-boot)
+  // timestamp and an alive pid (our own ppid) must NOT be reclaimed.
+  // This pins the boottime branch so it doesn't accidentally green-
+  // light reclaim of legitimate in-flight locks within the same
+  // process tree.
+  const { root, cleanup } = makeRoot();
+  const prev = process.env['GUILD_LOCK_MAX_AGE_MS'];
+  try {
+    delete process.env['GUILD_LOCK_MAX_AGE_MS']; // disable age branch
+    const liveAncestorHolder = {
+      pid: process.ppid,
+      ppid: 1,
+      started_at: new Date().toISOString(), // post-boot
+      verb: 'live',
+      actor: 'parent',
+      host: 'h',
+      cwd: '/tmp',
+      passage: 'gate',
+      guild_cli_version: '0.0.0',
+    };
+    writeFileSync(
+      join(root, '.guild-lock'),
+      JSON.stringify(liveAncestorHolder, null, 2) + '\n',
+      'utf8',
+    );
+    let caught: unknown = null;
+    try {
+      await withGuildLock(
+        { contentRoot: root },
+        META,
+        async () => 'should-not-run',
+      );
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(
+      caught instanceof LockBusyError,
+      `expected LockBusyError, got ${String(caught)}`,
+    );
+    // Lock file must still be on disk (we did NOT reclaim it).
+    assert.equal(existsSync(join(root, '.guild-lock')), true);
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_LOCK_MAX_AGE_MS'];
+    else process.env['GUILD_LOCK_MAX_AGE_MS'] = prev;
+    // Manually clean since we left the lock in place.
+    cleanup();
+  }
+});
+
 test('withGuildLock: writes metadata with the expected shape', async () => {
   const { root, cleanup } = makeRoot();
   try {

--- a/tests/integration/lock/_lockChild.ts
+++ b/tests/integration/lock/_lockChild.ts
@@ -1,0 +1,69 @@
+// _lockChild.ts — helper subprocess for the cross-passage race
+// E2E suite. Parent spawns this with the following env:
+//
+//   CHILD_ROOT          contentRoot for withGuildLock
+//   CHILD_BARRIER       barrier path (also passed as GUILD_LOCK_TEST_BARRIER)
+//   CHILD_READY         ready-marker path; we touch it just before
+//                       calling withGuildLock so the parent can
+//                       wait for "all children at the gate" before
+//                       releasing the barrier
+//   CHILD_PASSAGE       cosmetic; recorded in lock metadata
+//   CHILD_VERB          cosmetic; recorded in lock metadata
+//   CHILD_HOLD_MS       how long the winner sleeps inside fn
+//                       (gives losers time to retry/fail observably)
+//
+// Exit codes:
+//   0 → acquired, ran fn, released cleanly
+//   2 → LockBusyError (the loser path)
+//   1 → unexpected error
+//
+// stderr carries the error message (parent asserts on it).
+
+import { writeFileSync } from 'node:fs';
+import {
+  withGuildLock,
+  LockBusyError,
+} from '../../../src/infrastructure/lock/guildLock.js';
+
+function env(name: string): string {
+  const v = process.env[name];
+  if (v === undefined || v.length === 0) {
+    process.stderr.write(`_lockChild: missing env ${name}\n`);
+    process.exit(1);
+  }
+  return v;
+}
+
+async function main(): Promise<void> {
+  const root = env('CHILD_ROOT');
+  const ready = env('CHILD_READY');
+  const passage = env('CHILD_PASSAGE');
+  const verb = env('CHILD_VERB');
+  const holdMs = Number(process.env['CHILD_HOLD_MS'] ?? '50');
+
+  // Signal "I'm at the barrier" — parent waits for this file
+  // (per child) before touching the barrier file.
+  writeFileSync(ready, '1', 'utf8');
+
+  try {
+    await withGuildLock(
+      { contentRoot: root },
+      { passage, verb, actor: 'race-test' },
+      async () => {
+        // Hold briefly so a contending acquire can race and lose.
+        await new Promise<void>((r) => setTimeout(r, holdMs));
+        return null;
+      },
+    );
+    process.exit(0);
+  } catch (e) {
+    if (e instanceof LockBusyError) {
+      process.stderr.write(`lock_busy: ${e.message}\n`);
+      process.exit(2);
+    }
+    process.stderr.write(`unexpected: ${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/integration/lock/cross-passage-race.test.ts
+++ b/tests/integration/lock/cross-passage-race.test.ts
@@ -1,0 +1,215 @@
+// cross-passage-race.test.ts — issue #155 PR-B.
+//
+// Verifies the content-root lock actually serializes concurrent
+// writes ACROSS PROCESSES, not just within one Node event loop.
+//
+// Why this can't be done with Promise.all in-process: a single Node
+// process holds the file descriptor across the entire `withGuildLock`
+// call, so an in-process `Promise.all` of two `withGuildLock` calls
+// observes nothing surprising — the second call sees an EEXIST and
+// throws LockBusyError; that path is already covered by the unit
+// test in tests/infrastructure/lock/guildLock.test.ts. The thing
+// that's NOT covered there — and the thing that actually fails if
+// the lock is buggy — is a cross-process race where each process
+// independently hits `openSync(path, 'wx')` in the same kernel
+// scheduling window. That's what this suite spawns.
+//
+// Synchronization strategy: each child first touches its own ready
+// file, then calls withGuildLock. The acquire path inside
+// guildLock.ts honors GUILD_LOCK_TEST_BARRIER by busy-polling for
+// a barrier file before attempting `openExclusive`. The parent
+// waits for all children's ready files to appear, then `touch`es
+// the barrier — every child unblocks within a 5ms poll quantum and
+// they enter the open-O_EXCL race nearly simultaneously. Exactly
+// one child observes EEXIST → LockBusyError → exit 2; the rest
+// (one) acquires → exits 0.
+//
+// Note: this is a *probabilistic* race — on a heavily loaded host
+// the kernel might schedule child N so much later that child 1 has
+// already finished. The barrier dramatically reduces that window
+// but doesn't eliminate it. The hold time (CHILD_HOLD_MS=300) is
+// generous enough that we have not observed flakes locally.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  unlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+interface ChildOutcome {
+  exitCode: number | null;
+  stderr: string;
+}
+
+interface ChildSpec {
+  passage: string;
+  verb: string;
+}
+
+const CHILD_SCRIPT = resolve('dist/tests/integration/lock/_lockChild.js');
+const HOLD_MS = '300';
+const READY_TIMEOUT_MS = 8_000;
+
+function makeRoot(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-cli-race-'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`waitFor timeout: ${label}`);
+    }
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+}
+
+async function runRace(
+  root: string,
+  specs: readonly ChildSpec[],
+): Promise<ChildOutcome[]> {
+  const barrier = join(root, '.barrier');
+  const readyPaths = specs.map((_, i) => join(root, `.ready-${String(i)}`));
+
+  // Spawn all children. Each waits for the barrier before attempting
+  // openExclusive, so order of spawn doesn't materially affect the
+  // race outcome.
+  const children = specs.map((spec, i) => {
+    const child = spawn(process.execPath, [CHILD_SCRIPT], {
+      env: {
+        ...process.env,
+        CHILD_ROOT: root,
+        CHILD_BARRIER: barrier,
+        CHILD_READY: readyPaths[i] ?? '',
+        CHILD_PASSAGE: spec.passage,
+        CHILD_VERB: spec.verb,
+        CHILD_HOLD_MS: HOLD_MS,
+        GUILD_LOCK_TEST_BARRIER: barrier,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+    const done = new Promise<ChildOutcome>((res) => {
+      child.on('exit', (code) => res({ exitCode: code, stderr }));
+    });
+    return { child, done };
+  });
+
+  // Wait for all children to be at the barrier (ready files present).
+  await waitFor(
+    () => readyPaths.every((p) => existsSync(p)),
+    READY_TIMEOUT_MS,
+    'children-ready',
+  );
+
+  // Release the barrier. All children unblock within ~5ms (the
+  // Atomics.wait quantum inside awaitTestBarrier) and race.
+  writeFileSync(barrier, '1', 'utf8');
+
+  const outcomes = await Promise.all(children.map((c) => c.done));
+
+  // Best-effort cleanup of barrier (lock file is unlinked by the
+  // winner's release path; ready files live under root and will
+  // be removed by the cleanup() rm -rf).
+  try {
+    unlinkSync(barrier);
+  } catch {
+    // ignore
+  }
+  return outcomes;
+}
+
+function summarize(outcomes: readonly ChildOutcome[]): {
+  winners: number;
+  busy: number;
+  unexpected: ChildOutcome[];
+} {
+  let winners = 0;
+  let busy = 0;
+  const unexpected: ChildOutcome[] = [];
+  for (const o of outcomes) {
+    if (o.exitCode === 0) winners += 1;
+    else if (o.exitCode === 2) busy += 1;
+    else unexpected.push(o);
+  }
+  return { winners, busy, unexpected };
+}
+
+test('cross-passage race: same-entry duo → 1 winner, 1 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'request' },
+      { passage: 'gate', verb: 'request' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(
+      s.unexpected.length,
+      0,
+      `unexpected exit codes: ${JSON.stringify(s.unexpected)}`,
+    );
+    assert.equal(s.winners, 1, `expected exactly 1 winner, got ${String(s.winners)}`);
+    assert.equal(s.busy, 1, `expected exactly 1 busy, got ${String(s.busy)}`);
+    // Lock file must be cleaned up after the winner releases.
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('cross-passage race: gate vs agora → 1 winner, 1 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'approve' },
+      { passage: 'agora', verb: 'move' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(s.unexpected.length, 0);
+    assert.equal(s.winners, 1);
+    assert.equal(s.busy, 1);
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('cross-passage race: three-way (gate/agora/devil) → 1 winner, 2 busy', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    const outcomes = await runRace(root, [
+      { passage: 'gate', verb: 'request' },
+      { passage: 'agora', verb: 'play' },
+      { passage: 'devil', verb: 'open' },
+    ]);
+    const s = summarize(outcomes);
+    assert.equal(
+      s.unexpected.length,
+      0,
+      `unexpected exit codes: ${JSON.stringify(s.unexpected)}`,
+    );
+    assert.equal(s.winners, 1);
+    assert.equal(s.busy, 2);
+    assert.equal(existsSync(join(root, '.guild-lock')), false);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

PR-B of the #155 lock-file landing. Builds on #193 (PR-A). Stacked: base = `feat/guild-lock-pr-a`. **Will retarget to `main` after #193 merges.**

Adds the three pieces deferred from PR-A: boottime-based stale reclaim, cross-passage race E2E, and `buildContainer` invariant pin tests.

## Scope

### Modified
- `src/infrastructure/lock/guildLock.ts` — `isReclaimable` gains a boottime branch (`lock.started_at < (Date.now() - os.uptime() * 1000)` ⇒ reclaim, regardless of pid). `awaitTestBarrier()` hook honors `GUILD_LOCK_TEST_BARRIER` (env-only, no-op in production). Header comment captures the three reclaim branches and the design notes.
- `src/interface/shared/container.ts` — `BuildContainerOpts.cwd` (testability for the gate pin test).
- `src/passages/{agora,devil,ctx}/interface/index.ts` — switched to extracted container builders (no behavior change).
- `tests/infrastructure/lock/guildLock.test.ts` — +2 boottime cases.

### New
- `src/passages/{agora,devil,ctx}/interface/container.ts` — extracted builders so `buildContainer` is unit-testable per passage.
- `tests/infrastructure/{gate,agora,devil,ctx}Container.test.ts` — 4 invariant pins (each builder takes a tmp content_root and produces zero filesystem mutation; comment anchors *why*).
- `tests/integration/lock/_lockChild.ts` — child runner that two/three-way race tests spawn.
- `tests/integration/lock/cross-passage-race.test.ts` — three race cases (same-entry duo / gate vs agora / three-way) using `GUILD_LOCK_TEST_BARRIER` to align children inside a ~5ms window.

### Out of scope (PR-C)
- `SECURITY.md` rewrite ("Serialize at the caller" → guildLock-as-boundary)
- `docs/storage-format.md` `.guild-lock` contract
- `CHANGELOG.md` `[Unreleased]` entry

### Out of scope entirely (separate issues)
- #194 — agora/devil/ctx error catch path doesn't honor `--format json`
- #195 — malformed `.guild-lock` can wedge writers indefinitely
- #196 — lock metadata `actor` empty when `GUILD_ACTOR` unset
- #197 — TOCTOU between `EEXIST` and `readHolder`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx tsc` (full build) clean
- [x] `npm test` — 1070 tests, 1049 pass, **21 fail** (same pre-existing macOS local-env set as PR-A; **regression delta 0** vs PR-A baseline on this machine)
- [x] All 12 new tests pass (2 boottime + 3 race + 4 container pin + 3 supporting)
- [ ] CI green (Linux node 20/22 + Windows node 20/22)
- [ ] Asteria real-machine race validation (will follow up)

## Notes for reviewer

- **Race tests are probabilistic by nature**, but the barrier (`GUILD_LOCK_TEST_BARRIER`) shrinks the contention window to ~5ms and `HOLD_MS=300ms` ensures the loser's attempt overlaps the winner's hold reliably. Stable on local + CI in initial dogfood.
- **Boottime branch fires before the ancestor-pid safety valve**, so a reboot-spanning lock with a now-recycled ancestor pid can be reclaimed. Behavior is intentional and called out in code comments.
- **Container pin tests** snapshot directory entries before/after `buildContainer*({ cwd: tmp })` and assert no mutation. They exist to catch a future regression where someone adds `mkdirSync` / config-migration write to a constructor — that would silently break the lock guarantee since `buildContainer` runs **before** the lock middleware.
- No signal handlers added (per design choice; reclaim covers the gap).

Draft until #193 merges and asteria's race validation completes.