### PR TITLE
docs(lock): SECURITY.md / storage-format.md / CHANGELOG for #155 (PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+> **Cross-process write serialization** (#155 — landed via #193 as a
+> single squash that combined PR-A and PR-B; docs follow as PR-C).
+> Replaces "serialize at the caller" with `withGuildLock`, a
+> content-root-wide single-writer mutex enforced by per-entry
+> middleware across all five CLIs (`gate`, `guild`, `agora`, `devil`,
+> `ctx`). The optimistic per-record CAS is retained as an in-process
+> safety net.
+>
+> Convergence path: design (Eris + Noir) → devil-review surfaced 5
+> ship-blockers (entry coverage, host self-attestation, `buildContainer`
+> invariant, verb-set SOT, `doctor` chicken-and-egg) → all accepted →
+> implementation (Miki) → real-machine validation (Asteria, 14
+> scenarios) → final-gate devil pass (zero ship-blockers, 6
+> follow-ups filed: #194 / #195 / #196 / #197 / #200 / #201).
+
+### Added
+
+- **`withGuildLock` + `withEntryLock`** lock primitive and middleware
+  ([#155](https://github.com/eris-ths/guild-cli/issues/155),
+   [#193](https://github.com/eris-ths/guild-cli/pull/193)).
+  `${contentRoot}/.guild-lock` via `O_CREAT | O_EXCL`, JSON metadata
+  payload, `unlink` in `finally`. Three reclaim branches: dead pid
+  (`kill 0` → `ESRCH` with ancestor-pid safety valve), pre-boot lock
+  (`os.uptime()`-derived), and `GUILD_LOCK_MAX_AGE_MS` env cap.
+  Engaged by per-entry middleware that consults a per-passage
+  `verbs.ts` exporting three sets (`READ_VERBS` / `WRITE_VERBS` /
+  `LOCK_EXEMPT_VERBS`); decision order is EXEMPT → READ →
+  acquire-lock (unknown verbs are fail-safe to the lock side).
+  Cross-passage race is exercised in CI by
+  `tests/integration/lock/cross-passage-race.test.ts` (spawn-based
+  with a shared barrier file via `GUILD_LOCK_TEST_BARRIER`, no-op
+  in production). `buildContainer` invariant pin tests on each
+  passage (`tests/infrastructure/{gate,agora,devil,ctx}Container.test.ts`)
+  catch any regression that would put a write side-effect ahead of
+  the lock.
+- **`LockBusyError` (DomainError subclass)** — JSON envelope code
+  `lock_busy` on the gate path; non-gate parity tracked in #194.
+- **`SECURITY.md` § Concurrent writes** rewritten to describe
+  guildLock as the serialization boundary, with the threat-model
+  caveat (writers with content_root access are out of scope) and
+  links to the six follow-up issues.
+- **`docs/storage-format.md` § Cross-process serialization** —
+  on-disk contract for `.guild-lock` (path, payload shape, reclaim
+  rules, test barrier env) so the format is documented alongside
+  the rest of the substrate.
+
 > **Touch-feel campaign** (5 PRs, 1 design issue). A P3 dogfood pass
 > with fresh-agent eyes surfaced the same friction class repeatedly:
 > "the user knows something is wrong / done / different but not what

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -182,14 +182,49 @@ the issue is the active discussion.
   `tests/infrastructure/parseYamlSafe.test.ts`.
 - **Concurrent writes**
   ([#155](https://github.com/eris-ths/guild-cli/issues/155)).
-  There is no lock file. Two simultaneous writes on the same record
-  have a last-writer-wins race unless optimistic-lock detection
-  catches the second write's stale read — `RequestVersionConflict`,
-  `InboxVersionConflict`, and `IssueVersionConflict` each cover their
-  own record class. This catches **most** concurrent mutations but is
-  not a full serialization barrier (the CAS window between re-read
-  and atomic-rename is non-zero). Serialize at the caller for
-  critical operations on any record.
+  Mitigated as of v1-prep #155: `withGuildLock` is the
+  serialization boundary. A content-root-wide single-writer lock at
+  `${contentRoot}/.guild-lock` is acquired by per-entry middleware
+  (`withEntryLock`) on every write-classified verb across all five
+  entries (`gate`, `guild`, `agora`, `devil`, `ctx`). Mechanism:
+  `O_CREAT | O_EXCL` on the lock path, JSON metadata payload
+  (pid / ppid / started_at / verb / actor / host / cwd / passage /
+  guild_cli_version), `unlink` in `finally`. Competing acquire
+  surfaces as `LockBusyError` (DomainError subclass; JSON envelope
+  `code: "lock_busy"`).
+
+  Stale reclaim covers three cases on `EEXIST`: (a) the recorded pid
+  is dead (`kill 0` → `ESRCH`) and is neither the current process nor
+  its parent; (b) `lock.started_at` predates the current OS boot
+  (`os.uptime()`-derived); (c) `GUILD_LOCK_MAX_AGE_MS` env is set and
+  the lock is older than that bound. Cross-host auto-reclaim is
+  forbidden — different hosts sharing one content_root are off the
+  supported substrate (see iCloud / NFS note below).
+
+  The pre-existing per-record CAS (`RequestVersionConflict`,
+  `InboxVersionConflict`, `IssueVersionConflict`) is retained as an
+  in-process safety net against bugs that reorder writes within a
+  single process; it is no longer the cross-process barrier.
+
+  Out of scope (tracked separately):
+  [#194](https://github.com/eris-ths/guild-cli/issues/194)
+  (`--format json` envelope parity for `agora` / `devil` / `ctx`),
+  [#195](https://github.com/eris-ths/guild-cli/issues/195)
+  (malformed `.guild-lock` recovery),
+  [#196](https://github.com/eris-ths/guild-cli/issues/196)
+  (lock metadata `actor` empty when `GUILD_ACTOR` unset),
+  [#197](https://github.com/eris-ths/guild-cli/issues/197)
+  (TOCTOU between `EEXIST` and `readHolder`),
+  [#200](https://github.com/eris-ths/guild-cli/issues/200)
+  (`<write-verb> --help` acquires the lock), and remote-FS support
+  (NFS / SMB / iCloud Drive — `O_CREAT | O_EXCL` atomicity is not
+  guaranteed there; running guild-cli against a content_root on a
+  remote FS is unsupported).
+
+  Threat-model note: an attacker who already has write access to the
+  content_root can write any YAML directly and is therefore out of
+  scope for the lock mechanism — the lock is for honest concurrent
+  writers, not for adversarial ones.
 
 ## Reporting
 

--- a/docs/storage-format.md
+++ b/docs/storage-format.md
@@ -81,6 +81,73 @@ introducing a stored field that could itself drift.
 Inbox is explicit because it has a FIFO cap (`MAX_INBOX_SIZE`) — old
 messages are dropped from the head, so length isn't monotonic.
 
+The optimistic CAS is retained as an in-process safety net even after
+`.guild-lock` (next section) became the cross-process serialization
+barrier. CAS catches reordering bugs **inside** a single process;
+the lock catches concurrency **between** processes.
+
+---
+
+## Cross-process serialization (`.guild-lock`)
+
+Path: `${contentRoot}/.guild-lock`. Created by every write-classified
+verb across all five entries (`gate`, `guild`, `agora`, `devil`,
+`ctx`) via the `withEntryLock` middleware. Readers do not acquire the
+lock.
+
+Mechanism: `openSync(path, 'wx')` (i.e. `O_CREAT | O_EXCL`). The
+holder writes a JSON payload, runs the verb, and `unlink`s the file
+in `finally`. A competing acquire receives `EEXIST` and surfaces it
+as `LockBusyError` — a `DomainError` subclass that maps to JSON
+envelope `code: "lock_busy"` (gate path; other entries are tracked
+in #194).
+
+Lock metadata (treated as untrusted input on read — fields are
+escaped before display):
+
+| Field | Type | Purpose |
+|---|---|---|
+| `pid` | number | Holder's process id. Used for `kill 0` liveness check during reclaim. |
+| `ppid` | number | Holder's parent pid. Debug aid; also feeds the ancestor-pid safety valve in reclaim. |
+| `started_at` | ISO 8601 string | When the holder acquired. Used by both age-based and boottime-based reclaim. |
+| `verb` | string | The verb being executed. Surfaced in the busy-error message. |
+| `actor` | string | Resolved guild actor (env / `.guild-actor`). Currently empty when neither is set — see #196. |
+| `host` | string | Holder's hostname. Recorded for diagnostics; **not** trusted in reclaim judgement. |
+| `cwd` | string | Working directory at acquire. Helps disambiguate worktrees. |
+| `passage` | string | Entry that acquired (`gate` / `guild` / `agora` / `devil` / `ctx`). |
+| `guild_cli_version` | string | Version of the binary that wrote the lock. |
+
+Stale reclaim (best-effort, single retry on `EEXIST`):
+
+1. **Dead pid**: `kill(holder.pid, 0)` returns `ESRCH`, and
+   `holder.pid !== process.pid && holder.pid !== process.ppid` (the
+   ancestor-pid safety valve prevents reclaiming a still-running
+   ancestor).
+2. **Pre-boot lock**: `holder.started_at < (Date.now() - os.uptime() *
+   1000)` — the lock predates the current OS boot, so the original
+   process cannot be alive.
+3. **Age cap**: `GUILD_LOCK_MAX_AGE_MS` env is set, holder is older
+   than that bound. CI runners are expected to set this (e.g. 5
+   minutes); local development normally leaves it unset.
+
+If none match, the acquire fails with `LockBusyError` and surfaces
+the holder's metadata. Cross-host auto-reclaim is not implemented —
+multiple hosts sharing one content_root is off-substrate (NFS / SMB /
+iCloud Drive: atomicity of `O_CREAT | O_EXCL` is not guaranteed and
+running guild-cli there is unsupported).
+
+Test-only env: `GUILD_LOCK_TEST_BARRIER=<file>`. When set, acquire
+busy-polls for the file's existence before attempting `openExclusive`;
+production callers leave it unset and the hook is a no-op. Used by
+`tests/integration/lock/cross-passage-race.test.ts` to align spawned
+children inside a ~5ms contention window.
+
+Out-of-scope follow-ups: #194 (JSON envelope parity for non-gate
+entries), #195 (malformed lock recovery), #196 (`actor` empty when
+unset), #197 (TOCTOU between `EEXIST` and `readHolder`), #200
+(`<write-verb> --help` taking the lock), #201 (race-test child
+cleanup on barrier-wait timeout).
+
 ---
 
 ## Records


### PR DESCRIPTION
## Summary

PR-C of the #155 lock landing — docs only. PR-A + PR-B already shipped via #193.

## Changes

- **`SECURITY.md` § Concurrent writes** — rewritten to describe `withGuildLock` as the serialization boundary instead of the prior "no lock; serialize at the caller". Covers reclaim rules, the cross-host non-support stance (NFS / SMB / iCloud Drive), the threat-model carveout (writers with content_root access are out of scope), and links to the six follow-up issues.
- **`docs/storage-format.md` § Cross-process serialization (new)** — on-disk contract for `.guild-lock`: path, JSON payload shape, three reclaim branches (dead pid / pre-boot / age cap), and `GUILD_LOCK_TEST_BARRIER` as the test-only acquire hook.
- **`CHANGELOG.md` [Unreleased]** — framed entry above the existing "Touch-feel campaign" block. Convergence path (design → devil → impl → validation), components added, deferred follow-ups (#194 / #195 / #196 / #197 / #200 / #201).

## Test plan
- [x] `npx tsc --noEmit` clean (no code touched, but verified)
- [ ] CI green (docs-only; renders correctly on GitHub)