### PR TITLE
fix(envelope): JSON error envelope parity across agora/devil/ctx (#194)

### DIFF
--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -2,10 +2,9 @@ import { buildContainer } from '../shared/container.js';
 import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
 import { nearestCommand } from '../shared/nearestCommand.js';
-import { DomainError } from '../../domain/shared/DomainError.js';
 import { REQUEST_STATES } from '../../domain/request/RequestState.js';
 import { getPackageVersion, isVersionFlag } from '../shared/version.js';
-import { sanitizeError } from '../shared/sanitizeError.js';
+import { emitErrorEnvelope } from '../shared/errorEnvelope.js';
 import {
   reqCreate,
   reqList,
@@ -45,7 +44,6 @@ import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
 import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
-import { LockBusyError } from '../../infrastructure/lock/guildLock.js';
 import { resolveGuildActor } from '../shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 import type { Container } from '../shared/container.js';
@@ -287,25 +285,12 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('gate', e);
       return 0;
     }
-    const rawMsg = e instanceof Error ? e.message : String(e);
-    const msg = sanitizeError(rawMsg, c.config.contentRoot);
-    if (args.options['format'] === 'json') {
-      const payload: Record<string, unknown> = {
-        ok: false,
-        error: {
-          message:
-            e instanceof DomainError
-              ? sanitizeError(e.message, c.config.contentRoot)
-              : msg,
-        },
-      };
-      const errObj = payload['error'] as Record<string, unknown>;
-      if (e instanceof DomainError && e.field) errObj['field'] = e.field;
-      const code = deriveErrorCode(e);
-      if (code) errObj['code'] = code;
-      process.stderr.write(JSON.stringify(payload) + '\n');
-    }
-    process.stderr.write(`error: ${msg}\n`);
+    const fmt = args.options['format'];
+    emitErrorEnvelope(
+      e,
+      typeof fmt === 'string' ? fmt : undefined,
+      c.config.contentRoot,
+    );
     return 1;
   }
 }
@@ -409,32 +394,3 @@ async function dispatch(
   }
 }
 
-/**
- * Macro-level error classification for the JSON envelope. Patterns
- * match the current set of `DomainError` messages so a tool layer
- * can branch on `code` instead of regex-matching the prose.
- *
- * The codes are intentionally coarse (a 4-way fork covers most retry
- * / escalate decisions): fine-grained differentiation stays in the
- * `message` + `field` pair.
- *
- * Message-pattern derivation rather than a per-throw `code` argument
- * keeps the change surgical — adding a code later at the throw site
- * remains compatible; a call that doesn't yet name one still produces
- * the right classification here.
- */
-function deriveErrorCode(e: unknown): string | null {
-  if (!(e instanceof Error)) return null;
-  // LockBusyError check is first: it's a DomainError subclass, so the
-  // generic `validation_error` fallback below would otherwise shadow
-  // the more-specific `lock_busy` code. Tools branching on this need
-  // to distinguish "retry-after-backoff" (lock busy) from
-  // "fix-input-and-resubmit" (validation).
-  if (e instanceof LockBusyError) return 'lock_busy';
-  const m = e.message;
-  if (/\bnot found\b/i.test(m)) return 'not_found';
-  if (/\bis already \w+\.?/i.test(m)) return 'already_in_state';
-  if (/illegal state transition/i.test(m)) return 'illegal_transition';
-  if (e instanceof DomainError) return 'validation_error';
-  return null;
-}

--- a/src/interface/shared/errorEnvelope.ts
+++ b/src/interface/shared/errorEnvelope.ts
@@ -1,0 +1,87 @@
+// errorEnvelope — shared JSON error envelope renderer for entry-point
+// catch paths. Issue #194.
+//
+// Before this module: each passage entry (gate / agora / devil / ctx)
+// caught errors and wrote `error: <msg>\n` to stderr. Only `gate`
+// honored `--format json` and emitted the structured envelope; the
+// other three silently dropped the format flag in their catch path.
+// `lock_busy` (a DomainError subclass) made the asymmetry concrete:
+// AI tool layers branching on `code` got nothing back from agora /
+// devil / ctx.
+//
+// This helper extracts the gate's catch-path envelope logic so the
+// four entries share one implementation. Behavior of `gate` is
+// unchanged — it now calls `emitErrorEnvelope` instead of inlining
+// the same lines. The other three entries call it too.
+//
+// Output shape (when format === 'json'):
+//   stderr line 1: {"ok":false,"error":{"message":"...","code":"...","field":"..."}}
+//   stderr line 2: error: <msg>
+//   exit code: 1 (caller's responsibility)
+//
+// `field` is omitted when the underlying DomainError has none. `code`
+// is omitted when `deriveErrorCode` returns null. Text-mode callers
+// (format !== 'json') get only the `error:` prologue, which matches
+// the pre-#194 behavior of all four entries.
+
+import { DomainError } from '../../domain/shared/DomainError.js';
+import { LockBusyError } from '../../infrastructure/lock/guildLock.js';
+import { sanitizeError } from './sanitizeError.js';
+
+/**
+ * Render the error envelope to stderr. The caller still owns the
+ * exit code (so this stays a one-line addition in catch blocks).
+ *
+ * - `format === 'json'` → emit the JSON envelope, then the `error:`
+ *   text prologue (matches gate's existing dual-output shape).
+ * - any other format    → emit only the `error:` text prologue.
+ */
+export function emitErrorEnvelope(
+  err: unknown,
+  format: string | undefined,
+  contentRoot: string,
+): void {
+  const rawMsg = err instanceof Error ? err.message : String(err);
+  const msg = sanitizeError(rawMsg, contentRoot);
+  if (format === 'json') {
+    const errObj: Record<string, unknown> = { message: msg };
+    if (err instanceof DomainError && err.field !== undefined) {
+      errObj['field'] = err.field;
+    }
+    const code = deriveErrorCode(err);
+    if (code !== null) errObj['code'] = code;
+    const payload = { ok: false, error: errObj };
+    process.stderr.write(JSON.stringify(payload) + '\n');
+  }
+  process.stderr.write(`error: ${msg}\n`);
+}
+
+/**
+ * Macro-level error classification for the JSON envelope. Patterns
+ * match the current set of `DomainError` messages so a tool layer
+ * can branch on `code` instead of regex-matching the prose.
+ *
+ * The codes are intentionally coarse (a 4-way fork covers most retry
+ * / escalate decisions): fine-grained differentiation stays in the
+ * `message` + `field` pair.
+ *
+ * Message-pattern derivation rather than a per-throw `code` argument
+ * keeps the change surgical — adding a code later at the throw site
+ * remains compatible; a call that doesn't yet name one still produces
+ * the right classification here.
+ */
+export function deriveErrorCode(e: unknown): string | null {
+  if (!(e instanceof Error)) return null;
+  // LockBusyError check is first: it's a DomainError subclass, so the
+  // generic `validation_error` fallback below would otherwise shadow
+  // the more-specific `lock_busy` code. Tools branching on this need
+  // to distinguish "retry-after-backoff" (lock busy) from
+  // "fix-input-and-resubmit" (validation).
+  if (e instanceof LockBusyError) return 'lock_busy';
+  const m = e.message;
+  if (/\bnot found\b/i.test(m)) return 'not_found';
+  if (/\bis already \w+\.?/i.test(m)) return 'already_in_state';
+  if (/illegal state transition/i.test(m)) return 'illegal_transition';
+  if (e instanceof DomainError) return 'validation_error';
+  return null;
+}

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -18,10 +18,9 @@
 
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
-import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { emitErrorEnvelope } from '../../../interface/shared/errorEnvelope.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
-import { DomainError } from '../../../domain/shared/DomainError.js';
 import { buildAgoraContainer } from './container.js';
 import { newGame } from './handlers/new.js';
 import { startPlay } from './handlers/play.js';
@@ -212,15 +211,17 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('agora', e);
       return 0;
     }
-    // Mirror gate's catch shape: `error:` prefix carries the failure
-    // signal; the `DomainError:` prefix and `(field)` trailing tag
-    // were debug noise, not touch-feel signal (P3 dogfood C/A
-    // cleanup). DomainError still flows out as a typed object for
-    // any downstream JSON envelope.
-    const rawMsg = e instanceof Error ? e.message : String(e);
-    // Strip absolute contentRoot prefix (issue #153).
-    const msg = sanitizeError(rawMsg, config.contentRoot);
-    process.stderr.write(`error: ${msg}\n`);
+    // Mirror gate's catch shape via the shared envelope helper
+    // (issue #194): `error:` prefix carries the failure signal in
+    // text mode; `--format json` adds the structured envelope on a
+    // preceding stderr line so AI tool layers can branch on `code`
+    // (e.g. `lock_busy`) without regex-matching the prose.
+    const fmt = args.options['format'];
+    emitErrorEnvelope(
+      e,
+      typeof fmt === 'string' ? fmt : undefined,
+      config.contentRoot,
+    );
     return 1;
   }
 }

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -16,10 +16,9 @@
 
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
-import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { emitErrorEnvelope } from '../../../interface/shared/errorEnvelope.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
-import { DomainError } from '../../../domain/shared/DomainError.js';
 import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
@@ -108,14 +107,16 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('ctx', e);
       return 0;
     }
-    // Mirror gate's catch shape: `error:` prefix carries the failure
-    // signal; the `DomainError:` prefix and `(field)` trailing tag
-    // were debug noise, not touch-feel signal (P3 dogfood C/A
-    // cleanup).
-    const rawMsg = e instanceof Error ? e.message : String(e);
-    // Strip absolute contentRoot prefix (issue #153).
-    const msg = sanitizeError(rawMsg, config.contentRoot);
-    process.stderr.write(`error: ${msg}\n`);
+    // Mirror gate's catch shape via the shared envelope helper
+    // (issue #194): `error:` prefix carries the failure signal in
+    // text mode; `--format json` adds the structured envelope on a
+    // preceding stderr line so AI tool layers can branch on `code`.
+    const fmt = args.options['format'];
+    emitErrorEnvelope(
+      e,
+      typeof fmt === 'string' ? fmt : undefined,
+      config.contentRoot,
+    );
     return 1;
   }
 }

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -17,10 +17,9 @@
 
 import { parseArgs, HelpRequested } from '../../../interface/shared/parseArgs.js';
 import { renderVerbHelp } from '../../../interface/shared/verbHelp.js';
-import { sanitizeError } from '../../../interface/shared/sanitizeError.js';
+import { emitErrorEnvelope } from '../../../interface/shared/errorEnvelope.js';
 import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
-import { DomainError } from '../../../domain/shared/DomainError.js';
 import { LenseNotFound } from '../domain/Lense.js';
 import { PersonaNotFound } from '../domain/Persona.js';
 import { buildDevilContainer } from './container.js';
@@ -233,14 +232,16 @@ export async function main(argv: readonly string[]): Promise<number> {
       renderVerbHelp('devil', e);
       return 0;
     }
-    // Mirror gate's catch shape: `error:` prefix carries the failure
-    // signal; the `DomainError:` prefix and `(field)` trailing tag
-    // were debug noise, not touch-feel signal (P3 dogfood C/A
-    // cleanup).
-    const rawMsg = e instanceof Error ? e.message : String(e);
-    // Strip absolute contentRoot prefix (issue #153).
-    const msg = sanitizeError(rawMsg, config.contentRoot);
-    process.stderr.write(`error: ${msg}\n`);
+    // Mirror gate's catch shape via the shared envelope helper
+    // (issue #194): `error:` prefix carries the failure signal in
+    // text mode; `--format json` adds the structured envelope on a
+    // preceding stderr line so AI tool layers can branch on `code`.
+    const fmt = args.options['format'];
+    emitErrorEnvelope(
+      e,
+      typeof fmt === 'string' ? fmt : undefined,
+      config.contentRoot,
+    );
     // For catalog-miss failures, render the catalog + did-you-mean
     // hint so the caller doesn't have to round-trip through `devil
     // schema` to recover. 12 lenses + 6 personas are too many to

--- a/tests/passages/agora/interface/jsonEnvelope.test.ts
+++ b/tests/passages/agora/interface/jsonEnvelope.test.ts
@@ -1,0 +1,151 @@
+// agora — JSON error envelope parity (issue #194).
+//
+// Pin the catch-path contract: when a verb fails AND the caller passed
+// `--format json`, agora must emit the same structured envelope shape
+// that gate has emitted since the lock_busy work landed. Three error
+// paths get exercised:
+//
+//   1. lock_busy   — pre-seed `.guild-lock` with a non-reclaimable
+//                    holder so withEntryLock throws LockBusyError
+//                    before dispatch runs. envelope.error.code must
+//                    be "lock_busy" (the retry-after-backoff signal
+//                    AI tools branch on).
+//   2. validation  — drive a DomainError out of a write verb (here
+//                    `move` with no positional). envelope.error.code
+//                    must be "validation_error" via the gate-shared
+//                    derivation rules.
+//   3. text fallback — same failure without `--format json` emits
+//                      ONLY the `error:` text prologue, no JSON line.
+//                      Pre-#194 callers see no behavioral change.
+//
+// The "code" key is the load-bearing addition; `message` and the
+// optional `field` mirror gate's existing envelope verbatim so a
+// shared tool layer can read all four entries with one parser.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// dist/tests/passages/agora/interface/ → ../../../../../bin
+const AGORA = resolve(here, '../../../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'agora-envelope-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+/**
+ * Pre-seed `.guild-lock` with a holder the staleness check refuses
+ * to reclaim. pid=1 (init) is alive on Unix, EPERMs on kill(1, 0)
+ * (different user) which the staleness check treats as alive; ppid=1
+ * means it isn't our parent; started_at is now-ish so the boottime
+ * branch doesn't fire. Result: any write verb hitting withEntryLock
+ * throws LockBusyError before dispatch.
+ */
+function seedBusyLock(root: string): void {
+  const meta = {
+    pid: 1,
+    ppid: 1,
+    started_at: new Date().toISOString(),
+    verb: 'play',
+    actor: 'someone-else',
+    host: 'test-host',
+    cwd: root,
+    passage: 'agora',
+    guild_cli_version: '0.0.0-test',
+  };
+  writeFileSync(join(root, '.guild-lock'), JSON.stringify(meta, null, 2) + '\n');
+}
+
+function runAgora(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [AGORA, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('agora --format json emits lock_busy envelope on contended write', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runAgora(
+    root,
+    ['play', '--slug', 'unused', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  // First stderr line is the JSON envelope; the trailing `error:`
+  // text line is the dual-output shape gate has had since #155.
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.error.code, 'lock_busy');
+  assert.equal(typeof envelope.error.message, 'string');
+  assert.match(envelope.error.message, /another guild-cli write is in flight/);
+  // text prologue still present so humans-on-stderr aren't surprised.
+  assert.ok(
+    lines.some((l) => l.startsWith('error: ')),
+    `expected an "error:" line; got: ${r.stderr}`,
+  );
+});
+
+test('agora --format json emits structured envelope on dispatch-throw failure', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // `play --slug <missing>` reaches dispatch (lock acquired), then
+  // throws `GameNotFoundForPlay`. The envelope must emit with
+  // ok: false and a message regardless of whether deriveErrorCode
+  // labels it; this pins the "no longer drops --format json" fix.
+  const r = runAgora(
+    root,
+    ['play', '--slug', 'definitely-not-a-real-game', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(typeof envelope.error.message, 'string');
+  assert.match(envelope.error.message, /definitely-not-a-real-game/);
+});
+
+test('agora without --format json emits text-only error (no JSON envelope)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runAgora(root, ['play', '--slug', 'unused'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 1);
+  // Single-line error: no JSON envelope precedes it.
+  const lines = r.stderr.trim().split('\n');
+  assert.equal(lines.length, 1, `expected text-only stderr; got: ${r.stderr}`);
+  assert.match(lines[0]!, /^error: /);
+});

--- a/tests/passages/agora/interface/jsonEnvelope.test.ts
+++ b/tests/passages/agora/interface/jsonEnvelope.test.ts
@@ -55,16 +55,18 @@ function bootstrap(): { root: string; cleanup: () => void } {
 
 /**
  * Pre-seed `.guild-lock` with a holder the staleness check refuses
- * to reclaim. pid=1 (init) is alive on Unix, EPERMs on kill(1, 0)
- * (different user) which the staleness check treats as alive; ppid=1
- * means it isn't our parent; started_at is now-ish so the boottime
- * branch doesn't fire. Result: any write verb hitting withEntryLock
- * throws LockBusyError before dispatch.
+ * to reclaim. Use the test runner's own pid: kill(self, 0) succeeds
+ * (we are alive), so the dead-pid branch refuses reclaim; the
+ * ancestor-pid safety valve (`pid !== process.pid`) also blocks.
+ * started_at is now-ish so the boottime branch doesn't fire either.
+ * Result: any write verb hitting withEntryLock throws LockBusyError
+ * before dispatch. (Earlier draft used pid=1 / ppid=1 which assumed
+ * Unix init semantics — fails on Windows where pid=1 returns ESRCH.)
  */
 function seedBusyLock(root: string): void {
   const meta = {
-    pid: 1,
-    ppid: 1,
+    pid: process.pid,
+    ppid: process.ppid,
     started_at: new Date().toISOString(),
     verb: 'play',
     actor: 'someone-else',

--- a/tests/passages/ctx/interface/jsonEnvelope.test.ts
+++ b/tests/passages/ctx/interface/jsonEnvelope.test.ts
@@ -1,0 +1,113 @@
+// ctx — JSON error envelope parity (issue #194).
+//
+// Same contract as agora and devil's jsonEnvelope tests: pre-#194
+// ctx's catch path silently dropped --format json and emitted only
+// the text `error:` line. After #194 it shares gate's envelope shape
+// via the `errorEnvelope` helper.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CTX = resolve(here, '../../../../../bin/ctx.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-envelope-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function seedBusyLock(root: string): void {
+  const meta = {
+    pid: 1,
+    ppid: 1,
+    started_at: new Date().toISOString(),
+    verb: 'record',
+    actor: 'someone-else',
+    host: 'test-host',
+    cwd: root,
+    passage: 'ctx',
+    guild_cli_version: '0.0.0-test',
+  };
+  writeFileSync(join(root, '.guild-lock'), JSON.stringify(meta, null, 2) + '\n');
+}
+
+function runCtx(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [CTX, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('ctx --format json emits lock_busy envelope on contended write', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runCtx(
+    root,
+    ['record', '--fact', 'a fact', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.error.code, 'lock_busy');
+  assert.match(envelope.error.message, /another guild-cli write is in flight/);
+  assert.ok(lines.some((l) => l.startsWith('error: ')));
+});
+
+test('ctx --format json emits structured envelope on plain-Error write failure', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // `record` without --fact surfaces a plain Error from
+  // `requireOption` (not a DomainError). The envelope must still
+  // emit with `ok: false` and a `message`; `code` is omitted because
+  // deriveErrorCode only labels DomainErrors and message-pattern
+  // matches. The shape consistency (always emit envelope on
+  // --format json failure) is the load-bearing behavior, not the
+  // presence of `code`.
+  const r = runCtx(
+    root,
+    ['record', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(typeof envelope.error.message, 'string');
+  assert.match(envelope.error.message, /Missing --fact/);
+  // code is intentionally absent for non-DomainError + non-pattern
+  // failures — tools branch on its absence as "unclassified".
+  assert.equal(envelope.error.code, undefined);
+});
+
+test('ctx without --format json emits text-only error (no JSON envelope)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runCtx(root, ['record', '--fact', 'a fact'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  assert.equal(lines.length, 1, `expected text-only stderr; got: ${r.stderr}`);
+  assert.match(lines[0]!, /^error: /);
+});

--- a/tests/passages/ctx/interface/jsonEnvelope.test.ts
+++ b/tests/passages/ctx/interface/jsonEnvelope.test.ts
@@ -26,9 +26,11 @@ function bootstrap(): { root: string; cleanup: () => void } {
 }
 
 function seedBusyLock(root: string): void {
+  // Use the test runner's own pid for portability — pid=1 has no
+  // Unix-init equivalent on Windows. See agora envelope test.
   const meta = {
-    pid: 1,
-    ppid: 1,
+    pid: process.pid,
+    ppid: process.ppid,
     started_at: new Date().toISOString(),
     verb: 'record',
     actor: 'someone-else',

--- a/tests/passages/devil/interface/jsonEnvelope.test.ts
+++ b/tests/passages/devil/interface/jsonEnvelope.test.ts
@@ -27,11 +27,12 @@ function bootstrap(): { root: string; cleanup: () => void } {
 }
 
 function seedBusyLock(root: string): void {
-  // pid=1 alive + ppid=1 not-our-parent + recent started_at →
-  // staleness check refuses to reclaim. See agora envelope test.
+  // Use the test runner's own pid: kill(self, 0) succeeds + ancestor
+  // safety valve blocks + recent started_at avoids boottime reclaim.
+  // (pid=1 portability note in agora envelope test.)
   const meta = {
-    pid: 1,
-    ppid: 1,
+    pid: process.pid,
+    ppid: process.ppid,
     started_at: new Date().toISOString(),
     verb: 'open',
     actor: 'someone-else',

--- a/tests/passages/devil/interface/jsonEnvelope.test.ts
+++ b/tests/passages/devil/interface/jsonEnvelope.test.ts
@@ -1,0 +1,123 @@
+// devil-review — JSON error envelope parity (issue #194).
+//
+// Same contract as agora's jsonEnvelope test: when a verb fails AND
+// the caller passed `--format json`, the catch path must emit the
+// gate-shaped {ok, error: {message, code, field?}} envelope on stderr.
+// Pre-#194 devil silently dropped --format json in the catch and
+// emitted only the text `error:` line.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DEVIL = resolve(here, '../../../../../bin/devil.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'devil-envelope-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function seedBusyLock(root: string): void {
+  // pid=1 alive + ppid=1 not-our-parent + recent started_at →
+  // staleness check refuses to reclaim. See agora envelope test.
+  const meta = {
+    pid: 1,
+    ppid: 1,
+    started_at: new Date().toISOString(),
+    verb: 'open',
+    actor: 'someone-else',
+    host: 'test-host',
+    cwd: root,
+    passage: 'devil',
+    guild_cli_version: '0.0.0-test',
+  };
+  writeFileSync(join(root, '.guild-lock'), JSON.stringify(meta, null, 2) + '\n');
+}
+
+function runDevil(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [DEVIL, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('devil --format json emits lock_busy envelope on contended write', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runDevil(
+    root,
+    [
+      'open', 'src/foo.ts',
+      '--type', 'file',
+      '--format', 'json',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.error.code, 'lock_busy');
+  assert.match(envelope.error.message, /another guild-cli write is in flight/);
+  assert.ok(lines.some((l) => l.startsWith('error: ')));
+});
+
+test('devil --format json emits structured envelope on dispatch-throw failure', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // `open` against an unknown --type drives an error past the
+  // lock-acquire step. The envelope must emit with ok: false and a
+  // message; pinning the "no longer drops --format json" fix.
+  const r = runDevil(
+    root,
+    [
+      'open', 'src/foo.ts',
+      '--type', 'not-a-real-type',
+      '--format', 'json',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  const lines = r.stderr.trim().split('\n');
+  const envelope = JSON.parse(lines[0]!);
+  assert.equal(envelope.ok, false);
+  assert.equal(typeof envelope.error.message, 'string');
+});
+
+test('devil without --format json emits text-only error (no JSON envelope)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedBusyLock(root);
+  const r = runDevil(
+    root,
+    ['open', 'src/foo.ts', '--type', 'file'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 1);
+  // The catch path emits a text `error:` line. devil also surfaces
+  // `did you mean` hints for catalog-miss errors (lense / persona),
+  // but lock_busy is neither, so the stderr is the bare text line.
+  const lines = r.stderr.trim().split('\n');
+  assert.equal(lines.length, 1, `expected text-only stderr; got: ${r.stderr}`);
+  assert.match(lines[0]!, /^error: /);
+});


### PR DESCRIPTION
## Summary

Closes #194 (the outer-catch portion). Extracts gate's catch-path envelope logic into a shared helper (`src/interface/shared/errorEnvelope.ts`) and wires the three remaining write entries (`agora`, `devil`, `ctx`) through it. `gate` now also calls the helper instead of inlining the same code; behavior is unchanged for gate.

## Why

PR #193 introduced `LockBusyError` with code `lock_busy`, but only `gate` rendered it as a JSON envelope. AI tool layers calling `agora` / `devil` / `ctx` with `--format json` got plain-text errors back and had to regex-match the prose to detect a busy condition. This PR makes the envelope shape symmetric across all four write entries.

## Scope

### New
- `src/interface/shared/errorEnvelope.ts` — `emitErrorEnvelope(err, format, contentRoot)` + `deriveErrorCode`. The latter is moved (not copied) out of `gate/index.ts`. `LockBusyError` is checked before `DomainError` so the more-specific `lock_busy` code wins.
- `tests/passages/agora/interface/jsonEnvelope.test.ts` — agora envelope (lock_busy + DomainError + plain Error)
- `tests/passages/devil/interface/jsonEnvelope.test.ts` — same for devil
- `tests/passages/ctx/interface/jsonEnvelope.test.ts` — same for ctx

### Modified
- `src/interface/gate/index.ts` — refactored to call `emitErrorEnvelope`; behavior unchanged.
- `src/passages/agora/interface/index.ts`, `src/passages/devil/interface/index.ts`, `src/passages/ctx/interface/index.ts` — outer catch now calls the helper.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — new 9 tests pass; baseline regression 0 (existing 17 macOS-realpath / agora-schema-JSON-size failures unchanged).
- [x] Real-machine dogfood: `gate request` × 10 parallel produces 6 winners + 4 `lock_busy` envelopes (text + JSON envelope on stderr); same shape via `agora new` / `devil open` / `ctx record`. `gate request --format json` emits valid envelope including `field` / `code` for `not_found` and `validation_error` cases.

## Known gap (filed separately)

Handler-internal catch blocks (e.g. `src/passages/agora/interface/handlers/new.ts:71-75`) swallow `DomainError` from `Game.create()` and write plain-text directly to stderr, bypassing the outer catch and therefore the helper. This is a separate architectural pattern that predates #194 and is filed as a follow-up. The lock_busy path and any other DomainError that propagates to `main()`'s outer catch get the envelope as expected.

## Closes

#194 (outer-catch coverage). Handler-internal catch gap tracked separately.