### PR TITLE
feat(gate): surface authored requests with new reviews via boot (#205-followup)

### DIFF
--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -175,6 +175,31 @@ is agent-friendly but not agent-first: the agent has to decide "what
 do I fetch next" during orientation. `boot` bundles the three into
 one payload so the agent can acquire full context with one tool call.
 
+**`reviewed-authored` surface — scope is the Request aggregate.**
+When peers land reviews on a request you authored, `boot` lifts them
+into `verbs_available_now.actionable[]` (as `verb: 'show'`) and
+`suggested_next` (when no higher-priority transition is open), with
+a running total under `status.reviews_unseen`. The boundary that
+decides "unseen" is **the actor's last write to any Request
+aggregate** — `status_log` entries (transitions), `reviews[]` entries
+(judgements), or `thanks[]` entries (cross-actor appreciation). All
+three advance the boundary; reading via `gate show` does not (READ
+surfaces stay side-effect-free).
+
+`message` / `broadcast` / `issues` writes are **deliberately NOT**
+counted — those aggregates have their own notification surfaces
+(inbox unread, issue worklists), and folding them into the
+reviewed-authored boundary would dilute "have I responded to a peer
+review yet" into "have I done anything anywhere". The two signals
+are separate by design. The corollary: replying to a review by
+sending a `gate message` does not clear the surface; reply with
+`gate review` / `gate thank` (or land a state transition on the same
+request) and the surface advances naturally.
+
+The per-request actionable[] is capped at 5 entries to keep the boot
+payload lean (it sits on the agent hot path); deeper backlogs remain
+visible via `status.reviews_unseen`.
+
 ### Write verbs: `--format json` and `suggested_next`
 
 Every write verb (`request`, `approve`, `deny`, `execute`, `complete`,

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -368,6 +368,25 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     c.config.hostNames,
   );
 
+  // Populate status.reviews_unseen for the resolved actor. Mirrors the
+  // boundary used by `actionableTransitions` (Request aggregate scope)
+  // so the scalar in `status` and the per-request entries under
+  // `verbs_available_now.actionable[]` always agree on what counts as
+  // "unseen". Skipped when no actor is resolved — there is no boundary
+  // to evaluate against.
+  if (actor) {
+    const lastAuthoredAt = computeLastAuthoredWriteAt(actor, allRequests);
+    const lower = actor.toLowerCase();
+    let unseen = 0;
+    for (const r of allRequests) {
+      if (r.from.value !== lower) continue;
+      for (const v of r.reviews) {
+        if (lastAuthoredAt === null || v.at > lastAuthoredAt) unseen += 1;
+      }
+    }
+    if (unseen > 0) status.reviews_unseen = unseen;
+  }
+
   const crossPassage = await collectCrossPassage(c.config);
 
   const payload: BootPayload = {
@@ -500,6 +519,17 @@ export function deriveBootSuggestedNext(
           `(authored by ${top.request.from.value}); approve it to unblock, ` +
           `or deny with --reason if it shouldn't proceed.`,
       }, actor);
+    case 'reviewed-authored': {
+      const n = top.reviewsUnseen ?? top.request.reviews.length;
+      return stampActorResolved({
+        verb: 'show',
+        args: { id },
+        reason:
+          `${id} (you authored) has ${n} review(s) since your last activity ` +
+          `on a request — read with gate show ${id}. ` +
+          `(boundary advances when you write to any request: status_log, reviews, or thanks.)`,
+      }, actor);
+    }
   }
 }
 
@@ -566,23 +596,52 @@ type ActionableKind =
   | 'executing-mine'
   | 'unreviewed-mine'
   | 'approved-for-me'
-  | 'pending-as-executor';
+  | 'pending-as-executor'
+  | 'reviewed-authored';
 
 interface ActionableTransition {
   kind: ActionableKind;
   request: Request;
   /** For `executing-mine`, which role the actor plays. */
   executorRole?: 'executor' | 'author';
+  /**
+   * For `reviewed-authored`: how many reviews on the authored request
+   * landed after the actor's last write to any request aggregate.
+   * Surfaced in the reason text so the agent sees how many they're
+   * about to read.
+   */
+  reviewsUnseen?: number;
 }
 
 // Priority order for suggested_next selection. Lower = picked first.
 // `verbs_available_now` uses the full list in this order, too.
+//
+// `reviewed-authored` sits at PRIORITY=4 (after the four
+// pending/approved/executing/completed transitions) because it's a
+// READ surface — the actor authored a request, peers reviewed it,
+// and the agent should read those reviews when no higher-priority
+// state-transition work is open. Boundary advances when the actor
+// writes to ANY request aggregate (status_log, reviews, or thanks),
+// so once the reviews are read and acknowledged via review/thank/
+// complete the surface clears naturally.
 const ACTIONABLE_PRIORITY: Record<ActionableKind, number> = {
   'executing-mine': 0,
   'unreviewed-mine': 1,
   'approved-for-me': 2,
   'pending-as-executor': 3,
+  'reviewed-authored': 4,
 };
+
+/**
+ * Cap on how many `reviewed-authored` entries get appended to
+ * `verbs_available_now.actionable[]`. Without a cap, an actor with N
+ * authored requests × M reviews per request could balloon the boot
+ * payload — this verb sits on the agent hot path (every session
+ * start) so payload bloat is a real cost. 5 covers the "what's piled
+ * up since I last wrote" surface; deeper backlogs are still visible
+ * via `status.reviews_unseen` (the running counter).
+ */
+const REVIEWED_AUTHORED_ACTIONABLE_CAP = 5;
 
 /**
  * Single source of truth for "what verbs does the actor have open right
@@ -641,10 +700,76 @@ function actionableTransitions(
       out.push({ kind: 'pending-as-executor', request: r });
     }
   }
+
+  // reviewed-authored: only surface when the four state-transition
+  // kinds above are empty. Devil v3 ratify: the higher-priority kinds
+  // are about state changes the actor must drive; reviewed-authored
+  // is about catching up on peer feedback. Rolling them together
+  // would push critical transitions off the suggested_next slot for
+  // every actor with stale review traffic.
+  if (out.length === 0) {
+    const lastAuthoredAt = computeLastAuthoredWriteAt(actor, allRequests);
+    for (const r of allRequests) {
+      if (r.from.value !== lower) continue;
+      if (r.reviews.length === 0) continue;
+      // Latest review timestamp on this authored request.
+      let latest: string | null = null;
+      let unseen = 0;
+      for (const v of r.reviews) {
+        if (lastAuthoredAt === null || v.at > lastAuthoredAt) unseen += 1;
+        if (latest === null || v.at > latest) latest = v.at;
+      }
+      if (latest === null) continue;
+      if (lastAuthoredAt !== null && latest <= lastAuthoredAt) continue;
+      out.push({ kind: 'reviewed-authored', request: r, reviewsUnseen: unseen });
+    }
+  }
+
   out.sort(
     (a, b) => ACTIONABLE_PRIORITY[a.kind] - ACTIONABLE_PRIORITY[b.kind],
   );
   return out;
+}
+
+/**
+ * Latest timestamp at which the actor wrote to ANY request aggregate.
+ * Boundary scope is the Request aggregate — message/inbox/issues
+ * writes are intentionally NOT counted (those have their own
+ * notification surfaces; mixing them here would dilute the signal of
+ * "have I responded to a peer review yet").
+ *
+ * Aggregates three write paths Request.ts persists:
+ *   1. status_log[] entries (transitions: pending/approved/executing/...).
+ *   2. reviews[] entries (lense-driven judgements).
+ *   3. thanks[] entries (cross-actor appreciation).
+ *
+ * Returns null when the actor has never written to any request — in
+ * which case every review on every authored request is "after" their
+ * (nonexistent) last write, and the predicate falls through to
+ * "any review on my authored request".
+ *
+ * ISO8601 lexicographic comparison is exact when every timestamp is
+ * UTC-Z formatted (the only shape Request.ts emits, see Thank.ts:43,
+ * Review.ts and StatusLog entry.at).
+ */
+export function computeLastAuthoredWriteAt(
+  actor: string,
+  allRequests: ReadonlyArray<Request>,
+): string | null {
+  const lower = actor.toLowerCase();
+  let max: string | null = null;
+  for (const r of allRequests) {
+    for (const e of r.statusLog) {
+      if (e.by === lower && (max === null || e.at > max)) max = e.at;
+    }
+    for (const v of r.reviews) {
+      if (v.by.value === lower && (max === null || v.at > max)) max = v.at;
+    }
+    for (const t of r.thanks ?? []) {
+      if (t.by.value === lower && (max === null || t.at > max)) max = t.at;
+    }
+  }
+  return max;
 }
 
 const ALWAYS_READABLE_VERBS: readonly string[] = [
@@ -686,6 +811,11 @@ function deriveVerbsAvailableNow(
   // both functions; now each kind lives in `actionableTransitions` and
   // we expand it into its valid verbs here.
   const transitions = actionableTransitions(actor, allRequests);
+  // reviewed-authored entries get appended to actionable[] with a
+  // hard cap (REVIEWED_AUTHORED_ACTIONABLE_CAP) — the running total
+  // is exposed via status.reviews_unseen so the agent sees the full
+  // backlog without the payload itself ballooning.
+  let reviewedAuthoredAppended = 0;
   for (const t of transitions) {
     const id = t.request.id.value;
     switch (t.kind) {
@@ -729,6 +859,17 @@ function deriveVerbsAvailableNow(
           reason: `${id} is pending; deny with --reason if it shouldn't proceed`,
         });
         break;
+      case 'reviewed-authored': {
+        if (reviewedAuthoredAppended >= REVIEWED_AUTHORED_ACTIONABLE_CAP) break;
+        const n = t.reviewsUnseen ?? t.request.reviews.length;
+        actionable.push({
+          verb: 'show',
+          id,
+          reason: `${id} (you authored) has ${n} review(s) since your last activity`,
+        });
+        reviewedAuthoredAppended += 1;
+        break;
+      }
     }
   }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -291,7 +291,38 @@ const VERBS: readonly VerbSchema[] = [
             "re-interpret without the payload pre-baking a host assumption; " +
             "`always_readable` is the side-effect-free verb catalog.",
           properties: {
-            actionable: { type: 'array', items: { type: 'object' } },
+            actionable: {
+              type: 'array',
+              description:
+                'State-transition verbs the caller can fire as themselves, ' +
+                'each carrying the target id + reason. The `verb` enum ' +
+                'includes `show` for the `reviewed-authored` surface — ' +
+                'the actor authored a request, peers landed reviews on it, ' +
+                'and the agent should read those reviews. Boundary advances ' +
+                'when the actor writes to any request aggregate ' +
+                '(status_log, reviews, or thanks); message and issue ' +
+                'writes do NOT advance it (those have their own ' +
+                'notification surfaces — mixing dilutes the signal).',
+              items: {
+                type: 'object',
+                properties: {
+                  verb: {
+                    type: 'string',
+                    enum: [
+                      'approve',
+                      'deny',
+                      'execute',
+                      'complete',
+                      'fail',
+                      'review',
+                      'show',
+                    ],
+                  },
+                  id: str,
+                  reason: str,
+                },
+              },
+            },
             requires_other_actor: {
               type: 'array',
               items: {

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -33,6 +33,18 @@ export interface StatusSummary {
    */
   unresponded: number;
   inbox_unread: number;
+  /**
+   * Reviews on the actor's authored requests that landed AFTER the
+   * actor's last write to any request aggregate (status_log, reviews,
+   * or thanks). Optional — populated by callers that derive the
+   * boundary (currently `gate boot`); other surfaces leave it absent.
+   *
+   * Sibling counter to the per-request entries surfaced under
+   * `verbs_available_now.actionable[]` (capped). The actionable list
+   * shows top-N concrete request ids; this scalar shows the running
+   * total so the agent knows when the cap is hiding additional work.
+   */
+  reviews_unseen?: number;
   last_activity: string | null;
 }
 

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -497,3 +497,380 @@ test('gate boot: --tail <N> overrides the default', () => {
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+// ---------------------------------------------------------------
+// reviewed-authored surface (designed in 2026-05-06-0001).
+//
+// When peers land reviews on a request the actor authored, boot
+// lifts them via verbs_available_now.actionable[] (verb=show) and
+// suggested_next (when no higher-priority transition is open).
+// Boundary scope is the Request aggregate: status_log / reviews /
+// thanks all advance it. Message/issue writes do NOT advance it.
+//
+// Tests below pin the gap-1 (thanks integration), gap-2 (cap), and
+// the higher-priority-suppression invariant Devil v3 ratify named.
+// ---------------------------------------------------------------
+
+function bootstrapWithMembers(): { root: string; cleanup: () => void } {
+  // Two-member fixture so reviewer != author. alice authors, bob
+  // reviews — the minimal shape the reviewed-authored predicate
+  // needs.
+  const root = mkdtempSync(join(tmpdir(), 'guild-boot-rev-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('gate boot: reviewed-authored surfaces when peer reviews land on authored request', () => {
+  const { root, cleanup } = bootstrapWithMembers();
+  try {
+    // alice authors a fast-track (reaches completed in one shot).
+    const filed = runGate(
+      root,
+      [
+        'fast-track',
+        '--action',
+        'demo work',
+        '--reason',
+        'reviewed-authored pin',
+        '--format',
+        'json',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(filed.status, 0);
+    const id = JSON.parse(filed.stdout).id;
+    // bob reviews. bob's review is the boundary-crossing event.
+    const reviewed = runGate(
+      root,
+      [
+        'review',
+        id,
+        '--lense',
+        'devil',
+        '--verdict',
+        'ok',
+        '--comment',
+        'lgtm',
+      ],
+      { GUILD_ACTOR: 'bob' },
+    );
+    assert.equal(reviewed.status, 0);
+
+    // alice boots — should see reviewed-authored.
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next?.verb, 'show');
+    assert.equal(payload.suggested_next?.args?.id, id);
+    assert.match(payload.suggested_next?.reason ?? '', /you authored/);
+    assert.match(payload.suggested_next?.reason ?? '', /1 review/);
+    assert.equal(payload.status.reviews_unseen, 1);
+
+    // actionable[] mirrors it.
+    const actionable = payload.verbs_available_now.actionable;
+    assert.ok(
+      actionable.some(
+        (a: { verb: string; id: string }) => a.verb === 'show' && a.id === id,
+      ),
+      'reviewed-authored entry must appear in actionable[]',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: reviewed-authored boundary advances when author writes a thank (gap-1)', () => {
+  // Devil v3 concern: addThank does not touch status_log, so a
+  // thanks-only response from the author would not advance the
+  // boundary in v2. Pin that v3's thanks integration prevents the
+  // surface from sticking after the author thanks the reviewer.
+  const { root, cleanup } = bootstrapWithMembers();
+  try {
+    const filed = runGate(
+      root,
+      [
+        'fast-track',
+        '--action',
+        'thanks-advances-boundary',
+        '--reason',
+        'gap-1 regression pin',
+        '--format',
+        'json',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const id = JSON.parse(filed.stdout).id;
+    runGate(
+      root,
+      [
+        'review',
+        id,
+        '--lense',
+        'devil',
+        '--verdict',
+        'ok',
+        '--comment',
+        'lgtm',
+      ],
+      { GUILD_ACTOR: 'bob' },
+    );
+    // Confirm surface is up before the thank.
+    const before = JSON.parse(
+      runGate(root, ['boot'], { GUILD_ACTOR: 'alice' }).stdout,
+    );
+    assert.equal(before.suggested_next?.verb, 'show');
+    assert.equal(before.status.reviews_unseen, 1);
+
+    // alice thanks bob. addThank pushes onto thanks[] (no status_log
+    // touch). v3 boundary computes lastAuthoredWriteAt over thanks[]
+    // too, so the surface must clear.
+    const thanked = runGate(
+      root,
+      ['thank', 'bob', '--for', id, '--reason', 'thanks for the review'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(thanked.status, 0);
+
+    const after = JSON.parse(
+      runGate(root, ['boot'], { GUILD_ACTOR: 'alice' }).stdout,
+    );
+    // suggested_next must no longer point at this id (no other open
+    // loops in this fixture, so it should be null).
+    assert.equal(
+      after.suggested_next,
+      null,
+      'thank by author must advance boundary so reviewed-authored clears',
+    );
+    assert.ok(
+      !('reviews_unseen' in after.status) || after.status.reviews_unseen === 0,
+      'reviews_unseen must be cleared (or absent) after thank',
+    );
+    const actionable = after.verbs_available_now.actionable as Array<{
+      verb: string;
+      id: string;
+    }>;
+    assert.ok(
+      !actionable.some((a) => a.verb === 'show' && a.id === id),
+      'actionable[] must drop the reviewed-authored entry after thank',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: reviewed-authored actionable[] is capped at 5 entries', () => {
+  // Voice budget: an actor with N authored × M reviews could balloon
+  // the boot payload — boot is on the hot path. Cap actionable[] to
+  // 5; the running total still surfaces via status.reviews_unseen.
+  const { root, cleanup } = bootstrapWithMembers();
+  try {
+    const ids: string[] = [];
+    // 7 authored requests by alice — file ALL of them first, THEN
+    // bob reviews each. If we interleaved (fast-track then review,
+    // repeat), each subsequent fast-track would advance alice's
+    // boundary (status_log write) past the prior review, and only
+    // the most recent review would remain "unseen". Batching keeps
+    // every review strictly after alice's last write, which is the
+    // shape the cap is protecting against.
+    for (let i = 0; i < 7; i++) {
+      const filed = runGate(
+        root,
+        [
+          'fast-track',
+          '--action',
+          `cap probe ${i}`,
+          '--reason',
+          'cap-5 pin',
+          '--format',
+          'json',
+        ],
+        { GUILD_ACTOR: 'alice' },
+      );
+      assert.equal(filed.status, 0);
+      ids.push(JSON.parse(filed.stdout).id);
+    }
+    for (const id of ids) {
+      const reviewed = runGate(
+        root,
+        [
+          'review',
+          id,
+          '--lense',
+          'devil',
+          '--verdict',
+          'ok',
+          '--comment',
+          'lgtm',
+        ],
+        { GUILD_ACTOR: 'bob' },
+      );
+      assert.equal(reviewed.status, 0);
+    }
+
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    const showEntries = (
+      payload.verbs_available_now.actionable as Array<{ verb: string }>
+    ).filter((a) => a.verb === 'show');
+    assert.equal(
+      showEntries.length,
+      5,
+      'reviewed-authored entries in actionable[] must be capped at 5',
+    );
+    // Running total must reflect the full 7, not the capped view.
+    assert.equal(payload.status.reviews_unseen, 7);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: reviewed-authored is suppressed when a higher-priority transition is open', () => {
+  // Devil v3 ratify invariant: reviewed-authored sits at PRIORITY=4,
+  // appended only when the four state-transition kinds are empty.
+  // If alice has an executing-mine alongside a reviewed authored
+  // request, suggested_next must point at complete, not show.
+  const { root, cleanup } = bootstrapWithMembers();
+  try {
+    // Path A: authored request that gets a peer review (no exec to alice).
+    const filedA = runGate(
+      root,
+      [
+        'fast-track',
+        '--action',
+        'reviewed (low priority)',
+        '--reason',
+        'priority pin',
+        '--format',
+        'json',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const idA = JSON.parse(filedA.stdout).id;
+    runGate(
+      root,
+      [
+        'review',
+        idA,
+        '--lense',
+        'devil',
+        '--verdict',
+        'ok',
+        '--comment',
+        'lgtm',
+      ],
+      { GUILD_ACTOR: 'bob' },
+    );
+
+    // Path B: a request that ends up executing-by-alice. Use the
+    // four-step lifecycle so we can stop at executing.
+    const filedB = runGate(
+      root,
+      [
+        'request',
+        '--action',
+        'executing (high priority)',
+        '--reason',
+        'priority pin',
+        '--executor',
+        'alice',
+        '--format',
+        'json',
+      ],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(filedB.status, 0);
+    const idB = JSON.parse(filedB.stdout).id;
+    // Approve as host, then execute as alice.
+    const approved = runGate(root, ['approve', idB], { GUILD_ACTOR: 'human' });
+    assert.equal(approved.status, 0);
+    const executed = runGate(root, ['execute', idB], { GUILD_ACTOR: 'alice' });
+    assert.equal(executed.status, 0);
+
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    // Highest-priority transition wins suggested_next.
+    assert.equal(payload.suggested_next?.verb, 'complete');
+    assert.equal(payload.suggested_next?.args?.id, idB);
+    // reviewed-authored must NOT contaminate actionable[] when
+    // transitions are present (the if-guard is `out.length === 0`).
+    const actionable = payload.verbs_available_now.actionable as Array<{
+      verb: string;
+      id: string;
+    }>;
+    assert.ok(
+      !actionable.some((a) => a.verb === 'show' && a.id === idA),
+      'reviewed-authored must be suppressed when state-transition work is pending',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('computeLastAuthoredWriteAt aggregates across status_log, reviews, and thanks', async () => {
+  // Direct unit test — bypass the CLI to assert the aggregation
+  // independently of the boot wiring. status_log (transitions),
+  // reviews[] (judgements), and thanks[] (appreciation) all
+  // contribute to the boundary. Latest of the three wins.
+  const { computeLastAuthoredWriteAt } = await import(
+    // Sibling-test pattern: source-relative spec, resolves to
+    // dist/src after tsc emit (matches schema.test.ts, voices.test.ts).
+    '../../src/interface/gate/handlers/boot.js'
+  );
+
+  // Stub `Request`-shaped objects with just the getters
+  // computeLastAuthoredWriteAt reads. Plain objects suffice — the
+  // function uses no Request methods, only the three array getters.
+  // Mirror the in-memory shape: status_log carries `by: string` (raw
+  // shape on entries), while reviews[]/thanks[] expose `by: MemberName`
+  // via getters — so the stub uses `{ value }` for those.
+  type MemberNameStub = { value: string };
+  type Stub = {
+    statusLog: ReadonlyArray<{ by: string; at: string }>;
+    reviews: ReadonlyArray<{ by: MemberNameStub; at: string }>;
+    thanks: ReadonlyArray<{ by: MemberNameStub; at: string }>;
+  };
+  const stubs: Stub[] = [
+    {
+      statusLog: [{ by: 'alice', at: '2026-05-01T10:00:00.000Z' }],
+      reviews: [{ by: { value: 'alice' }, at: '2026-05-02T10:00:00.000Z' }],
+      thanks: [{ by: { value: 'alice' }, at: '2026-05-03T10:00:00.000Z' }],
+    },
+    {
+      statusLog: [{ by: 'bob', at: '2026-05-04T10:00:00.000Z' }],
+      reviews: [],
+      thanks: [],
+    },
+  ];
+
+  const lastAlice = computeLastAuthoredWriteAt(
+    'alice',
+    stubs as unknown as Parameters<typeof computeLastAuthoredWriteAt>[1],
+  );
+  // Latest of the three alice writes is the thank at 2026-05-03.
+  assert.equal(lastAlice, '2026-05-03T10:00:00.000Z');
+
+  // bob has no thanks/reviews; only status_log contributes.
+  const lastBob = computeLastAuthoredWriteAt(
+    'bob',
+    stubs as unknown as Parameters<typeof computeLastAuthoredWriteAt>[1],
+  );
+  assert.equal(lastBob, '2026-05-04T10:00:00.000Z');
+
+  // Actor with no writes anywhere yields null.
+  const lastNobody = computeLastAuthoredWriteAt(
+    'nobody',
+    stubs as unknown as Parameters<typeof computeLastAuthoredWriteAt>[1],
+  );
+  assert.equal(lastNobody, null);
+});


### PR DESCRIPTION
## Summary

Adds a fifth `ActionableKind` (`reviewed-authored`) so `gate boot` lifts an authored request the moment a peer review lands on it, and clears the surface naturally when the author writes any return verb (review / thank / status transition) on any request.

- `boot.suggested_next` picks `{verb: show, args: {id}}` at PRIORITY=4 — only when none of the four existing transitions (`executing-mine` / `unreviewed-mine` / `approved-for-me` / `pending-as-executor`) are open. State-transition work always wins suggested_next.
- `boot.verbs_available_now.actionable[]` mirrors the surface with a hard cap of 5 entries (hot-path payload protection); the running total surfaces via the new optional `status.reviews_unseen` so a deeper backlog stays visible without payload bloat.
- `gate schema` declares `show` in the `actionable[].verb` enum and names the Request-aggregate scope.
- `docs/verbs.md` boot section gains a subsection documenting the surface, the boundary semantics, and the deliberate exclusion of message / issue writes.

Boundary semantics: `lastAuthoredWriteAt(actor)` aggregates the actor's most recent `status_log[].at`, `reviews[].at`, and `thanks[].at` across all requests. Any of the three advances the boundary; `gate show` (READ) does not. Message / inbox / issue writes are deliberately NOT counted — those have their own notification surfaces, and folding them in would dilute the signal.

## Why this shape

Designed via guild-cli's own substrate (`data/guild/`) — request 2026-05-06-0001 with three Noir / Devil review rounds before implementation:

- **v1** (member-yaml `last_seen_review_at` + `gate ack`) was rejected by Devil for three structural breakages: host (eris/nao) has no member yaml, `Member.toJSON` silently drops unknown fields, and reclassifying `gate show` from READ to WRITE would have broken the `verbs.ts` / `verbs-consistency.test.ts` invariant and added a lock to a hot read path.
- **v2** derived `lastAuthoredWriteAt` from existing data (no persistence added). Devil ratified the structure but flagged gap-1: `addThank` writes only into `thanks[]`, so a thanks-only response from the author would not advance the v2 boundary.
- **v3** (this PR) integrates `thanks[]` into the aggregation and documents the Request-aggregate scope explicitly in both the suggested_next reason text and `docs/verbs.md`.

Three implementation hand-off notes from Devil ratify v3 are honored:
1. Domain getters everywhere (`r.statusLog` / `r.reviews` / `r.thanks` — not the snake_case `toJSON()` shape) so camelCase / snake_case do not mix.
2. `r.thanks ?? []` for nullish-safe iteration (matches `Request.ts:286-288`).
3. The reviewed-authored loop only runs when the four transition kinds yielded nothing, keeping cost zero on the common path.

## Test plan

- [x] `npm run build` clean
- [x] 5 new unit + e2e tests GREEN:
  - `gate boot: reviewed-authored surfaces when peer reviews land on authored request`
  - `gate boot: reviewed-authored boundary advances when author writes a thank (gap-1 regression pin)`
  - `gate boot: reviewed-authored actionable[] is capped at 5 entries`
  - `gate boot: reviewed-authored is suppressed when a higher-priority transition is open`
  - `computeLastAuthoredWriteAt aggregates across status_log, reviews, and thanks`
- [x] No preexisting GREEN tests regressed (diff of failing-test set vs baseline = empty; remaining failures are preexisting `/private` vs `/var` path-resolution flakes and agora/devil schema parse issues unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)