### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `guild-cli` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to the versioning policy described in [POLICY.md](./POLICY.md).
+and this project adheres to the versioning policy described in [docs/POLICY.md](./docs/POLICY.md).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to the versioning policy described in [POLICY.md](./POL
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-06
+
+> **substrate self-improvement wave** (#207 / #208) closes the loop:
+> guild-cli's own `gate` substrate was used to design and ship two
+> guild-cli improvements — meta-experiment that doubled as a v0.5
+> hardening pass.
+>
+> - **`gate boot` surfaces authored requests with new reviews**
+>   ([#207](https://github.com/eris-ths/guild-cli/pull/207)). Adds a
+>   fifth `ActionableKind` `reviewed-authored` (PRIORITY=4) lifted via
+>   a derived `lastAuthoredWriteAt(actor)` boundary aggregating
+>   `status_log[].at ∪ reviews[].at ∪ thanks[].at` per actor. Zero
+>   persistence, READ/WRITE invariants intact, host/member treated
+>   uniformly (string actor space). Designed entirely via the
+>   guild-cli substrate at `data/guild/` (Noir v1→Devil reject→Noir
+>   v2→Devil concern→Noir v3→Devil ratify→Miki impl).
+> - **`<write-verb> --help` bypasses the lock**
+>   ([#208](https://github.com/eris-ths/guild-cli/pull/208)). Detects
+>   `args.options.help` after `parseArgs` and routes dispatch around
+>   `withEntryLock` so help is never gated by a contended lock.
+>   Closes [#200](https://github.com/eris-ths/guild-cli/issues/200).
+> - **Wave 8 (#155 lock landing) + envelope contract (#194 / #205)**
+>   — full notes below; v0.5 ships the locking substrate, the JSON
+>   error envelope contract across all four entries, and the
+>   handler-internal catch fix that closes the envelope gap left by
+>   #204.
+
 > **Cross-process write serialization** (#155 — landed via #193 as a
 > single squash that combined PR-A and PR-B; docs follow as PR-C).
 > Replaces "serialize at the caller" with `withGuildLock`, a
@@ -2153,7 +2180,9 @@ the infrastructure to make 0.3.0's agent-first features possible.
 - README: tighten redundancy, clarify scope and requirements. (#22)
 - CI lockfile sync, version drift guard. (#23)
 
-[Unreleased]: https://github.com/eris-ths/guild-cli/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/eris-ths/guild-cli/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/eris-ths/guild-cli/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/eris-ths/guild-cli/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/eris-ths/guild-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/eris-ths/guild-cli/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/eris-ths/guild-cli/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "guild-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "guild-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guild-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Guild CLI — DDD/TS member & request management with Two-Persona Devil Review",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cut v0.5.0 release.

- \`package.json\` / \`package-lock.json\`: 0.4.0 → 0.5.0
- \`CHANGELOG.md\`: \`[Unreleased]\` content moved under \`[0.5.0] — 2026-05-06\` heading; new \`[Unreleased]\` empty section opened above; compare-link entries fixed (the prior file had a stale \`v0.3.0...HEAD\` link and missing \`[0.4.0]\` entry — both corrected).

## Wave coverage

- **Wave 8 (#155 lock landing)**: \`withGuildLock\` + \`withEntryLock\` + 4-entry middleware + boottime reclaim + cross-passage race E2E + \`buildContainer\` pin tests.
- **Envelope contract**: #194 parity + #205 handler-internal catch close (25 sites + GameSlugCollision/PlayIdAmbiguous reclassify).
- **substrate self-improvement**: #207 gate boot \`reviewed-authored\` (designed via guild-cli substrate at \`data/guild/\`) + #208 \`<write-verb> --help\` bypass lock.

## v0.5 vs v1

This is intentionally not v1.0.0. The substrate is functional and self-improving but the API surface and storage format are still evolving — v1 cut is deferred until external usage signals stability.

## Test plan

- [x] No code changes; only \`package.json\` / \`package-lock.json\` / \`CHANGELOG.md\`.
- [ ] CI green on the release branch.
- [ ] After merge: tag \`v0.5.0\` on the squash-merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)