### PR TITLE
docs(policy): redact company name from distribution context

### DIFF
--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -158,7 +158,7 @@ Report security issues via GitHub's private vulnerability reporting
 
 ## Distribution context
 
-`guild-cli` is currently distributed within the Anotete group of
+`guild-cli` is currently distributed within a private group of
 companies as an internal tool, in addition to being public OSS. This
 policy applies uniformly to both audiences: there are no private
 breaking changes. All consumers — internal and external — see the same


### PR DESCRIPTION
## Summary

Replace the proper noun naming the internal distribution group with a generic `"a private group of companies"` phrasing.

```diff
- `guild-cli` is currently distributed within the Anotete group of
+ `guild-cli` is currently distributed within a private group of
   companies as an internal tool, in addition to being public OSS. This
   policy applies uniformly to both audiences: there are no private
   breaking changes. ...
```

Preserves the semantic content (dual internal + public OSS distribution; uniform policy across both) while dropping the surface that ties the public doc to a specific organisation.

## Test plan

- [x] No code changes; doc-only redaction
- [x] Section's other content (versioning policy, no-private-breaks invariant) unchanged

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_