### PR TITLE
feat(touch-feel): port gate list --state all sugar to agora and devil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Added
+
+- **`agora list --state all` and `devil list --state all` accept the
+  cross-passage sugar.** A v0.5 dogfood pass surfaced a touch-feel
+  asymmetry: `gate list --state all` and `gate issues list --state all`
+  both accept `all` as sugar for "every state, no filter" (#170), but
+  the sibling `agora list` and `devil list` errored:
+  ```
+  agora: error: --state must be one of playing|suspended|concluded, got: all
+  devil: error: review state must be one of open, concluded, got: all
+  ```
+  Same friction class #170 closed for `gate` — muscle memory between
+  sibling list verbs across passages was breaking on the `agora` /
+  `devil` boundary. Both now accept `--state all` and treat it as
+  "no filter" at the interface layer; the domain enums are
+  unchanged (the sugar is a CLI affordance, not a state). agora's
+  invalid-state error now also names `|all` so the option is
+  discoverable from the failure itself.
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/passages/agora/interface/handlers/list.ts
+++ b/src/passages/agora/interface/handlers/list.ts
@@ -19,12 +19,15 @@ const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  * agora list — enumerate games and plays.
  *
  * Usage:
- *   agora list [--game <slug>] [--state playing|suspended|concluded] [--format json|text]
+ *   agora list [--game <slug>] [--state playing|suspended|concluded|all] [--format json|text]
  *
  * Default: lists every game and every play in the content root.
  * Filters narrow the scope:
  *   --game <slug>  : only plays for the given game (games list dropped)
- *   --state <s>    : only plays in the given state
+ *   --state <s>    : only plays in the given state; `all` is sugar
+ *                    for "every state, no filter" (parity with
+ *                    `gate list --state all` and `gate issues list
+ *                    --state all`)
  *
  * Read-only verb. Output shape per principle 11: JSON envelope is
  * the agent contract; text is the projection.
@@ -44,10 +47,11 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
     stateFilter !== undefined &&
     stateFilter !== 'playing' &&
     stateFilter !== 'suspended' &&
-    stateFilter !== 'concluded'
+    stateFilter !== 'concluded' &&
+    stateFilter !== 'all'
   ) {
     process.stderr.write(
-      `error: --state must be one of playing|suspended|concluded, got: ${stateFilter}\n`,
+      `error: --state must be one of playing|suspended|concluded|all, got: ${stateFilter}\n`,
     );
     return 1;
   }
@@ -64,7 +68,8 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
   let plays: Play[] = await deps.plays.listAll(
     gameFilter ? { gameSlug: gameFilter } : {},
   );
-  if (stateFilter) {
+  // `all` is interface-layer sugar for "no filter" — treat as undefined.
+  if (stateFilter && stateFilter !== 'all') {
     plays = plays.filter((p) => p.state === stateFilter);
   }
 
@@ -115,9 +120,12 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
   }
 
   // text rendering
+  // `--state all` is "no filter" — don't surface it as a filter
+  // segment in the text header (would read as state=all, confusing).
+  const showStateSegment = stateFilter && stateFilter !== 'all';
   if (gameFilter) {
     process.stdout.write(`plays for game=${gameFilter}`);
-    if (stateFilter) process.stdout.write(` state=${stateFilter}`);
+    if (showStateSegment) process.stdout.write(` state=${stateFilter}`);
     process.stdout.write(` (${plays.length}):\n`);
   } else {
     process.stdout.write(`games (${games.length}):\n`);
@@ -131,7 +139,7 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
       }
     }
     process.stdout.write(`\nplays`);
-    if (stateFilter) process.stdout.write(` state=${stateFilter}`);
+    if (showStateSegment) process.stdout.write(` state=${stateFilter}`);
     process.stdout.write(` (${plays.length}):\n`);
   }
   if (plays.length === 0) {

--- a/src/passages/agora/interface/handlers/schema.ts
+++ b/src/passages/agora/interface/handlers/schema.ts
@@ -289,8 +289,9 @@ const VERBS: readonly VerbSchema[] = [
         game: strOpt('narrow plays to one game (drops games list from output)'),
         state: {
           type: 'string',
-          enum: ['playing', 'suspended', 'concluded'],
-          description: 'narrow plays to one state',
+          enum: ['playing', 'suspended', 'concluded', 'all'],
+          description:
+            'narrow plays to one state, or `all` for every state (no filter)',
         },
         format: formatField,
       },

--- a/src/passages/agora/interface/index.ts
+++ b/src/passages/agora/interface/index.ts
@@ -81,10 +81,11 @@ Usage:
                               Agent dispatch contract for this passage
                               (principle 10). draft-07 JSON Schema subset.
 
-  agora list [--game <slug>] [--state playing|suspended|concluded] [--format json|text]
+  agora list [--game <slug>] [--state playing|suspended|concluded|all] [--format json|text]
                               Enumerate games and plays. Filters: --game
                               narrows plays to one game (drops games list);
-                              --state narrows plays to a single state.
+                              --state narrows plays to a single state, or
+                              'all' for every state, no filter.
 
   agora show <slug-or-play-id> [--game <slug>] [--format json|text]
                               Detail view of one game or one play. Argument

--- a/src/passages/devil/interface/handlers/list.ts
+++ b/src/passages/devil/interface/handlers/list.ts
@@ -17,7 +17,7 @@ const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  * devil list — enumerate review sessions in the content_root.
  *
  * Usage:
- *   devil list [--state open|concluded]
+ *   devil list [--state open|concluded|all]
  *              [--target-type pr|file|function|commit]
  *              [--format json|text]
  *
@@ -26,7 +26,9 @@ const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  * "what's open right now?" surface. For full detail use `devil show`.
  *
  * Filters compose: --state open --target-type pr returns only open
- * reviews on PR targets. Order is most-recent-first by id.
+ * reviews on PR targets. `--state all` is sugar for "every state,
+ * no filter" — parity with `gate list --state all` and
+ * `gate issues list --state all`. Order is most-recent-first by id.
  */
 export interface ListDeps {
   readonly reviews: DevilReviewRepository;
@@ -38,7 +40,11 @@ export async function listReviews(deps: ListDeps, args: ParsedArgs): Promise<num
 
   const stateRaw = optionalOption(args, 'state');
   let stateFilter: ReviewState | undefined;
-  if (stateRaw !== undefined) {
+  if (stateRaw !== undefined && stateRaw !== 'all') {
+    // `all` is interface-layer sugar for "no filter" — parseReviewState
+    // rejects it (the domain has no 'all' state), so intercept here.
+    // Anything else still routes through the domain parser so the
+    // single source of truth for ReviewState is preserved.
     stateFilter = parseReviewState(stateRaw); // throws DomainError on bad input
   }
   const typeRaw = optionalOption(args, 'target-type');

--- a/src/passages/devil/interface/handlers/schema.ts
+++ b/src/passages/devil/interface/handlers/schema.ts
@@ -173,13 +173,14 @@ const VERBS: readonly VerbSchema[] = [
     category: 'read',
     summary:
       'enumerate review sessions in the content_root. Filters: --state narrows by ' +
-      'open|concluded; --target-type narrows by pr|file|function|commit. Read-only.',
+      'open|concluded, or `all` for every state (no filter); --target-type ' +
+      'narrows by pr|file|function|commit. Read-only.',
     input: {
       type: 'object',
       properties: {
         state: {
           type: 'string',
-          enum: ['open', 'concluded'],
+          enum: ['open', 'concluded', 'all'],
         },
         'target-type': {
           type: 'string',

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -62,11 +62,12 @@ Usage:
                               author-defender / mirror); ingest-only
                               personas are rejected here.
 
-  devil list [--state open|concluded] [--target-type pr|file|function|commit]
+  devil list [--state open|concluded|all] [--target-type pr|file|function|commit]
              [--format json|text]
                               Enumerate review sessions. Read-only,
                               one-line-per-review summary; --state and
-                              --target-type narrow the result.
+                              --target-type narrow the result. --state
+                              all is sugar for "every state, no filter".
 
   devil show <rev-id> [--format json|text]
                               Detail view of one review (full entries +

--- a/tests/passages/agora/list.test.ts
+++ b/tests/passages/agora/list.test.ts
@@ -186,7 +186,74 @@ test('agora list: --state with invalid value rejects', (t) => {
     { GUILD_ACTOR: 'alice' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--state must be one of playing\|suspended\|concluded/);
+  // The enum the error names now includes `|all` so the sugar is
+  // discoverable from the error itself (parity with gate list).
+  assert.match(r.stderr, /--state must be one of playing\|suspended\|concluded\|all/);
+});
+
+test('agora list: --state all returns plays in every state (sugar parity with gate)', (t) => {
+  // Mirrors `gate list --state all` and `gate issues list --state all`
+  // touch-feel sugar: muscle memory between sibling list verbs across
+  // passages should not drop on the floor at the agora boundary.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  // Three plays — leave one playing, suspend one, conclude one.
+  // After the run we have one of each state.
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+  const today = new Date().toISOString().slice(0, 10);
+  runAgora(
+    root,
+    ['suspend', `${today}-002`, '--cliff', 'c', '--invitation', 'i'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runAgora(
+    root,
+    ['conclude', `${today}-003`, '--note', 'done'],
+    { GUILD_ACTOR: 'alice' },
+  );
+
+  const r = runAgora(
+    root,
+    ['list', '--state', 'all', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.plays.length, 3);
+  const states = new Set(payload.plays.map((p: { state: string }) => p.state));
+  // All three states present — no filter applied.
+  assert.deepEqual(
+    [...states].sort(),
+    ['concluded', 'playing', 'suspended'],
+    `expected mixed states, got: ${[...states].join(',')}`,
+  );
+});
+
+test('agora list: --state all text output omits the state= header segment', (t) => {
+  // `--state all` is "no filter", so showing `state=all` in the
+  // text header would read as a filter. Header should look like
+  // the no-state default (just the play count).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runAgora(
+    root,
+    ['new', '--slug', 'g', '--kind', 'sandbox', '--title', 'g'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runAgora(root, ['play', '--slug', 'g'], { GUILD_ACTOR: 'alice' });
+
+  const r = runAgora(root, ['list', '--state', 'all'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /state=all/);
+  // Default header still present.
+  assert.match(r.stdout, /plays \(1\):/);
 });
 
 test('agora list: JSON envelope is snake_case (principle 11)', (t) => {

--- a/tests/passages/devil/listShow.test.ts
+++ b/tests/passages/devil/listShow.test.ts
@@ -92,7 +92,40 @@ test('list --state invalid fails with enum error', (t) => {
   t.after(cleanup);
   const r = runDevil(root, ['list', '--state', 'paused']);
   assert.equal(r.status, 1);
+  // `all` is interface-layer sugar (treated as no-filter before
+  // parseReviewState runs); domain still rejects unknown values
+  // through parseReviewState's existing message.
   assert.match(r.stderr, /review state must be one of/);
+});
+
+test('list --state all is accepted as sugar for "no filter" (parity with gate)', (t) => {
+  // Mirrors `gate list --state all` and `gate issues list --state all`
+  // touch-feel sugar: a user moving across passages should not get
+  // an enum error from a sibling list verb. Pre-fix, devil rejected
+  // `--state all` with `review state must be one of open, concluded`.
+  //
+  // Synthesizing a concluded review for a state-mix assertion would
+  // require driving conclude, which has its own lense-coverage gate;
+  // that's orthogonal to the sugar contract. Test the contract: the
+  // call succeeds, returns every review the substrate has, and the
+  // envelope does not echo `all` as if it were a domain state.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  openOne(root, 'file', 'src/a.ts');
+  openOne(root, 'pr', 'https://github.com/x/y/pull/1');
+
+  const r = runDevil(root, ['list', '--state', 'all', '--format', 'json']);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr=${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.reviews.length, 2);
+  // `all` is an interface affordance — JSON should record "no filter"
+  // (filters.state omitted), not a fictional state value. Substrate
+  // truth: there was no domain-level filter applied.
+  assert.equal(
+    payload.filters.state,
+    undefined,
+    'filters.state should be omitted when --state all is sugar for no-filter',
+  );
 });
 
 test('list --target-type filters by target.type', (t) => {


### PR DESCRIPTION
## Summary

Closes a cross-passage `--state all` asymmetry surfaced during a v0.5 dogfood pass.

PR #170 (P3 touch-feel campaign) added `--state all` sugar to `gate list` to match the pre-existing `gate issues list --state all`. The same friction class re-emerged at the agora / devil boundary:

```
agora: error: --state must be one of playing|suspended|concluded, got: all
devil: error: review state must be one of open, concluded, got: all
```

A user moving across sibling list verbs across passages had their muscle memory break exactly where #170 said it shouldn't. This PR ports the same sugar to both remaining passages.

## Contract

- **`all`** is interface-layer sugar for "every state, no filter". The domain enums (`RequestState`, `ReviewState`, agora's play state union) are **unchanged** — `parseRequestState` / `parseReviewState` still reject `all` when called outside the list-verb sugar boundary, so the single domain truth is preserved.
- agora's invalid-state error now spells `|all` so the sugar is discoverable from the failure itself (parity with `gate list`'s hint shape).
- devil's invalid-state error continues to come from `parseReviewState` (domain-truth path); `all` is intercepted before the parse call so the domain never sees it.
- text-mode headers skip the `state=all` segment — it'd read as a filter, but "no filter" is the substrate truth.
- devil's JSON envelope omits `filters.state` when `--state all` is the only state input (same reasoning).

## Files

- `src/passages/agora/interface/handlers/list.ts` — enum widened, error message + text header updates
- `src/passages/agora/interface/index.ts` + `handlers/schema.ts` — help block + agent-dispatch schema advertise `|all`
- `src/passages/devil/interface/handlers/list.ts` — intercept `all` before parseReviewState
- `src/passages/devil/interface/index.ts` + `handlers/schema.ts` — help block + schema
- `tests/passages/agora/list.test.ts` — existing invalid-state assertion updated; two new tests pin the sugar (JSON state-mix + text-header omission)
- `tests/passages/devil/listShow.test.ts` — one new test pins the sugar contract (envelope `filters.state` omission)
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] Full suite green (1117 passing)
- [x] Manual cross-passage dogfood:
  - `gate list --state all` ✓ (unchanged)
  - `agora list --state all` ✓ (was error, now lists every state)
  - `devil list --state all` ✓ (was error, now lists every state)
  - `agora list --state bogus` → error names `|all`
- [x] No domain-layer changes — `parseRequestState` / `parseReviewState` still reject `all`

## Out of scope

- `agora last --state all` — `last` returns a single play, so "no filter" semantics differ; deliberate scope discipline.
- devil's invalid-state error message doesn't yet name `|all` (it routes through `parseReviewState` which is domain-truth). The discoverability path is `<verb> --help` and the agent-dispatch schema. Touchable in a follow-up if it shows up in dogfood.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_