### PR TITLE
feat(touch-feel): unify actor-flag missing-arg errors across passages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Changed
+
+- **Actor-flag missing-arg errors unified across agora / devil / ctx
+  to the #164 `requireOption` shape.** A v0.5 dogfood sweep found 16
+  callsites still using the pre-#164 pattern
+  (`optionalOption` + manual `--by required (or set GUILD_ACTOR)`
+  stderr write) — the gate sweep had been thorough but agora / devil /
+  ctx kept the older bespoke message. Now every actor-flag error
+  reads `Missing --by <m> (or set GUILD_ACTOR).` regardless of which
+  passage emitted it. Net deletion of ~90 lines (one `requireOption`
+  call replaces six lines of manual handling). Tests asserting the
+  prior `/--by required/` shape updated to `/Missing --by/`.
+
 ### Added
 
 - **`agora list --state all` and `devil list --state all` accept the

--- a/src/passages/agora/interface/handlers/conclude.ts
+++ b/src/passages/agora/interface/handlers/conclude.ts
@@ -7,6 +7,7 @@ import {
   ParsedArgs,
   optionalOption,
   rejectUnknownFlags,
+  requireOption,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
@@ -57,13 +58,7 @@ export async function concludePlay(
     return 1;
   }
   const note = optionalOption(args, 'note');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora conclude attributes the conclusion to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/agora/interface/handlers/last.ts
+++ b/src/passages/agora/interface/handlers/last.ts
@@ -4,8 +4,8 @@ import {
   ParsedArgs,
   optionalOption,
   rejectUnknownFlags,
+  requireOption,
 } from '../../../../interface/shared/parseArgs.js';
-import { resolveGuildActor } from '../../../../interface/shared/resolveGuildActor.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 
 const LAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
@@ -58,13 +58,7 @@ export interface LastDeps {
 export async function lastPlay(deps: LastDeps, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, LAST_KNOWN_FLAGS, 'last');
 
-  const by = optionalOption(args, 'by') ?? resolveGuildActor();
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora last is per-actor — it asks "which play am I in?"\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
 
   const stateFilter = optionalOption(args, 'state');
   if (

--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -50,13 +50,7 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
     return 1;
   }
   const text = requireOption(args, 'text', '"..."');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora move attributes the move to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -47,13 +47,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   const kind = optionalOption(args, 'kind') ?? 'sandbox';
   const title = optionalOption(args, 'title') ?? slug;
   const description = optionalOption(args, 'description');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora new attributes the creation to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -43,13 +43,7 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
   rejectUnknownFlags(args, PLAY_KNOWN_FLAGS, 'play');
 
   const slug = requireOption(args, 'slug', '<game-slug>');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora play attributes the start to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -8,6 +8,7 @@ import {
   ParsedArgs,
   optionalOption,
   rejectUnknownFlags,
+  requireOption,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
@@ -54,13 +55,7 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
     return 1;
   }
   const note = optionalOption(args, 'note');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora resume attributes the resume to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -61,13 +61,7 @@ export async function suspendPlay(
   }
   const cliff = requireOption(args, 'cliff', '"<what just happened>"');
   const invitation = requireOption(args, 'invitation', '"<next opener\'s move>"');
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). agora suspend attributes the suspension to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/ctx/interface/handlers/record.ts
+++ b/src/passages/ctx/interface/handlers/record.ts
@@ -6,7 +6,6 @@ import {
   requireOption,
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
-import { resolveGuildActor } from '../../../../interface/shared/resolveGuildActor.js';
 
 const RECORD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'fact',
@@ -53,13 +52,7 @@ export async function recordCtx(
 
   const fact = requireOption(args, 'fact', '"..."');
   const tags = parseTagList(optionalOption(args, 'tag'));
-  const by = optionalOption(args, 'by') ?? resolveGuildActor();
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR / .guild-actor). ctx record attributes the observation to an actor.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/conclude.ts
+++ b/src/passages/devil/interface/handlers/conclude.ts
@@ -89,13 +89,7 @@ export async function concludeReview(
         .filter((s) => s.length > 0)
     : [];
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil conclude attributes the close.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/dismiss.ts
+++ b/src/passages/devil/interface/handlers/dismiss.ts
@@ -82,13 +82,7 @@ export async function dismissEntry(
   const reason: DismissalReason = parseDismissalReason(reasonRaw);
   const note = optionalOption(args, 'note');
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil dismiss attributes the dismissal.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -108,13 +108,7 @@ export async function entryOnReview(
   );
   const text = requireOption(args, 'text', '"..."');
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil entry attributes the entry author.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/ingest.ts
+++ b/src/passages/devil/interface/handlers/ingest.ts
@@ -194,13 +194,7 @@ export async function ingestSource(
     return 1;
   }
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil ingest attributes the ingest invocation.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/open.ts
+++ b/src/passages/devil/interface/handlers/open.ts
@@ -58,13 +58,7 @@ export async function openReview(deps: OpenDeps, args: ParsedArgs): Promise<numb
   // bubble to the dispatcher's catch (turns into stderr error: ...).
   const type = parseTargetType(typeRaw);
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil open attributes the review opener.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/resolve.ts
+++ b/src/passages/devil/interface/handlers/resolve.ts
@@ -9,6 +9,7 @@ import {
   ParsedArgs,
   optionalOption,
   rejectUnknownFlags,
+  requireOption,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
@@ -73,13 +74,7 @@ export async function resolveEntry(
     return 1;
   }
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil resolve attributes the resolution.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/resume.ts
+++ b/src/passages/devil/interface/handlers/resume.ts
@@ -9,6 +9,7 @@ import {
   ParsedArgs,
   optionalOption,
   rejectUnknownFlags,
+  requireOption,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
@@ -67,13 +68,7 @@ export async function resumeReview(
 
   const note = optionalOption(args, 'note');
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil resume attributes the re-entry.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/src/passages/devil/interface/handlers/suspend.ts
+++ b/src/passages/devil/interface/handlers/suspend.ts
@@ -72,13 +72,7 @@ export async function suspendReview(
   const cliff = requireOption(args, 'cliff', '"<what just happened>"');
   const invitation = requireOption(args, 'invitation', '"<next opener\'s move>"');
 
-  const by = optionalOption(args, 'by', 'GUILD_ACTOR');
-  if (!by) {
-    process.stderr.write(
-      'error: --by required (or set GUILD_ACTOR). devil suspend attributes the pause.\n',
-    );
-    return 1;
-  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);

--- a/tests/passages/agora/conclude.test.ts
+++ b/tests/passages/agora/conclude.test.ts
@@ -224,7 +224,9 @@ test('agora conclude: missing positional / actor / unknown flag handled', (t) =>
     { GUILD_ACTOR: '' },
   );
   assert.notEqual(noActor.status, 0);
-  assert.match(noActor.stderr, /--by required/);
+  // Post-#164 sweep across passages: actor-flag errors say
+  // `Missing --by <m> (or set GUILD_ACTOR).`
+  assert.match(noActor.stderr, /Missing --by/);
 
   const bogus = runAgora(
     root,

--- a/tests/passages/agora/lastAndCliff.test.ts
+++ b/tests/passages/agora/lastAndCliff.test.ts
@@ -170,7 +170,7 @@ test('agora last: --by overrides GUILD_ACTOR; missing actor errors clearly', (t)
   // No --by, no GUILD_ACTOR → error
   const r2 = run(AGORA, root, ['last']);
   assert.notEqual(r2.status, 0);
-  assert.match(r2.stderr, /--by required/);
+  assert.match(r2.stderr, /Missing --by/);
 });
 
 test('agora last: text mode renders one-line summary + cliff lines when suspended', (t) => {

--- a/tests/passages/agora/move.test.ts
+++ b/tests/passages/agora/move.test.ts
@@ -180,7 +180,7 @@ test('agora move: missing actor fails closed', (t) => {
     { GUILD_ACTOR: '' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--by required/);
+  assert.match(r.stderr, /Missing --by/);
 });
 
 test('agora move: rejects unknown flag (principle 10 input contract)', (t) => {

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -292,7 +292,7 @@ test('agora new: missing GUILD_ACTOR and no --by produces a clear error', (t) =>
     { GUILD_ACTOR: '' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--by required/);
+  assert.match(r.stderr, /Missing --by/);
 });
 
 test('agora new: rejects unknown flags loud (principle 10 input contract)', (t) => {

--- a/tests/passages/agora/play.test.ts
+++ b/tests/passages/agora/play.test.ts
@@ -184,7 +184,7 @@ test('agora play: missing actor fails closed', (t) => {
     { GUILD_ACTOR: '' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--by required/);
+  assert.match(r.stderr, /Missing --by/);
 });
 
 test('agora play: rejects unknown flag (principle 10 input contract)', (t) => {

--- a/tests/passages/devil/open.test.ts
+++ b/tests/passages/devil/open.test.ts
@@ -145,7 +145,7 @@ test('devil open without --by and no GUILD_ACTOR fails', (t) => {
     { GUILD_ACTOR: '' },
   );
   assert.equal(r.status, 1);
-  assert.match(r.stderr, /--by required/);
+  assert.match(r.stderr, /Missing --by/);
 });
 
 test('devil open allocates per-day sequences (001, 002, 003)', (t) => {


### PR DESCRIPTION
## Summary

Closes a cross-passage error-shape asymmetry surfaced in v0.5 dogfood. PR #164 rolled out `requireOption(args, key, shape, envFallback)` and the `Missing --<flag> <shape> (or set <ENV>).` shape across `gate`, but **16 callsites** in `agora` / `devil` / `ctx` kept the older bespoke pattern:

```
const by = optionalOption(args, 'by', 'GUILD_ACTOR');
if (!by) {
  process.stderr.write(
    'error: --by required (or set GUILD_ACTOR). agora suspend ' +
    'attributes the suspension to an actor.\n',
  );
  return 1;
}
```

Same flag, two different error shapes depending on which CLI emitted it. The pedagogical "agora suspend attributes the suspension to an actor" addendum was mildly informative but the `<m>` shape + env hint `(or set GUILD_ACTOR)` already convey what to do.

## Migration

All 16 callsites become a single line:

```
const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
```

Net deletion of ~90 lines. Six test files asserting `/--by required/` updated to `/Missing --by/`.

## Files

- agora handlers (7): `conclude`, `last`, `move`, `new`, `play`, `resume`, `suspend`
- devil handlers (8): `conclude`, `dismiss`, `entry`, `ingest`, `open`, `resolve`, `resume`, `suspend`
- ctx handlers (1): `record`
- 6 test files updated

Side effect: `agora last` and `ctx record` drop a now-unused `resolveGuildActor` import — `requireOption(..., 'GUILD_ACTOR')` threads through `resolveEnvOrActorFile` which already calls `resolveGuildActor` internally. One source of truth for the 3-source actor resolution (env / flag / `.guild-actor` file).

## Test plan

- [x] Build green (`tsc`)
- [x] Full suite green (1117 passing)
- [x] Manual cross-passage dogfood — `agora new`, `devil open`, `ctx record` without `GUILD_ACTOR` and `--by` all emit the same `error: Missing --by <m> (or set GUILD_ACTOR).` shape

## Out of scope

- ctx record had a slightly different message mentioning `.guild-actor` file alongside `GUILD_ACTOR`. The unified shape says `(or set GUILD_ACTOR)` only — the `.guild-actor` file is documented elsewhere and threaded by the underlying resolver.
- Positional-argument errors (`error: positional <play-id> required.`) are out of scope; they're a separate pattern handled by direct stderr writes after `args.positional[0]` is undefined.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_