### PR TITLE
feat(bin): detect partial dist staleness (src newer than dist) at entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **Partial-dist-staleness detector at bin entry.** The existing
+  guard at #139/#140 catches "dist not built at all" but not
+  "dist exists, but lags src after a `git pull`". A v0.5 dogfood
+  pass hit the lag case — `agora last` returned `unknown verb`
+  because dist held the pre-#179 dispatcher. New shared helper
+  `bin/_lib/checkDistFreshness.mjs` (plain ESM, lives outside
+  `dist/` to avoid the circular trap) compares newest src/`*.ts`
+  mtime against newest `dist/src/*.js` mtime, with a 2-second
+  grace for fs clock skew. Emits a single stderr notice and
+  continues — staleness is dev-loop friction, not a correctness
+  failure (a stale dist often runs fine for the verbs that didn't
+  change). Silent when src/ is missing (installed-via-npm shape).
+  Wired into all 5 bin entries (gate / guild / agora / devil / ctx).
+
 - **`agora list --state all` and `devil list --state all` accept the
   cross-passage sugar.** A v0.5 dogfood pass surfaced a touch-feel
   asymmetry: `gate list --state all` and `gate issues list --state all`

--- a/bin/_lib/checkDistFreshness.mjs
+++ b/bin/_lib/checkDistFreshness.mjs
@@ -1,0 +1,96 @@
+// Partial-dist-staleness detector.
+//
+// Lives in bin/_lib/ rather than dist/ for the same reason the
+// existing dist-missing guard is inlined: a helper that itself
+// lived in dist/ would be silently absent precisely when the
+// problem fires (circular trap). This file is plain .mjs and is
+// not transpiled, so all 5 bin entries can import it directly.
+//
+// What it catches: the case where dist/ exists and the entry
+// loads successfully, BUT one or more src/ files have been
+// modified since the last build — so the binary runs against a
+// stale compiled tree. The dogfood symptom that motivated this
+// (May 2026) was `agora last` returning `unknown verb` after a
+// `git pull` because the dispatcher in dist/ predated the
+// last.ts addition in src/. The existing ERR_MODULE_NOT_FOUND
+// path didn't fire because the dispatcher loaded fine — just
+// without the new verb registered.
+//
+// Heuristic: compare the newest mtime of any *.ts file under
+// src/ against the newest mtime of any *.js file under dist/src/.
+// If src wins (with a small grace to absorb fs clock skew), the
+// build is stale. Emit a stderr notice; do not block execution.
+// The user can rebuild with `npm run build` and retry.
+//
+// Why notice and not error: the partial-staleness case is a
+// dev-loop friction, not a correctness violation. A stale dist
+// often runs fine for the verbs that haven't changed; failing
+// closed would block work on the unchanged verbs while a more
+// expensive `tsc` is queued. The dist-MISSING case (existing
+// guard) does block — there's nothing to run.
+//
+// Ship-mode short-circuit: when guild-cli is installed via npm,
+// package.json's `files` field excludes src/, so the directory
+// won't exist alongside dist/. Callers should pass null/missing
+// paths and the helper returns silently.
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * @param {string} srcDir  absolute path to src/ (the TypeScript tree)
+ * @param {string} distDir absolute path to dist/src/ (the compiled tree)
+ * @returns {void}         emits a stderr notice if dist is stale; otherwise silent
+ */
+export function checkDistFreshness(srcDir, distDir) {
+  if (!existsSync(srcDir) || !existsSync(distDir)) {
+    // Installed-via-npm shape (no src/) or first-run-before-build
+    // (no dist/, the existing guard handles that case). Either
+    // way nothing to compare.
+    return;
+  }
+  const srcMtime = newestMtime(srcDir, '.ts');
+  const distMtime = newestMtime(distDir, '.js');
+  if (srcMtime === 0 || distMtime === 0) return;
+
+  // 2-second grace: tsc emits .js files that may have a slightly
+  // older mtime than the .ts they were compiled from on some
+  // filesystems. Avoid flapping notices when the gap is within
+  // single-digit seconds.
+  const GRACE_MS = 2000;
+  if (srcMtime > distMtime + GRACE_MS) {
+    process.stderr.write(
+      'guild-cli: dist/ is stale relative to src/ (some src files modified after the last build).\n' +
+        '  Run: npm run build  (rebuild before re-running)\n' +
+        '  Hint: this commonly fires after a `git pull`. The current run will continue against the stale dist.\n',
+    );
+  }
+}
+
+/**
+ * Recursively find the newest mtime of any file under `root`
+ * whose name ends with `ext`. Returns 0 if no matches found
+ * or if the walk hit an error (treat as "no signal").
+ *
+ * @param {string} root
+ * @param {string} ext
+ * @returns {number}
+ */
+function newestMtime(root, ext) {
+  let max = 0;
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(root, e.name);
+      if (e.isDirectory()) {
+        max = Math.max(max, newestMtime(p, ext));
+      } else if (e.isFile() && e.name.endsWith(ext)) {
+        max = Math.max(max, statSync(p).mtimeMs);
+      }
+    }
+  } catch {
+    // Permission error / race / missing dir — treat as no signal.
+    return 0;
+  }
+  return max;
+}

--- a/bin/agora.mjs
+++ b/bin/agora.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 // Two coupled facts to remember if you change anything here:
-//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
-//      intentionally — a shared helper would itself live in dist/ and
-//      hit the same load failure (circular trap). Re-evaluate if a
-//      5th entry is added.
+//   1. The dist-missing guard is duplicated across the 5 bin entries
+//      intentionally — see gate.mjs for the rationale. The
+//      partial-staleness check is shared via bin/_lib/.
 //   2. The error message references `npm install` and the `prepare`
 //      script. If package.json drops `prepare: tsc`, update the message.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+const here = dirname(fileURLToPath(import.meta.url));
+checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
+
 const ENTRY_URL = new URL('../dist/src/passages/agora/interface/index.js', import.meta.url).href;
 
 let main;

--- a/bin/ctx.mjs
+++ b/bin/ctx.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 // Two coupled facts to remember if you change anything here:
-//   1. This guard is duplicated across bin/{gate,guild,agora,devil,ctx}.mjs
-//      intentionally — a shared helper would itself live in dist/ and
-//      hit the same load failure (circular trap). Re-evaluate if a
-//      6th entry is added.
+//   1. The dist-missing guard is duplicated across the 5 bin entries
+//      intentionally — see gate.mjs for the rationale. The
+//      partial-staleness check is shared via bin/_lib/.
 //   2. The error message references `npm install` and the `prepare`
 //      script. If package.json drops `prepare: tsc`, update the message.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+const here = dirname(fileURLToPath(import.meta.url));
+checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
+
 const ENTRY_URL = new URL('../dist/src/passages/ctx/interface/index.js', import.meta.url).href;
 
 let main;

--- a/bin/devil.mjs
+++ b/bin/devil.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 // Two coupled facts to remember if you change anything here:
-//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
-//      intentionally — a shared helper would itself live in dist/ and
-//      hit the same load failure (circular trap). Re-evaluate if a
-//      5th entry is added.
+//   1. The dist-missing guard is duplicated across the 5 bin entries
+//      intentionally — see gate.mjs for the rationale. The
+//      partial-staleness check is shared via bin/_lib/.
 //   2. The error message references `npm install` and the `prepare`
 //      script. If package.json drops `prepare: tsc`, update the message.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+const here = dirname(fileURLToPath(import.meta.url));
+checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
+
 const ENTRY_URL = new URL('../dist/src/passages/devil/interface/index.js', import.meta.url).href;
 
 let main;

--- a/bin/gate.mjs
+++ b/bin/gate.mjs
@@ -1,11 +1,18 @@
 #!/usr/bin/env node
 // Two coupled facts to remember if you change anything here:
-//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
-//      intentionally — a shared helper would itself live in dist/ and
-//      hit the same load failure (circular trap). Re-evaluate if a
-//      5th entry is added.
+//   1. The dist-missing guard is duplicated across the 5 bin entries
+//      (gate / guild / agora / devil / ctx) intentionally — a shared
+//      helper that itself lived in dist/ would hit the same load
+//      failure (circular trap). The partial-staleness check, by
+//      contrast, lives in bin/_lib/ as plain .mjs and is shared.
 //   2. The error message references `npm install` and the `prepare`
 //      script. If package.json drops `prepare: tsc`, update the message.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+const here = dirname(fileURLToPath(import.meta.url));
+checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
+
 const ENTRY_URL = new URL('../dist/src/interface/gate/index.js', import.meta.url).href;
 
 let main;

--- a/bin/guild.mjs
+++ b/bin/guild.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 // Two coupled facts to remember if you change anything here:
-//   1. This guard is duplicated across bin/{gate,guild,agora,devil}.mjs
-//      intentionally — a shared helper would itself live in dist/ and
-//      hit the same load failure (circular trap). Re-evaluate if a
-//      5th entry is added.
+//   1. The dist-missing guard is duplicated across the 5 bin entries
+//      intentionally — see gate.mjs for the rationale. The
+//      partial-staleness check is shared via bin/_lib/.
 //   2. The error message references `npm install` and the `prepare`
 //      script. If package.json drops `prepare: tsc`, update the message.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+const here = dirname(fileURLToPath(import.meta.url));
+checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
+
 const ENTRY_URL = new URL('../dist/src/interface/guild/index.js', import.meta.url).href;
 
 let main;

--- a/tests/interface/distFreshness.test.ts
+++ b/tests/interface/distFreshness.test.ts
@@ -32,11 +32,16 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
-// dist/tests/interface/ → repo root is three levels up.
-const HELPER = resolve(here, '../../../bin/_lib/checkDistFreshness.mjs');
+// dist/tests/interface/ → repo root is three levels up. Convert to a
+// file:// URL for the dynamic import — Node's ESM loader on Windows
+// rejects bare absolute paths with backslashes; same Windows-ESM
+// trap that #161 fixed for the doctor handler's plugin loader.
+const HELPER = pathToFileURL(
+  resolve(here, '../../../bin/_lib/checkDistFreshness.mjs'),
+).href;
 
 interface Helper {
   checkDistFreshness: (srcDir: string, distDir: string) => void;

--- a/tests/interface/distFreshness.test.ts
+++ b/tests/interface/distFreshness.test.ts
@@ -1,0 +1,181 @@
+// Partial-dist-staleness detector tests.
+//
+// Pins the contract for `bin/_lib/checkDistFreshness.mjs`:
+//   - silent when src and dist are in sync (within grace)
+//   - silent when either dir is missing (installed-via-npm or
+//     pre-build state — the existing dist-missing guard handles
+//     the latter; this helper stays out of its way)
+//   - emits a stderr notice when src has a .ts file newer than
+//     the newest .js under dist by more than the 2s grace
+//   - never blocks execution (notice only, not exit-1)
+//
+// The helper is plain ESM .mjs so the test imports it directly
+// rather than spawning a bin script. Spawning would fold the
+// staleness signal into stderr beside other notices and require
+// rebuilding dist between cases, which is slow and brittle.
+//
+// Why this matters: the dist-missing guard at #139/#140 catches
+// "no dist at all" but not "dist exists but lags src". A May 2026
+// dogfood pass hit the lag case — a `git pull` brought new src
+// files (`agora last`, `agora cliff`) but dist still held the
+// previous dispatcher, so the new verbs returned `unknown verb`
+// without a clue about staleness. This helper closes that gap.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  utimesSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// dist/tests/interface/ → repo root is three levels up.
+const HELPER = resolve(here, '../../../bin/_lib/checkDistFreshness.mjs');
+
+interface Helper {
+  checkDistFreshness: (srcDir: string, distDir: string) => void;
+}
+
+async function loadHelper(): Promise<Helper> {
+  return (await import(HELPER)) as Helper;
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'dist-freshness-'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+/** Capture stderr writes during a synchronous call. */
+function captureStderr(fn: () => void): string {
+  const orig = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  // Override only for the duration of the call. Node's typing for
+  // process.stderr.write is overloaded; cast through unknown to
+  // satisfy the assignment without disturbing the production type.
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured += chunk.toString();
+    return true;
+  }) as unknown as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = orig;
+  }
+  return captured;
+}
+
+function setMtime(path: string, secondsAgo: number): void {
+  const t = (Date.now() - secondsAgo * 1000) / 1000;
+  utimesSync(path, t, t);
+}
+
+test('checkDistFreshness: silent when src and dist mtimes match', async (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src');
+  const dist = join(root, 'dist', 'src');
+  mkdirSync(src, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(src, 'a.ts'), '// src');
+  writeFileSync(join(dist, 'a.js'), '// dist');
+  // Pin both files to the same mtime — within-grace, no signal.
+  setMtime(join(src, 'a.ts'), 100);
+  setMtime(join(dist, 'a.js'), 100);
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.equal(stderr, '', `expected no notice; got: ${stderr}`);
+});
+
+test('checkDistFreshness: silent when src dir is missing (installed-via-npm)', async (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src'); // never created
+  const dist = join(root, 'dist', 'src');
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(dist, 'a.js'), '// dist');
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.equal(stderr, '', 'no src/ → installed-via-npm shape; helper must stay silent');
+});
+
+test('checkDistFreshness: silent when dist dir is missing (existing guard handles it)', async (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src');
+  const dist = join(root, 'dist', 'src'); // never created
+  mkdirSync(src, { recursive: true });
+  writeFileSync(join(src, 'a.ts'), '// src');
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.equal(stderr, '', 'no dist/ → existing #139/#140 guard fires; this helper stays silent');
+});
+
+test('checkDistFreshness: emits notice when src is newer than dist beyond the grace', async (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src');
+  const dist = join(root, 'dist', 'src');
+  mkdirSync(src, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(src, 'a.ts'), '// src');
+  writeFileSync(join(dist, 'a.js'), '// dist');
+  // dist 60s old; src now → 60s gap, well past the 2s grace.
+  setMtime(join(dist, 'a.js'), 60);
+  setMtime(join(src, 'a.ts'), 0);
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.match(stderr, /dist\/ is stale relative to src\//);
+  assert.match(stderr, /npm run build/);
+});
+
+test('checkDistFreshness: silent when src is only marginally newer (within the 2s grace)', async (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src');
+  const dist = join(root, 'dist', 'src');
+  mkdirSync(src, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(src, 'a.ts'), '// src');
+  writeFileSync(join(dist, 'a.js'), '// dist');
+  // 1s gap — inside the 2s grace, treated as in-sync.
+  setMtime(join(dist, 'a.js'), 2);
+  setMtime(join(src, 'a.ts'), 1);
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.equal(stderr, '', `expected no notice within grace; got: ${stderr}`);
+});
+
+test('checkDistFreshness: walks nested directories (newest mtime wins per tree)', async (t) => {
+  // Pins the recursive walk: a deeply-nested .ts that's fresher
+  // than every .js triggers the notice. Mirrors the real-world
+  // case (a single `agora last.ts` newer than the dispatcher).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const { checkDistFreshness } = await loadHelper();
+  const src = join(root, 'src');
+  const nestedSrc = join(src, 'passages', 'agora', 'interface', 'handlers');
+  const dist = join(root, 'dist', 'src');
+  mkdirSync(nestedSrc, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+  // Most of dist + the top-level .ts are old; one nested .ts is new.
+  writeFileSync(join(src, 'top.ts'), '// top');
+  writeFileSync(join(nestedSrc, 'last.ts'), '// new');
+  writeFileSync(join(dist, 'a.js'), '// dist');
+  setMtime(join(src, 'top.ts'), 100);
+  setMtime(join(dist, 'a.js'), 100);
+  setMtime(join(nestedSrc, 'last.ts'), 0);
+
+  const stderr = captureStderr(() => checkDistFreshness(src, dist));
+  assert.match(stderr, /dist\/ is stale/);
+});


### PR DESCRIPTION
## Summary

Closes a dist-staleness detection gap surfaced in v0.5 dogfood. The existing #139/#140 guard catches **"dist not built at all"** (entry import fails with `ERR_MODULE_NOT_FOUND`) but not **"dist exists, but lags src after a `git pull`"** — the dispatcher loads fine, just without the new verbs registered.

## The motivating dogfood case

Pulled `main` after a stretch where #179 (`agora last`/`agora cliff`) had merged. Forgot to rebuild. Ran `agora last` → got:

```
agora: unknown verb: last
  did you mean: agora list?
```

Took a beat to realize this was a stale-dist symptom, not an unimplemented verb. The dispatcher object was the pre-#179 one; the new handlers existed in `src/` but weren't compiled.

## Approach

New shared helper at `bin/_lib/checkDistFreshness.mjs`:

- **Plain ESM `.mjs`** — lives outside `dist/` so it can be imported even when `dist/` itself is the problem. Avoids the circular-trap the existing inline duplication was working around (the comment at the top of every bin entry hints at this).
- **Mtime walk**: compares newest `*.ts` under `src/` with newest `*.js` under `dist/src/`. If src wins by more than a 2-second grace (fs clock skew absorber), emits a single stderr notice.
- **Notice-only**, never blocks. Staleness is dev-loop friction, not a correctness failure. A stale dist often runs fine for the verbs that didn't change; failing closed would block work on unchanged verbs while the user queues `tsc`.
- **Silent in installed-via-npm shape**: when `src/` is absent (per package.json `files` field), short-circuit. The detector is dev-only.

Wired into all 5 bin entries (gate / guild / agora / devil / ctx). package.json's `files: [bin, ...]` already ships `bin/_lib/` automatically.

## Files

- `bin/_lib/checkDistFreshness.mjs` (NEW) — the helper
- `bin/{gate,guild,agora,devil,ctx}.mjs` — call the helper before the existing dist-missing guard. Updated the inline comment so future readers know which guard catches what.
- `tests/interface/distFreshness.test.ts` (NEW) — six tests pin: in-sync silence, missing-src silence, missing-dist silence, fires on >grace gap, silence within grace, recursive walk.
- `CHANGELOG.md` — `[Unreleased]` entry under Added

## Test plan

- [x] Build green (`tsc`)
- [x] Full suite green (1117 → 1123 passing, +6 new)
- [x] Manual:
  - Fresh build + run → silent ✓
  - `touch src/.../list.ts` + run → notice fires ✓
  - Rebuild → silent again ✓

## Out of scope

- The notice text is informative but doesn't name *which* file is newer. Could be added later if dogfood shows the bare "dist is stale" message isn't enough — keeping the first cut minimal.
- Test runs spawn a shell-via-`spawnSync` for dogfood verification but the helper test imports the helper directly. The full-suite duration impact (+6 tests) is ~100ms.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_