### PR TITLE
feat(whoami): disclose actor source provenance (env vs .guild-actor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   verbs per CLI passed the comparison so a regression in the
   unknown-flag error shape doesn't silently empty the loop.
 
+- **`gate whoami` discloses actor source provenance.** When
+  `GUILD_ACTOR` (env) and `.guild-actor` (file) both produce a
+  valid identity, the resolved actor looks the same on the
+  surface but the *path* that produced it carried different
+  signals (env from shell vs. file dropped into the tree by a
+  colleague). New `actor source: GUILD_ACTOR (env)` /
+  `actor source: .guild-actor (file)` line under `you are X`
+  closes the orientation gap. Sibling helper
+  `resolveGuildActorWithSource()` exposes the source as a typed
+  field for other surfaces that want it. Mirrors principle 09
+  (orientation-disclosure) — when two valid configurations
+  produce the same value, name which one was used.
+
 ### Changed
 
 - **Actor-flag missing-arg errors unified across agora / devil / ctx

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -1,4 +1,7 @@
-import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+import {
+  resolveGuildActor,
+  resolveGuildActorWithSource,
+} from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -214,8 +217,8 @@ const WHOAMI_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
 
 export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, WHOAMI_KNOWN_FLAGS, 'whoami');
-  const actor = resolveGuildActor();
-  if (!actor || actor.length === 0) {
+  const resolved = resolveGuildActorWithSource();
+  if (!resolved) {
     process.stderr.write(
       'GUILD_ACTOR is not set.\n' +
         'Export it in your shell to identify yourself:\n' +
@@ -224,6 +227,7 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
     );
     return 1;
   }
+  const actor = resolved.actor;
 
   const members = await c.memberUC.list();
   const actorLower = actor.toLowerCase();
@@ -246,6 +250,15 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   const displayName = memberRecord?.displayName;
   const displayChunk = displayName ? ` — ${displayName}` : '';
   process.stdout.write(`you are ${actor}${displayChunk} (${role})\n`);
+  // Disclose the resolution source so a fresh agent can tell
+  // GUILD_ACTOR-from-shell apart from a `.guild-actor` file dropped
+  // into the tree by a colleague. Same observability principle as
+  // `gate boot`'s misconfigured_cwd disclosure: when two equally-
+  // valid configurations produce the same resolved value, the
+  // surface should name which one was used.
+  const sourceLabel =
+    resolved.source === 'env' ? 'GUILD_ACTOR (env)' : '.guild-actor (file)';
+  process.stdout.write(`actor source: ${sourceLabel}\n`);
 
   const limit = parseOptionalIntOption(args, 'limit') ?? 5;
 

--- a/src/interface/shared/resolveGuildActor.ts
+++ b/src/interface/shared/resolveGuildActor.ts
@@ -41,6 +41,43 @@ export function resolveGuildActor(start: string = process.cwd()): string | undef
 }
 
 /**
+ * The two non-flag sources `resolveGuildActor` consults, in
+ * priority order: `env` wins over `file` when both are set.
+ *
+ * Surfaced as a public type so verbs that want to disclose
+ * provenance (e.g. `gate whoami`) can name the source the actor
+ * came from. Callers that synthesise a third value when the
+ * actor came from an explicit `--by`/`--from` flag should map
+ * that to `'flag'` themselves; this helper only sees the env
+ * and file branches.
+ */
+export type ActorSource = 'env' | 'file';
+
+export interface ResolvedActor {
+  actor: string;
+  source: ActorSource;
+}
+
+/**
+ * Same resolution as `resolveGuildActor` but reports which of
+ * the two sources won. Returns undefined when neither matches —
+ * the caller decides how to surface the absence.
+ */
+export function resolveGuildActorWithSource(
+  start: string = process.cwd(),
+): ResolvedActor | undefined {
+  const env = process.env['GUILD_ACTOR'];
+  if (env !== undefined && env.length > 0) {
+    return { actor: env, source: 'env' };
+  }
+  const fromFile = findActorFile(start);
+  if (fromFile !== undefined) {
+    return { actor: fromFile, source: 'file' };
+  }
+  return undefined;
+}
+
+/**
  * Walk up from `start` looking for `.guild-actor`. Returns the first
  * file's trimmed contents or `undefined` if none found within the lookup
  * window. Same 10-level cap as `findConfig`; cross-platform via

--- a/tests/interface/resolveGuildActor.test.ts
+++ b/tests/interface/resolveGuildActor.test.ts
@@ -16,7 +16,10 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveGuildActor } from '../../src/interface/shared/resolveGuildActor.js';
+import {
+  resolveGuildActor,
+  resolveGuildActorWithSource,
+} from '../../src/interface/shared/resolveGuildActor.js';
 
 function withEnv(actor: string | undefined, fn: () => void): void {
   const prev = process.env['GUILD_ACTOR'];
@@ -161,4 +164,69 @@ test('default start defaults to process.cwd() when no arg passed', () => {
     const result = resolveGuildActor();
     assert.equal(result, 'cwd-test');
   });
+});
+
+// ---- resolveGuildActorWithSource ----
+//
+// Same env > file > undefined contract as `resolveGuildActor`, but
+// reports which of the two sources won. Used by `gate whoami` to
+// disclose actor provenance.
+
+test('with-source: env wins, source = "env"', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv('from-env', () => {
+      assert.deepEqual(resolveGuildActorWithSource(root), {
+        actor: 'from-env',
+        source: 'env',
+      });
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('with-source: file fallback, source = "file"', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv(undefined, () => {
+      assert.deepEqual(resolveGuildActorWithSource(root), {
+        actor: 'from-file',
+        source: 'file',
+      });
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('with-source: returns undefined when neither source resolves', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    withEnv(undefined, () => {
+      assert.equal(resolveGuildActorWithSource(root), undefined);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('with-source: empty env string falls through to file (parity with bare resolver)', () => {
+  // The bare resolver treats GUILD_ACTOR='' as unset; the with-source
+  // variant must mirror that — otherwise callers that switched to the
+  // new helper would see different behaviour for the same input.
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, '.guild-actor'), 'from-file');
+    withEnv('', () => {
+      assert.deepEqual(resolveGuildActorWithSource(root), {
+        actor: 'from-file',
+        source: 'file',
+      });
+    });
+  } finally {
+    cleanup();
+  }
 });

--- a/tests/interface/whoamiSourceProvenance.test.ts
+++ b/tests/interface/whoamiSourceProvenance.test.ts
@@ -1,0 +1,111 @@
+// `gate whoami` discloses which source the resolved actor came from.
+//
+// `resolveGuildActor` consults two non-flag sources in priority
+// order: `GUILD_ACTOR` env, then a `.guild-actor` file walked up
+// from cwd. When both produce equally-valid identities, the
+// "two configurations look the same on the surface" surface
+// (paraphrasing principle 09: orientation-disclosure) means the
+// reader can't tell *why* whoami answered the way it did.
+//
+// This test pins the contract: `gate whoami` writes an `actor
+// source: ...` line right after `you are X` that names whichever
+// of GUILD_ACTOR / .guild-actor was used. Same disclosure shape
+// as `gate boot`'s misconfigured-cwd hint — orientation surfaces
+// disclose the path that produced the answer.
+//
+// Sibling helper test in `resolveGuildActor.test.ts` covers the
+// underlying `resolveGuildActorWithSource` function directly;
+// this file is the surface assertion.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'whoami-source-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  env: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  // Build a clean env: take parent env, then apply overrides where
+  // an undefined value means "delete this key". Avoids inheriting a
+  // GUILD_ACTOR set on the developer's machine into the file-only test.
+  const finalEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete finalEnv[k];
+    else finalEnv[k] = v;
+  }
+  const r = spawnSync(process.execPath, [GATE, 'whoami'], {
+    cwd,
+    env: finalEnv,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('whoami: env source labelled GUILD_ACTOR (env)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /you are alice .*\(member\)/);
+  assert.match(r.stdout, /actor source: GUILD_ACTOR \(env\)/);
+});
+
+test('whoami: file source labelled .guild-actor (file)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, '.guild-actor'), 'alice\n');
+  const r = run(root, { GUILD_ACTOR: undefined });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /you are alice .*\(member\)/);
+  assert.match(r.stdout, /actor source: \.guild-actor \(file\)/);
+});
+
+test('whoami: env wins over file (legacy contract: env > file)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Both set; env should win and surface accordingly.
+  writeFileSync(join(root, '.guild-actor'), 'bob\n');
+  const r = run(root, { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /you are alice/);
+  assert.match(r.stdout, /actor source: GUILD_ACTOR \(env\)/);
+  // Negative — the file-source label must NOT also fire.
+  assert.doesNotMatch(r.stdout, /actor source: \.guild-actor/);
+});
+
+test('whoami: no source set still fails closed (no provenance line on error path)', (t) => {
+  // Pre-existing contract: when neither source resolves, whoami
+  // exits 1 with the GUILD_ACTOR-not-set hint. The provenance
+  // line is success-path only — no source means no label.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, { GUILD_ACTOR: undefined });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /GUILD_ACTOR is not set/);
+  assert.doesNotMatch(r.stdout, /actor source:/);
+});


### PR DESCRIPTION
## Summary

`resolveGuildActor` consults two non-flag sources in priority order — `GUILD_ACTOR` env wins over `.guild-actor` file (the file fallback was introduced in #136 to support agent-loop subprocess shells). When both produce a valid identity, `whoami` answered truthfully but didn't disclose **which source** was used. A fresh agent reading the substrate can't tell a shell-env configuration apart from a file a colleague dropped into the tree.

Surfaced during v0.5 dogfood (boundary-design observation α): "two equally-valid configurations look the same on the surface."

## Approach

1. **Sibling helper** `resolveGuildActorWithSource(start)` returns `{ actor, source: 'env' | 'file' }`. The bare `resolveGuildActor` keeps its existing 8 callsites — same input → same output. Touch-feel verbs that want provenance call the new helper.

2. **`gate whoami`** writes a second line right after `you are X`:
   ```
   you are alice (member)
   actor source: GUILD_ACTOR (env)
   ```
   When the file fallback was used:
   ```
   you are alice (member)
   actor source: .guild-actor (file)
   ```
   When env wins over file (the "both set" case): the file-source label correctly does NOT also fire.

Mirrors principle 09 (orientation-disclosure): when two valid configurations produce the same value, name which one was used. Same shape as `gate boot`'s misconfigured-cwd hint.

## Files

- `src/interface/shared/resolveGuildActor.ts` — new `ResolvedActor` type + `resolveGuildActorWithSource()`
- `src/interface/gate/handlers/read.ts` — whoami uses the source-aware helper, writes the disclosure line
- `tests/interface/resolveGuildActor.test.ts` — +4 tests on the helper
- `tests/interface/whoamiSourceProvenance.test.ts` (NEW) — +4 tests on whoami output
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] Build green (`tsc`)
- [x] Full suite green (1121 → 1135, +14 new)
- [x] Manual:
  - `GUILD_ACTOR=alice gate whoami` → `actor source: GUILD_ACTOR (env)` ✓
  - `(unset env) + .guild-actor=alice` → `actor source: .guild-actor (file)` ✓
  - Both set → env wins, label says env, file label absent ✓
  - Neither set → existing exit-1 hint, no provenance line on error path ✓

## Out of scope

- Verbs that take `--by`/`--from` flags don't yet expose the **third** source ("flag"). The `--by` path goes through `requireOption(... , 'GUILD_ACTOR')` which calls `resolveEnvOrActorFile` internally; threading `source: 'flag'` through that surface is a larger change. Filing as a follow-up if it shows up in dogfood.
- `whoami` JSON envelope — verb is text-only today; adding `--format json` would also surface `actor_source` cleanly. Out of scope for this PR (touch-feel only); easy to add later.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_