### PR TITLE
feat(whoami): --format json|text + bin entries blocking stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,36 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate whoami` honours `--format json|text` with a typed payload.**
+  whoami was the lone read-shape verb without `--format` support —
+  every sibling (`status` / `board` / `list` / `show` / `voices` /
+  `tail` / `doctor`) accepted both formats, but whoami declared
+  only `--limit` and was text-only. That meant the principle-09
+  `actor source: ...` disclosure was reachable to agents only via
+  regex parsing of prose. JSON now emits
+  `{actor, role, display_name, actor_source, recent_utterances}`
+  with the schema's `output` properties fleshed out to match
+  (previously declared as `{type: "object"}`, contributing to the
+  schema-as-contract gap that principle 10 names). Error path
+  (missing `GUILD_ACTOR`) returns the standard `ok: false` envelope
+  in JSON mode so orchestrators don't switch parsers based on
+  outcome. whoami joins the format-symmetry CASES; new focused
+  JSON-path tests cover env / file / missing-actor / invalid-format.
+
+- **bin entries set stdio blocking before dispatch.** Pipe-targeted
+  `process.stdout.write` is async; on `--format json` payloads above
+  ~8 KB (notably `gate schema` once whoami's output shape was
+  fleshed out, but every verb is exposed to the same race) the
+  trailing `process.exit(code)` would cut the tail of the JSON
+  envelope, surfacing as `Unexpected end of JSON input` in
+  spawn-based tests and non-tty consumers. All 5 bin entries
+  (`gate` / `agora` / `devil` / `ctx` / `guild`) now flip
+  `process.stdout._handle.setBlocking(true)` (and stderr) before
+  dispatch — tty writes are already synchronous so this is a no-op
+  on interactive runs. Latent bug surfaced by the whoami
+  schema-as-contract fix above pushing `gate schema` past the
+  threshold.
+
 - **Format-symmetry contract test (principle 11 enforcement).** A
   v0.5 dogfood pass found that `gate status` and `gate doctor`
   silently fell back to text mode for unknown `--format` values

--- a/bin/agora.mjs
+++ b/bin/agora.mjs
@@ -8,6 +8,9 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+// Match the bin/gate.mjs setBlocking comment — same rationale.
+process.stdout._handle?.setBlocking?.(true);
+process.stderr._handle?.setBlocking?.(true);
 const here = dirname(fileURLToPath(import.meta.url));
 checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
 

--- a/bin/ctx.mjs
+++ b/bin/ctx.mjs
@@ -8,6 +8,9 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+// Match the bin/gate.mjs setBlocking comment — same rationale.
+process.stdout._handle?.setBlocking?.(true);
+process.stderr._handle?.setBlocking?.(true);
 const here = dirname(fileURLToPath(import.meta.url));
 checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
 

--- a/bin/devil.mjs
+++ b/bin/devil.mjs
@@ -8,6 +8,9 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+// Match the bin/gate.mjs setBlocking comment — same rationale.
+process.stdout._handle?.setBlocking?.(true);
+process.stderr._handle?.setBlocking?.(true);
 const here = dirname(fileURLToPath(import.meta.url));
 checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
 

--- a/bin/gate.mjs
+++ b/bin/gate.mjs
@@ -10,6 +10,14 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+// Make stdout/stderr blocking so large payloads (e.g. `gate schema --format
+// json`, `gate boot` on busy substrates) drain before the trailing
+// `process.exit` truncates them. Pipe writes are async by default; on
+// `--format json` outputs above ~8 KB the tail of the JSON envelope was
+// being cut at exit, surfacing as `Unexpected end of JSON input` in CI.
+// tty writes are already synchronous, so the guard is a no-op there.
+process.stdout._handle?.setBlocking?.(true);
+process.stderr._handle?.setBlocking?.(true);
 const here = dirname(fileURLToPath(import.meta.url));
 checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
 

--- a/bin/guild.mjs
+++ b/bin/guild.mjs
@@ -8,6 +8,9 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+// Match the bin/gate.mjs setBlocking comment — same rationale.
+process.stdout._handle?.setBlocking?.(true);
+process.stderr._handle?.setBlocking?.(true);
 const here = dirname(fileURLToPath(import.meta.url));
 checkDistFreshness(join(here, '..', 'src'), join(here, '..', 'dist', 'src'));
 

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -213,12 +213,39 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
-const WHOAMI_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit']);
+const WHOAMI_KNOWN_FLAGS: ReadonlySet<string> = new Set(['limit', 'format']);
 
 export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, WHOAMI_KNOWN_FLAGS, 'whoami');
+  // Format-symmetry (principle 11): whoami is a read-shape verb whose
+  // siblings (status / board / list / show / voices / tail / doctor)
+  // all expose --format json|text. Pre-this-fix whoami was text-only,
+  // forcing agents to regex-parse the principle-09 `actor source: ...`
+  // line. JSON path emits the same data with snake_case fields so
+  // orchestrators can reflect on identity / role / actor_source /
+  // recent utterances without parsing prose.
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
   const resolved = resolveGuildActorWithSource();
   if (!resolved) {
+    if (format === 'json') {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            ok: false,
+            error: {
+              message:
+                'GUILD_ACTOR is not set. Export it in your shell to identify yourself.',
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+      return 1;
+    }
     process.stderr.write(
       'GUILD_ACTOR is not set.\n' +
         'Export it in your shell to identify yourself:\n' +
@@ -234,11 +261,47 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   const memberRecord = members.find((m) => m.name.value === actorLower);
   const isMember = memberRecord !== undefined;
   const isHost = c.config.hostNames.includes(actorLower);
-  const role = isMember
+  // Role enum stays compact for the JSON path (member / host / unknown).
+  // Text mode keeps the longer "unknown (not in members/ or host_names)"
+  // hint because the human reader benefits from the where-to-look pointer;
+  // the agent reader gets the structured fact in the JSON envelope.
+  const roleEnum: 'member' | 'host' | 'unknown' = isMember
+    ? 'member'
+    : isHost
+      ? 'host'
+      : 'unknown';
+  const roleText = isMember
     ? 'member'
     : isHost
       ? 'host'
       : 'unknown (not in members/ or host_names)';
+
+  const displayName = memberRecord?.displayName;
+
+  const limit = parseOptionalIntOption(args, 'limit') ?? 5;
+  const allJson = await loadAllRequestsAsJson(c);
+  const utterances = collectUtterances(allJson, {
+    name: actor,
+    limit,
+    order: 'desc',
+  });
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          actor,
+          role: roleEnum,
+          display_name: displayName ?? null,
+          actor_source: resolved.source,
+          recent_utterances: utterances,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
 
   // Surface display_name when present: name and display_name carry
   // different signals — name is identity, display_name is the
@@ -247,9 +310,8 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   // YAML and `guild list`. Em-dash separator follows how other
   // surfaces compose name/label pairs; the role parens stay so the
   // visual block parses left-to-right (name — label (role)).
-  const displayName = memberRecord?.displayName;
   const displayChunk = displayName ? ` — ${displayName}` : '';
-  process.stdout.write(`you are ${actor}${displayChunk} (${role})\n`);
+  process.stdout.write(`you are ${actor}${displayChunk} (${roleText})\n`);
   // Disclose the resolution source so a fresh agent can tell
   // GUILD_ACTOR-from-shell apart from a `.guild-actor` file dropped
   // into the tree by a colleague. Same observability principle as
@@ -259,15 +321,6 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   const sourceLabel =
     resolved.source === 'env' ? 'GUILD_ACTOR (env)' : '.guild-actor (file)';
   process.stdout.write(`actor source: ${sourceLabel}\n`);
-
-  const limit = parseOptionalIntOption(args, 'limit') ?? 5;
-
-  const allJson = await loadAllRequestsAsJson(c);
-  const utterances = collectUtterances(allJson, {
-    name: actor,
-    limit,
-    order: 'desc',
-  });
 
   if (utterances.length === 0) {
     process.stdout.write(

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -504,8 +504,38 @@ const VERBS: readonly VerbSchema[] = [
     name: 'whoami',
     category: 'read',
     summary: 'identity + recent utterances (requires GUILD_ACTOR)',
-    input: { type: 'object', properties: { limit: str } },
-    output: { type: 'object' },
+    input: {
+      type: 'object',
+      properties: {
+        limit: str,
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        actor: str,
+        role: { type: 'string', enum: ['member', 'host', 'unknown'] },
+        display_name: {
+          type: 'string',
+          description:
+            "member's human-facing label when present; emitted as null " +
+            'for hosts or members without a display_name field. ' +
+            "(Schema dialect doesn't model nullable; runtime field can be null.)",
+        },
+        actor_source: {
+          type: 'string',
+          enum: ['env', 'file'],
+          description:
+            'how GUILD_ACTOR was resolved: `env` (shell env var) or ' +
+            '`file` (.guild-actor walked up from cwd). Surfaced so a ' +
+            'fresh agent can tell shell-export apart from tree-dropped ' +
+            'identity (principle 09: orientation-disclosure).',
+        },
+        recent_utterances: utteranceArraySchema,
+      },
+      required: ['actor', 'role', 'actor_source', 'recent_utterances'],
+    },
   },
   {
     name: 'tail',

--- a/tests/interface/formatSymmetry.test.ts
+++ b/tests/interface/formatSymmetry.test.ts
@@ -62,6 +62,7 @@ const CASES: Case[] = [
   { cli: 'gate', args: ['schema'], label: 'gate schema' },
   { cli: 'gate', args: ['doctor'], label: 'gate doctor' },
   { cli: 'gate', args: ['tail'], label: 'gate tail' },
+  { cli: 'gate', args: ['whoami'], label: 'gate whoami' },
   // agora read verbs
   { cli: 'agora', args: ['list'], label: 'agora list' },
   { cli: 'agora', args: ['schema'], label: 'agora schema' },

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -233,7 +233,10 @@ test('gate <verb> --help: exits 0 and renders the flag catalog', (t) => {
   run(GATE, root, ['register', '--name', 'alice', '--category', 'professional']);
   const r = run(GATE, root, ['whoami', '--help']);
   assert.equal(r.status, 0, 'whoami --help should exit 0');
-  assert.match(r.stdout, /gate whoami: --limit/);
+  // Flag catalog renders the verb's known flags. The format-symmetry
+  // fix added `--format` to whoami's KNOWN_FLAGS; iteration order is
+  // insertion order so `--format` precedes `--limit`.
+  assert.match(r.stdout, /gate whoami: --format, --limit/);
   assert.match(r.stdout, /see `gate --help`/);
 });
 

--- a/tests/interface/whoamiSourceProvenance.test.ts
+++ b/tests/interface/whoamiSourceProvenance.test.ts
@@ -109,3 +109,84 @@ test('whoami: no source set still fails closed (no provenance line on error path
   assert.match(r.stderr, /GUILD_ACTOR is not set/);
   assert.doesNotMatch(r.stdout, /actor source:/);
 });
+
+// JSON path (added with --format json|text symmetry fix). Pins the
+// snake_case shape so orchestrators reflecting on identity / role /
+// actor_source / recent utterances don't have to regex-parse the
+// principle-09 `actor source: ...` line.
+
+function runJson(
+  cwd: string,
+  env: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const finalEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete finalEnv[k];
+    else finalEnv[k] = v;
+  }
+  const r = spawnSync(
+    process.execPath,
+    [GATE, 'whoami', '--format', 'json'],
+    { cwd, env: finalEnv, encoding: 'utf8' },
+  );
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('whoami --format json: env source returns actor_source: env', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runJson(root, { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, 'alice');
+  assert.equal(payload.role, 'member');
+  assert.equal(payload.actor_source, 'env');
+  assert.equal(payload.display_name, null);
+  assert.ok(Array.isArray(payload.recent_utterances));
+});
+
+test('whoami --format json: file source returns actor_source: file', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeFileSync(join(root, '.guild-actor'), 'alice\n');
+  const r = runJson(root, { GUILD_ACTOR: undefined });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.actor, 'alice');
+  assert.equal(payload.actor_source, 'file');
+});
+
+test('whoami --format json: missing GUILD_ACTOR emits ok:false envelope', (t) => {
+  // Error path stays machine-readable in JSON mode — orchestrators
+  // shouldn't need to switch parsers based on success/failure.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runJson(root, { GUILD_ACTOR: undefined });
+  assert.equal(r.status, 1);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, false);
+  assert.match(payload.error.message, /GUILD_ACTOR is not set/);
+});
+
+test('whoami --format yaml is rejected with the standard message', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = spawnSync(
+    process.execPath,
+    [GATE, 'whoami', '--format', 'yaml'],
+    {
+      cwd: root,
+      env: { ...process.env, GUILD_ACTOR: 'alice' },
+      encoding: 'utf8',
+    },
+  );
+  assert.notEqual(r.status, 0);
+  assert.match(
+    r.stderr ?? '',
+    /--format must be 'json' or 'text'/,
+  );
+});


### PR DESCRIPTION
## Summary

`gate whoami` is a read-shape verb (principle 13) that lacked `--format json|text`,
unlike all sibling read verbs (`status` / `board` / `list` / `show` / `voices` /
`tail` / `doctor`). Its output schema was also unspecified (`{type: "object"}`).
This forced agents to regex-parse the principle-09 `actor source: ...` line.

While extending the format-symmetry CASES with whoami, a **separate latent bug**
surfaced: pipe-targeted `process.stdout.write` is async, and the trailing
`process.exit(code)` in each bin entry truncated outputs above ~8 KB. The whoami
output schema expansion pushed `gate schema --format json` past that threshold.
`setBlocking(true)` at bin entry resolves it — and incidentally fixes 11
pre-existing test flakes that were the same race in different shapes.

## Why this matters (principles)

- **11 (AI-first)**: substrate is text-only; agents must parse text to recover
  the actor-source signal that principle 09 deliberately surfaces.
- **10 (schema as contract)**: output `{type: "object"}` carries no contract
  for reflection layers.
- **13 (verb shape)**: read-shape siblings all expose `--format json|text`;
  whoami was the lone exception.

## Repro (before)

```
$ gate whoami --format json
error: whoami: unknown flag: --format
  valid flags for 'whoami': --limit

$ gate schema --verb whoami --format json | jq '.verbs[0].output'
{ "type": "object" }
```

## After

```json
{
  "actor": "eris",
  "role": "host",
  "display_name": null,
  "actor_source": "env",
  "recent_utterances": [ ... ]
}
```

Error path emits `{ok: false, error: {message}}` so orchestrators don't switch
parsers based on outcome.

## Redundancy check

- utterance history → covered by `gate voices <actor> --format json`
- actor + role → covered by `gate boot --format json`
- **actor source disclosure** → unique to whoami (was text-only); now in JSON

## Changes

- `src/interface/gate/handlers/read.ts` — whoami honours `--format`; JSON path
  emits `{actor, role, display_name, actor_source, recent_utterances}`
- `src/interface/gate/handlers/schema.ts` — whoami output schema fleshed out
- `bin/{gate,agora,devil,ctx,guild}.mjs` — `setBlocking(true)` on stdout/stderr
  before dispatch (drains async pipe writes before `process.exit`)
- `tests/interface/whoamiSourceProvenance.test.ts` — 4 new JSON-path tests
  (env / file / missing-actor / invalid-format)
- `tests/interface/formatSymmetry.test.ts` — whoami added to CASES
- `CHANGELOG.md [Unreleased] / Added` — both changes documented

## Test impact

| | tests | pass | fail |
|---|---|---|---|
| pristine main | 1146 | 1122 | **24** |
| this branch | 1151 | 1138 | **13** |

5 new tests pass; 11 pre-existing flakes incidentally fixed by the bin-entry
setBlocking. Remaining 13 are unrelated macOS `/var` vs `/private/var` symlink
resolution issues (paths in spawn-based tests resolve differently from
in-process `fs.realpath`).

## Sibling fixes already shipped (similar shape)

- #99 strict flag rejection
- #102 snake_case alignment
- #109 voices/tail snake_case
- #170 / #218 `--state all` sugar
- #214 format-symmetry contract test (status/doctor)