### PR TITLE
feat(broadcast): expects-response opt-in surfaced via boot (#220 phase 1)

### DIFF
--- a/src/application/message/MessageUseCases.ts
+++ b/src/application/message/MessageUseCases.ts
@@ -103,6 +103,7 @@ export class MessageUseCases {
     text: string;
     type?: string;
     invokedBy?: string;
+    expectsResponse?: boolean;
   }): Promise<BroadcastResult> {
     const from = await assertActor(input.from, '--from', this.deps.members);
     const text = sanitizeMessageText(input.text);
@@ -126,6 +127,9 @@ export class MessageUseCases {
           text,
           at: now,
           ...(invokedBy !== undefined ? { invokedBy } : {}),
+          ...(input.expectsResponse === true
+            ? { expectsResponse: true }
+            : {}),
         });
         delivered.push(to.value);
       } catch (e) {

--- a/src/application/ports/NotificationPort.ts
+++ b/src/application/ports/NotificationPort.ts
@@ -15,6 +15,17 @@ export interface Notification {
    * stamped when they disagree.
    */
   invokedBy?: string;
+  /**
+   * Opt-in marker that the sender expects readers to respond
+   * (broadcast scope; default false). Persisted per-recipient
+   * inbox entry as `expects_response: true`. Boot uses this flag
+   * to surface unread broadcasts as `broadcast-pending-response`
+   * in `suggested_next` — read-with-mark-read is the proxy for
+   * "ack". Phase 1 does NOT track who/when responded; the bit
+   * disappears from the boot surface the moment the recipient
+   * marks the entry read.
+   */
+  expectsResponse?: boolean;
 }
 
 /**
@@ -47,6 +58,16 @@ export interface InboxMessage {
    */
   invokedBy?: string;
   related?: string;
+  /**
+   * Mirrored from the sender's `Notification.expectsResponse` opt-in.
+   * Persisted as `expects_response: true` in the inbox YAML; absent
+   * (undefined) and `false` are equivalent — Phase 1 does not
+   * rewrite legacy records to stamp `false` (records-outlive-writers,
+   * principle 04). Surfaced by `gate boot` as the
+   * `broadcast-pending-response` suggested_next kind for unread
+   * broadcasts that opted in.
+   */
+  expectsResponse?: boolean;
 }
 
 /**

--- a/src/infrastructure/persistence/FsInboxNotification.ts
+++ b/src/infrastructure/persistence/FsInboxNotification.ts
@@ -78,6 +78,12 @@ export class FsInboxNotification implements NotificationPort {
     };
     if (n.related !== undefined) entry['related'] = n.related;
     if (n.invokedBy !== undefined) entry['invoked_by'] = n.invokedBy;
+    // Opt-in only: stamp `expects_response: true` when the sender
+    // asked for it; absent otherwise. Default-false records stay
+    // visually clean and legacy entries (no field) hydrate as false
+    // via normalizeMessage — principle 04 says we don't rewrite
+    // history just to add a default.
+    if (n.expectsResponse === true) entry['expects_response'] = true;
     file.messages.push(entry);
     if (file.messages.length > MAX_INBOX_SIZE) {
       file.messages = file.messages.slice(-MAX_INBOX_SIZE);
@@ -247,5 +253,11 @@ function normalizeMessage(raw: Record<string, unknown>): InboxMessage {
   if (typeof raw['read_by'] === 'string') msg.readBy = raw['read_by'];
   if (typeof raw['invoked_by'] === 'string') msg.invokedBy = raw['invoked_by'];
   if (typeof raw['related'] === 'string') msg.related = raw['related'];
+  // Strict-true coerce: only the literal `true` lights this up.
+  // Missing / false / non-boolean alike map to undefined (effectively
+  // false) — the boot detector treats undefined as false anyway, but
+  // not stamping the field at all keeps the InboxMessage shape
+  // matching what was actually on disk.
+  if (raw['expects_response'] === true) msg.expectsResponse = true;
   return msg;
 }

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -50,6 +50,42 @@ export interface BootSuggestedNext {
 }
 
 /**
+ * Surface for unread broadcasts whose sender opted into
+ * `expects_response: true`. Distinct shape (no verb/args/reason
+ * triple) because Phase 1 deliberately does NOT prescribe a verb to
+ * call — the recipient decides whether to reply with `gate message`,
+ * file a request, mark-read as ack, or ignore. Read-with-mark-read
+ * is the proxy for "ack"; the entry disappears from this surface
+ * the moment the inbox entry flips to read.
+ *
+ * Priority sits below every state-transition kind in
+ * `actionableTransitions` (executing-mine ... reviewed-authored) so
+ * a pending review or executing request always wins suggested_next.
+ */
+export interface BootBroadcastPendingResponse {
+  kind: 'broadcast-pending-response';
+  broadcast_from: string;
+  broadcast_at: string;
+  hint: string;
+  /**
+   * Mirrors the `actor_resolved` field on `BootSuggestedNext` (and on
+   * the write-response `SuggestedNext` shape in writeFormat.ts) so the
+   * two variants of `boot.suggested_next` share one consumer-facing
+   * field. The pending-broadcast surface is always actor-resolved
+   * (true): it only fires for the calling actor's own inbox, so the
+   * "next move" is unambiguously theirs to make. Carried verbatim
+   * rather than inferred at the consumer so an orchestrator that
+   * reads `.actor_resolved` across both variants never has to
+   * branch on `.kind` first.
+   */
+  actor_resolved: true;
+}
+
+export type BootSuggestedNextOrPendingResponse =
+  | BootSuggestedNext
+  | BootBroadcastPendingResponse;
+
+/**
  * gate boot [--format json|text] [--tail <N>] [--utterances <N>]
  *
  * Single-command session orientation for agents. Composes the
@@ -81,7 +117,18 @@ interface BootPayload {
   status: StatusSummary;
   tail: ReturnType<typeof collectUtterances>;
   your_recent: ReturnType<typeof collectUtterances> | null;
-  inbox_unread: Array<{ at: string; from: string; text: string; type: string }>;
+  inbox_unread: Array<{
+    at: string;
+    from: string;
+    text: string;
+    type: string;
+    /**
+     * Mirrors `InboxMessage.expectsResponse`. Emitted only when the
+     * sender opted in (true) — absent otherwise, matching the
+     * omit-when-undefined convention used elsewhere on this payload.
+     */
+    expects_response?: boolean;
+  }>;
   last_activity: string | null;
   /**
    * Diagnostic hints to help agents detect misconfiguration early.
@@ -202,7 +249,7 @@ interface BootPayload {
    * `hints` because it's directive (a verb to call), not diagnostic
    * (a condition to notice).
    */
-  suggested_next: BootSuggestedNext | null;
+  suggested_next: BootSuggestedNextOrPendingResponse | null;
 }
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -261,7 +308,13 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       const unread = msgs.filter((m) => !m.read);
       status.inbox_unread = unread.length;
       for (const m of unread) {
-        inboxUnread.push({ at: m.at, from: m.from, text: m.text, type: m.type });
+        inboxUnread.push({
+          at: m.at,
+          from: m.from,
+          text: m.text,
+          type: m.type,
+          ...(m.expectsResponse === true ? { expects_response: true } : {}),
+        });
       }
     } catch {
       // inbox may not exist for this actor — non-fatal
@@ -355,12 +408,23 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     // Diagnostic errored — skip health, keep boot usable.
   }
 
-  const suggestedNext = deriveBootSuggestedNext(
+  const baseSuggestedNext = deriveBootSuggestedNext(
     actor,
     role,
     members,
     allRequests,
   );
+  // broadcast-pending-response sits at the tail of the priority
+  // ladder: only fires when no transition-kind suggestion was found
+  // (executing/unreviewed/approved/pending/reviewed-authored all
+  // empty). Pre-onboarding hints (register, export GUILD_ACTOR) also
+  // suppress it — those are stronger signals than an unanswered
+  // broadcast. Phase 1 does not resolve "who replied"; surface
+  // disappears when the entry is mark-read (read = ack proxy).
+  const suggestedNext: BootSuggestedNextOrPendingResponse | null =
+    baseSuggestedNext !== null
+      ? baseSuggestedNext
+      : derivePendingBroadcastResponse(inboxUnread);
   const verbsAvailableNow = deriveVerbsAvailableNow(
     actor,
     role,
@@ -577,6 +641,69 @@ async function collectCrossPassage(
     }
   }
   return out;
+}
+
+/**
+ * Lowest-priority hint: pick the oldest unread broadcast whose sender
+ * stamped `expects_response: true`. Returns null when no such entry
+ * exists, when expectsResponse was never opted in, or when every
+ * matching entry has been mark-read.
+ *
+ * "Oldest first" is deliberate — broadcasts pile up FIFO and the
+ * surface should drain in the same order so a backlog doesn't have
+ * the newest one perpetually shadow the earliest unanswered ask.
+ *
+ * Hint text names the sender + the act available (gate message back,
+ * or mark-read as ack). It deliberately does NOT prescribe a verb,
+ * because the reply could be a new request, a thank, a counter-
+ * broadcast, or just acknowledgement; suggesting only one would push
+ * readers toward a single shape Phase 1 doesn't intend to mandate.
+ */
+function isBroadcastPendingResponse(
+  n: BootSuggestedNextOrPendingResponse,
+): n is BootBroadcastPendingResponse {
+  return (n as BootBroadcastPendingResponse).kind === 'broadcast-pending-response';
+}
+
+function derivePendingBroadcastResponse(
+  inboxUnread: BootPayload['inbox_unread'],
+): BootBroadcastPendingResponse | null {
+  // Filter to flagged broadcast entries only. Filtering by
+  // `type === 'broadcast'` so a custom `--type handoff` direct
+  // message (which can't carry the expects_response opt-in via the
+  // broadcast handler today) doesn't accidentally surface here even
+  // if a future writer set the bit out-of-band.
+  const flagged = inboxUnread.filter(
+    (m) => m.type === 'broadcast' && m.expects_response === true,
+  );
+  if (flagged.length === 0) return null;
+  // Explicit FIFO sort: oldest `at` first. inboxUnread is already
+  // chronologically ordered today (post() appends, listFor preserves
+  // order), but sorting here pins the contract at the consumer:
+  // a long backlog must drain in the order the senders asked, even
+  // if the inbox loader's order ever changes. Lexicographic compare
+  // on ISO-Z timestamps is exact (Thank.ts:43 / Review.ts / inbox
+  // entries all emit UTC-Z).
+  const sorted = [...flagged].sort((a, b) => a.at.localeCompare(b.at));
+  const oldest = sorted[0]!;
+  // `+N more pending` suffix is FLAGGED-only: it counts the
+  // pending-response candidates, not the entire unread inbox. An
+  // unflagged twin from the same sender (or any unrelated unread
+  // entry) must NOT inflate this count — the surface is about
+  // unanswered opt-in asks, and the suffix has to mean exactly that.
+  const more =
+    sorted.length > 1 ? ` (+${sorted.length - 1} more pending)` : '';
+  return {
+    kind: 'broadcast-pending-response',
+    broadcast_from: oldest.from,
+    broadcast_at: oldest.at,
+    hint:
+      `unread broadcast from ${oldest.from} marked expects_response=true${more}; ` +
+      'reply with `gate message --to ' + oldest.from + ' --text ...` if you ' +
+      'have a substantive response, or `gate inbox mark-read` to ' +
+      'acknowledge in passing — the surface clears either way.',
+    actor_resolved: true,
+  };
 }
 
 function stampActorResolved(
@@ -1045,7 +1172,18 @@ function renderBootText(p: BootPayload): string {
     // Render the hint as a concrete shell command so the reader can
     // copy-paste. `export` is special-cased because it's a shell
     // builtin, not a gate subcommand.
-    const n = p.suggested_next;
+    const n: BootSuggestedNextOrPendingResponse = p.suggested_next;
+    if (isBroadcastPendingResponse(n)) {
+      // No single verb to print — the recipient picks the shape of
+      // their reply (message back, mark-read as ack, or branch into
+      // a request). Lead with the broadcaster + timestamp so the
+      // reader can locate the entry in their inbox.
+      lines.push(
+        `→ pending broadcast response: from ${n.broadcast_from} at ${n.broadcast_at}`,
+      );
+      lines.push(`  (${n.hint})`);
+      return lines.join('\n') + '\n';
+    }
     if (n.verb === 'export') {
       const [k, v] = Object.entries(n.args)[0] ?? ['GUILD_ACTOR', '<your-name>'];
       lines.push(`→ next: export ${k}=${v}`);

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -33,6 +33,10 @@ function toInboxJson(m: InboxMessage): Record<string, unknown> {
   if (m.readBy !== undefined) out['read_by'] = m.readBy;
   if (m.invokedBy !== undefined) out['invoked_by'] = m.invokedBy;
   if (m.related !== undefined) out['related'] = m.related;
+  // Mirror the on-disk YAML: emit `expects_response: true` only when
+  // the sender opted in. Default/legacy records omit the key — same
+  // omit-when-undefined policy as the other optional fields above.
+  if (m.expectsResponse === true) out['expects_response'] = true;
   return out;
 }
 
@@ -46,6 +50,7 @@ const MESSAGE_BROADCAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
   'text',
   'type',
+  'expects-response',
 ]);
 const INBOX_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'for',
@@ -115,6 +120,9 @@ export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
   let text = requireOption(args, 'text', '"..."');
   if (text === '-') text = (await readStdin()).trim();
   const type = optionalOption(args, 'type');
+  // Bare `--expects-response` → true (parser converts no-value flags
+  // to boolean true). Absent flag → false. Default false: opt-in.
+  const expectsResponse = args.options['expects-response'] === true;
   const invokedBy = deriveInvokedBy(from);
   if (invokedBy !== undefined) {
     emitInvokedByNotice(from, invokedBy, 'broadcast from', from);
@@ -124,6 +132,7 @@ export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
     text,
     ...(type !== undefined ? { type } : {}),
     ...(invokedBy !== undefined ? { invokedBy } : {}),
+    ...(expectsResponse ? { expectsResponse: true } : {}),
   });
   if (delivered.length === 0 && failed.length === 0) {
     process.stdout.write(

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -276,10 +276,52 @@ const VERBS: readonly VerbSchema[] = [
             'Advisory — NOT a directive. Orientation-time guidance ' +
             'about what to do next, derived from queues + open loops. ' +
             "Read `reason` and override when your judgement differs. " +
-            'Priority is shared with `gate suggest`; both are hints.',
-          // Same canonical sub-schema as suggest so the two surfaces
-          // never disagree on the suggested_next shape.
-          properties: suggestedNextProperties,
+            'Priority is shared with `gate suggest`; both are hints. ' +
+            'Two shapes share this slot: the canonical verb/args/reason ' +
+            'triple (state-transition hints) and the ' +
+            '`broadcast-pending-response` shape ' +
+            '({kind, broadcast_from, broadcast_at, hint, actor_resolved}) ' +
+            'when the only open loop is an unread opt-in broadcast. The ' +
+            'discriminator is the `kind` field — present for ' +
+            'broadcast-pending-response, absent for state-transition hints. ' +
+            '`actor_resolved` is shared across both variants (always true ' +
+            'for the broadcast variant — the surface only fires on the ' +
+            "caller's own inbox). Phase 1 does NOT track who/when " +
+            'responded; the surface clears on inbox mark-read.',
+          // Open-shape union: every field from both variants is listed
+          // as an optional property. The validator (validateActualOutput)
+          // is permissive on extras and strict on declared types, so
+          // either variant validates without false positives. JsonSchema
+          // draft-07 oneOf would be cleaner but the gate schema subset
+          // doesn't include it (see schema.ts header).
+          properties: {
+            ...suggestedNextProperties,
+            kind: {
+              type: 'string',
+              enum: ['broadcast-pending-response'],
+              description:
+                'discriminator for the pending-broadcast variant. ' +
+                'Absent on state-transition hints.',
+            },
+            broadcast_from: {
+              type: 'string',
+              description:
+                '[broadcast-pending-response only] sender of the unread ' +
+                'opt-in broadcast.',
+            },
+            broadcast_at: {
+              type: 'string',
+              description:
+                '[broadcast-pending-response only] ISO timestamp of the ' +
+                'broadcast post.',
+            },
+            hint: {
+              type: 'string',
+              description:
+                '[broadcast-pending-response only] free-form recipient ' +
+                'guidance — does not prescribe a verb.',
+            },
+          },
         },
         verbs_available_now: {
           type: 'object',
@@ -931,6 +973,16 @@ const VERBS: readonly VerbSchema[] = [
         from: str,
         text: str,
         type: strOpt('optional message kind label (e.g. "handoff", "note") — free-form, surfaced verbatim in each recipient inbox'),
+        'expects-response': {
+          type: 'boolean',
+          description:
+            'opt-in (default false). When true, each recipient inbox entry ' +
+            'is stamped expects_response: true; gate boot surfaces unread ' +
+            'opt-in broadcasts under suggested_next as ' +
+            '`broadcast-pending-response` until the recipient marks the ' +
+            'entry read (read = ack proxy). Phase 1 tracks expectation, ' +
+            'not resolution.',
+        },
       },
       required: ['text'],
     },

--- a/tests/interface/broadcastExpectsResponse.test.ts
+++ b/tests/interface/broadcastExpectsResponse.test.ts
@@ -1,0 +1,332 @@
+// Phase 1 of issue #220: surface broadcast/issue implicit-response
+// expectations via boot.
+//
+// Pins the contract for the `--expects-response` opt-in:
+//   * broadcast with --expects-response stamps each recipient inbox
+//     entry with `expects_response: true` and gate boot surfaces the
+//     unread entry under suggested_next as
+//     `broadcast-pending-response`.
+//   * mark-read drains the surface (read = ack proxy in Phase 1).
+//   * legacy / opt-out broadcasts (no field, or field absent) never
+//     surface — the bit is opt-in only and pre-existing records are
+//     not rewritten with a default false (principle 04:
+//     records-outlive-writers).
+//   * any state-transition kind in actionableTransitions
+//     (executing-mine ... reviewed-authored) wins over the broadcast
+//     surface — broadcast-pending-response is the tail of the ladder.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-bcer-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('broadcast --expects-response: opt-in stamps expects_response on inbox YAML', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'all hands?', '--expects-response'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, `broadcast failed: ${r.stderr}`);
+  const yaml = readFileSync(join(root, 'inbox', 'bob.yaml'), 'utf8');
+  assert.match(
+    yaml,
+    /expects_response:\s*true/,
+    'expected on-disk expects_response: true marker',
+  );
+});
+
+test('broadcast WITHOUT --expects-response: no expects_response field on disk', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'fyi'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const yaml = readFileSync(join(root, 'inbox', 'bob.yaml'), 'utf8');
+  // Default-false is encoded as field-absence (opt-in semantics + no
+  // legacy rewrite). The string must not appear.
+  assert.ok(
+    !yaml.includes('expects_response'),
+    `expects_response should be absent for opt-out broadcasts; saw:\n${yaml}`,
+  );
+});
+
+test('boot suggested_next surfaces broadcast-pending-response for unread opt-in broadcasts', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'please reply', '--expects-response'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.suggested_next, 'expected non-null suggested_next');
+  assert.equal(payload.suggested_next.kind, 'broadcast-pending-response');
+  assert.equal(payload.suggested_next.broadcast_from, 'alice');
+  assert.equal(typeof payload.suggested_next.broadcast_at, 'string');
+  assert.ok(typeof payload.suggested_next.hint === 'string' && payload.suggested_next.hint.length > 0);
+  // inbox_unread also exposes the bit on the entry itself.
+  assert.ok(Array.isArray(payload.inbox_unread));
+  assert.equal(payload.inbox_unread.length, 1);
+  assert.equal(payload.inbox_unread[0].expects_response, true);
+});
+
+test('mark-read drains the broadcast-pending-response surface (read = ack proxy)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'please reply', '--expects-response'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runGate(
+    root,
+    ['inbox', 'mark-read', '--for', 'bob'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  const r = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload = JSON.parse(r.stdout);
+  // No transition exists; pre-onboarding hint shouldn't fire either
+  // (bob is registered and has no actor-resolution issue). With the
+  // entry now read, broadcast-pending-response also doesn't fire
+  // → suggested_next is null.
+  assert.equal(payload.suggested_next, null);
+});
+
+test('opt-out broadcasts do NOT surface (default false; opt-in semantics)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'fyi'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.suggested_next, null);
+  // The entry is still in inbox_unread (it was a real broadcast),
+  // just without the expects_response marker. Phase 1 boundary.
+  assert.equal(payload.inbox_unread.length, 1);
+  assert.equal(payload.inbox_unread[0].expects_response, undefined);
+});
+
+test('legacy inbox YAML without expects_response field hydrates as false (no surface)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Hand-write a pre-Phase-1 shape: an unread broadcast with no
+  // expects_response key at all. Mirrors records-outlive-writers
+  // (principle 04): boot must read what's there without rewriting.
+  writeFileSync(
+    join(root, 'inbox', 'bob.yaml'),
+    [
+      'version: 1',
+      'messages:',
+      '  - from: alice',
+      '    to: bob',
+      '    type: broadcast',
+      '    text: legacy entry',
+      '    at: 2026-01-01T00:00:00.000Z',
+      '    read: false',
+      '',
+    ].join('\n'),
+  );
+  const r = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.suggested_next, null);
+  assert.equal(payload.inbox_unread.length, 1);
+  assert.equal(payload.inbox_unread[0].expects_response, undefined);
+});
+
+test('state-transition kinds win over broadcast-pending-response (priority-tail)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Plant an opt-in broadcast → would surface as
+  // broadcast-pending-response in isolation.
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'please reply', '--expects-response'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  // Now plant a higher-priority transition for bob: a pending
+  // request that names bob as executor (pending-as-executor).
+  runGate(
+    root,
+    [
+      'request',
+      '--from', 'alice',
+      '--action', 'do-thing',
+      '--reason', 'because',
+      '--executor', 'bob',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload = JSON.parse(r.stdout);
+  assert.ok(payload.suggested_next, 'expected non-null suggested_next');
+  // suggested_next is the canonical verb/args triple, NOT the
+  // broadcast variant.
+  assert.equal(typeof payload.suggested_next.verb, 'string');
+  assert.notEqual(payload.suggested_next.kind, 'broadcast-pending-response');
+  assert.equal(payload.suggested_next.verb, 'approve');
+});
+
+test('edge: same sender, expects_response=true then false to same recipient — only flagged surfaces, no +N inflation, no disk rewrite', (t) => {
+  // Leysia's room-tidying eye: a broadcaster reverses themselves
+  // mid-stream. Two unread entries from alice land in bob's inbox; the
+  // first declared expects_response=true, the second did NOT. Boot must
+  // pick up the flagged one only — not double-count, not get confused
+  // by the later FYI re-issue, and the unflagged twin must NOT inflate
+  // any "+N more pending" suffix on the hint. Marking the flagged one
+  // read clears the surface even though the unflagged twin remains
+  // unread (it never was a candidate). Disk rewrite is forbidden:
+  // unflagged record must keep field-absence (records-outlive-writers).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'reply please', '--expects-response'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'nm — sorted'],
+    { GUILD_ACTOR: 'alice' },
+  );
+
+  // Bob has two unread broadcasts from alice. Only the first carries
+  // the flag — surface must show exactly one pending-response, no
+  // "+N more pending" suffix (only one was flagged).
+  const boot = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload = JSON.parse(boot.stdout);
+  assert.equal(payload.suggested_next?.kind, 'broadcast-pending-response');
+  assert.equal(payload.suggested_next.broadcast_from, 'alice');
+  assert.equal(payload.suggested_next.actor_resolved, true);
+  assert.ok(
+    !/\+\d+ more pending/.test(payload.suggested_next.hint),
+    `expected no "+N more pending" suffix; got hint: ${payload.suggested_next.hint}`,
+  );
+
+  // Bob marks the flagged entry (it was posted first → idx 1).
+  const m = runGate(
+    root,
+    ['inbox', 'mark-read', '1', '--for', 'bob'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  assert.equal(m.status, 0, m.stderr);
+
+  // Surface clears even though the unflagged second broadcast is
+  // still unread — it never was a candidate.
+  const boot2 = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+  const payload2 = JSON.parse(boot2.stdout);
+  assert.equal(
+    payload2.suggested_next,
+    null,
+    'mark-read on flagged entry should clear the surface — unflagged twin must not back-fill the slot',
+  );
+
+  // Sanity on disk: unflagged record carries no expects_response key
+  // (omit-when-false), and the inbox listing shows one read + one
+  // unread without any rewrite of the unflagged entry.
+  const inbox = runGate(
+    root,
+    ['inbox', '--for', 'bob', '--format', 'json'],
+    { GUILD_ACTOR: 'bob' },
+  );
+  const msgs = JSON.parse(inbox.stdout) as Array<Record<string, unknown>>;
+  assert.equal(msgs.length, 2);
+  assert.equal(msgs[0]!.read, true, 'first (flagged) marked read');
+  assert.equal(msgs[1]!.read, false, 'second (unflagged) still unread');
+  assert.equal(
+    msgs[0]!.expects_response,
+    true,
+    'flagged record carries expects_response: true',
+  );
+  assert.ok(
+    !('expects_response' in (msgs[1] as object)),
+    'unflagged record must not have expects_response key (omit-when-false; no rewrite)',
+  );
+});
+
+test('schema declares broadcast-pending-response shape on boot.suggested_next', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['schema', '--verb', 'boot']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const verb = payload.verbs[0];
+  const sn = verb.output.properties.suggested_next;
+  assert.ok(sn, 'boot.output.suggested_next missing');
+  assert.ok(sn.properties.kind, 'kind discriminator missing on suggested_next');
+  assert.deepEqual(sn.properties.kind.enum, ['broadcast-pending-response']);
+  assert.ok(sn.properties.broadcast_from);
+  assert.ok(sn.properties.broadcast_at);
+  assert.ok(sn.properties.hint);
+});
+
+test('schema declares --expects-response on broadcast input properties', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['schema', '--verb', 'broadcast']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const verb = payload.verbs[0];
+  assert.ok(verb.input.properties['expects-response']);
+  assert.equal(verb.input.properties['expects-response'].type, 'boolean');
+});


### PR DESCRIPTION
## Summary

Closes Phase 1 of #220.

- Opt-in `--expects-response` flag on `gate broadcast` — each recipient inbox entry persists `expects_response: true`
- `gate boot` surfaces unread opt-in broadcasts under `suggested_next` with new `broadcast-pending-response` kind
- Phase 1 ack proxy: `mark-read`. Resolution tracking (who/when responded) is out of scope, follow-up issue planned

## Design (Devil-ratified, 0004)

- Discriminated union on suggested_next preserves `boot.ts deliberately does NOT prescribe a verb` design intent (principle 10)
- VOICE_BUDGET unchanged: kind enum literal is structural discriminator, not doctrinal phrase (principle 08)
- FIFO oldest first; `+N more pending` suffix counts only flagged candidates
- Same-sender twin-send (true → false) edge case covered

## Backward compatibility

- `expects_response` default: `false`
- Absent records hydrate as false (no legacy rewrite, principle 04)
- Read-side only on boot (principle 05)

## Test plan

- [x] `npm run build` GREEN
- [x] `tests/interface/broadcastExpectsResponse.test.ts` (new)
- [x] schema input drift detector GREEN
- [x] schema-validates-actual-output GREEN
- [x] voiceBudget GREEN (no `broadcast-pending-response` entry per Devil 0004)
- [x] message surface tests GREEN

## Substrate trail

Implemented via guild-cli substrate-experiment (実験4: agent-driven wave):
- `2026-05-07-0001` Miki impl
- `2026-05-07-0002` Leysia impl (parallel, worktree-isolated)
- `2026-05-07-0003` Noir wave director (independent comparison)
- `2026-05-07-0004` Devil verdict (overturned director bias on VOICE_BUDGET)
- `2026-05-07-0005` Final integration (Miki, this commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)