### PR TITLE
feat(gate): gate request --depth advisory (#221 phase 1 substrate slot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,31 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate request --depth shallow|standard|deep` reviewer-depth advisory**
+  ([#221](https://github.com/eris-ths/guild-cli/issues/221) phase 1
+  substrate slot).
+  Substrate-experiment 実験 2 で発見した sharp edge への対応:
+  Devil agent が常時最大深度で grep + 検証するため、極小実装に
+  対しオーバーレビューが構造的に発生していた (PR #207 の事例)。
+  `--depth` flag を `gate request` に opt-in で追加し、enum
+  `[shallow, standard, deep]` で reviewer 側 (Devil agent) に
+  advisory を渡せるようにする。
+  - `shallow`: surface 点検、grep 自走しない
+  - `standard`: 現行と等価 (default、互換)
+  - `deep`: arch / threat-model まで掘る
+  - **substrate slot のみ**: agent 側の prompt 3 段階化は
+    operator/agent setup 側で対応する (本 repo の外)。
+    principle 02 (advisory-not-directive) のとおり、reviewer は
+    depth を尊重する義務を負わず、substrate は signal を carry
+    するだけ。
+  - **byte-stable**: `--depth` 省略時は YAML に `depth:` フィールド
+    を書かない。pre-#221 record と round-trip-byte-同等
+    (principle 04: records-outlive-writers)。
+  - hydrate tolerance: 既存 record ですべての older 形 (`depth:`
+    なし) が clean に load される test。
+  - Schema input + drift detector update + advisory-framing
+    description (principle 02 / 10)。
+
 - **`gate whoami` honours `--format json|text` with a typed payload.**
   whoami was the lone read-shape verb without `--format` support —
   every sibling (`status` / `board` / `list` / `show` / `voices` /

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -44,6 +44,10 @@ export class RequestUseCases {
     reason: string;
     executor?: string;
     target?: string;
+    /** Reviewer-depth advisory ('shallow' | 'standard' | 'deep').
+     *  Validated at the domain boundary in Request.create. See
+     *  RequestProps.depth and issue #221. */
+    depth?: string;
     autoReview?: string;
     with?: readonly string[];
     invokedBy?: string;
@@ -83,6 +87,7 @@ export class RequestUseCases {
     };
     if (input.executor !== undefined) createArgs.executor = input.executor;
     if (input.target !== undefined) createArgs.target = input.target;
+    if (input.depth !== undefined) createArgs.depth = input.depth;
     if (input.autoReview !== undefined)
       createArgs.autoReview = input.autoReview;
     if (input.with !== undefined && input.with.length > 0)

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -4,6 +4,7 @@ import {
   assertTransition,
   parseRequestState,
 } from './RequestState.js';
+import { RequestDepth, parseRequestDepth } from './RequestDepth.js';
 import { Review } from './Review.js';
 import { Thank } from './Thank.js';
 import { MemberName } from '../member/MemberName.js';
@@ -39,6 +40,15 @@ export interface RequestProps {
   reason: string;
   executor?: MemberName;
   target?: string;
+  /**
+   * Reviewer-depth advisory (issue #221). Optional; absence reads
+   * as 'standard' to honour the pre-#222 default. The substrate
+   * carries the signal — adjusting the reviewer's prompt to act
+   * on it lives in operator/agent setup, not here. Per principle
+   * 02 (advisory-not-directive), --depth shallow is an invitation
+   * to point-check; the reviewer can disagree.
+   */
+  depth?: RequestDepth;
   autoReview?: MemberName;
   /**
    * Dialogue partners during the formation of this request — who was
@@ -101,6 +111,10 @@ export class Request {
     reason: string;
     executor?: string;
     target?: string;
+    /** Reviewer-depth advisory; rejected at create time if not in
+     *  the RequestDepth enum. Absent = no field persisted ('standard'
+     *  default at read time). See RequestProps.depth. */
+    depth?: string;
     autoReview?: string;
     with?: readonly string[];
     createdAt?: string;
@@ -152,6 +166,13 @@ export class Request {
     if (input.target !== undefined) {
       props.target = sanitizeText(input.target, 'target');
     }
+    if (input.depth !== undefined) {
+      // parseRequestDepth throws DomainError on a non-enum value, so
+      // an explicit `--depth bogus` fails closed at the domain
+      // boundary (interface layer can also pre-check; both paths
+      // point at the same enum).
+      props.depth = parseRequestDepth(input.depth);
+    }
     if (input.with !== undefined && input.with.length > 0) {
       // Deduplicate while preserving first-mention order — avoids
       // "with eris, eris" if callers normalize casing differently.
@@ -198,6 +219,12 @@ export class Request {
   }
   get executor(): MemberName | undefined {
     return this.props.executor;
+  }
+  get target(): string | undefined {
+    return this.props.target;
+  }
+  get depth(): RequestDepth | undefined {
+    return this.props.depth;
   }
   get autoReview(): MemberName | undefined {
     return this.props.autoReview;
@@ -341,6 +368,11 @@ export class Request {
     if (this.props.autoReview)
       out['auto_review'] = this.props.autoReview.value;
     if (this.props.target !== undefined) out['target'] = this.props.target;
+    // depth surfaces only when set — absence on read is 'standard'
+    // by convention (issue #221). Records pre-#221 have no depth
+    // field; toJSON honours that by omitting the key, keeping older
+    // YAML byte-stable on round-trip.
+    if (this.props.depth !== undefined) out['depth'] = this.props.depth;
     if (this.props.with && this.props.with.length > 0)
       out['with'] = this.props.with.map((m) => m.value);
     if (this.props.promotedFrom !== undefined)

--- a/src/domain/request/RequestDepth.ts
+++ b/src/domain/request/RequestDepth.ts
@@ -1,0 +1,48 @@
+import { DomainError } from '../shared/DomainError.js';
+
+/**
+ * Reviewer-depth advisory carried on a Request.
+ *
+ * Surfaced by issue #221 (substrate-experiment 実験 2 sharp edge):
+ * substrate enables cheap iteration but has no built-in adjustment
+ * for how *deeply* a downstream reviewer (typically the Devil
+ * agent) should engage with a given wave. Default is 'standard' —
+ * pre-#222 behaviour, what the agent has been doing.
+ *
+ * The values are an **advisory** to the reviewer (principle 02):
+ * the substrate carries the signal, but it does not enforce
+ * anything on the reviewer's actual behaviour. Adjusting the
+ * agent's prompt to honour the depth lives outside the substrate
+ * (operator/agent setup), not in this repo.
+ *
+ *   - shallow:  1-file / <50 LOC / no architectural change.
+ *               Reviewer is invited to point-check the surface
+ *               and not grep-walk the rest of the tree.
+ *   - standard: current default. Up to 3 review rounds, normal
+ *               grep + threading. The pre-#221 behaviour, kept
+ *               name-equivalent so no silent change occurs.
+ *   - deep:     architectural / cross-cutting / security-bearing
+ *               waves where the reviewer is invited to widen
+ *               scope to threat model and posture.
+ */
+export type RequestDepth = 'shallow' | 'standard' | 'deep';
+
+const VALID_DEPTHS: ReadonlySet<RequestDepth> = new Set([
+  'shallow',
+  'standard',
+  'deep',
+]);
+
+export function isRequestDepth(raw: unknown): raw is RequestDepth {
+  return typeof raw === 'string' && VALID_DEPTHS.has(raw as RequestDepth);
+}
+
+export function parseRequestDepth(raw: unknown): RequestDepth {
+  if (!isRequestDepth(raw)) {
+    throw new DomainError(
+      `depth must be one of ${[...VALID_DEPTHS].join(', ')}, got: ${String(raw)}`,
+      'depth',
+    );
+  }
+  return raw;
+}

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -8,6 +8,7 @@ import {
   parseRequestState,
 } from '../../domain/request/RequestState.js';
 import { Review } from '../../domain/request/Review.js';
+import { isRequestDepth } from '../../domain/request/RequestDepth.js';
 import { Thank } from '../../domain/request/Thank.js';
 import { MemberName } from '../../domain/member/MemberName.js';
 import {
@@ -471,6 +472,16 @@ function hydrate(
     if (typeof obj['auto_review'] === 'string')
       props.autoReview = MemberName.of(obj['auto_review']);
     if (typeof obj['target'] === 'string') props.target = obj['target'] as string;
+    // depth (issue #221): hydrate only when the on-disk value matches
+    // the enum. Unknown values are *dropped silently* rather than
+    // throwing — older records with an unrecognised depth (e.g. an
+    // experimental value from a future minor) still load. This is the
+    // same conservative read pattern other optional fields use; a
+    // strict reader would refuse the whole record, but principle 04
+    // says records outlive writers.
+    if (typeof obj['depth'] === 'string' && isRequestDepth(obj['depth'])) {
+      props.depth = obj['depth'];
+    }
     if (Array.isArray(obj['with'])) {
       const partners: MemberName[] = [];
       for (const raw of obj['with'] as unknown[]) {

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -18,6 +18,7 @@ const REQUEST_CREATE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'reason',
   'executor',
   'target',
+  'depth',
   'auto-review',
   'with',
   'format',
@@ -113,10 +114,27 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   };
   const executor = optionalOption(args, 'executor');
   const target = optionalOption(args, 'target');
+  const depth = optionalOption(args, 'depth');
   const autoReview = optionalOption(args, 'auto-review');
   const withPartners = parseWithList(optionalOption(args, 'with'));
   if (executor !== undefined) input.executor = executor;
   if (target !== undefined) input.target = target;
+  // depth (issue #221): pre-check at the interface boundary so the
+  // caller sees a flag-shaped error before the domain layer fires.
+  // The advisory framing — 'shallow ⇒ surface point-check, deep ⇒
+  // arch / threat model' — lives in `gate request --help` and the
+  // schema description. Per principle 02, the value is advisory:
+  // the substrate carries it through, the reviewer agent is the one
+  // who chooses whether to honour it.
+  if (depth !== undefined) {
+    if (depth !== 'shallow' && depth !== 'standard' && depth !== 'deep') {
+      process.stderr.write(
+        `error: --depth must be one of shallow|standard|deep, got: ${depth}\n`,
+      );
+      return 1;
+    }
+    input.depth = depth;
+  }
   if (autoReview !== undefined) input.autoReview = autoReview;
   if (withPartners.length > 0) input.with = withPartners;
   // Request creation is a proxy-eligible verb same as approve/review:

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -758,6 +758,17 @@ const VERBS: readonly VerbSchema[] = [
         reason: str,
         executor: strOpt('who will execute'),
         target: str,
+        depth: {
+          type: 'string',
+          enum: ['shallow', 'standard', 'deep'],
+          description:
+            'reviewer-depth advisory (issue #221). shallow = surface ' +
+            'point-check, no scope-widening; standard = current default ' +
+            '(unchanged); deep = arch / threat-model. Advisory only — ' +
+            'the substrate carries the value; the reviewer (typically ' +
+            'the Devil agent) is the one that adapts. Default is ' +
+            '"standard" when omitted.',
+        },
         'auto-review': strOpt('member assigned as critic'),
         with: strOpt('comma-separated dialogue partners (pair-mode)'),
         format: formatField,

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -72,7 +72,7 @@ Getting started:
 Requests:
   gate request --from <m> --action <a> --reason <r>
                  [--executor <m>] [--target <s>] [--auto-review <m>]
-                 [--with <n1>[,<n2>...]]
+                 [--with <n1>[,<n2>...]] [--depth shallow|standard|deep]
   gate pending [--for <m>]
   gate board [--for <m>] [--format json|text]
                        What's in flight: pending + approved +

--- a/tests/domain/RequestDepth.test.ts
+++ b/tests/domain/RequestDepth.test.ts
@@ -1,0 +1,59 @@
+// RequestDepth — reviewer-depth advisory enum (issue #221).
+//
+// Pins:
+//   - the three accepted values (shallow / standard / deep)
+//   - parser throws DomainError on anything else, with field='depth'
+//     so JSON envelope consumers can branch on the structured field
+//   - isRequestDepth narrows TypeScript correctly + accepts only
+//     strings (a numeric or null value is not a depth even if it
+//     happens to round-trip).
+//
+// The behavioural side of the contract — "the reviewer agent
+// adapts its review strategy when it sees a depth value" — lives
+// outside the substrate (operator/agent setup). This test is for
+// the substrate slot only.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isRequestDepth,
+  parseRequestDepth,
+} from '../../src/domain/request/RequestDepth.js';
+import { DomainError } from '../../src/domain/shared/DomainError.js';
+
+test('parseRequestDepth accepts the three documented values', () => {
+  assert.equal(parseRequestDepth('shallow'), 'shallow');
+  assert.equal(parseRequestDepth('standard'), 'standard');
+  assert.equal(parseRequestDepth('deep'), 'deep');
+});
+
+test('parseRequestDepth rejects unknown strings with DomainError(field="depth")', () => {
+  try {
+    parseRequestDepth('bogus');
+    assert.fail('expected DomainError');
+  } catch (e) {
+    assert.ok(e instanceof DomainError);
+    assert.equal((e as DomainError).field, 'depth');
+    assert.match(
+      (e as DomainError).message,
+      /depth must be one of shallow, standard, deep/,
+    );
+  }
+});
+
+test('parseRequestDepth rejects non-string inputs (number / null / undefined)', () => {
+  for (const bad of [0, 1, null, undefined, true, {}, []]) {
+    assert.throws(() => parseRequestDepth(bad), DomainError);
+  }
+});
+
+test('isRequestDepth: narrows correctly for valid + invalid values', () => {
+  assert.equal(isRequestDepth('shallow'), true);
+  assert.equal(isRequestDepth('standard'), true);
+  assert.equal(isRequestDepth('deep'), true);
+  assert.equal(isRequestDepth('bogus'), false);
+  assert.equal(isRequestDepth(''), false);
+  assert.equal(isRequestDepth(0), false);
+  assert.equal(isRequestDepth(null), false);
+  assert.equal(isRequestDepth(undefined), false);
+});

--- a/tests/interface/gateRequestDepth.test.ts
+++ b/tests/interface/gateRequestDepth.test.ts
@@ -1,0 +1,170 @@
+// gate request --depth — reviewer-depth advisory (issue #221).
+//
+// Pins the substrate-level contract:
+//   - --depth shallow / standard / deep are accepted, persisted in
+//     the request YAML, and round-tripped on read.
+//   - Unknown values are rejected at the interface boundary with
+//     a flag-shape error message; the value never reaches the
+//     domain layer in that case.
+//   - --depth omitted: NO depth field in the persisted YAML
+//     (pre-#221 byte-stable). Reading code defaults absence to
+//     'standard' (issue #221: "Default = standard (互換)").
+//   - Hydrate tolerance: a request YAML written before #221 (no
+//     depth field) must load without error.
+//
+// What this test does NOT pin: the Devil agent's behaviour change
+// when reading the depth value. That contract lives in operator /
+// agent setup (outside this repo); the substrate's job here is
+// only to carry the signal through.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'gate-depth-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'alice', ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function extractRequestId(out: string): string {
+  const m = out.match(/(\d{4}-\d{2}-\d{2}-\d{4})/);
+  if (!m) throw new Error(`no request id in output: ${out}`);
+  return m[0] as string;
+}
+
+function readPendingYaml(root: string, id: string): string {
+  return readFileSync(join(root, 'requests', 'pending', `${id}.yaml`), 'utf8');
+}
+
+for (const depth of ['shallow', 'standard', 'deep'] as const) {
+  test(`--depth ${depth}: accepted; persisted as depth: ${depth} in YAML`, (t) => {
+    const { root, cleanup } = bootstrap();
+    t.after(cleanup);
+    const r = run(root, ['request', '--action', 'a', '--reason', 'r', '--depth', depth]);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    const id = extractRequestId(r.stdout);
+    const yaml = readPendingYaml(root, id);
+    assert.match(yaml, new RegExp(`^depth: ${depth}$`, 'm'));
+  });
+}
+
+test('--depth bogus: rejected at interface with flag-shape error; no record written', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, ['request', '--action', 'a', '--reason', 'r', '--depth', 'bogus']);
+  assert.notEqual(r.status, 0);
+  assert.match(
+    r.stderr,
+    /--depth must be one of shallow\|standard\|deep, got: bogus/,
+  );
+  // No partial write: reject before c.requestUC.create is called.
+  // The pending dir may not exist yet — both 'no dir' and 'empty dir'
+  // satisfy the contract.
+  let entries: string[] = [];
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { readdirSync } = require('node:fs');
+    entries = readdirSync(join(root, 'requests', 'pending'));
+  } catch {
+    entries = [];
+  }
+  assert.equal(entries.length, 0, `expected no pending records; got: ${entries.join(',')}`);
+});
+
+test('--depth omitted: NO depth field in persisted YAML (byte-stable with pre-#221 records)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, ['request', '--action', 'a', '--reason', 'r']);
+  assert.equal(r.status, 0);
+  const id = extractRequestId(r.stdout);
+  const yaml = readPendingYaml(root, id);
+  // Negative: depth must be absent. A `depth: standard` write would
+  // make every existing record bit-different on next save.
+  assert.doesNotMatch(yaml, /^depth:/m);
+});
+
+test('hydrate tolerance: pre-#221 record (no depth field) loads cleanly', (t) => {
+  // Synthesize a YAML record by hand without `depth:` and confirm
+  // gate show reads it without error. Mirrors how doctor / chain
+  // would walk older records on a partially-migrated content root.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'requests', 'pending'), { recursive: true });
+  const id = '2026-05-07-9999';
+  const yaml = [
+    `id: ${id}`,
+    'from: alice',
+    'action: legacy',
+    'reason: pre-221 record',
+    'state: pending',
+    `created_at: 2026-05-07T00:00:00.000Z`,
+    'status_log:',
+    '  - state: pending',
+    '    by: alice',
+    `    at: 2026-05-07T00:00:00.000Z`,
+    '    note: created',
+    'reviews: []',
+    '',
+  ].join('\n');
+  writeFileSync(join(root, 'requests', 'pending', `${id}.yaml`), yaml);
+
+  const r = run(root, ['show', id, '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.equal(payload['id'], id);
+  // Absence is the contract: no depth key at all on a legacy record.
+  assert.equal('depth' in payload, false);
+});
+
+test('--depth shallow: gate show JSON surfaces depth so reviewer agents see the signal', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = run(root, [
+    'request', '--action', 'a', '--reason', 'r', '--depth', 'shallow',
+  ]);
+  const id = extractRequestId(created.stdout);
+
+  const r = run(root, ['show', id, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.equal(payload['depth'], 'shallow');
+});


### PR DESCRIPTION
## Summary

Phase 1 substrate slot for issue [#221](https://github.com/eris-ths/guild-cli/issues/221) (review depth axis for substrate-driven waves). Adds `--depth shallow|standard|deep` to `gate request` so the reviewer-depth advisory can travel with the request through the substrate.

## Why this layer split

Substrate-experiment 実験 2 found a sharp edge: the Devil agent always reviews at maximum depth (grep + multi-round verification), so tiny implementations (PR #207: boot.ts 1 branch + 3-line scan + status.ts 1 line) consume the same review budget as a 25-site wave.

The right layer split per principle 02 (advisory-not-directive):

- **Substrate** carries the depth signal (this PR).
- **Reviewer agent** (Devil agent prompt — operator/agent setup, *outside this repo*) reads the value and adapts its review strategy.

Issue #221 stays open until the agent half lands too; this PR closes the substrate half.

## What this PR ships

- **Domain**: `RequestDepth` enum (`shallow | standard | deep`) + `parseRequestDepth` with `DomainError(field='depth')` on bad input.
- **Aggregate**: `RequestProps.depth?` + plumb through `Request.create` and `toJSON`.
- **Application**: `RequestUseCases.create({ depth })` accepts the optional value.
- **Infrastructure**: `YamlRequestRepository` hydrates `depth` from YAML; unknown values drop silently per principle 04 (records-outlive-writers) so a newer-format record from a future minor still loads.
- **Interface**: `gate request --depth` flag; pre-checked at the interface boundary so the user sees a flag-shape error before the domain layer fires.
- **Schema**: `gate request` schema entry gains `depth` with enum + advisory-framing description (principle 02 wording — the advisory is for the reviewer agent, the substrate doesn't enforce).
- **Help**: `gate --help` request line lists `[--depth shallow|standard|deep]`.

## Byte-stable contract (principle 04)

- **`--depth` omitted**: NO `depth:` field in persisted YAML. Record reads byte-identically to a pre-#221 write of the same input. Test pins this.
- **`--depth standard`**: `depth: standard` IS written. The substrate distinguishes "default by absence" from "explicitly chose standard" — both reads as standard, but the explicit choice is recorded for audit.
- **Hydrate tolerance**: pre-#221 records (no `depth:` field) load cleanly. Test pins this.

## Out of scope (per #221 body)

- **Devil agent prompt 3 段階化** — operator / agent setup, lives outside this repo. Substrate provides the slot; reviewer agent uses it.
- **Auto-estimation of depth** from request shape — Phase 2.
- **Adoption-metric drift detection** — separate follow-up issue per Noir's concern note ("depth=shallow が「Devil 軽量化の言い訳」化する drift").

## Files

- `src/domain/request/RequestDepth.ts` (NEW) — enum + parser
- `src/domain/request/Request.ts` — RequestProps.depth + create/toJSON
- `src/application/request/RequestUseCases.ts` — plumb depth through
- `src/infrastructure/persistence/YamlRequestRepository.ts` — hydrate
- `src/interface/gate/handlers/request.ts` — `--depth` flag + interface enum check
- `src/interface/gate/handlers/schema.ts` — schema entry with advisory description
- `src/interface/gate/index.ts` — `gate --help` updated
- `tests/domain/RequestDepth.test.ts` (NEW) — 4 tests
- `tests/interface/gateRequestDepth.test.ts` (NEW) — 7 tests
- `CHANGELOG.md` — `[Unreleased]` Added entry

The schema flag-coverage CI test from PR #215 auto-tracks the new flag — schema and handler both register `depth` in the same PR.

## Test plan

- [x] Build green (`tsc`)
- [x] Full suite green (1161 → 1172, +11 new)
- [x] Manual:
  - `gate request --depth shallow|standard|deep` → persisted, exit 0 ✓
  - `gate request --depth bogus` → flag-shape error, exit 1 ✓
  - `gate request` (no flag) → no `depth:` field in YAML ✓
  - `gate show <id> --format json` → `depth` field present when set, absent when not ✓

## Versioning

Additive, non-breaking. Lands into the same minor cut as #218's BREAKING (`gate list` default). 0.6.0 cut will collect both.

cc: phase 1 of [#221](https://github.com/eris-ths/guild-cli/issues/221)

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_