### PR TITLE
fix(touch-feel): close bare-optional-flag silent + inbox text expects-response gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Fixed
+
+- **`optionalOption` rejects bare flags (`--depth`, `--executor`,
+  `--state`, ... with no value).** Pre-fix, an optional flag passed
+  without a value silently fell through to the env fallback / undefined.
+  Surfaced in v0.5 dogfood: `gate request --depth` (intending to set
+  the value but forgetting to type it) silently created a request
+  with no depth. Same fail-open class `requireOption` already protects
+  against; `optionalOption` now mirrors the shape:
+  ```
+  error: Missing --depth value.
+    (If your value begins with "--", use --depth=<value> or place "-- <value>" after the other flags.)
+  ```
+  Affects every callsite — `--executor`, `--target`, `--state`,
+  `--game`, `--note`, etc — uniformly. Bare-flag short-circuits the
+  env fallback path so a typo can't be silently overridden by ambient
+  GUILD_ACTOR.
+
+- **Inbox text-mode surfaces `(unread, expects response)`.** Phase 1
+  of [#220](https://github.com/eris-ths/guild-cli/issues/220) (PR #222)
+  stamped `expects_response` on inbox YAML and surfaced it via
+  `gate boot`'s `suggested_next`, but the inbox **text** rendering
+  only said `(unread)` for both flagged and unflagged broadcasts. A
+  human scanning the text inbox couldn't tell them apart without
+  re-running with `--format json`. Now the marker shows inline:
+  ```
+  1. [...] broadcast from nao (unread, expects response)
+     audit needed
+  2. [...] broadcast from nao (unread)
+     FYI only
+  ```
+  Read state suppresses the marker (Phase 1 ack proxy: read drains
+  the surface). Same principle-09 disclosure shape — visible at the
+  surface that emits it, in both text and JSON.
+
 ### **BREAKING**
 
 - **`gate list` (no `--state`) now defaults to `--state all`**

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -199,13 +199,28 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
     if (unreadOnly && m.read) continue;
     const idx = i + 1;
     const related = m.related ? ` (ref: ${m.related})` : '';
-    const readTag = m.read
-      ? m.readAt
+    // expects_response surface (issue #220 phase 1 follow-up):
+    // text mode previously showed `(unread)` only; the
+    // expects_response stamp lived only in JSON, so a human
+    // scanning the text inbox couldn't tell which broadcasts
+    // wanted a substantive response without re-running with
+    // --format json. Show it inline on unread; once read the
+    // broadcast is treated as ack'd (Phase 1 contract: read-with-
+    // mark-read is the ack proxy), so the marker would just
+    // nag rather than inform.
+    let readTag: string;
+    if (m.read) {
+      readTag = m.readAt
         ? m.readBy && m.readBy !== forName
           ? ` (read ${m.readAt} by ${m.readBy})`
           : ` (read ${m.readAt})`
-        : ' (read)'
-      : ' (unread)';
+        : ' (read)';
+    } else {
+      readTag =
+        m.expectsResponse === true
+          ? ' (unread, expects response)'
+          : ' (unread)';
+    }
     // Show invoked_by on the sender side so a recipient can tell a
     // ghost-sent message from a hand-typed one at a glance. The
     // mark-read side already has its own "by ..." marker on readTag.

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -169,6 +169,22 @@ export function optionalOption(
 ): string | undefined {
   const v = args.options[key];
   if (typeof v === 'string') return v;
+  // Bare flag (`--executor` with no value) lands as boolean `true`.
+  // Pre-fix this silently fell through to envFallback / undefined,
+  // which read as "no value given". A user typing `--depth` and
+  // forgetting the enum value would see their request go through
+  // with depth unset — exact fail-open shape `tail`'s strict-reject
+  // and `gate doctor`'s --format-validation already protect against.
+  // Fail closed with the same shape `requireOption` uses for the
+  // same condition.
+  if (v === true) {
+    const envPart = envFallback ? ` (or set ${envFallback})` : '';
+    throw new Error(
+      `Missing --${key} value${envPart}.\n` +
+        `  (If your value begins with "--", use --${key}=<value> ` +
+        `or place "-- <value>" after the other flags.)`,
+    );
+  }
   if (envFallback) {
     const fallback = resolveEnvOrActorFile(envFallback);
     if (fallback !== undefined) return fallback;

--- a/tests/interface/broadcastExpectsResponse.test.ts
+++ b/tests/interface/broadcastExpectsResponse.test.ts
@@ -330,3 +330,72 @@ test('schema declares --expects-response on broadcast input properties', (t) => 
   assert.ok(verb.input.properties['expects-response']);
   assert.equal(verb.input.properties['expects-response'].type, 'boolean');
 });
+
+// ---- inbox text-mode visibility (v0.5 dogfood follow-up) ----
+
+test('inbox text mode: unread expects_response broadcast renders "(unread, expects response)"', (t) => {
+  // Pre-fix (PR #222): JSON inbox carried the expects_response stamp
+  // but the text rendering only said "(unread)". A human scanning
+  // the inbox text couldn't tell a normal broadcast apart from one
+  // that wanted a substantive response — they'd have to re-run with
+  // --format json to see the stamp. Surface the signal inline on
+  // the text path so the principle-09 disclosure shape (visible at
+  // the surface that emits it) holds for both formats.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    [
+      'broadcast',
+      '--from', 'alice',
+      '--text', 'audit needed',
+      '--expects-response',
+    ],
+  );
+  const r = runGate(root, ['inbox'], { GUILD_ACTOR: 'bob' });
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /broadcast from alice .*\(unread, expects response\)/,
+    `expected expects-response marker on unread; got:\n${r.stdout}`,
+  );
+});
+
+test('inbox text mode: unread without expects_response stays "(unread)" (no over-broadcasting)', (t) => {
+  // Sibling negative: the marker only appears when the sender
+  // opted in. A FYI broadcast must not be retro-flagged as
+  // expecting a response — that would defeat the opt-in design.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    ['broadcast', '--from', 'alice', '--text', 'FYI only'],
+  );
+  const r = runGate(root, ['inbox'], { GUILD_ACTOR: 'bob' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /broadcast from alice .*\(unread\)/);
+  assert.doesNotMatch(r.stdout, /expects response/);
+});
+
+test('inbox text mode: read state suppresses the marker (Phase 1 ack proxy)', (t) => {
+  // Phase 1 contract: read = ack proxy. Once mark-read fires the
+  // expectation surface drains in boot too (see "mark-read drains
+  // the broadcast-pending-response surface" above). Mirror that on
+  // the inbox text — past read time the marker would just nag the
+  // reader instead of orienting them.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    [
+      'broadcast', '--from', 'alice',
+      '--text', 'audit needed',
+      '--expects-response',
+    ],
+  );
+  runGate(root, ['inbox', 'mark-read'], { GUILD_ACTOR: 'bob' });
+  const r = runGate(root, ['inbox'], { GUILD_ACTOR: 'bob' });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /broadcast from alice .*\(read/);
+  assert.doesNotMatch(r.stdout, /expects response/);
+});

--- a/tests/interface/parseArgs.test.ts
+++ b/tests/interface/parseArgs.test.ts
@@ -172,6 +172,62 @@ test('optionalOption: explicit value wins over env', () => {
   }
 });
 
+test('optionalOption: bare flag (no value) errors instead of silently passing', () => {
+  // Pre-fix `--depth` (no value) silently fell through to envFallback /
+  // undefined. A user typing `gate request --depth` expecting to set
+  // the value would see the request go through with depth unset.
+  // Surfaced in v0.5 dogfood; same fail-open class `requireOption`
+  // already protected against.
+  const args = parseArgs(['--depth']);
+  try {
+    optionalOption(args, 'depth');
+    assert.fail('expected throw on bare flag');
+  } catch (e) {
+    assert.match((e as Error).message, /Missing --depth value\./);
+    // Surface the escape-valve hint so a user whose value legitimately
+    // begins with `--` (e.g. `--from --foo`) sees how to pass it.
+    assert.match(
+      (e as Error).message,
+      /If your value begins with "--", use --depth=<value>/,
+    );
+  }
+});
+
+test('optionalOption: bare flag with envFallback names the env in the error', () => {
+  // Sibling shape to requireOption's same-condition error; the env
+  // hint propagates so a user who set GUILD_ACTOR sees that path is
+  // still available even though they typo'd the flag.
+  const args = parseArgs(['--for']);
+  try {
+    optionalOption(args, 'for', 'GUILD_ACTOR');
+    assert.fail('expected throw on bare flag');
+  } catch (e) {
+    assert.match(
+      (e as Error).message,
+      /Missing --for value \(or set GUILD_ACTOR\)\./,
+    );
+  }
+});
+
+test('optionalOption: bare flag error fires BEFORE env fallback resolves', () => {
+  // Pre-fix order was: bare flag → undefined → envFallback wins.
+  // Post-fix: bare flag is itself a user error and short-circuits
+  // the env path. Otherwise a typo'd `--for` would be silently
+  // overridden by the ambient env, exact silent-fail-open shape.
+  const args = parseArgs(['--for']);
+  const prev = process.env['GUILD_ACTOR'];
+  process.env['GUILD_ACTOR'] = 'should-not-be-returned';
+  try {
+    assert.throws(
+      () => optionalOption(args, 'for', 'GUILD_ACTOR'),
+      /Missing --for value/,
+    );
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_ACTOR'];
+    else process.env['GUILD_ACTOR'] = prev;
+  }
+});
+
 test('withCleanCwd isolates the .guild-actor file fallback (issue #183 regression)', () => {
   // Simulate the develop-branch CI condition: ambient .guild-actor in
   // an ancestor directory of cwd. Without withCleanCwd, env-unset


### PR DESCRIPTION
## Summary

Closes two touch-feel holes surfaced in the v0.5-dogfood loop after #218-#223 landed. Both are **pre-existing fail-open shapes** that became visible once new flags / new surfaces compounded with them.

## (1) `optionalOption` silently accepts bare flags

**Symptom**:
```
$ gate request --action a --reason r --depth      # no value!
✓ created: 2026-05-07-0001 (state=pending)         # silently no depth set
```

Same shape on every optional string flag — `--executor`, `--target`, `--state`, `--game`, `--note`, etc. The user types the flag, forgets the value, and the substrate accepts the call as if the flag wasn't there. Exact fail-open class `requireOption` already protects against — that asymmetry is what made it hide.

**Fix**: when `args.options[key] === true` (bare flag), emit the same `"Missing --<flag> value."` error shape `requireOption` uses, including the `--key=value` / `-- value` escape-valve hint for legitimate `--`-prefixed values. The env fallback path is short-circuited — a typo'd `--for` must not be silently overridden by ambient `GUILD_ACTOR`.

**Net effect**: every `optionalOption` callsite now fails closed on bare-flag input. Full suite stayed green at 1172 — no test relied on the silent-acceptance behaviour. 4 new tests pin the contract (bare flag errors, env fallback hint propagates, env path short-circuits before fallback).

## (2) Inbox text mode hides `expects_response`

**Symptom**:
```
1. [2026-05-07T...] broadcast from alice (unread)    ← could be either
   audit needed
2. [2026-05-07T...] broadcast from alice (unread)
   FYI only
```

Phase 1 of #220 (PR #222) stamped `expects_response` on inbox YAML and surfaced it via `gate boot`'s `suggested_next`, but the inbox **text** rendering only said `(unread)` regardless. JSON was complete; text wasn't. A human scanning text inbox couldn't distinguish a flagged broadcast from a FYI without re-running with `--format json`.

**Fix**:
```
1. [2026-05-07T...] broadcast from alice (unread, expects response)
   audit needed
2. [2026-05-07T...] broadcast from alice (unread)
   FYI only
```

Read state **suppresses** the marker — Phase 1 ack-proxy contract: read drains the surface, so showing it on read state would just nag rather than orient. Same disclosure shape now applies to both text and JSON, satisfying principle 09 (orientation-disclosure).

3 new tests pin the contract (unread flagged shows marker; unread unflagged stays clean; read suppresses marker).

## Files

- `src/interface/shared/parseArgs.ts` — `optionalOption` rejects bare flags
- `src/interface/gate/handlers/messages.ts` — inbox text marker
- `tests/interface/parseArgs.test.ts` — +4 tests
- `tests/interface/broadcastExpectsResponse.test.ts` — +3 tests
- `CHANGELOG.md` — two entries under `[Unreleased]` § Fixed

## Test plan

- [x] Build green (`tsc`)
- [x] Full suite green (1172 → 1178, +6 net)
- [x] Manual: `gate request --depth` (no value) → `Missing --depth value.` ✓
- [x] Manual: `gate request --depth shallow` → still works ✓
- [x] Manual: inbox text shows `(unread, expects response)` for flagged broadcasts ✓
- [x] Manual: `inbox mark-read` clears the marker (read state) ✓

## Versioning

Both are bug fixes / additive. Non-breaking. Lands into the same minor cut as #218 (BREAKING) and #211-#223 (additive). 0.6.0 collects.

## Related

- #220 phase 1 (PR #222) — added the `expects_response` stamp; this PR closes the text-mode visibility gap.
- #221 phase 1 (PR #223) — added `--depth`; the bare-flag silent-fail surfaced once `--depth` joined the list of `optionalOption` callsites.

https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz3rw52NS3afdrZLh3AfRj)_