### PR TITLE
feat(request): --depth shallow|standard|deep flag (#221 phase 1)

### DIFF
--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -51,6 +51,10 @@ export class RequestUseCases {
      *  promote`). Tool-generated structured link surviving any
      *  --action / --reason overrides. */
     promotedFrom?: string;
+    /** Author-declared review depth (issue #221). Advisory hint for
+     *  downstream reviewers; does not gate any transition. Persisted
+     *  unchanged. Validated at the interface layer. */
+    depth?: 'shallow' | 'standard' | 'deep';
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -90,6 +94,7 @@ export class RequestUseCases {
     if (input.invokedBy !== undefined) createArgs.invokedBy = input.invokedBy;
     if (input.promotedFrom !== undefined)
       createArgs.promotedFrom = input.promotedFrom;
+    if (input.depth !== undefined) createArgs.depth = input.depth;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -15,6 +15,29 @@ const MAX_REVIEWS = 50;
 const MAX_THANKS = 50;
 const MAX_STATUS_LOG = 100;
 
+/**
+ * Review depth hint set on a request at creation time.
+ *
+ *   - `shallow`  — small, single-file, no arch change. Reviewer is
+ *     expected to skim, not grep.
+ *   - `standard` — current default; reviewer behaves as-is. Stored as
+ *     "absent" on disk (no field) so existing records hydrate
+ *     unchanged (principle 04: records-outlive-writers).
+ *   - `deep`     — cross-cutting / arch / threat-model territory.
+ *
+ * The field is **advisory**: it is a hint to reviewers, not a directive.
+ * A reviewer may always escalate from `shallow` to `deep` if the
+ * surface turns out to be larger than the author thought (and vice
+ * versa). Phase 1 only persists the hint; Phase 2 will branch Devil
+ * agent prompts on it (issue #221, out of scope here).
+ */
+export type RequestDepth = 'shallow' | 'standard' | 'deep';
+export const REQUEST_DEPTHS: readonly RequestDepth[] = [
+  'shallow',
+  'standard',
+  'deep',
+];
+
 export interface StatusLogEntry {
   state: RequestState;
   by: string;
@@ -61,6 +84,15 @@ export interface RequestProps {
    * other tool-generated relationship fields (executor, autoReview).
    */
   promotedFrom?: string;
+  /**
+   * Author-declared review depth (issue #221, Phase 1). One of
+   * `shallow | standard | deep`. Advisory only — no transition reads
+   * it; downstream Devil/reviewer agents MAY read it to right-size
+   * scrutiny in a follow-up PR. Undefined for records written before
+   * the flag existed (the common case during rollout). Stored verbatim,
+   * never derived.
+   */
+  depth?: 'shallow' | 'standard' | 'deep';
   state: RequestState;
   createdAt: string;
   reviews: Review[];
@@ -115,6 +147,8 @@ export class Request {
     /** See RequestProps.promotedFrom — issue id this request was
      *  promoted from. Populated by `gate issues promote` only. */
     promotedFrom?: string;
+    /** See RequestProps.depth — advisory review depth hint. */
+    depth?: 'shallow' | 'standard' | 'deep';
   }): Request {
     const from = MemberName.of(input.from);
     const action = sanitizeText(input.action, 'action');
@@ -171,6 +205,23 @@ export class Request {
     if (input.promotedFrom !== undefined) {
       props.promotedFrom = input.promotedFrom;
     }
+    if (input.depth !== undefined) {
+      // Defense-in-depth: interface already validates the enum, but
+      // the domain re-asserts so a future caller (other use case,
+      // restore path with a malformed YAML, etc.) cannot persist a
+      // value outside the contracted three.
+      if (
+        input.depth !== 'shallow' &&
+        input.depth !== 'standard' &&
+        input.depth !== 'deep'
+      ) {
+        throw new DomainError(
+          `depth must be one of shallow|standard|deep, got: ${String(input.depth)}`,
+          'depth',
+        );
+      }
+      props.depth = input.depth;
+    }
     // New requests have no on-disk predecessor; loadedVersion=0 marks
     // "never seen" for the optimistic-lock check in save().
     return new Request(props, 0);
@@ -204,6 +255,9 @@ export class Request {
   }
   get promotedFrom(): string | undefined {
     return this.props.promotedFrom;
+  }
+  get depth(): 'shallow' | 'standard' | 'deep' | undefined {
+    return this.props.depth;
   }
   get with(): readonly MemberName[] {
     return this.props.with ?? [];
@@ -345,6 +399,12 @@ export class Request {
       out['with'] = this.props.with.map((m) => m.value);
     if (this.props.promotedFrom !== undefined)
       out['promoted_from'] = this.props.promotedFrom;
+    // Depth surfaces only when the author declared one. Records created
+    // before #221 (no --depth ever passed) emit no `depth` key — same
+    // forward-compat shape as `thanks` and `with`. Default-on-read is
+    // not synthesised here: a missing key means "author did not declare",
+    // which is semantically distinct from "author chose standard".
+    if (this.props.depth !== undefined) out['depth'] = this.props.depth;
     // Derive legacy closure keys from the last status_log entry so
     // external consumers (chain / voices / show --format text) keep
     // working unchanged. Single source of truth: status_log[-1].note.

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -481,6 +481,18 @@ function hydrate(
     if (typeof obj['promoted_from'] === 'string') {
       props.promotedFrom = obj['promoted_from'] as string;
     }
+    // Depth (issue #221). Hydrate only the three contracted values;
+    // a malformed value (typo, future-extension we don't recognise)
+    // is dropped silently so a corrupt record can still be read for
+    // recovery. The drift detector + interface enum prevent malformed
+    // values from being WRITTEN; the read path stays forgiving.
+    if (
+      obj['depth'] === 'shallow' ||
+      obj['depth'] === 'standard' ||
+      obj['depth'] === 'deep'
+    ) {
+      props.depth = obj['depth'] as 'shallow' | 'standard' | 'deep';
+    }
     // Legacy top-level closure keys (completion_note / deny_reason /
     // failure_reason) are no longer written separately — status_log[-1].note
     // is the single source of truth. Handle the three migration cases

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -20,7 +20,21 @@ const REQUEST_CREATE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'target',
   'auto-review',
   'with',
+  'depth',
   'format',
+]);
+
+// `--depth` advertises the author's intended review depth (issue #221
+// Phase 1). Advisory: a downstream Devil agent / reviewer MAY read this
+// to right-size scrutiny, but the value does not gate any state
+// transition or refuse any review. The author can always be overridden
+// by a reviewer choosing to go deeper. Phase 1 records the value;
+// Devil prompt three-stage routing is deliberately scope-out (separate
+// PR) so silent behavioural change can't ride this PR.
+const REQUEST_DEPTH_VALUES: ReadonlySet<string> = new Set([
+  'shallow',
+  'standard',
+  'deep',
 ]);
 const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -115,10 +129,22 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   const target = optionalOption(args, 'target');
   const autoReview = optionalOption(args, 'auto-review');
   const withPartners = parseWithList(optionalOption(args, 'with'));
+  const depth = optionalOption(args, 'depth');
   if (executor !== undefined) input.executor = executor;
   if (target !== undefined) input.target = target;
   if (autoReview !== undefined) input.autoReview = autoReview;
   if (withPartners.length > 0) input.with = withPartners;
+  if (depth !== undefined) {
+    if (!REQUEST_DEPTH_VALUES.has(depth)) {
+      // Reject up-front with the same enum-list shape `gate review
+      // --verdict <bad>` uses, so the agent dispatch error is
+      // shape-symmetric with the schema enum it would have read.
+      throw new Error(
+        `--depth must be one of: shallow, standard, deep (got: ${depth})`,
+      );
+    }
+    input.depth = depth as 'shallow' | 'standard' | 'deep';
+  }
   // Request creation is a proxy-eligible verb same as approve/review:
   // when GUILD_ACTOR differs from --from, the agent is filing on a
   // member's behalf. Derive the invoker pre-create so it lands on

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -760,6 +760,19 @@ const VERBS: readonly VerbSchema[] = [
         target: str,
         'auto-review': strOpt('member assigned as critic'),
         with: strOpt('comma-separated dialogue partners (pair-mode)'),
+        depth: {
+          type: 'string',
+          enum: ['shallow', 'standard', 'deep'],
+          // Advisory framing (principle 02): the value is the author's
+          // declared review intent, not a directive. A reviewer MAY
+          // right-size scrutiny based on it, but is free to go deeper
+          // — the author cannot bind a reviewer's depth. Phase 1
+          // (issue #221) records the value; downstream Devil prompt
+          // three-stage routing is a separate PR so behavioural change
+          // is not bundled with the schema admission.
+          description:
+            "author-declared review depth hint; advisory only — a reviewer may go deeper. shallow = 1 file / <50 LOC / no arch change; standard = current default; deep = cross-cutting / arch / security.",
+        },
         format: formatField,
       },
       required: ['action', 'reason'],

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -556,6 +556,66 @@ test('Request.toJSON omits promoted_from when not set (pre-promote requests byte
   assert.equal('promoted_from' in r.toJSON(), false);
 });
 
+test('Request.create accepts depth and surfaces it via toJSON', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    depth: 'shallow',
+  });
+  assert.equal(r.depth, 'shallow');
+  assert.equal(r.toJSON()['depth'], 'shallow');
+});
+
+test('Request.toJSON omits depth when undeclared (pre-#221 records byte-identical)', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+  });
+  assert.equal('depth' in r.toJSON(), false);
+  assert.equal(r.depth, undefined);
+});
+
+test('Request.create rejects malformed depth at the domain boundary', () => {
+  // Defense-in-depth: interface validates first, but if a future
+  // caller bypasses the handler the domain still refuses.
+  assert.throws(
+    () =>
+      Request.create({
+        id: RequestId.generate(d, 1),
+        from: 'alice',
+        action: 'a',
+        reason: 'r',
+        // @ts-expect-error — purposely malformed
+        depth: 'medium',
+      }),
+    DomainError,
+  );
+});
+
+test('Request.restore round-trips all three depth values', () => {
+  for (const depth of ['shallow', 'standard', 'deep'] as const) {
+    const r = Request.restore({
+      id: RequestId.generate(d, 1),
+      from: MemberName.of('alice'),
+      action: 'a',
+      reason: 'r',
+      state: 'pending',
+      createdAt: '2026-04-14T00:00:00.000Z',
+      statusLog: [
+        { state: 'pending', by: 'alice', at: '2026-04-14T00:00:00.000Z' },
+      ],
+      reviews: [],
+      depth,
+    });
+    assert.equal(r.depth, depth);
+    assert.equal(r.toJSON()['depth'], depth);
+  }
+});
+
 test('Request.restore preserves promotedFrom on round-trip', () => {
   // Simulates the repo rehydrating a request that was promoted.
   // The field must survive load → toJSON without needing domain

--- a/tests/interface/requestDepthFlag.test.ts
+++ b/tests/interface/requestDepthFlag.test.ts
@@ -1,0 +1,210 @@
+// gate request --depth (issue #221, Phase 1)
+//
+// Coverage:
+//   1. schema declares `depth` as a string enum on `request`
+//   2. enum is exactly [shallow, standard, deep]
+//   3. CLI accepts each of the three values + persists it on disk
+//      (round-trips via `gate show --format json`)
+//   4. CLI rejects a non-enum value with a shape-symmetric error
+//   5. Absent --depth: created request emits NO `depth` key (records-
+//      outlive-writers; pre-#221 records remain byte-identical)
+//   6. KNOWN_FLAGS accepts --depth (no rejectUnknownFlags trip)
+//
+// Devil prompt three-stage routing is OUT OF SCOPE for this PR
+// (issue #221 explicitly defers it). This test pins ONLY the
+// flag-admission + persistence layer so a future PR cannot silently
+// regress the contract.
+//
+// The standard=current-behaviour invariant is enforced structurally
+// here: standard is a "no field" on disk (toJSON omits it when the
+// author declared standard, by design). See the "no depth → no key"
+// case below.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-depth-flag-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// ── schema ────────────────────────────────────────────────────────
+
+test('schema: request declares depth as a string enum [shallow, standard, deep]', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'request']);
+    assert.equal(r.status, 0, r.stderr);
+    const payload = JSON.parse(r.stdout);
+    const reqVerb = payload.verbs.find((v: { name: string }) => v.name === 'request');
+    assert.ok(reqVerb, 'schema must include `request`');
+    const depthProp = reqVerb.input.properties.depth;
+    assert.ok(depthProp, 'schema.request.input.properties.depth must be declared');
+    assert.equal(depthProp.type, 'string');
+    assert.deepEqual(depthProp.enum, ['shallow', 'standard', 'deep']);
+    // Advisory framing must be on the description so MCP wirings
+    // reading the schema see "hint, not directive" up front.
+    assert.match(
+      String(depthProp.description ?? ''),
+      /advisory/i,
+      'depth.description must use advisory framing',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// ── happy path: each enum value persists and round-trips ──────────
+
+for (const depth of ['shallow', 'standard', 'deep'] as const) {
+  test(`gate request --depth ${depth}: persisted and visible via gate show`, () => {
+    const { root, cleanup } = bootstrap();
+    try {
+      const create = runGate(root, [
+        'request',
+        '--from',
+        'alice',
+        '--action',
+        'a',
+        '--reason',
+        'r',
+        '--depth',
+        depth,
+        '--format',
+        'json',
+      ]);
+      assert.equal(create.status, 0, create.stderr);
+      const created = JSON.parse(create.stdout);
+      const id = created.id as string;
+      assert.ok(id.match(/^\d{4}-\d{2}-\d{2}-\d+$/), `bad id: ${id}`);
+
+      const show = runGate(root, ['show', id, '--format', 'json']);
+      assert.equal(show.status, 0, show.stderr);
+      const payload = JSON.parse(show.stdout);
+      assert.equal(
+        payload.depth,
+        depth,
+        `round-trip lost depth (got: ${JSON.stringify(payload.depth)})`,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+}
+
+// ── omission: pre-#221 byte-identical shape ───────────────────────
+
+test('gate request without --depth: depth key absent on the resulting record', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const create = runGate(root, [
+      'request',
+      '--from',
+      'alice',
+      '--action',
+      'a',
+      '--reason',
+      'r',
+      '--format',
+      'json',
+    ]);
+    assert.equal(create.status, 0, create.stderr);
+    const id = JSON.parse(create.stdout).id as string;
+    const show = runGate(root, ['show', id, '--format', 'json']);
+    assert.equal(show.status, 0, show.stderr);
+    const payload = JSON.parse(show.stdout);
+    assert.equal(
+      'depth' in payload,
+      false,
+      'absent --depth must NOT emit a depth key (records-outlive-writers)',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// ── enum rejection ────────────────────────────────────────────────
+
+test('gate request --depth medium: rejected with the schema enum listed in the error', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, [
+      'request',
+      '--from',
+      'alice',
+      '--action',
+      'a',
+      '--reason',
+      'r',
+      '--depth',
+      'medium',
+    ]);
+    assert.notEqual(r.status, 0, 'malformed depth must fail');
+    assert.match(r.stderr, /shallow.*standard.*deep/);
+    assert.match(r.stderr, /medium/);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── KNOWN_FLAGS admission (drift detector also covers it) ─────────
+
+test('gate request --depth: NOT rejected by the unknown-flag guard', () => {
+  // If --depth ever drops out of REQUEST_CREATE_KNOWN_FLAGS the
+  // rejectUnknownFlags helper would fire BEFORE the enum check, with
+  // an "unknown flag" message. This test pins admission distinct from
+  // enum validity.
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, [
+      'request',
+      '--from',
+      'alice',
+      '--action',
+      'a',
+      '--reason',
+      'r',
+      '--depth',
+      'shallow',
+    ]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.doesNotMatch(r.stderr, /unknown flag/i);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Phase 1 (minimum) of #221. `gate request` に `--depth shallow|standard|deep` flag を追加。Devil prompt 段階化は **scope 外** (Phase 2 別 PR)。

- enum validation (interface → application → domain で 3 段防御)
- `--depth standard` 明示 vs 未指定 を **意味論的に区別** (toYaml で missing key 保持、Phase 2 で drift 観察できるように)
- `--depth` 未指定時は disk byte-identical with pre-#221 (principle 04: records-outlive-writers)
- read-side hydrate は 3 値以外を silent drop (recovery 優先)

## Substrate trail

実験5 (agent-driven wave): brief 抽象化テスト
- `2026-05-07-0006` Miki impl (本 PR)
- `2026-05-07-0007` Leysia parallel impl (worktree、artifact 不在問題は別 issue で調査)
- `2026-05-07-0008` Noir wave director — Devil 不召集判断、Miki 採用判定
- 副次知見: brief 抽象化で structural diff が voice 差より深く出る (実験4 副次収穫の検証)
- もう一つの副次知見: director (Noir) が host (Eris) の brief 誤読を独立検証で訂正 (Miki も沈黙/明示を区別側だった)

## Out of scope (Phase 2)
- Devil agent prompt の 3 段階化
- `standard` = 現行 Devil 振る舞い等価 test (pin 対象が無い時点では追加せず)
- depth 自動推定
- depth drift 観察 hook

## Concern (Noir verdict より)
- ENOENT edge (不正値 reject 時に persist dir 不在ケース) は Miki domain layer で reject されるため persist 段に到達しない構造のはずだが、follow-up issue で確認推奨

## Test plan

- [x] \`npm run build\` GREEN (tsc 0 error)
- [x] domain Request: 4 ケース (round-trip / omission / 不正値拒否 / restore 3 値)
- [x] interface requestDepthFlag: 8 ケース (schema 宣言 / 3 値永続 / omission byte-identity / enum 拒否 / KNOWN_FLAGS 通過)
- [x] schema input drift detector / actual output validator GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)