### PR TITLE
docs(changelog): fix v0.4.0 strikethrough rendering — bare `<s>` opened HTML strike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1308,8 +1308,8 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   error.** Pre-fix, when the user opened the editor (no
   `--comment`/positional/stdin) and saved without writing,
   `readCommentViaEditor` returned an empty string and the caller's
-  generic "review comment is required (use --comment <s>, …, or
-  run interactively so $EDITOR opens)" error fired — but the
+  generic `review comment is required (use --comment <s>, …, or
+  run interactively so $EDITOR opens)` error fired — but the
   "run interactively" hint was misleading because the user had
   just done so. Post-fix the editor flow throws its own message:
 


### PR DESCRIPTION
## Summary

- L1311 of CHANGELOG.md had a bare `<s>` outside backticks inside a quoted error-message string. GitHub markdown renders `<s>` as an HTML strikethrough open tag, and no closing `</s>` ever appeared, so the entire v0.4.0 section after the `gate review empty editor` entry rendered as struck-through text.
- Fix: wrap the literal CLI error message in backticks (code-inline). The 7 other `<s>` occurrences in CHANGELOG.md are all already inside backticks; only this one was naked prose.
- 1 file changed, 2 insertions / 2 deletions.

## Test plan

- [ ] Visit https://github.com/eris-ths/guild-cli/blob/fix/changelog-strikethrough-bare-s-tag/CHANGELOG.md and confirm v0.4.0 section onward is no longer struck through.
- [ ] Confirm the quoted error message renders as code-inline span (matching the doc's convention for CLI references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)