### PR TITLE
fix(config): discover .gate-sessions/guild.config.yaml in addition to top-level

### DIFF
--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -139,8 +139,18 @@ export class GuildConfig implements GuildConfigProps {
 function findConfig(start: string): string | null {
   let dir = resolve(start);
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, 'guild.config.yaml');
-    if (existsSync(candidate)) return candidate;
+    // Prefer in-repo `.gate-sessions/` convention adopted by repos that
+    // sandbox guild data into a single subdirectory (projector,
+    // yori-code, ...). When the config lives there, content_root and
+    // path entries inside the file resolve relative to `.gate-sessions/`,
+    // which is what those repos already write.
+    const inSubdir = join(dir, '.gate-sessions', 'guild.config.yaml');
+    if (existsSync(inSubdir)) return inSubdir;
+    // Legacy top-level placement: when the project IS the guild
+    // (THS-style content_root where everything sits at the top of the
+    // tree), guild.config.yaml lives directly next to requests/issues/...
+    const topLevel = join(dir, 'guild.config.yaml');
+    if (existsSync(topLevel)) return topLevel;
     const parent = resolve(dir, '..');
     if (parent === dir) break;
     dir = parent;

--- a/tests/infrastructure/guildConfigDiscovery.test.ts
+++ b/tests/infrastructure/guildConfigDiscovery.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GuildConfig } from '../../src/infrastructure/config/GuildConfig.js';
+
+/**
+ * GuildConfig.load() / findConfig() must discover both supported
+ * placements:
+ *
+ *   <repo>/guild.config.yaml                   — legacy / THS-style
+ *   <repo>/.gate-sessions/guild.config.yaml    — in-repo convention
+ *                                                 (projector, yori-code)
+ *
+ * `.gate-sessions/` takes precedence when both exist (in-repo
+ * convention is the more recent and the more containment-friendly).
+ */
+
+function setupRepo(): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'guild-cli-cfg-'));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('GuildConfig.load: discovers <repo>/guild.config.yaml at top level', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    writeFileSync(
+      join(dir, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [nao]\n',
+    );
+    const cfg = GuildConfig.load(dir);
+    assert.equal(cfg.configFile, join(dir, 'guild.config.yaml'));
+    assert.equal(cfg.contentRoot, dir);
+  } finally {
+    cleanup();
+  }
+});
+
+test('GuildConfig.load: discovers <repo>/.gate-sessions/guild.config.yaml', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    const sub = join(dir, '.gate-sessions');
+    mkdirSync(sub);
+    writeFileSync(
+      join(sub, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [nao]\n',
+    );
+    const cfg = GuildConfig.load(dir);
+    assert.equal(cfg.configFile, join(sub, 'guild.config.yaml'));
+    // content_root: . resolves relative to the config file's directory,
+    // so it points at .gate-sessions/ — that's where projector and
+    // yori-code put members/requests/issues/inbox.
+    assert.equal(cfg.contentRoot, sub);
+  } finally {
+    cleanup();
+  }
+});
+
+test('GuildConfig.load: .gate-sessions/ takes precedence over top-level when both exist', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    writeFileSync(
+      join(dir, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [legacy]\n',
+    );
+    const sub = join(dir, '.gate-sessions');
+    mkdirSync(sub);
+    writeFileSync(
+      join(sub, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [in_repo]\n',
+    );
+    const cfg = GuildConfig.load(dir);
+    assert.equal(cfg.configFile, join(sub, 'guild.config.yaml'));
+    assert.deepEqual(cfg.hostNames, ['in_repo']);
+  } finally {
+    cleanup();
+  }
+});
+
+test('GuildConfig.load: walks up parents to find .gate-sessions/ from a nested cwd', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    const sub = join(dir, '.gate-sessions');
+    mkdirSync(sub);
+    writeFileSync(
+      join(sub, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [nao]\n',
+    );
+    const nested = join(dir, 'packages', 'engine', 'src');
+    mkdirSync(nested, { recursive: true });
+    const cfg = GuildConfig.load(nested);
+    assert.equal(cfg.configFile, join(sub, 'guild.config.yaml'));
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## 背景

In-repo guild substrate を adopt した repo (projector, yori-code) は guild data を `.gate-sessions/` に sandboxed する慣用を取っている:

```
projector/
├── package.json
└── .gate-sessions/
    ├── guild.config.yaml
    ├── members/
    ├── requests/
    ├── issues/
    └── inbox/
```

しかし current `findConfig` は **`<dir>/guild.config.yaml` を root から walk up**するだけで、`.gate-sessions/` 内を見ない:

```ts
const candidate = join(dir, 'guild.config.yaml');  // top-level only
```

→ projector や yori-code の repo cwd で `gate boot` を叩くと:
```
misconfigured_cwd: true
last_activity: null
requests: []   // 既存 request も読めない
```

Eris THS 側 schema review で発見 (2026-05-08 ShareMind session 18 の延長で β-1 として projector を見直し中)。

## 変更

`findConfig` が in-repo `.gate-sessions/` 配置を **先に** check し、無ければ legacy top-level に fallback。

```ts
const inSubdir = join(dir, '.gate-sessions', 'guild.config.yaml');
if (existsSync(inSubdir)) return inSubdir;
const topLevel = join(dir, 'guild.config.yaml');
if (existsSync(topLevel)) return topLevel;
```

`content_root: .` は config file の置き場所からの relative なので、`.gate-sessions/guild.config.yaml` の場合 content_root は `.gate-sessions/` 自身を指す → projector / yori-code の既存 layout (`members/`, `requests/` 等は `.gate-sessions/` 直下) と一致。

## 動作確認

| repo | 修正前 | 修正後 |
|---|---|---|
| `eris-ths/projector` | `misconfigured_cwd=True, last_activity=None` | `role=member, last_activity=2026-05-01T08:32:25` (2026-05-01-0001 request 読める) |
| `eris-ths/yori-code` | `misconfigured_cwd=True` | `misconfigured_cwd=False, last_activity=2026-04-27T10:27:46` |
| `THS data/guild` (top-level) | OK | OK (regression なし) |

## tests

`tests/infrastructure/guildConfigDiscovery.test.ts` に 4 件追加:

1. top-level discovery (legacy)
2. `.gate-sessions/` discovery
3. precedence (`.gate-sessions/` > top-level when both exist)
4. walk-up from nested cwd finds `.gate-sessions/`

すべて pass。pre-existing な 12 件の `/var/` vs `/private/var/` macOS env 失敗は本 PR と無関係 (main HEAD でも fail)。

## why precedence: in-repo > top-level

両方存在する状況は実用上発生しないが、precedence を決めておくと「移行期に top-level を残しつつ `.gate-sessions/` で上書きできる」 ので segment 移行が安全。in-repo convention の方が新しく、containment-friendly (1 ディレクトリで完結) なので preferred.