### PR TITLE
test(darwin): unify path comparison via fs.realpath (#238) — 12 flakes resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **darwin path-comparison flakes in `tests/{interface,passages}/`
+  ([#238](https://github.com/eris-ths/guild-cli/issues/238)).** Twelve
+  tests across `boot`, `doctor`, `register`, and `agora new`/`play`
+  asserted on absolute paths derived from `mkdtempSync(os.tmpdir())`
+  via `new RegExp(escapeRegex(root))`. On macOS, `os.tmpdir()` returns
+  `/var/folders/...` but child processes resolve their cwd through the
+  `/var → /private/var` symlink, so subprocess output names the
+  `/private/var/...` form and the regex `^...$` anchors miss. Fix:
+  wrap `mkdtempSync(...)` results in `realpathSync` at the test
+  bootstrap so the root used in assertions matches what spawned
+  subprocesses emit. Test-infra only — no production code touched.
+
 - **`optionalOption` rejects bare flags (`--depth`, `--executor`,
   `--state`, ... with no value).** Pre-fix, an optional flag passed
   without a value silently fell through to the env fallback / undefined.

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -13,6 +13,7 @@ import {
   writeFileSync,
   rmSync,
   mkdirSync,
+  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -24,7 +25,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), 'guild-boot-'));
+  // realpathSync resolves macOS's /var → /private/var symlink so the
+  // root we use in regex assertions matches what subprocesses see when
+  // they resolve their own cwd. See darwin path-comparison fix (#238).
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-boot-')));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -373,7 +377,8 @@ test('gate boot text: no-config-found case discloses cwd-as-fallback', () => {
   // fallback root)`. The misconfigured_cwd block (no-config + no-
   // data) keeps its bigger warning; this fires for the no-config
   // + has-data case (someone deliberately using cwd as root).
-  const root = mkdtempSync(join(tmpdir(), 'guild-boot-nocfg-'));
+  // realpathSync — see #238 / bootstrap() comment above.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-boot-nocfg-')));
   try {
     // Plant a member so we're past the misconfigured_cwd trigger.
     mkdirSync(join(root, 'members'));

--- a/tests/interface/doctorContentRoot.test.ts
+++ b/tests/interface/doctorContentRoot.test.ts
@@ -28,6 +28,7 @@ import {
   writeFileSync,
   rmSync,
   mkdirSync,
+  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -37,7 +38,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), 'guild-doc-cr-'));
+  // realpathSync resolves macOS's /var → /private/var symlink so the
+  // root we use in regex assertions matches what subprocesses see when
+  // they resolve their own cwd. See darwin path-comparison fix (#238).
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-doc-cr-')));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -108,7 +112,8 @@ test('doctor text: no-config-found case discloses cwd-as-fallback (totals > 0)',
   // cwd as implicit content_root (no parent config) gets the
   // `(config: none — cwd used as fallback root)` segment naming
   // the implicit default.
-  const root = mkdtempSync(join(tmpdir(), 'guild-doc-cr-nocfg-'));
+  // realpathSync — see #238 / bootstrap() comment above.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-doc-cr-nocfg-')));
   try {
     mkdirSync(join(root, 'members'));
     writeFileSync(

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -16,6 +16,7 @@ import {
   existsSync,
   rmSync,
   mkdirSync,
+  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -25,7 +26,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), 'guild-register-'));
+  // realpathSync resolves macOS's /var → /private/var symlink so the
+  // root we use in regex assertions matches what subprocesses see when
+  // they resolve their own cwd. See darwin path-comparison fix (#238).
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-register-')));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -432,7 +436,8 @@ test('register: no-config fallback path surfaces "config: none" so the implicit-
   // used as content_root with no warning. Post-fix the notice
   // names it (`config: none — cwd used as fallback root`) so the
   // agent learns the implicit default exists.
-  const root = mkdtempSync(join(tmpdir(), 'guild-register-nocfg-'));
+  // realpathSync — see #238 / bootstrap() comment above.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-register-nocfg-')));
   try {
     const r = runGate(root, ['register', '--name', 'cwdsolo']);
     assert.equal(r.status, 0);

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -23,6 +23,7 @@ import {
   rmSync,
   mkdirSync,
   existsSync,
+  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -36,7 +37,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const AGORA = resolve(here, '../../../../bin/agora.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), 'agora-new-'));
+  // realpathSync resolves macOS's /var → /private/var symlink so the
+  // root we use in regex assertions matches what subprocesses see when
+  // they resolve their own cwd. See darwin path-comparison fix (#238).
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'agora-new-')));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',

--- a/tests/passages/agora/play.test.ts
+++ b/tests/passages/agora/play.test.ts
@@ -23,6 +23,7 @@ import {
   mkdirSync,
   existsSync,
   readdirSync,
+  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -32,7 +33,10 @@ const here = dirname(fileURLToPath(import.meta.url));
 const AGORA = resolve(here, '../../../../bin/agora.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  const root = mkdtempSync(join(tmpdir(), 'agora-play-'));
+  // realpathSync resolves macOS's /var → /private/var symlink so the
+  // root we use in regex assertions matches what subprocesses see when
+  // they resolve their own cwd. See darwin path-comparison fix (#238).
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'agora-play-')));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',


### PR DESCRIPTION
## Summary

Closes #238. Resolves 12 darwin (macOS) test failures caused by `/var/folders/...` (raw `os.tmpdir()`) vs `/private/var/folders/...` (symlink-resolved subprocess output) mismatch.

## Approach

Normalize at the entry point: each `bootstrap()` (and 2 inline `mkdtempSync` callers) now wraps the temp dir in `realpathSync()`. Every downstream `escapeRegex(root)` / `join(root, ...)` then matches subprocess output naturally — single source-of-truth for the canonical path.

## Touched (test infra only, `src/**` untouched)

- `tests/interface/boot.test.ts`
- `tests/interface/doctorContentRoot.test.ts`
- `tests/interface/register.test.ts`
- `tests/passages/agora/new.test.ts`
- `tests/passages/agora/play.test.ts`
- `CHANGELOG.md` — Unreleased > Fixed entry

## Result

`npm test`: **1200/1212 → 1212/1212 pass**. No regression elsewhere; prod code unchanged.

## Follow-up (deferred to separate issue)

The verifier (Asteria) noted: future test authors writing `mkdtempSync` directly without wrapping in `realpathSync` could regress this. Root-cause options:

- (a) shared `makeTempRoot()` helper that ships realpath built-in
- (b) ESLint custom rule warning on raw `mkdtempSync` in tests/

To be filed as a follow-up issue (not in this PR's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Asteria (SubAgent) <noreply@anthropic.com>