### PR TITLE
feat(gate): enforce worktree isolation for parallel waves under profile: swarm (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Added
+
+- **Worktree isolation enforcement for parallel waves under
+  `profile: swarm` ([#231](https://github.com/eris-ths/guild-cli/issues/231)).**
+  Filesystem-layer guard for the substrate-experiment-6 race that sits
+  one layer below the multi-executor record fix (#230). New
+  `guild.config.yaml` keys: `profile: standard | swarm` and
+  `features.worktree_required_for_parallel`. Under `profile: swarm`,
+  `gate request --executors a,b,...` stamps
+  `requires_worktree_isolation: true` on the record, and `gate execute`
+  refuses a second invocation from the same filesystem cwd against the
+  same target — the operator must spawn the second executor in a
+  separate git worktree. New `gate execute --cwd <path>` flag (defaults
+  to `process.cwd()`) + `executing_at_cwd` stamp on the `executing`
+  status_log entry. Pre-#231 records hydrate as non-isolated (no
+  false-refuse). Under `profile: standard` the same input emits a
+  warning notice but does not refuse, preserving existing single-cwd
+  workflows.
+
 ### Fixed
 
 - **darwin path-comparison flakes in `tests/{interface,passages}/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,31 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   `features.worktree_required_for_parallel`. Under `profile: swarm`,
   `gate request --executors a,b,...` stamps
   `requires_worktree_isolation: true` on the record, and `gate execute`
-  refuses a second invocation from the same filesystem cwd against the
+  refuses a second invocation from the same physical cwd against the
   same target — the operator must spawn the second executor in a
   separate git worktree. New `gate execute --cwd <path>` flag (defaults
   to `process.cwd()`) + `executing_at_cwd` stamp on the `executing`
-  status_log entry. Pre-#231 records hydrate as non-isolated (no
-  false-refuse). Under `profile: standard` the same input emits a
-  warning notice but does not refuse, preserving existing single-cwd
-  workflows.
+  status_log entry. Both the supplied cwd and the on-disk peer values
+  are canonicalised via `realpath` so symlink farms (`/var/X` vs
+  `/private/var/X` on darwin tmpdir, etc.) collapse to a single
+  identity for the comparison. Pre-#231 records hydrate as
+  non-isolated (no false-refuse). Under `profile: standard` the same
+  input emits a warning notice but does not refuse, preserving
+  existing single-cwd workflows.
+
+  **Best-effort race window (Devil HIGH-2 follow-up).** The collision
+  check is a peer scan → judgment → save sequence. The optimistic-lock
+  in `YamlRequestRepository.save` only guards same-request concurrent
+  writes; it does NOT serialize judgments across peer aggregates. Two
+  `gate execute` invocations against *different* request ids sharing a
+  `target` + cwd can both pass the scan before either lands. A
+  cross-process advisory lock (e.g. `<root>/requests/.execute.lock`)
+  is the structural fix and is scoped out of this wave — cross-platform
+  locking has its own design surface (Windows `LockFile`, NFS quirks,
+  stale-lock recovery) and belongs in a follow-up issue. Until then,
+  the record + agent-loop layers (#230) carry the actual safety; #231
+  closes the read-the-screen-and-recognise-the-collision class, not
+  the microsecond-window race.
 
 ### Fixed
 

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -59,6 +59,10 @@ export class RequestUseCases {
      *  promote`). Tool-generated structured link surviving any
      *  --action / --reason overrides. */
     promotedFrom?: string;
+    /** Worktree-isolation flag (#231). Set by the interface layer
+     *  when profile=swarm + executors.length > 1. Persisted only
+     *  when true; absence reads as false. */
+    requiresWorktreeIsolation?: boolean;
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -116,6 +120,8 @@ export class RequestUseCases {
     if (input.invokedBy !== undefined) createArgs.invokedBy = input.invokedBy;
     if (input.promotedFrom !== undefined)
       createArgs.promotedFrom = input.promotedFrom;
+    if (input.requiresWorktreeIsolation === true)
+      createArgs.requiresWorktreeIsolation = true;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);
@@ -192,11 +198,16 @@ export class RequestUseCases {
     by: string,
     note?: string,
     invokedBy?: string,
-    opts?: { dryRun?: boolean },
+    opts?: { dryRun?: boolean; cwd?: string },
   ): Promise<Request> {
     const req = await this.loadOrThrow(id);
     const actor = await assertActor(by, '--by', this.deps.members);
-    req.execute(actor, note, invokedBy);
+    // cwd lands on the status_log entry only when supplied. The
+    // worktree-isolation collision check (#231) lives in the
+    // interface layer (it needs to read peer requests across
+    // states); the use case is the persistence path for the cwd
+    // stamp itself.
+    req.execute(actor, note, invokedBy, opts?.cwd);
     if (!opts?.dryRun) await this.deps.requests.save(req);
     return req;
   }

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -350,7 +350,13 @@ export class Request {
    *  record predates #231). Returns the freshest entry so a request
    *  that re-entered `executing` (rare but possible after a `fail`-
    *  retry edit path) reflects the latest filesystem. Read by the
-   *  gate execute cwd-collision check. */
+   *  gate execute cwd-collision check.
+   *
+   *  TODO (Devil follow-up #231): same shape as the executor scalar
+   *  leak Devil flagged on #230 — a "latest-only" getter silently
+   *  drops history. Promote to `hasExecutingFromCwd(cwd)` predicate
+   *  in a follow-up issue once we settle whether older `executing`
+   *  entries should ever count for collision detection. */
   get lastExecutingCwd(): string | undefined {
     for (let i = this.props.statusLog.length - 1; i >= 0; i--) {
       const entry = this.props.statusLog[i]!;

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -31,6 +31,17 @@ export interface StatusLogEntry {
    * (the common case, so existing records stay byte-identical).
    */
   invokedBy?: string;
+  /**
+   * Filesystem cwd at which this transition was issued. Stamped on
+   * `executing` entries when a `cwd` is supplied, so the worktree-
+   * isolation check (issue #231) can compare two parallel executors'
+   * filesystems and refuse the second when they collide. Persisted
+   * as `executing_at_cwd` to keep the field name self-documenting in
+   * YAML — it's the path that was current at execute time, not a
+   * generic "cwd of any actor". Absent on every non-execute entry
+   * and on pre-#231 records.
+   */
+  executingAtCwd?: string;
 }
 
 export interface RequestProps {
@@ -83,6 +94,18 @@ export interface RequestProps {
    * other tool-generated relationship fields (executor, autoReview).
    */
   promotedFrom?: string;
+  /**
+   * Worktree-isolation requirement (issue #231). When true, parallel
+   * `gate execute` invocations on the same target from the SAME
+   * filesystem cwd are refused — the second `execute` errors out so
+   * the operator can spawn each agent in its own git worktree before
+   * retrying. Filesystem-layer guard for the substrate-experiment-6
+   * race that sits one layer below the multi-executor record fix
+   * (#230). Set at request-creation time when the `swarm` profile
+   * sees `executors.length > 1`; absent (= false) on every other
+   * record, including all pre-#231 history.
+   */
+  requiresWorktreeIsolation?: boolean;
   state: RequestState;
   createdAt: string;
   reviews: Review[];
@@ -150,6 +173,12 @@ export class Request {
     /** See RequestProps.promotedFrom — issue id this request was
      *  promoted from. Populated by `gate issues promote` only. */
     promotedFrom?: string;
+    /** See RequestProps.requiresWorktreeIsolation — set by the
+     *  interface layer when profile=swarm + executors.length > 1.
+     *  Persisted as `requires_worktree_isolation: true` only when
+     *  truthy; older / single-executor / standard-profile records
+     *  carry no field at all (false-by-absence). Issue #231. */
+    requiresWorktreeIsolation?: boolean;
   }): Request {
     const from = MemberName.of(input.from);
     const action = sanitizeText(input.action, 'action');
@@ -241,6 +270,13 @@ export class Request {
     if (input.promotedFrom !== undefined) {
       props.promotedFrom = input.promotedFrom;
     }
+    // Worktree-isolation: persist only when explicitly true. The
+    // false case is represented by field absence on disk so the YAML
+    // surface stays minimal (matches `depth`, `with`, `target` etc).
+    // Issue #231.
+    if (input.requiresWorktreeIsolation === true) {
+      props.requiresWorktreeIsolation = true;
+    }
     // New requests have no on-disk predecessor; loadedVersion=0 marks
     // "never seen" for the optimistic-lock check in save().
     return new Request(props, 0);
@@ -301,6 +337,29 @@ export class Request {
   get with(): readonly MemberName[] {
     return this.props.with ?? [];
   }
+  /** Issue #231 — true when the request was created under
+   *  profile=swarm with multiple executors and so demands per-cwd
+   *  isolation at execute time. False (or absent) on every other
+   *  record, including all pre-#231 history. Read surface used by
+   *  the gate execute handler to gate the cwd-collision check. */
+  get requiresWorktreeIsolation(): boolean {
+    return this.props.requiresWorktreeIsolation === true;
+  }
+  /** Most recent `executing` status_log entry's cwd, or undefined
+   *  when the request has never been executed (or when the on-disk
+   *  record predates #231). Returns the freshest entry so a request
+   *  that re-entered `executing` (rare but possible after a `fail`-
+   *  retry edit path) reflects the latest filesystem. Read by the
+   *  gate execute cwd-collision check. */
+  get lastExecutingCwd(): string | undefined {
+    for (let i = this.props.statusLog.length - 1; i >= 0; i--) {
+      const entry = this.props.statusLog[i]!;
+      if (entry.state === 'executing' && entry.executingAtCwd !== undefined) {
+        return entry.executingAtCwd;
+      }
+    }
+    return undefined;
+  }
   get action(): string {
     return this.props.action;
   }
@@ -342,8 +401,16 @@ export class Request {
     this.transition('denied', by, reason, invokedBy);
   }
 
-  execute(by: MemberName, note?: string, invokedBy?: string): void {
-    this.transition('executing', by, note, invokedBy);
+  execute(
+    by: MemberName,
+    note?: string,
+    invokedBy?: string,
+    cwd?: string,
+  ): void {
+    // cwd lands on the status_log entry only when supplied; the
+    // common (#231-unaware) call path keeps emitting byte-identical
+    // YAML.
+    this.transition('executing', by, note, invokedBy, cwd);
   }
 
   complete(by: MemberName, note?: string, invokedBy?: string): void {
@@ -385,6 +452,7 @@ export class Request {
     by: MemberName,
     note?: string,
     invokedBy?: string,
+    cwd?: string,
   ): void {
     assertTransition(this.props.state, to);
     this.props.state = to;
@@ -407,6 +475,13 @@ export class Request {
     // YAML with redundant fields.
     if (invokedBy !== undefined && invokedBy !== by.value) {
       entry.invokedBy = invokedBy;
+    }
+    // cwd is meaningful only on `executing` entries: it's what the
+    // worktree-isolation check (#231) compares across parallel
+    // executors. Stamping cwd on approve/complete/fail would just
+    // bloat the log without giving the check anything to read.
+    if (to === 'executing' && cwd !== undefined && cwd.length > 0) {
+      entry.executingAtCwd = cwd;
     }
     this.props.statusLog.push(entry);
   }
@@ -458,6 +533,12 @@ export class Request {
       out['with'] = this.props.with.map((m) => m.value);
     if (this.props.promotedFrom !== undefined)
       out['promoted_from'] = this.props.promotedFrom;
+    // Worktree isolation requirement (#231). Surface only when true —
+    // the YAML stays minimal and pre-#231 records remain byte-stable
+    // on round-trip (false-by-absence is the load tolerance).
+    if (this.props.requiresWorktreeIsolation === true) {
+      out['requires_worktree_isolation'] = true;
+    }
     // Derive legacy closure keys from the last status_log entry so
     // external consumers (chain / voices / show --format text) keep
     // working unchanged. Single source of truth: status_log[-1].note.
@@ -507,6 +588,7 @@ function statusLogEntryToJSON(e: StatusLogEntry): Record<string, unknown> {
   };
   if (e.note !== undefined) out['note'] = e.note;
   if (e.invokedBy !== undefined) out['invoked_by'] = e.invokedBy;
+  if (e.executingAtCwd !== undefined) out['executing_at_cwd'] = e.executingAtCwd;
   return out;
 }
 

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -22,6 +22,29 @@ export const defaultOnMalformed: OnMalformed = (source, msg) => {
   process.stderr.write(`warn: ${source}: ${msg}\n`);
 };
 
+/**
+ * Guild profile (#231). `standard` is the default, single-machine /
+ * single-cwd workflow. `swarm` is a stricter mode that enforces per-
+ * cwd isolation for parallel waves — its primary effect is to default
+ * `features.worktree_required_for_parallel` to true. Profiles are
+ * intentionally coarse: a small set of named presets reads better in
+ * `guild.config.yaml` than a sprawl of per-feature booleans, and most
+ * deployments fall cleanly into one bucket or the other.
+ */
+export type GuildProfile = 'standard' | 'swarm';
+
+export interface GuildFeatures {
+  /**
+   * When true, parallel waves (multi-executor requests) carry a
+   * `requires_worktree_isolation: true` flag, and `gate execute`
+   * refuses a second concurrent invocation from the same filesystem
+   * cwd. Defaults to false under profile=standard, true under
+   * profile=swarm — the explicit feature key lets a deployment opt
+   * in/out without flipping the whole profile.
+   */
+  worktreeRequiredForParallel: boolean;
+}
+
 export interface GuildConfigProps {
   root: string;
   contentRoot: string;
@@ -34,6 +57,8 @@ export interface GuildConfigProps {
   hostNames: readonly string[];
   lenses: readonly string[];
   doctorPlugins: readonly string[];
+  profile: GuildProfile;
+  features: GuildFeatures;
   onMalformed: OnMalformed;
 }
 
@@ -53,6 +78,8 @@ export class GuildConfig implements GuildConfigProps {
     readonly hostNames: readonly string[],
     readonly lenses: readonly string[],
     readonly doctorPlugins: readonly string[],
+    readonly profile: GuildProfile,
+    readonly features: GuildFeatures,
     readonly onMalformed: OnMalformed,
     /**
      * Absolute path to the `guild.config.yaml` that produced this
@@ -110,7 +137,35 @@ export class GuildConfig implements GuildConfigProps {
           'Add `trusted: true` under `doctor:` in guild.config.yaml to enable.',
       );
     }
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, onMalformed, configPath);
+    // Profile + features (#231). The two interact: `profile: swarm`
+    // flips the default of `features.worktree_required_for_parallel`
+    // to true, but an explicit `features:` block always wins so a
+    // deployment can opt in/out without changing profile. Unknown
+    // profile values fall back to 'standard' with an onMalformed
+    // notice — same conservative read pattern other optional fields
+    // use (per principle 04, records / configs outlive writers).
+    let profile: GuildProfile = 'standard';
+    if (typeof raw.profile === 'string') {
+      if (raw.profile === 'standard' || raw.profile === 'swarm') {
+        profile = raw.profile;
+      } else {
+        onMalformed(
+          configPath,
+          `unknown profile "${raw.profile}" — falling back to 'standard'. ` +
+            `Valid: standard | swarm.`,
+        );
+      }
+    }
+    const featuresRaw = raw.features ?? {};
+    const explicitWorktreeRequired =
+      typeof featuresRaw.worktree_required_for_parallel === 'boolean'
+        ? featuresRaw.worktree_required_for_parallel
+        : undefined;
+    const features: GuildFeatures = {
+      worktreeRequiredForParallel:
+        explicitWorktreeRequired ?? (profile === 'swarm'),
+    };
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, profile, features, onMalformed, configPath);
   }
 
   static default(
@@ -130,6 +185,8 @@ export class GuildConfig implements GuildConfigProps {
       [...DEFAULT_HOSTS],
       [...DEFAULT_LENSES],
       [],
+      'standard',
+      { worktreeRequiredForParallel: false },
       onMalformed,
       null,
     );

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -410,6 +410,10 @@ function hydrate(
         if (typeof so['note'] === 'string') entry.note = so['note'] as string;
         if (typeof so['invoked_by'] === 'string')
           entry.invokedBy = so['invoked_by'] as string;
+        // executing_at_cwd (#231): hydrated only when present and a
+        // non-empty string. Pre-#231 entries simply lack the field.
+        if (typeof so['executing_at_cwd'] === 'string' && so['executing_at_cwd'].length > 0)
+          entry.executingAtCwd = so['executing_at_cwd'] as string;
         statusLog.push(entry);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -516,6 +520,14 @@ function hydrate(
     }
     if (typeof obj['promoted_from'] === 'string') {
       props.promotedFrom = obj['promoted_from'] as string;
+    }
+    // requires_worktree_isolation (#231). Tolerated as a strict boolean
+    // only — anything else (string "true", number 1) is dropped silently
+    // following the same conservative read pattern as `depth`. Pre-#231
+    // records simply lack the field; treated as false. Records-outlive-
+    // writers (principle 04): we never reject, only ignore.
+    if (obj['requires_worktree_isolation'] === true) {
+      props.requiresWorktreeIsolation = true;
     }
     // Legacy top-level closure keys (completion_note / deny_reason /
     // failure_reason) are no longer written separately — status_log[-1].note

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -1,3 +1,4 @@
+import { resolve as resolvePath } from 'node:path';
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
@@ -40,6 +41,7 @@ const DENY_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 const EXECUTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
   'note',
+  'cwd',
   'dry-run',
   'format',
 ]);
@@ -142,6 +144,28 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   }
   if (executor !== undefined) input.executor = executor;
   if (target !== undefined) input.target = target;
+  // Worktree-isolation gating (#231). Two effects, both keyed on
+  // "is this a parallel wave?" (executors.length > 1):
+  //   - profile=swarm  → stamp `requires_worktree_isolation: true`
+  //                       so `gate execute` later refuses a same-cwd
+  //                       collision (filesystem-layer guard).
+  //   - profile=standard → emit a warning notice (no stamp).
+  // Single-executor requests are never gated, regardless of profile —
+  // there is no race to gate against.
+  const parallelExecutors =
+    Array.isArray(input.executors) && input.executors.length > 1;
+  if (parallelExecutors) {
+    if (c.config.features.worktreeRequiredForParallel) {
+      input.requiresWorktreeIsolation = true;
+    } else {
+      process.stderr.write(
+        `notice: parallel executors (${input.executors!.length}) under ` +
+          `profile=${c.config.profile} — same-cwd collisions are NOT refused. ` +
+          `Set 'profile: swarm' (or 'features.worktree_required_for_parallel: true') ` +
+          `in guild.config.yaml to enforce per-cwd isolation.\n`,
+      );
+    }
+  }
   // depth (issue #221): pre-check at the interface boundary so the
   // caller sees a flag-shaped error before the domain layer fires.
   // The advisory framing — 'shallow ⇒ surface point-check, deep ⇒
@@ -620,19 +644,63 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
 export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, EXECUTE_KNOWN_FLAGS, 'execute');
   const id = args.positional[0];
-  if (!id) throw new Error('Usage: gate execute <id> --by <m> [--dry-run]');
+  if (!id)
+    throw new Error('Usage: gate execute <id> --by <m> [--cwd <path>] [--dry-run]');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
   const note = optionalOption(args, 'note');
+  // --cwd lets a caller declare "I'm running from THIS filesystem"
+  // explicitly. Defaults to process.cwd() because every real call
+  // path already runs from the agent's worktree; the override exists
+  // mainly for tests (which spawn a subprocess and want to assert
+  // the cwd-collision check fires deterministically) and for tools
+  // that proxy the verb without changing process directories.
+  // Issue #231.
+  const cwdFlag = optionalOption(args, 'cwd');
+  const cwd = cwdFlag !== undefined ? resolvePath(cwdFlag) : process.cwd();
   const invokedBy = resolveInvokedBy(by, 'execute', id);
+
+  // Worktree-isolation collision check (#231). Runs only for
+  // requests that were stamped at creation time (profile=swarm +
+  // executors > 1). The check is best-effort, not transactional:
+  //   1. Load the target request.
+  //   2. Find every OTHER request with the same `target` whose state
+  //      is `executing`.
+  //   3. If any of them last entered `executing` from THIS cwd,
+  //      refuse — the operator must spawn a separate worktree.
+  // Race window between this check and the save() inside
+  // requestUC.execute is intentional: filesystem layer is one of
+  // three race-mitigations (record + agent loop + filesystem), and
+  // the optimistic-lock in YamlRequestRepository.save catches any
+  // residual collision at the *record* layer.
+  const target = await c.requestUC.show(id);
+  if (target && target.requiresWorktreeIsolation && target.target !== undefined) {
+    const peers = await c.requestUC.listByState('executing');
+    for (const peer of peers) {
+      if (peer.id.value === id) continue;
+      if (peer.target !== target.target) continue;
+      const peerCwd = peer.lastExecutingCwd;
+      if (peerCwd !== undefined && peerCwd === cwd) {
+        process.stderr.write(
+          `error: refusing to execute ${id} from cwd=${cwd}: ` +
+            `peer request ${peer.id.value} (target=${peer.target}) is already ` +
+            `executing from the same filesystem. This wave was created with ` +
+            `requires_worktree_isolation=true (profile=swarm); ` +
+            `spawn this executor in a separate git worktree and retry.\n`,
+        );
+        return 1;
+      }
+    }
+  }
+
   if (isDryRun(args)) {
     const prior = await c.requestUC.show(id);
     if (!prior) throw new Error(`Request not found: ${id}`);
     const fromState = prior.state;
-    const r = await c.requestUC.execute(id, by, note, invokedBy, { dryRun: true });
+    const r = await c.requestUC.execute(id, by, note, invokedBy, { dryRun: true, cwd });
     emitDryRunPreview({ verb: 'execute', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
-  const r = await c.requestUC.execute(id, by, note, invokedBy);
+  const r = await c.requestUC.execute(id, by, note, invokedBy, { cwd });
   // `--executor` / `--executors` is informational, not access
   // control: the substrate records both the assignment and the actual
   // actor, but does not refuse a mismatched execute. Surface a notice

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -1,4 +1,5 @@
 import { resolve as resolvePath } from 'node:path';
+import { realpathSync } from 'node:fs';
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import {
   ParsedArgs,
@@ -656,7 +657,25 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   // that proxy the verb without changing process directories.
   // Issue #231.
   const cwdFlag = optionalOption(args, 'cwd');
-  const cwd = cwdFlag !== undefined ? resolvePath(cwdFlag) : process.cwd();
+  // Canonicalize via realpath so symlink farms collapse to a single
+  // identity. Devil HIGH-1 (#231 follow-up): plain `path.resolve`
+  // leaves `/var/foo` and `/private/var/foo` distinct strings even
+  // though they name the same physical directory — on darwin the
+  // tmpdir is the canonical example. The collision check compares
+  // against `peer.lastExecutingCwd` which was ALSO realpath'd at
+  // write time below, so equality reflects "same physical worktree"
+  // and not "same string". Falls back to the resolved (un-canonical)
+  // path on EACCES / ENOENT so a missing parent doesn't crash a
+  // legitimate execute — the comparison is best-effort by design
+  // (race window noted in CHANGELOG; advisory lock is follow-up).
+  const cwdResolved =
+    cwdFlag !== undefined ? resolvePath(cwdFlag) : process.cwd();
+  let cwd: string;
+  try {
+    cwd = realpathSync(cwdResolved);
+  } catch {
+    cwd = cwdResolved;
+  }
   const invokedBy = resolveInvokedBy(by, 'execute', id);
 
   // Worktree-isolation collision check (#231). Runs only for

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -829,6 +829,11 @@ const VERBS: readonly VerbSchema[] = [
         id: idStr,
         by: str,
         note: str,
+        cwd: {
+          type: 'string',
+          description:
+            'filesystem cwd at which this execute is issued; defaults to process.cwd(). Stamped on the status_log entry as executing_at_cwd, and used by the worktree-isolation check (issue #231) when the request was created with requires_worktree_isolation=true. Same-cwd peer in `executing` → refused.',
+        },
         format: formatField,
         'dry-run': dryRunField,
       },

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -762,7 +762,10 @@ const VERBS: readonly VerbSchema[] = [
             'e.g. "miki, leysia" or "miki,leysia" (issue #230, ' +
             'multi-executor; mutually exclusive with --executor). Each name ' +
             'must match /^[a-z][a-z0-9_-]{0,31}$/; duplicates and empty ' +
-            'entries rejected.',
+            'entries rejected. Under profile=swarm, supplying >1 executor ' +
+            'auto-stamps requires_worktree_isolation: true on the record so ' +
+            'a later `gate execute` from the same physical cwd is refused ' +
+            '(issue #231).',
         ),
         target: str,
         depth: {

--- a/tests/domain/Request.test.ts
+++ b/tests/domain/Request.test.ts
@@ -309,6 +309,67 @@ test('Request.toJSON: emits executors array (multi)', () => {
   assert.deepEqual(r.toJSON()['executors'], ['miki', 'leysia']);
 });
 
+// Issue #231 — worktree-isolation domain round-trip. The flag is set
+// at create time and surfaces only when truthy; the cwd lives on the
+// `executing` status_log entry. These tests pin both the persistence
+// shape (toJSON / statusLogEntry serialiser) and the read accessors
+// (`requiresWorktreeIsolation`, `lastExecutingCwd`) the interface layer
+// reads to gate the cwd-collision check.
+test('Request: requires_worktree_isolation round-trip (#231)', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    executors: ['miki', 'leysia'],
+    requiresWorktreeIsolation: true,
+  });
+  assert.equal(r.requiresWorktreeIsolation, true);
+  assert.equal(r.toJSON()['requires_worktree_isolation'], true);
+});
+
+test('Request: requires_worktree_isolation absent when not set (default false)', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    executors: ['miki'],
+  });
+  assert.equal(r.requiresWorktreeIsolation, false);
+  assert.equal(r.toJSON()['requires_worktree_isolation'], undefined);
+});
+
+test('Request.execute(cwd): stamps executing_at_cwd on the status_log entry', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    executor: 'miki',
+  });
+  r.approve(MemberName.of('alice'));
+  r.execute(MemberName.of('miki'), undefined, undefined, '/tmp/worktree-A');
+  assert.equal(r.lastExecutingCwd, '/tmp/worktree-A');
+  const last = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal(last[last.length - 1]!['executing_at_cwd'], '/tmp/worktree-A');
+});
+
+test('Request.execute(): no cwd → executing_at_cwd absent (back-compat)', () => {
+  const r = Request.create({
+    id: RequestId.generate(d, 1),
+    from: 'alice',
+    action: 'a',
+    reason: 'r',
+    executor: 'miki',
+  });
+  r.approve(MemberName.of('alice'));
+  r.execute(MemberName.of('miki'));
+  assert.equal(r.lastExecutingCwd, undefined);
+  const log = r.toJSON()['status_log'] as Array<Record<string, unknown>>;
+  assert.equal(log[log.length - 1]!['executing_at_cwd'], undefined);
+});
+
 test('Request.toJSON: omits executors key when none assigned', () => {
   const r = Request.create({
     id: RequestId.generate(d, 1),

--- a/tests/interface/worktreeIsolation.test.ts
+++ b/tests/interface/worktreeIsolation.test.ts
@@ -1,0 +1,363 @@
+// Worktree-isolation enforcement (issue #231).
+//
+// Filesystem-layer guard for the substrate-experiment-6 race: two
+// SubAgents started under the same cwd let the first-committer's
+// `git add` scoop the second's uncommitted files, destroying
+// attribution. The record-layer fix (#230, multi-executor) keeps the
+// substrate honest about who was assigned. This wave keeps the
+// FILESYSTEM honest about who is currently writing.
+//
+// Surface contract verified here:
+//   - profile=standard + parallel executors + same cwd → warning notice,
+//     execute is allowed (records-outlive-writers / no enforcement)
+//   - profile=swarm    + parallel executors + same cwd → second execute
+//     refused with exit 1 and an actionable error
+//   - profile=swarm    + parallel executors + different cwds → both pass
+//   - profile=swarm    + single executor → no constraint (no race to gate)
+//   - hydrate tolerance: a request without the new field reads as
+//     non-isolated (no false-refuse on legacy records)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Bootstrap {
+  root: string;
+  cleanup: () => void;
+}
+
+function bootstrap(profile: 'standard' | 'swarm'): Bootstrap {
+  const root = mkdtempSync(join(tmpdir(), `guild-wti-${profile}-`));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    `content_root: .\nhost_names: [eris]\nprofile: ${profile}\n`,
+  );
+  mkdirSync(join(root, 'members'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  actor?: string,
+): { stdout: string; stderr: string; status: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (actor !== undefined) env['GUILD_ACTOR'] = actor;
+  else delete env['GUILD_ACTOR'];
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function registerAll(root: string, names: string[]): void {
+  for (const n of names) {
+    run(root, ['register', '--name', n]);
+  }
+}
+
+// Create + approve in a single helper so the table tests below stay
+// readable. Returns the freshly approved request id.
+function createApproved(
+  root: string,
+  args: { from: string; executors: string[]; target: string },
+): string {
+  const r = run(root, [
+    'request',
+    '--from',
+    args.from,
+    '--action',
+    'wave work',
+    '--reason',
+    'parallel impl',
+    '--executors',
+    args.executors.join(','),
+    '--target',
+    args.target,
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+  const ap = run(root, ['approve', id, '--by', args.from]);
+  assert.equal(ap.status, 0, `approve failed: ${ap.stderr}`);
+  return id;
+}
+
+test('profile=standard + parallel executors + same cwd: warns, both execute', (t) => {
+  const { root, cleanup } = bootstrap('standard');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  // Two SEPARATE requests on the same target — substrate-experiment 6
+  // shape: a wave fanned out across multiple executors, each on its
+  // own request id. Standard profile must warn but not refuse.
+  const id1 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+  const id2 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+
+  const e1 = run(root, ['execute', id1, '--by', 'miki', '--cwd', root]);
+  assert.equal(e1.status, 0, `execute1 failed: ${e1.stderr}`);
+  const e2 = run(root, ['execute', id2, '--by', 'leysia', '--cwd', root]);
+  assert.equal(
+    e2.status,
+    0,
+    `execute2 should pass under profile=standard but failed: ${e2.stderr}`,
+  );
+});
+
+test('profile=standard + parallel executors: request emits a warning notice on stderr', (t) => {
+  const { root, cleanup } = bootstrap('standard');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'parallel work',
+    '--reason',
+    'r',
+    '--executors',
+    'miki,leysia',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  // Notice mentions both the profile and the explicit feature key so a
+  // reader knows exactly what to flip in guild.config.yaml.
+  assert.match(r.stderr, /profile=standard/);
+  assert.match(r.stderr, /worktree_required_for_parallel/);
+});
+
+test('profile=swarm + parallel executors + same cwd: second execute refused', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const id1 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+  const id2 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+
+  const e1 = run(root, ['execute', id1, '--by', 'miki', '--cwd', root]);
+  assert.equal(e1.status, 0, `first execute should succeed: ${e1.stderr}`);
+
+  const e2 = run(root, ['execute', id2, '--by', 'leysia', '--cwd', root]);
+  assert.equal(
+    e2.status,
+    1,
+    `second execute should refuse but exited ${e2.status}: ${e2.stderr}`,
+  );
+  assert.match(e2.stderr, /refusing to execute/);
+  assert.match(e2.stderr, /requires_worktree_isolation/);
+});
+
+test('profile=swarm + parallel executors + DIFFERENT cwds: both execute', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const id1 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+  const id2 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+
+  // Simulate separate worktrees by passing different --cwd values.
+  // The collision check compares the resolved absolute paths, so any
+  // two distinct directories suffice.
+  const wt1 = mkdtempSync(join(tmpdir(), 'wti-wt1-'));
+  const wt2 = mkdtempSync(join(tmpdir(), 'wti-wt2-'));
+  t.after(() => {
+    rmSync(wt1, { recursive: true, force: true });
+    rmSync(wt2, { recursive: true, force: true });
+  });
+
+  const e1 = run(root, ['execute', id1, '--by', 'miki', '--cwd', wt1]);
+  assert.equal(e1.status, 0, `execute1 failed: ${e1.stderr}`);
+  const e2 = run(root, ['execute', id2, '--by', 'leysia', '--cwd', wt2]);
+  assert.equal(
+    e2.status,
+    0,
+    `different-cwd execute should succeed: ${e2.stderr}`,
+  );
+});
+
+test('profile=swarm + single executor: requires_worktree_isolation NOT set, no constraint', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki']);
+
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'solo work',
+    '--reason',
+    'r',
+    '--executor',
+    'miki',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+
+  // Verify the on-disk record carries no isolation flag — a singleton
+  // wave has no race to gate, so the field should be absent.
+  const showJson = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(showJson.stdout) as Record<string, unknown>;
+  assert.equal(
+    payload['requires_worktree_isolation'],
+    undefined,
+    'single-executor should not stamp the flag',
+  );
+});
+
+test('profile=swarm + parallel: persisted record carries requires_worktree_isolation: true', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'wave',
+    '--reason',
+    'r',
+    '--executors',
+    'miki,leysia',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+
+  const showJson = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(showJson.stdout) as Record<string, unknown>;
+  assert.equal(payload['requires_worktree_isolation'], true);
+});
+
+test('hydrate tolerance: a record without the field loads as non-isolated (no false-refuse)', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki']);
+
+  // Hand-write a pre-#231 shaped pending file and make sure execute
+  // does NOT spuriously refuse it. The field is simply absent.
+  const pendingDir = join(root, 'requests', 'pending');
+  mkdirSync(pendingDir, { recursive: true });
+  const id = '2026-04-14-0001';
+  const yaml = [
+    `id: ${id}`,
+    'from: alice',
+    'action: legacy work',
+    'reason: pre-#231 record',
+    'state: pending',
+    'created_at: 2026-04-14T00:00:00.000Z',
+    'executors:',
+    '  - miki',
+    'status_log:',
+    '  - state: pending',
+    '    by: alice',
+    '    at: 2026-04-14T00:00:00.000Z',
+    '    note: created',
+    'reviews: []',
+    '',
+  ].join('\n');
+  writeFileSync(join(pendingDir, `${id}.yaml`), yaml);
+
+  // Approve then execute — neither path should refuse the legacy
+  // record despite running under profile=swarm.
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  assert.equal(ap.status, 0, `approve failed: ${ap.stderr}`);
+  const ex = run(root, ['execute', id, '--by', 'miki', '--cwd', root]);
+  assert.equal(
+    ex.status,
+    0,
+    `legacy record should execute without refusal: ${ex.stderr}`,
+  );
+});
+
+test('execute --cwd stamps executing_at_cwd into the status_log entry', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki']);
+
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'work',
+    '--reason',
+    'r',
+    '--executor',
+    'miki',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+  run(root, ['approve', id, '--by', 'alice']);
+
+  const wt = mkdtempSync(join(tmpdir(), 'wti-stamp-'));
+  t.after(() => rmSync(wt, { recursive: true, force: true }));
+  const ex = run(root, ['execute', id, '--by', 'miki', '--cwd', wt]);
+  assert.equal(ex.status, 0, ex.stderr);
+
+  // Read the on-disk YAML directly — verify the field landed where
+  // the spec says it should (status_log[-1].executing_at_cwd).
+  const executingDir = join(root, 'requests', 'executing');
+  const files = readdirSync(executingDir).filter((f) => f.startsWith(id));
+  assert.equal(files.length, 1, `expected one executing file for ${id}`);
+  const text = readFileSync(join(executingDir, files[0]!), 'utf8');
+  assert.match(text, /executing_at_cwd:/);
+  assert.match(text, new RegExp(wt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});

--- a/tests/interface/worktreeIsolation.test.ts
+++ b/tests/interface/worktreeIsolation.test.ts
@@ -27,6 +27,8 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
+  symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -35,13 +37,24 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
+// Wrap mkdtempSync so every test directory is canonical. On darwin
+// `os.tmpdir()` returns `/var/folders/...` which is itself a symlink
+// to `/private/var/folders/...`; passing the symlink form into the
+// CLI and asserting against the realpath form (or vice-versa) is the
+// exact ambiguity #231 had to resolve — pin tests to canonical to
+// avoid co-mingling that with the actual collision logic. (Pattern
+// established in #238 for the same reason.)
+function mkdtempReal(prefix: string): string {
+  return realpathSync(mkdtempSync(prefix));
+}
+
 interface Bootstrap {
   root: string;
   cleanup: () => void;
 }
 
 function bootstrap(profile: 'standard' | 'swarm'): Bootstrap {
-  const root = mkdtempSync(join(tmpdir(), `guild-wti-${profile}-`));
+  const root = mkdtempReal(join(tmpdir(), `guild-wti-${profile}-`));
   writeFileSync(
     join(root, 'guild.config.yaml'),
     `content_root: .\nhost_names: [eris]\nprofile: ${profile}\n`,
@@ -209,8 +222,8 @@ test('profile=swarm + parallel executors + DIFFERENT cwds: both execute', (t) =>
   // Simulate separate worktrees by passing different --cwd values.
   // The collision check compares the resolved absolute paths, so any
   // two distinct directories suffice.
-  const wt1 = mkdtempSync(join(tmpdir(), 'wti-wt1-'));
-  const wt2 = mkdtempSync(join(tmpdir(), 'wti-wt2-'));
+  const wt1 = mkdtempReal(join(tmpdir(), 'wti-wt1-'));
+  const wt2 = mkdtempReal(join(tmpdir(), 'wti-wt2-'));
   t.after(() => {
     rmSync(wt1, { recursive: true, force: true });
     rmSync(wt2, { recursive: true, force: true });
@@ -347,7 +360,7 @@ test('execute --cwd stamps executing_at_cwd into the status_log entry', (t) => {
   const id = (JSON.parse(r.stdout) as { id: string }).id;
   run(root, ['approve', id, '--by', 'alice']);
 
-  const wt = mkdtempSync(join(tmpdir(), 'wti-stamp-'));
+  const wt = mkdtempReal(join(tmpdir(), 'wti-stamp-'));
   t.after(() => rmSync(wt, { recursive: true, force: true }));
   const ex = run(root, ['execute', id, '--by', 'miki', '--cwd', wt]);
   assert.equal(ex.status, 0, ex.stderr);
@@ -360,4 +373,96 @@ test('execute --cwd stamps executing_at_cwd into the status_log entry', (t) => {
   const text = readFileSync(join(executingDir, files[0]!), 'utf8');
   assert.match(text, /executing_at_cwd:/);
   assert.match(text, new RegExp(wt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});
+
+// Devil HIGH-1 (#231 follow-up): symlink-bypass regression. Pre-fix,
+// `path.resolve` was used on the supplied --cwd, which leaves
+// symlinks intact: `/var/X` and `/private/var/X` (or any local
+// symlink farm) name the same physical directory but compare
+// non-equal as strings, so the second execute would slip through
+// the collision check. Post-fix, both sides are realpath'd before
+// comparison, so the second invocation is refused.
+test('Devil HIGH-1: symlink form of an already-executing cwd is canonicalised and refused', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const id1 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+  const id2 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+
+  // Build a real directory + a symlink pointing at it. We then run
+  // two executes: the first via the real path, the second via the
+  // symlink form. With realpath canonicalisation, both flatten to
+  // the same identity → refuse. Without it (pre-fix) the second
+  // would have passed.
+  const realWt = mkdtempReal(join(tmpdir(), 'wti-real-'));
+  const linkParent = mkdtempReal(join(tmpdir(), 'wti-link-'));
+  const linkWt = join(linkParent, 'symlinked-worktree');
+  symlinkSync(realWt, linkWt, 'dir');
+  t.after(() => {
+    rmSync(realWt, { recursive: true, force: true });
+    rmSync(linkParent, { recursive: true, force: true });
+  });
+
+  const e1 = run(root, ['execute', id1, '--by', 'miki', '--cwd', realWt]);
+  assert.equal(e1.status, 0, `real-path execute failed: ${e1.stderr}`);
+
+  const e2 = run(root, ['execute', id2, '--by', 'leysia', '--cwd', linkWt]);
+  assert.equal(
+    e2.status,
+    1,
+    `symlink-form execute should be refused (realpath canonicalisation), got ${e2.status}: ${e2.stderr}`,
+  );
+  assert.match(e2.stderr, /refusing to execute/);
+});
+
+// Sister test: the canonical form of the on-disk peer cwd is also
+// realpath'd at write time, so the comparison is symmetric — start
+// via the symlink, then attempt the real path. Both directions
+// must collapse identically, otherwise the order of arrival
+// determines safety which is exactly the kind of fail-open Devil
+// flagged.
+test('Devil HIGH-1: symmetric — first via symlink, second via realpath also refused', (t) => {
+  const { root, cleanup } = bootstrap('swarm');
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+
+  const id1 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+  const id2 = createApproved(root, {
+    from: 'alice',
+    executors: ['miki', 'leysia'],
+    target: 'shared-target',
+  });
+
+  const realWt = mkdtempReal(join(tmpdir(), 'wti-real2-'));
+  const linkParent = mkdtempReal(join(tmpdir(), 'wti-link2-'));
+  const linkWt = join(linkParent, 'symlinked-worktree');
+  symlinkSync(realWt, linkWt, 'dir');
+  t.after(() => {
+    rmSync(realWt, { recursive: true, force: true });
+    rmSync(linkParent, { recursive: true, force: true });
+  });
+
+  const e1 = run(root, ['execute', id1, '--by', 'miki', '--cwd', linkWt]);
+  assert.equal(e1.status, 0, `symlink-form first execute failed: ${e1.stderr}`);
+
+  const e2 = run(root, ['execute', id2, '--by', 'leysia', '--cwd', realWt]);
+  assert.equal(
+    e2.status,
+    1,
+    `real-path second execute should be refused, got ${e2.status}: ${e2.stderr}`,
+  );
+  assert.match(e2.stderr, /refusing to execute/);
 });


### PR DESCRIPTION
## Summary

Closes #231. Implements the filesystem-layer race defense for parallel-impl waves under `profile: swarm`. Complements #230 (record + agent-loop layers) — together they form the three-layer attribution-race defense surfaced by substrate-experiment 実験6.

## Behavior

- New config: `features.worktree_required_for_parallel: boolean`. `profile: swarm` flips the default to `true`; `profile: standard` keeps `false`. Explicit override possible at any profile.
- `gate request` (when feature on + executors > 1) stamps `requires_worktree_isolation: true` on the record.
- `gate execute` accepts `--cwd <path>` (default: `process.cwd()`). When `requires_worktree_isolation=true`, scans peer requests with state=executing on the same target and refuses if any is currently executing at the same canonicalized cwd. Distinct cwds (= different worktrees) pass through.
- `profile: standard` + multi-executor without isolation → warning notice only; execution proceeds.

## Devil follow-up applied (commit e7aff28)

- **HIGH-1 (production cwd symlink bypass)**: `reqExecute` now applies `fs.realpath` to both the input cwd and the persisted `executing_at_cwd` in `status_log`. Symlink farms (`/var/X` ↔ `/private/var/X`) collapse to a single canonical identity. `EACCES`/`ENOENT` fall back to the resolved-only value. Two new symlink-bypass tests (`/var` vs `/private/var`) explicitly assert collision is now caught.
- **HIGH-2 (race-window honesty)**: CHANGELOG `[Unreleased]` entry now states "best-effort race window — advisory lock not yet implemented" with a follow-up issue path for cross-platform `flock`-equivalent.
- Schema description for `requires_worktree_isolation` documents the auto-stamp behavior (`profile: swarm` + executors > 1 sets it implicitly).
- TODO comment on `Request.lastExecutingCwd` flagging predicate-style follow-up (`hasExecutingFromCwd`) for the post-#230 SOT-split discipline.

## Architecture

- Three-layer defense (record + agent-loop + filesystem) is now structurally complete:
  - **record**: `executors: string[]` (#230 ✅)
  - **agent-loop**: `Request.hasExecutor()` predicate (#230 ✅)
  - **filesystem**: cwd-collision refuse + canonicalized identity (this PR)
- Collision check sits in the interface layer (`reqExecute` handler) rather than a dedicated UC. Rationale: peer-scanning is read-cross-cutting, not single-aggregate UC territory. UC migration documented as follow-up.
- "racy-by-design" at the third layer: optimistic-lock at the record layer protects same-aggregate writes; this layer protects cross-aggregate filesystem identity. CHANGELOG note acknowledges the residual window.

## Test plan

- [x] Build clean (tsc).
- [x] Full suite: **1226 / 1226 pass** post-rebase on `887ac7b`. No regressions.
- [x] 67 targeted tests (8 new interface + 4 new domain + 2 new symlink-bypass + existing). Each new test pinned to the exact behavior it guards.
- [x] Realpath verification: removing `fs.realpath` from production code reproduces test failure (verified by Miki post-fix).
- [x] Devil 2-pass review: blockers resolved, design judgments approved.

## Substrate trail

- substrate-experiment 実験6 (2026-05-08) — race symptom captured
- gate wave (this PR's predecessor) — agora play `subagents-taisei/2026-05-08-001` discussion lineage
- Devil 1st verdict: reject (production cwd realpath missing)
- Devil 2nd verdict: approve after `e7aff28` follow-up

## Follow-ups (separate issues)

- Advisory lock for filesystem-layer race window (cross-platform challenge).
- `Request.lastExecutingCwd` getter → `hasExecutingFromCwd(cwd)` predicate (post-#230 SOT-split discipline).
- Collision check UC layer migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Miki (SubAgent) <noreply@anthropic.com>