### PR TITLE
feat(gate): witness verb (#226 phase 2) + concurrency safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   omitted when empty). `gate show` surfaces `witnesses: a, b, c` below
   the claim line in text mode, and exposes the structured `witnesses`
   array in JSON mode (omitted when empty in both surfaces).
+  + Hydrate dedup: hand-edited YAML with duplicate `witnesses` entries
+    is collapsed to first-occurrence on load (matching the domain's
+    set-by-first-registration semantic) and the migration surfaces via
+    `onMalformed` rather than passing silently — without this, a single
+    `unwitness` would leave duplicate names visible on `show`.
+    + Terminal-aware `unwitness` error: when invoked on a closed record
+    (completed/failed/denied) where auto-reset has already cleared the
+    list, the error message names the auto-release behavior and signals
+    "no action needed", distinguishing a benign cleanup pass from a
+    real misnamed `--by` typo (which keeps the original phrasing on
+    pending/approved/executing).
 
 - **`gate claim <id> --by <actor>` for cross-session stake**
   ([#226](https://github.com/eris-ths/guild-cli/issues/226) phase 1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate witness <id> --by <actor>` / `gate unwitness <id> --by <actor>`
+  for non-exclusive cross-session observation**
+  ([#244](https://github.com/eris-ths/guild-cli/issues/244),
+  [#226](https://github.com/eris-ths/guild-cli/issues/226) phase 2).
+  Companion verb to `claim` (phase 1): where claim is "I'm working on
+  this right now, do not double-stake" (exclusive, refuses on
+  conflict), witness is "I'm watching this" (non-exclusive — multiple
+  actors can witness simultaneously, never refuses on conflict with a
+  claim or another witness). Re-witness by the same actor is a no-op
+  (idempotent — the array doubles as a set ordered by first
+  registration). `unwitness` removes only the caller's own witness,
+  refusing on a foreign actor (no kick semantics in this primitive).
+  State guard: witness allowed on pending/approved/executing (the live
+  race window — passive observation of in-progress work is
+  legitimate); terminal states refuse and auto-reset existing
+  witnesses to `[]` on the transition. Pre-#244 records hydrate as no
+  witnesses and YAML stays byte-stable (the `witnesses:` field is
+  omitted when empty). `gate show` surfaces `witnesses: a, b, c` below
+  the claim line in text mode, and exposes the structured `witnesses`
+  array in JSON mode (omitted when empty in both surfaces).
+
 - **`gate claim <id> --by <actor>` for cross-session stake**
   ([#226](https://github.com/eris-ths/guild-cli/issues/226) phase 1).
   Two concurrent main-session agents that independently pick up the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,32 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **`witness` / `unwitness` / `claim` concurrency safety
+  ([#244](https://github.com/eris-ths/guild-cli/issues/244) Devil
+  REJECT root cause).** Pre-fix: these verbs mutated state without
+  appending to `status_log` / `reviews` / `thanks`, so the optimistic-
+  lock token (sum of those three array lengths) was non-monotonic
+  across them. Two concurrent `gate witness` calls both passed the
+  lock check on identical pre-state and last-writer-wins atomic
+  rename silently dropped one of the two writes — Devil's repro
+  showed 4 parallel witnesses landing exactly 1 entry, parallel
+  `unwitness` losing the loser, and `claim ⊥ witness` mixed races
+  destroying the #244 core promise that "witness coexists with any
+  claim". Fix: each `claim` / `witness` / `unwitness` mutation (and
+  every per-actor terminal auto-reset) bumps a new `mutation_seq`
+  counter on Request, and `computeVersion` includes it in the
+  optimistic-lock token; concurrent writers now throw
+  `RequestVersionConflict` and the use case
+  (`RequestUseCases.{claim,witness,unwitness}`) retries the load →
+  mutate → save loop on conflict (bounded, with stagger). Idempotent
+  re-claim / re-witness by the same actor does NOT bump (no-op, save
+  skipped). Per-actor accounting on terminal auto-reset means a
+  frontier collapsing "claim + 3 witnesses" contributes `+4` so the
+  seq delta remains a faithful "how many actors were mediating"
+  signal. YAML byte-stable: `mutation_seq` is omitted when 0, so
+  pre-#244 records and never-mediated post-fix records round-trip
+  identically.
+
 - **darwin path-comparison flakes in `tests/{interface,passages}/`
   ([#238](https://github.com/eris-ths/guild-cli/issues/238)).** Twelve
   tests across `boot`, `doctor`, `register`, and `agora new`/`play`

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -11,6 +11,7 @@ import { compareSequenceIds } from '../../domain/shared/compareSequenceIds.js';
 import {
   RequestRepository,
   RequestIdCollision,
+  RequestVersionConflict,
 } from '../ports/RequestRepository.js';
 import { MemberRepository } from '../ports/MemberRepository.js';
 import { NotificationPort } from '../ports/NotificationPort.js';
@@ -309,13 +310,22 @@ export class RequestUseCases {
     by: string;
     dryRun?: boolean;
   }): Promise<{ request: Request; mutated: boolean }> {
-    const req = await this.loadOrThrow(input.id);
     const actor = await assertActor(input.by, '--by', this.deps.members);
-    const before = req.claimedBy?.value;
-    req.claim(actor, this.deps.clock.now().toISOString());
-    const mutated = before !== req.claimedBy?.value;
-    if (mutated && !input.dryRun) await this.deps.requests.save(req);
-    return { request: req, mutated };
+    // Retry on RequestVersionConflict: claim/witness/unwitness mediate
+    // a live cross-session race window (#244 root cause), so a
+    // concurrent claim/witness landing between our load and save is
+    // expected, not exceptional. Re-load and re-apply — the domain
+    // verb is idempotent on no-op (same-actor re-claim) and refuses
+    // on conflict (different-actor claim already held), so retry is
+    // safe and bounded.
+    return retryOnVersionConflict('claim', input.id, async () => {
+      const req = await this.loadOrThrow(input.id);
+      const before = req.claimedBy?.value;
+      req.claim(actor, this.deps.clock.now().toISOString());
+      const mutated = before !== req.claimedBy?.value;
+      if (mutated && !input.dryRun) await this.deps.requests.save(req);
+      return { request: req, mutated };
+    });
   }
 
   /**
@@ -331,13 +341,15 @@ export class RequestUseCases {
     by: string;
     dryRun?: boolean;
   }): Promise<{ request: Request; mutated: boolean }> {
-    const req = await this.loadOrThrow(input.id);
     const actor = await assertActor(input.by, '--by', this.deps.members);
-    const before = req.witnesses.length;
-    req.witness(actor);
-    const mutated = before !== req.witnesses.length;
-    if (mutated && !input.dryRun) await this.deps.requests.save(req);
-    return { request: req, mutated };
+    return retryOnVersionConflict('witness', input.id, async () => {
+      const req = await this.loadOrThrow(input.id);
+      const before = req.witnesses.length;
+      req.witness(actor);
+      const mutated = before !== req.witnesses.length;
+      if (mutated && !input.dryRun) await this.deps.requests.save(req);
+      return { request: req, mutated };
+    });
   }
 
   /**
@@ -351,11 +363,13 @@ export class RequestUseCases {
     by: string;
     dryRun?: boolean;
   }): Promise<Request> {
-    const req = await this.loadOrThrow(input.id);
     const actor = await assertActor(input.by, '--by', this.deps.members);
-    req.unwitness(actor);
-    if (!input.dryRun) await this.deps.requests.save(req);
-    return req;
+    return retryOnVersionConflict('unwitness', input.id, async () => {
+      const req = await this.loadOrThrow(input.id);
+      req.unwitness(actor);
+      if (!input.dryRun) await this.deps.requests.save(req);
+      return req;
+    });
   }
 
   private async loadOrThrow(id: string): Promise<Request> {
@@ -369,4 +383,58 @@ function sortRequests(items: Request[]): Request[] {
   return [...items].sort((a, b) =>
     compareSequenceIds(a.id.value, b.id.value),
   );
+}
+
+/**
+ * Re-run a load → mutate → save pipeline up to N times on
+ * `RequestVersionConflict`, with a small staggered backoff to avoid
+ * livelock when many actors race on the same id.
+ *
+ * Why retry lives at the use case (not the repository): the
+ * repository's optimistic-lock check is the *signal*; deciding what
+ * to retry and how is a use-case-level policy. claim / witness /
+ * unwitness mediate a live cross-session race window (#244 Devil
+ * REJECT root cause: two concurrent witnesses both passing the lock
+ * because length-based version was non-monotonic, then last-writer-
+ * wins atomic rename silently dropping one). The mutation_seq fix
+ * makes the conflict observable; this helper makes it recoverable.
+ *
+ * Bounds: 8 attempts is generous for the realistic cases (4 parallel
+ * witnesses on the same id) while still terminating on a pathological
+ * thrash. The domain verbs are idempotent on no-op and refuse on
+ * genuine conflict (different-actor claim while one is held), so
+ * "retry until success" is safe semantically — it doesn't paper over
+ * legitimate refusals.
+ *
+ * Last attempt re-throws so the caller still sees the error if the
+ * race window genuinely never closes.
+ */
+async function retryOnVersionConflict<T>(
+  verb: string,
+  id: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const maxAttempts = 8;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (!(e instanceof RequestVersionConflict)) throw e;
+      lastErr = e;
+      // Tiny staggered backoff — multiplicative on attempt to spread
+      // out hot-spot contention. The numbers are deliberately small:
+      // we're racing on a local file, not a remote service, and the
+      // contention window is sub-millisecond.
+      const delayMs = Math.min(2 * (attempt + 1), 16);
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  // Out of attempts — annotate the error so the operator can tell a
+  // genuine pile-up from a single conflict, then re-throw the last
+  // one so the existing error envelope still surfaces.
+  if (lastErr instanceof Error) {
+    lastErr.message = `${verb}(${id}): ${lastErr.message} [exhausted ${maxAttempts} retries]`;
+  }
+  throw lastErr;
 }

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -318,6 +318,46 @@ export class RequestUseCases {
     return { request: req, mutated };
   }
 
+  /**
+   * Register a non-exclusive observer (issue #244). Thin wrapper over
+   * `Request.witness`: validates `by` against the member directory,
+   * delegates the idempotency / state-guard logic to the aggregate.
+   * Save is skipped when the witness already exists (re-witness no-op)
+   * since the aggregate stays unchanged and persisting would only
+   * churn the file's version-lock.
+   */
+  async witness(input: {
+    id: string;
+    by: string;
+    dryRun?: boolean;
+  }): Promise<{ request: Request; mutated: boolean }> {
+    const req = await this.loadOrThrow(input.id);
+    const actor = await assertActor(input.by, '--by', this.deps.members);
+    const before = req.witnesses.length;
+    req.witness(actor);
+    const mutated = before !== req.witnesses.length;
+    if (mutated && !input.dryRun) await this.deps.requests.save(req);
+    return { request: req, mutated };
+  }
+
+  /**
+   * Remove the caller's witness (issue #244). Sibling of `witness`:
+   * domain throws when the actor is not a current witness, so the
+   * use case stays a thin pass-through. Always saves on success
+   * because unwitness is always a real mutation (length decreases).
+   */
+  async unwitness(input: {
+    id: string;
+    by: string;
+    dryRun?: boolean;
+  }): Promise<Request> {
+    const req = await this.loadOrThrow(input.id);
+    const actor = await assertActor(input.by, '--by', this.deps.members);
+    req.unwitness(actor);
+    if (!input.dryRun) await this.deps.requests.save(req);
+    return req;
+  }
+
   private async loadOrThrow(id: string): Promise<Request> {
     const req = await this.deps.requests.findById(RequestId.of(id));
     if (!req) throw new DomainError(`Request not found: ${id}`, 'id');

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -617,20 +617,28 @@ export class Request {
    *
    * State guard intentionally absent: unwitness must work in any
    * state so an observer who joined a request which then progressed
-   * to a terminal state can still clean up. (In practice the auto-
-   * reset on terminal transition does this for them, but a manual
-   * unwitness on a closed record stays a clean no-mutation throw.)
+   * to a terminal state can still clean up. In practice the auto-
+   * reset on terminal transition does the cleanup first, so a manual
+   * unwitness on a closed record finds an empty list — we surface a
+   * terminal-aware "no action needed" message instead of the typo
+   * error, so an actor running a defensive cleanup pass can tell the
+   * benign case from a real misnamed --by.
    */
   unwitness(by: MemberName): void {
     const list = this.props.witnesses ?? [];
     const idx = list.findIndex((m) => m.value === by.value);
     if (idx < 0) {
-      throw new DomainError(
-        `${by.value} is not a witness of request ${this.props.id.value}; ` +
+      const state = this.props.state;
+      const isTerminal =
+        state === 'completed' || state === 'failed' || state === 'denied';
+      const msg = isTerminal
+        ? `${by.value} is not currently a witness of request ${this.props.id.value} ` +
+          `(state=${state}; witnesses are auto-released on terminal transitions, ` +
+          `so any prior witness has already been cleared. No action needed.)`
+        : `${by.value} is not a witness of request ${this.props.id.value}; ` +
           `unwitness only removes the caller's own witness (use witness ` +
-          `to register first, or check the actor name).`,
-        'witnesses',
-      );
+          `to register first, or check the actor name).`;
+      throw new DomainError(msg, 'witnesses');
     }
     list.splice(idx, 1);
     if (list.length === 0) {

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -135,6 +135,22 @@ export interface RequestProps {
   /** ISO 8601 timestamp of the claim, paired with `claimedBy`. Both
    *  fields move together — set together, cleared together. */
   claimedAt?: string;
+  /**
+   * Cross-session non-exclusive observers (issue #226 phase 2 / #244).
+   * Sibling primitive to `claimedBy`: where claim is "I'm working on
+   * this right now, do not double-stake" (exclusive, refuses on
+   * conflict), `witnesses` is "I'm watching this" (non-exclusive,
+   * multiple actors can witness simultaneously, never refuses on
+   * conflict with claim or with another witness). Order is meaningful
+   * — registration order — so a reader can see "first observer" first.
+   *
+   * Persistence: omitted from YAML when empty (byte-stable round-trip
+   * with pre-#244 records). Old records hydrate as []. Auto-resets
+   * to [] on terminal transitions for the same reason claim does:
+   * the verb mediates the live cross-session race window, and a
+   * terminal record carries no further race signal.
+   */
+  witnesses?: MemberName[];
 }
 
 /**
@@ -539,6 +555,104 @@ export class Request {
     delete this.props.claimedAt;
   }
 
+  /** Current witnesses in registration order. Empty when no observers. Issue #244. */
+  get witnesses(): readonly MemberName[] {
+    return this.props.witnesses ?? [];
+  }
+
+  /**
+   * Register a non-exclusive observer (issue #244). Witness is the
+   * companion verb to claim:
+   *
+   *   - claim     : "I'm working on this" — exclusive; refuses on conflict.
+   *   - witness   : "I'm watching this" — non-exclusive; never refuses.
+   *
+   * Multiple actors may witness in parallel; a witness coexists with
+   * any claim (by the same actor or a different one). Re-witness by
+   * the same actor is a no-op — duplicates are not appended, so the
+   * array doubles as a set ordered by first registration. The state
+   * guard mirrors claim: only `pending` / `approved` / `executing`
+   * accept new witnesses, since terminal records have moved past the
+   * live race window the verb exists to surface.
+   *
+   * Unlike claim, witness is permitted on `executing` because passive
+   * observation of work-in-progress is a legitimate "I'm following
+   * this" signal, whereas claim on `executing` would be too late to
+   * mediate the cross-session race claim is designed for.
+   */
+  witness(by: MemberName): void {
+    if (
+      this.props.state !== 'pending' &&
+      this.props.state !== 'approved' &&
+      this.props.state !== 'executing'
+    ) {
+      throw new DomainError(
+        `Cannot witness a request in state "${this.props.state}"; ` +
+          `witness only applies while pending, approved, or executing ` +
+          `(the live race window).`,
+        'state',
+      );
+    }
+    const list = this.props.witnesses ?? [];
+    if (list.some((m) => m.value === by.value)) {
+      // Idempotent re-witness — already observing, no mutation.
+      return;
+    }
+    list.push(by);
+    this.props.witnesses = list;
+  }
+
+  /**
+   * Remove the caller's witness (issue #244). Three outcomes:
+   *
+   *   1. Caller is in the list → remove (the normal case).
+   *   2. Caller is not in the list → throw. Quietly no-op'ing would
+   *      make a typo (`gate unwitness <id> --by mki`) indistinguishable
+   *      from success, and the intent of `unwitness` is to assert
+   *      "I want my name OFF this" — a missing entry is meaningful.
+   *   3. Foreign actor on someone else's witness → throw. The verb is
+   *      reflexive: each actor may only release their own witness,
+   *      never another's. (No "kick" semantics in this primitive; if
+   *      that ever lands, it gets its own verb name.)
+   *
+   * State guard intentionally absent: unwitness must work in any
+   * state so an observer who joined a request which then progressed
+   * to a terminal state can still clean up. (In practice the auto-
+   * reset on terminal transition does this for them, but a manual
+   * unwitness on a closed record stays a clean no-mutation throw.)
+   */
+  unwitness(by: MemberName): void {
+    const list = this.props.witnesses ?? [];
+    const idx = list.findIndex((m) => m.value === by.value);
+    if (idx < 0) {
+      throw new DomainError(
+        `${by.value} is not a witness of request ${this.props.id.value}; ` +
+          `unwitness only removes the caller's own witness (use witness ` +
+          `to register first, or check the actor name).`,
+        'witnesses',
+      );
+    }
+    list.splice(idx, 1);
+    if (list.length === 0) {
+      // Drop the prop entirely so toJSON's "omit when empty" branch
+      // emits the same byte-stable YAML as a never-witnessed record.
+      delete this.props.witnesses;
+    } else {
+      this.props.witnesses = list;
+    }
+  }
+
+  /**
+   * Clear all witnesses. Called from `transition` on terminal states
+   * for the same reason claim auto-releases — once the request is
+   * completed/failed/denied, the live observation channel is moot,
+   * and leaving stale witness names on a closed record is just noise.
+   */
+  private resetWitnesses(): void {
+    if (this.props.witnesses === undefined) return;
+    delete this.props.witnesses;
+  }
+
   private transition(
     to: RequestState,
     by: MemberName,
@@ -586,6 +700,10 @@ export class Request {
     // surviving across that boundary as a "still mine" marker.
     if (to === 'completed' || to === 'failed' || to === 'denied') {
       this.releaseClaim();
+      // Witnesses (issue #244) auto-reset on the same terminal frontier
+      // as claim. Same rationale: the verb mediates the live race
+      // window, and a terminal record carries no further race signal.
+      this.resetWitnesses();
     }
   }
 
@@ -652,6 +770,15 @@ export class Request {
     if (this.props.claimedBy !== undefined && this.props.claimedAt !== undefined) {
       out['claimed_by'] = this.props.claimedBy.value;
       out['claimed_at'] = this.props.claimedAt;
+    }
+    // Witnesses (issue #244). Surface only when non-empty — empty
+    // witnesses is the common case and an empty array would clutter
+    // every YAML record. Order is preserved (registration order, not
+    // sorted) so a reader sees "first observer first". Pre-#244
+    // records lack the field entirely and round-trip clean.
+    const witnessList = this.props.witnesses ?? [];
+    if (witnessList.length > 0) {
+      out['witnesses'] = witnessList.map((m) => m.value);
     }
     // Derive legacy closure keys from the last status_log entry so
     // external consumers (chain / voices / show --format text) keep

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -151,6 +151,39 @@ export interface RequestProps {
    * terminal record carries no further race signal.
    */
   witnesses?: MemberName[];
+  /**
+   * Monotonic mutation counter for cross-session-mutating verbs that
+   * are NOT append-only on a recorded array (issue #244 follow-up;
+   * Devil REJECT root cause). `claim` / `witness` / `unwitness` and
+   * the terminal auto-reset of both can each remove entries from
+   * `claimed_by` / `witnesses[]`, so length-based version tokens
+   * (`status_log + reviews + thanks`) are non-monotonic across these
+   * verbs and let the optimistic-lock check pass concurrent writers
+   * that would silently drop one another's mutation under last-
+   * writer-wins atomic rename.
+   *
+   * Bumped exactly once per real mutation:
+   *   - `claim()` — first-time claim by an actor (idempotent re-claim
+   *     by same actor does NOT bump, matching its no-op save path).
+   *   - `witness()` — first-time witness by an actor (re-witness no-op
+   *     does NOT bump).
+   *   - `unwitness()` — every successful removal.
+   *   - `transition()` terminal auto-reset — `+1` per cleared actor
+   *     (one for the claim if held, one per witness in the list) so
+   *     a single terminal frontier collapsing "claim + 3 witnesses"
+   *     bumps `+4` total. Per-actor accounting keeps the version
+   *     observable from outside: a reader can see "exactly 4 actors
+   *     were mediating at terminal time" via the seq delta.
+   *
+   * Persistence: `mutation_seq` is omitted from YAML when 0 (the
+   * common case for never-mediated records — pre-#244 records load
+   * as 0 and round-trip clean). Hydrate accepts the field when
+   * present and a finite non-negative number; anything else is
+   * treated as 0 with an `onMalformed` warn so the migration is
+   * visible. Surfaced through `computeVersion` so the repository's
+   * optimistic-lock check is monotonic across every legal mutation.
+   */
+  mutationSeq?: number;
 }
 
 /**
@@ -318,13 +351,22 @@ export class Request {
 
   static restore(props: RequestProps): Request {
     // loadedVersion snapshots the TOTAL mutation count at load time —
-    // status_log entries PLUS reviews. Using status_log alone would
-    // miss concurrent addReview races (reviews push into reviews[]
-    // without touching status_log), letting two simultaneous reviewers
-    // silently lose one review on last-writer-wins. See
-    // `computeVersion` below for the single place that defines the
-    // invariant.
-    return new Request({ ...props }, computeVersion(props.statusLog.length, props.reviews.length, (props.thanks ?? []).length));
+    // status_log entries + reviews + thanks + mutation_seq. The first
+    // three are append-only array lengths (concurrent addReview races
+    // would silently drop a review under last-writer-wins if the
+    // counter ignored reviews). mutation_seq closes the equivalent
+    // hole for claim / witness / unwitness, which mutate state without
+    // appending to any of those arrays. See `computeVersion` below
+    // for the single place that defines the invariant.
+    return new Request(
+      { ...props },
+      computeVersion(
+        props.statusLog.length,
+        props.reviews.length,
+        (props.thanks ?? []).length,
+        props.mutationSeq ?? 0,
+      ),
+    );
   }
 
   get id(): RequestId {
@@ -415,11 +457,13 @@ export class Request {
   /**
    * Total mutation count observed when this aggregate was loaded from
    * disk (0 for freshly-created instances). Defined as
-   * `status_log.length + reviews.length + thanks.length` — all three
-   * arrays are append-only, so their combined length is a monotonic
-   * version. The repository uses it as an optimistic-lock token: if
-   * the on-disk total has grown since, another writer won the race
-   * and our save is rejected.
+   * `status_log.length + reviews.length + thanks.length + mutation_seq`
+   * — the first three are append-only arrays, the fourth is an
+   * explicit monotonic counter for non-array mutations (claim /
+   * witness / unwitness; see `RequestProps.mutationSeq`). The
+   * repository uses the sum as an optimistic-lock token: if the on-
+   * disk total has grown since, another writer won the race and our
+   * save is rejected (`RequestVersionConflict`).
    */
   get loadedVersion(): number {
     return this._loadedVersion;
@@ -430,7 +474,27 @@ export class Request {
    * repository will write with, so `loadedVersion` + delta = `currentVersion`.
    */
   get currentVersion(): number {
-    return computeVersion(this.props.statusLog.length, this.props.reviews.length, (this.props.thanks ?? []).length);
+    return computeVersion(
+      this.props.statusLog.length,
+      this.props.reviews.length,
+      (this.props.thanks ?? []).length,
+      this.props.mutationSeq ?? 0,
+    );
+  }
+
+  /** Current mutation-sequence counter (0 when never mediated by
+   *  claim / witness / unwitness or their terminal auto-reset). See
+   *  `RequestProps.mutationSeq` for the full contract. */
+  get mutationSeq(): number {
+    return this.props.mutationSeq ?? 0;
+  }
+
+  /** Bump the mutation counter by one. Private — only the verbs that
+   *  contractually count as a "mutation" (claim/witness/unwitness and
+   *  the terminal auto-reset, per-cleared-actor) call this. Defined
+   *  centrally so the invariant lives in one place. */
+  private bumpMutationSeq(): void {
+    this.props.mutationSeq = (this.props.mutationSeq ?? 0) + 1;
   }
 
   approve(by: MemberName, note?: string, invokedBy?: string): void {
@@ -541,6 +605,11 @@ export class Request {
     }
     this.props.claimedBy = by;
     this.props.claimedAt = at;
+    // Real mutation — bump so the optimistic-lock token moves and a
+    // concurrent claim by another actor (which would race past the
+    // status_log+reviews+thanks length check, since claim doesn't
+    // touch any of those) is detected at save time.
+    this.bumpMutationSeq();
   }
 
   /**
@@ -553,6 +622,11 @@ export class Request {
     if (this.props.claimedBy === undefined) return;
     delete this.props.claimedBy;
     delete this.props.claimedAt;
+    // Per-actor accounting: a terminal frontier that clears one claim
+    // counts as one mutation. See `RequestProps.mutationSeq` for the
+    // rationale (observability of how many actors were mediating at
+    // the time the request closed).
+    this.bumpMutationSeq();
   }
 
   /** Current witnesses in registration order. Empty when no observers. Issue #244. */
@@ -600,6 +674,9 @@ export class Request {
     }
     list.push(by);
     this.props.witnesses = list;
+    // Real mutation — bump for the same reason claim does. See
+    // `bumpMutationSeq` doc and `RequestProps.mutationSeq`.
+    this.bumpMutationSeq();
   }
 
   /**
@@ -648,6 +725,11 @@ export class Request {
     } else {
       this.props.witnesses = list;
     }
+    // Real mutation — bump so two concurrent unwitness calls by
+    // different actors don't both pass the optimistic-lock check
+    // (which sees identical pre-mutation length on both sides) and
+    // last-writer-wins one of them off the record.
+    this.bumpMutationSeq();
   }
 
   /**
@@ -657,8 +739,15 @@ export class Request {
    * and leaving stale witness names on a closed record is just noise.
    */
   private resetWitnesses(): void {
-    if (this.props.witnesses === undefined) return;
+    const list = this.props.witnesses;
+    if (list === undefined || list.length === 0) return;
+    const cleared = list.length;
     delete this.props.witnesses;
+    // Per-actor accounting: bump once per cleared witness so a
+    // terminal frontier collapsing N witnesses contributes +N to the
+    // version token. Keeps "how many actors were observing at close"
+    // recoverable from the seq delta around the terminal entry.
+    for (let i = 0; i < cleared; i++) this.bumpMutationSeq();
   }
 
   private transition(
@@ -788,6 +877,15 @@ export class Request {
     if (witnessList.length > 0) {
       out['witnesses'] = witnessList.map((m) => m.value);
     }
+    // mutation_seq (issue #244 follow-up). Surface only when > 0 so
+    // pre-#244 records and never-mediated post-#244 records both emit
+    // byte-identical YAML — the field appears on disk only after the
+    // first claim/witness/unwitness mutation. See
+    // `RequestProps.mutationSeq` for the optimistic-lock contract.
+    const seq = this.props.mutationSeq ?? 0;
+    if (seq > 0) {
+      out['mutation_seq'] = seq;
+    }
     // Derive legacy closure keys from the last status_log entry so
     // external consumers (chain / voices / show --format text) keep
     // working unchanged. Single source of truth: status_log[-1].note.
@@ -842,17 +940,34 @@ function statusLogEntryToJSON(e: StatusLogEntry): Record<string, unknown> {
 }
 
 /**
- * Total mutation count: status_log entries + reviews + thanks. All
- * three arrays are append-only so the sum is monotonic across any
- * legal mutation. Thanks are included despite being orthogonal to the
- * analytical memory (principle 06): they are still records that
- * outlive writers (principle 04), and a concurrent addThank that
- * silently loses to last-writer-wins would violate append-only.
+ * Total mutation count: status_log entries + reviews + thanks +
+ * mutation_seq. The first three are append-only array lengths
+ * (monotonic by construction — entries are only ever pushed, never
+ * removed during a mutation). The fourth is the explicit counter for
+ * verbs that DON'T touch any of those arrays but still mutate state
+ * (`claim`, `witness`, `unwitness`, terminal auto-reset of either) —
+ * see `RequestProps.mutationSeq` for the full rationale.
+ *
+ * Thanks are included despite being orthogonal to the analytical
+ * memory (principle 06): they are still records that outlive writers
+ * (principle 04), and a concurrent addThank that silently loses to
+ * last-writer-wins would violate append-only. mutation_seq closes the
+ * symmetric hole for non-array mutations (Devil REJECT root cause on
+ * #244): without it, two concurrent witnesses both saw `{statusLog,
+ * reviews, thanks}` length unchanged and both passed the optimistic-
+ * lock check, letting last-writer-wins atomic rename silently drop
+ * one of them.
+ *
  * Kept as a module-private helper so the invariant is defined in one
  * place and the repository can reuse it when reading raw YAML.
  */
-export function computeVersion(statusLogLen: number, reviewsLen: number, thanksLen: number = 0): number {
-  return statusLogLen + reviewsLen + thanksLen;
+export function computeVersion(
+  statusLogLen: number,
+  reviewsLen: number,
+  thanksLen: number = 0,
+  mutationSeq: number = 0,
+): number {
+  return statusLogLen + reviewsLen + thanksLen + mutationSeq;
 }
 
 // Local wrapper over the shared sanitizer: every call in this file used

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -222,12 +222,17 @@ export class YamlRequestRepository implements RequestRepository {
     }
 
     // 2. Optimistic-lock check: the highest on-disk total mutation
-    //    count (status_log.length + reviews.length) must equal the
-    //    version we loaded. Using status_log alone would miss
-    //    concurrent addReview races — two reviewers writing at once
-    //    both touch reviews[] without growing status_log, so a
-    //    status_log-only check would let one review silently vanish
-    //    under last-writer-wins.
+    //    count (status_log.length + reviews.length + thanks.length +
+    //    mutation_seq) must equal the version we loaded. status_log
+    //    alone would miss concurrent addReview races; status_log +
+    //    reviews + thanks alone would miss concurrent claim/witness/
+    //    unwitness (Devil REJECT root cause on #244) — those verbs
+    //    mutate without appending to any array, so length-only check
+    //    saw identical pre/post and let last-writer-wins atomic
+    //    rename silently drop one of two concurrent witnesses. The
+    //    explicit mutation_seq counter (bumped per real claim/witness/
+    //    unwitness/terminal-reset, see Request.bumpMutationSeq) closes
+    //    that hole.
     const maxOnDisk = existing.reduce((m, e) => Math.max(m, e.version), 0);
     if (maxOnDisk !== request.loadedVersion) {
       throw new RequestVersionConflict(
@@ -301,7 +306,19 @@ function readVersion(parsed: unknown): number {
   const thanks = Array.isArray(obj['thanks'])
     ? (obj['thanks'] as unknown[]).filter(isObjectEntry).length
     : 0;
-  return computeVersion(log, reviews, thanks);
+  // mutation_seq (issue #244 follow-up). Tolerated on read only when
+  // it's a finite non-negative number; anything else (string, NaN,
+  // negative, missing) is treated as 0 — mirrors the conservative
+  // hydrate path. The version-token monotonicity is enforced at write
+  // time by the domain (`Request.bumpMutationSeq`), so a malformed
+  // on-disk value just degrades to "no extra signal" rather than
+  // poisoning the lock.
+  const rawSeq = obj['mutation_seq'];
+  const seq =
+    typeof rawSeq === 'number' && Number.isFinite(rawSeq) && rawSeq >= 0
+      ? Math.floor(rawSeq)
+      : 0;
+  return computeVersion(log, reviews, thanks, seq);
 }
 
 /**
@@ -577,6 +594,29 @@ function hydrate(
         );
       }
       if (observers.length > 0) props.witnesses = observers;
+    }
+    // mutation_seq (issue #244 follow-up; Devil REJECT root cause).
+    // Counter for cross-session-mutating verbs (claim/witness/
+    // unwitness + terminal auto-reset) that don't grow status_log /
+    // reviews / thanks but still must move the optimistic-lock token.
+    // Tolerated only as a finite non-negative number; anything else
+    // is treated as 0 with an `onMalformed` warn so silent corruption
+    // is impossible. Pre-#244 records lack the field and load as 0
+    // (the never-mediated default), preserving byte-stable round-trip.
+    if (obj['mutation_seq'] !== undefined) {
+      const rawSeq = obj['mutation_seq'];
+      if (
+        typeof rawSeq === 'number' &&
+        Number.isFinite(rawSeq) &&
+        rawSeq >= 0
+      ) {
+        props.mutationSeq = Math.floor(rawSeq);
+      } else {
+        onMalformed(
+          source,
+          `mutation_seq is not a non-negative finite number (got ${typeof rawSeq === 'number' ? String(rawSeq) : typeof rawSeq}); treating as 0 — the optimistic-lock counter degrades to "no extra signal" until the next mutation rebuilds it`,
+        );
+      }
     }
     // Legacy top-level closure keys (completion_note / deny_reason /
     // failure_reason) are no longer written separately — status_log[-1].note

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -542,6 +542,18 @@ function hydrate(
       props.claimedBy = MemberName.of(obj['claimed_by']);
       props.claimedAt = obj['claimed_at'] as string;
     }
+    // Witnesses (issue #244). Restore only well-typed string entries;
+    // anything else (objects, numbers) is dropped silently following
+    // the same conservative read pattern as `with`. Pre-#244 records
+    // lack the field entirely and hydrate as no witnesses (the empty-
+    // by-absence default), preserving byte-stable round-trip.
+    if (Array.isArray(obj['witnesses'])) {
+      const observers: MemberName[] = [];
+      for (const raw of obj['witnesses'] as unknown[]) {
+        if (typeof raw === 'string') observers.push(MemberName.of(raw));
+      }
+      if (observers.length > 0) props.witnesses = observers;
+    }
     // Legacy top-level closure keys (completion_note / deny_reason /
     // failure_reason) are no longer written separately — status_log[-1].note
     // is the single source of truth. Handle the three migration cases

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -547,10 +547,34 @@ function hydrate(
     // the same conservative read pattern as `with`. Pre-#244 records
     // lack the field entirely and hydrate as no witnesses (the empty-
     // by-absence default), preserving byte-stable round-trip.
+    //
+    // Dedup invariant: the domain `witness()` keeps the array as a set
+    // ordered by first registration (re-witness is a no-op), so the
+    // hydrated array must match — otherwise hand-edited YAML carrying
+    // `witnesses: [asteria, asteria]` would let `unwitness` consume
+    // entries one-at-a-time (findIndex + splice removes one), forcing
+    // the actor to invoke unwitness twice and see their name still on
+    // `show` between the two calls. We dedup here on first-occurrence
+    // (same order semantics as the domain) and warn via onMalformed so
+    // the migration is visible, not silent.
     if (Array.isArray(obj['witnesses'])) {
       const observers: MemberName[] = [];
+      const seen = new Set<string>();
+      let duplicates = 0;
       for (const raw of obj['witnesses'] as unknown[]) {
-        if (typeof raw === 'string') observers.push(MemberName.of(raw));
+        if (typeof raw !== 'string') continue;
+        if (seen.has(raw)) {
+          duplicates += 1;
+          continue;
+        }
+        seen.add(raw);
+        observers.push(MemberName.of(raw));
+      }
+      if (duplicates > 0) {
+        onMalformed(
+          source,
+          `witnesses array contained ${duplicates} duplicate entr${duplicates === 1 ? 'y' : 'ies'}; deduped on first occurrence (the domain treats witnesses as a set; the next save will emit the deduped form)`,
+        );
       }
       if (observers.length > 0) props.witnesses = observers;
     }

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -496,6 +496,14 @@ function formatRequestText(r: Request): string {
     if (typeof j['claimed_by'] === 'string' && typeof j['claimed_at'] === 'string') {
       lines.push(`    claimed by: ${j['claimed_by']} at ${j['claimed_at']}`);
     }
+    // Witnesses (issue #244). Surfaced just below the claim line —
+    // both share the "who has eyes on this right now" axis. Only
+    // rendered when non-empty; an unwitnessed record is the common
+    // case and an empty `witnesses:` line would clutter every show.
+    if (Array.isArray(j['witnesses']) && j['witnesses'].length > 0) {
+      const names = (j['witnesses'] as unknown[]).map((w) => String(w)).join(', ');
+      lines.push(`    witnesses: ${names}`);
+    }
   }
 
   const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -904,7 +904,9 @@ const VERBS: readonly VerbSchema[] = [
     summary:
       'stake a cross-session claim on a pending or approved request (issue #226 phase 1). ' +
       'Same-actor re-claim is a no-op; conflicting claim by a different actor is refused. ' +
-      'Auto-releases when the request reaches a terminal state (completed/failed/denied).',
+      'Auto-releases when the request reaches a terminal state (completed/failed/denied). ' +
+      'Concurrency: each mutation bumps a monotonic mutation_seq mediated by the optimistic-lock; ' +
+      'concurrent writes throw RequestVersionConflict and rely on the use-case retry loop.',
     input: {
       type: 'object',
       properties: {
@@ -923,7 +925,9 @@ const VERBS: readonly VerbSchema[] = [
     summary:
       'register as a non-exclusive observer on a pending/approved/executing request (issue #244). ' +
       'Multiple actors may witness simultaneously; coexists with any claim. ' +
-      'Same-actor re-witness is a no-op. Auto-resets when the request reaches a terminal state.',
+      'Same-actor re-witness is a no-op. Auto-resets when the request reaches a terminal state. ' +
+      'Concurrency: each mutation bumps a monotonic mutation_seq mediated by the optimistic-lock; ' +
+      'concurrent writes throw RequestVersionConflict and rely on the use-case retry loop.',
     input: {
       type: 'object',
       properties: {
@@ -941,7 +945,9 @@ const VERBS: readonly VerbSchema[] = [
     category: 'write',
     summary:
       "remove the caller's own witness from a request (issue #244). " +
-      'Refuses if the caller is not currently a witness, or for any other actor.',
+      'Refuses if the caller is not currently a witness, or for any other actor. ' +
+      'Concurrency: each mutation bumps a monotonic mutation_seq mediated by the optimistic-lock; ' +
+      'concurrent writes throw RequestVersionConflict and rely on the use-case retry loop.',
     input: {
       type: 'object',
       properties: {

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -918,6 +918,43 @@ const VERBS: readonly VerbSchema[] = [
     output: writeResponseSchema,
   },
   {
+    name: 'witness',
+    category: 'write',
+    summary:
+      'register as a non-exclusive observer on a pending/approved/executing request (issue #244). ' +
+      'Multiple actors may witness simultaneously; coexists with any claim. ' +
+      'Same-actor re-witness is a no-op. Auto-resets when the request reaches a terminal state.',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        by: strOpt('observer (defaults to $GUILD_ACTOR)'),
+        format: formatField,
+        'dry-run': dryRunField,
+      },
+      required: ['id'],
+    },
+    output: writeResponseSchema,
+  },
+  {
+    name: 'unwitness',
+    category: 'write',
+    summary:
+      "remove the caller's own witness from a request (issue #244). " +
+      'Refuses if the caller is not currently a witness, or for any other actor.',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        by: strOpt('observer to remove (must match caller; defaults to $GUILD_ACTOR)'),
+        format: formatField,
+        'dry-run': dryRunField,
+      },
+      required: ['id'],
+    },
+    output: writeResponseSchema,
+  },
+  {
     name: 'thank',
     category: 'write',
     summary:

--- a/src/interface/gate/handlers/witness.ts
+++ b/src/interface/gate/handlers/witness.ts
@@ -1,0 +1,99 @@
+import {
+  ParsedArgs,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C, isDryRun, emitDryRunPreview } from './internal.js';
+import { emitWriteResponse, parseFormat } from './writeFormat.js';
+
+// Issue #244 (#226 phase 2) — non-exclusive cross-session observer.
+//
+// `gate witness <id> --by <actor>` registers the actor as an observer
+// without taking the exclusive stake `claim` provides. Unlike claim,
+// multiple actors can witness the same request simultaneously, and a
+// witness coexists with any claim (by the same actor or a different
+// one). Companion verb `unwitness` removes the caller's own witness;
+// removing another actor's witness is refused.
+//
+// Design points:
+//
+//   - Re-witness by the same actor is a no-op (idempotent). The
+//     witness list doubles as a set ordered by first registration —
+//     duplicates are not appended.
+//
+//   - State guard lives in the domain: witness allowed on pending /
+//     approved / executing (the live race window — passive observation
+//     of in-progress work is legitimate). Terminal states refuse.
+//
+//   - unwitness has NO state guard so an observer who joined a
+//     request which then progressed to terminal can still clean up
+//     manually (in practice the auto-reset on terminal already does
+//     this, so this matters for races).
+//
+//   - Auto-reset to [] lives in `Request.transition` for completed/
+//     failed/denied — same terminal frontier as claim.
+
+const WITNESS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'dry-run',
+  'format',
+]);
+
+export async function reqWitness(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WITNESS_KNOWN_FLAGS, 'witness');
+  const id = args.positional[0];
+  if (!id) {
+    throw new Error('Usage: gate witness <id> --by <m> [--dry-run]');
+  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  if (isDryRun(args)) {
+    const { request } = await c.requestUC.witness({ id, by, dryRun: true });
+    // Witness doesn't transition lifecycle state — orthogonal to
+    // pending/approved/executing — so omit `would_transition`.
+    emitDryRunPreview({
+      verb: 'witness',
+      id,
+      by,
+      after: request,
+      format: parseFormat(args),
+    });
+    return 0;
+  }
+  const { request, mutated } = await c.requestUC.witness({ id, by });
+  // Re-witness message is distinct so the caller can tell whether
+  // anything landed (idempotent re-run is legitimate; we just want
+  // to make the no-op visible).
+  const message = mutated
+    ? `✓ witnessed: ${id} by ${by}`
+    : `✓ already witnessing: ${id} by ${by} (no change)`;
+  emitWriteResponse(parseFormat(args), request, message, c.config);
+  return 0;
+}
+
+export async function reqUnwitness(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WITNESS_KNOWN_FLAGS, 'unwitness');
+  const id = args.positional[0];
+  if (!id) {
+    throw new Error('Usage: gate unwitness <id> --by <m> [--dry-run]');
+  }
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  if (isDryRun(args)) {
+    const request = await c.requestUC.unwitness({ id, by, dryRun: true });
+    emitDryRunPreview({
+      verb: 'unwitness',
+      id,
+      by,
+      after: request,
+      format: parseFormat(args),
+    });
+    return 0;
+  }
+  const request = await c.requestUC.unwitness({ id, by });
+  emitWriteResponse(
+    parseFormat(args),
+    request,
+    `✓ unwitnessed: ${id} by ${by}`,
+    c.config,
+  );
+  return 0;
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -18,6 +18,7 @@ import {
 } from './handlers/request.js';
 import { reqReview } from './handlers/review.js';
 import { reqClaim } from './handlers/claim.js';
+import { reqWitness, reqUnwitness } from './handlers/witness.js';
 import { reqThank } from './handlers/thank.js';
 import {
   reqVoices,
@@ -108,6 +109,17 @@ Requests:
                        is refused. The claim auto-releases when the
                        request reaches a terminal state (completed /
                        failed / denied).
+  gate witness <id> --by <m> [--dry-run]
+  gate unwitness <id> --by <m> [--dry-run]
+                       Register / remove a non-exclusive observer on
+                       a pending / approved / executing request
+                       (issue #244). Multiple actors may witness in
+                       parallel and witness coexists with any claim.
+                       Same-actor re-witness is a no-op; unwitness
+                       only removes the caller's own witness (refuses
+                       on a foreign actor). Auto-resets to no
+                       witnesses when the request reaches a terminal
+                       state.
                        --dry-run on any write verb above emits a
                        preview JSON envelope (dry_run/verb/would_
                        transition/preview) without persisting.
@@ -256,7 +268,8 @@ Meta:
 const KNOWN_COMMANDS = [
   'request', 'pending', 'board', 'list', 'show', 'voices', 'tail',
   'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
-  'complete', 'fail', 'review', 'claim', 'thank', 'fast-track', 'issues', 'message',
+  'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
+  'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
   'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
   'unresponded',
@@ -367,6 +380,10 @@ async function dispatch(
       return await reqReview(c, args);
     case 'claim':
       return await reqClaim(c, args);
+    case 'witness':
+      return await reqWitness(c, args);
+    case 'unwitness':
+      return await reqUnwitness(c, args);
     case 'thank':
       return await reqThank(c, args);
     case 'fast-track':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -47,6 +47,8 @@ export const WRITE_VERBS: ReadonlySet<string> = new Set([
   'fail',
   'review',
   'claim',
+  'witness',
+  'unwitness',
   'thank',
   'fast-track',
   'register',

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -38,7 +38,8 @@ interface Case {
 const GATE_ALL = [
   'request', 'pending', 'board', 'list', 'show', 'voices', 'tail',
   'whoami', 'register', 'chain', 'approve', 'deny', 'execute',
-  'complete', 'fail', 'review', 'claim', 'thank', 'fast-track', 'issues',
+  'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
+  'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded',

--- a/tests/interface/witness.test.ts
+++ b/tests/interface/witness.test.ts
@@ -3,7 +3,9 @@
 // (phase 1): claim is exclusive, witness is plural.
 //
 // Coverage:
-//   - first-time witness appends actor; multiple actors witness in parallel
+//   - first-time witness appends actor; multiple sequential witnesses
+//     preserve registration order (true-concurrency in
+//     witnessConcurrency.test.ts)
 //   - re-witness by same actor is a no-op (idempotent, no duplicate)
 //   - witness coexists with a claim (same actor or different actor)
 //   - claim coexists with witnesses by other actors (witness doesn't
@@ -119,7 +121,13 @@ test('gate witness: first-time stamps witnesses array', (t) => {
   assert.deepEqual(j['witnesses'], ['leysia']);
 });
 
-test('gate witness: multiple actors witness in parallel (registration order)', (t) => {
+// NOTE: this test was previously titled "in parallel" but the calls
+// are sequential (spawnSync is blocking). The misleading name was
+// flagged in the #244 Devil REJECT — true-concurrency coverage now
+// lives in `witnessConcurrency.test.ts`. This test stays as the
+// "registration order is preserved across multiple sequential
+// witnesses" canary.
+test('gate witness: multiple sequential witnesses preserve registration order', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   registerAll(root, ['alice', 'leysia', 'miki', 'yuki']);

--- a/tests/interface/witness.test.ts
+++ b/tests/interface/witness.test.ts
@@ -1,0 +1,390 @@
+// `gate witness` / `gate unwitness` — non-exclusive cross-session
+// observer (issue #244 / #226 phase 2). Sibling verb to claim
+// (phase 1): claim is exclusive, witness is plural.
+//
+// Coverage:
+//   - first-time witness appends actor; multiple actors witness in parallel
+//   - re-witness by same actor is a no-op (idempotent, no duplicate)
+//   - witness coexists with a claim (same actor or different actor)
+//   - claim coexists with witnesses by other actors (witness doesn't
+//     conflict)
+//   - unwitness removes the caller's own witness (and only theirs)
+//   - unwitness for an actor not in the list → refuse
+//   - witness on terminal states (completed / failed / denied) → refuse;
+//     existing witnesses auto-reset on the terminal transition
+//   - hydrate tolerance: a record without `witnesses` field loads as
+//     unwitnessed
+//   - gate show text mode shows `witnesses: a, b, c` line
+//   - gate show json includes structured witnesses array
+//   - byte-stable: empty witnesses YAML omits the field
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-witness-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  actor?: string,
+): { stdout: string; stderr: string; status: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (actor !== undefined) env['GUILD_ACTOR'] = actor;
+  else delete env['GUILD_ACTOR'];
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function registerAll(root: string, names: string[]): void {
+  for (const n of names) {
+    run(root, ['register', '--name', n]);
+  }
+}
+
+function newRequest(root: string, from: string, executor?: string): string {
+  const args = [
+    'request',
+    '--from',
+    from,
+    '--action',
+    'do thing',
+    '--reason',
+    'because',
+    '--format',
+    'json',
+  ];
+  if (executor !== undefined) {
+    args.push('--executor', executor);
+  }
+  const r = run(root, args);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  return (JSON.parse(r.stdout) as { id: string }).id;
+}
+
+function readShowJson(
+  root: string,
+  id: string,
+): Record<string, unknown> {
+  const r = run(root, ['show', id, '--format', 'json']);
+  assert.equal(r.status, 0, `show failed: ${r.stderr}`);
+  return JSON.parse(r.stdout) as Record<string, unknown>;
+}
+
+test('gate witness: first-time stamps witnesses array', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+
+  const r = run(root, ['witness', id, '--by', 'leysia', '--format', 'json']);
+  assert.equal(r.status, 0, `witness failed: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.equal(payload['ok'], true);
+  assert.equal(payload['id'], id);
+
+  const j = readShowJson(root, id);
+  assert.deepEqual(j['witnesses'], ['leysia']);
+});
+
+test('gate witness: multiple actors witness in parallel (registration order)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki', 'yuki']);
+  const id = newRequest(root, 'alice');
+
+  // Register in a deliberate order; the array must preserve it.
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'yuki']).status, 0);
+
+  const j = readShowJson(root, id);
+  assert.deepEqual(j['witnesses'], ['leysia', 'miki', 'yuki']);
+});
+
+test('gate witness: re-witness by same actor is a no-op (no duplicate)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+
+  const second = run(root, ['witness', id, '--by', 'leysia', '--format', 'text']);
+  assert.equal(second.status, 0);
+  assert.match(second.stdout, /already witnessing/);
+
+  const j = readShowJson(root, id);
+  assert.deepEqual(
+    j['witnesses'],
+    ['leysia', 'miki'],
+    'order preserved, no duplicate',
+  );
+});
+
+test('gate witness: coexists with a claim by the same actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+
+  assert.equal(run(root, ['claim', id, '--by', 'leysia']).status, 0);
+  assert.equal(
+    run(root, ['witness', id, '--by', 'leysia']).status,
+    0,
+    'witnessing your own claim should be allowed',
+  );
+
+  const j = readShowJson(root, id);
+  assert.equal(j['claimed_by'], 'leysia');
+  assert.deepEqual(j['witnesses'], ['leysia']);
+});
+
+test('gate witness: coexists with a claim by a different actor (no conflict)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+
+  assert.equal(run(root, ['claim', id, '--by', 'leysia']).status, 0);
+  // miki witnesses while leysia holds the claim — must NOT refuse.
+  const r = run(root, ['witness', id, '--by', 'miki']);
+  assert.equal(r.status, 0, `witness on claimed-by-other should succeed: ${r.stderr}`);
+
+  const j = readShowJson(root, id);
+  assert.equal(j['claimed_by'], 'leysia');
+  assert.deepEqual(j['witnesses'], ['miki']);
+});
+
+test('gate witness: allowed on executing state (live race window)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice', 'leysia');
+  assert.equal(run(root, ['approve', id, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', id, '--by', 'leysia']).status, 0);
+
+  // Witness while executing — claim refuses here, witness must accept.
+  const r = run(root, ['witness', id, '--by', 'miki']);
+  assert.equal(r.status, 0, `witness on executing should succeed: ${r.stderr}`);
+  const j = readShowJson(root, id);
+  assert.deepEqual(j['witnesses'], ['miki']);
+});
+
+test('gate witness: refuses on terminal state (completed) and auto-resets', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice', 'leysia');
+
+  // Witness while pending, then walk to completed. Witnesses should
+  // auto-reset; a fresh witness on the terminal record should refuse.
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['approve', id, '--by', 'eris']).status, 0);
+  // Mid-flow: witness survives approve.
+  let j = readShowJson(root, id);
+  assert.deepEqual(j['witnesses'], ['miki']);
+
+  assert.equal(run(root, ['execute', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['complete', id, '--by', 'leysia']).status, 0);
+
+  j = readShowJson(root, id);
+  assert.equal(j['witnesses'], undefined, 'witnesses should auto-reset on complete');
+
+  const refuse = run(root, ['witness', id, '--by', 'leysia']);
+  assert.equal(refuse.status, 1, 'witness on completed should refuse');
+  assert.match(refuse.stderr, /Cannot witness a request in state "completed"/);
+});
+
+test('gate witness: deny / fail also auto-reset witnesses', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+
+  // deny path
+  const idDeny = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', idDeny, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['deny', idDeny, '--by', 'eris', '--reason', 'no']).status, 0);
+  assert.equal(readShowJson(root, idDeny)['witnesses'], undefined);
+
+  // fail path
+  const idFail = newRequest(root, 'alice', 'leysia');
+  assert.equal(run(root, ['witness', idFail, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['approve', idFail, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', idFail, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['fail', idFail, '--by', 'leysia', '--reason', 'oops']).status, 0);
+  assert.equal(readShowJson(root, idFail)['witnesses'], undefined);
+});
+
+test('gate unwitness: caller removes their own witness', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki', 'yuki']);
+  const id = newRequest(root, 'alice');
+
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'yuki']).status, 0);
+
+  const r = run(root, ['unwitness', id, '--by', 'miki', '--format', 'text']);
+  assert.equal(r.status, 0, `unwitness failed: ${r.stderr}`);
+  assert.match(r.stdout, /unwitnessed/);
+
+  const j = readShowJson(root, id);
+  assert.deepEqual(
+    j['witnesses'],
+    ['leysia', 'yuki'],
+    'only miki is removed, order preserved',
+  );
+});
+
+test("gate unwitness: refuses to remove another actor's witness", (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+
+  // miki tries to unwitness leysia — but the verb only takes --by
+  // (the caller). unwitness with --by leysia would only succeed if
+  // miki *is* leysia. The semantics are: --by names the witness to
+  // remove, which by design is the caller. Foreign-actor removal is
+  // refused because miki is not in the witnesses list.
+  const r = run(root, ['unwitness', id, '--by', 'miki']);
+  assert.equal(r.status, 1, 'unwitness for non-witness should refuse');
+  assert.match(r.stderr, /miki is not a witness/);
+
+  // leysia is still witnessing
+  const j = readShowJson(root, id);
+  assert.deepEqual(j['witnesses'], ['leysia']);
+});
+
+test('gate unwitness: removing the last witness omits the field on disk', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['unwitness', id, '--by', 'leysia']).status, 0);
+
+  const dir = join(root, 'requests', 'pending');
+  const yaml = readFileSync(join(dir, `${id}.yaml`), 'utf8');
+  assert.doesNotMatch(
+    yaml,
+    /witnesses/,
+    'empty witnesses must not surface in YAML (byte-stable round-trip)',
+  );
+});
+
+test('gate show text: witnesses line surfaces below the claim line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['claim', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /witnesses: miki/);
+
+  const idxClaim = r.stdout.indexOf('claimed by:');
+  const idxWit = r.stdout.indexOf('witnesses:');
+  assert.ok(
+    idxClaim >= 0 && idxWit > idxClaim,
+    'witnesses line should appear after the claim line',
+  );
+});
+
+test('gate show text: unwitnessed record omits the witnesses line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const id = newRequest(root, 'alice');
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /witnesses:/);
+});
+
+test('hydrate tolerance: legacy record (no witnesses field) loads as unwitnessed', (t) => {
+  // Forge a YAML record with no witnesses field — the shape every
+  // pre-#244 record carries. The repo must hydrate without error and
+  // gate show JSON must report the field as absent.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const dir = join(root, 'requests', 'pending');
+  mkdirSync(dir, { recursive: true });
+  const legacy = `id: 2026-01-01-001
+from: alice
+action: legacy
+reason: pre-witness record
+state: pending
+created_at: '2026-01-01T00:00:00.000Z'
+status_log:
+  - state: pending
+    by: alice
+    at: '2026-01-01T00:00:00.000Z'
+    note: created
+reviews: []
+`;
+  writeFileSync(join(dir, '2026-01-01-001.yaml'), legacy);
+
+  const j = readShowJson(root, '2026-01-01-001');
+  assert.equal(j['witnesses'], undefined);
+
+  // And it can still be witnessed afterwards (proves the legacy path
+  // doesn't corrupt the record on the next save).
+  registerAll(root, ['leysia']);
+  const w = run(root, ['witness', '2026-01-01-001', '--by', 'leysia']);
+  assert.equal(w.status, 0, `witness on legacy failed: ${w.stderr}`);
+
+  const yaml = readFileSync(join(dir, '2026-01-01-001.yaml'), 'utf8');
+  assert.match(yaml, /witnesses:/);
+  assert.match(yaml, /- leysia/);
+});
+
+test('byte-stable: unwitnessed YAML omits the field (round-trip clean)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const id = newRequest(root, 'alice');
+  const dir = join(root, 'requests', 'pending');
+  const yaml = readFileSync(join(dir, `${id}.yaml`), 'utf8');
+  assert.doesNotMatch(yaml, /witnesses/);
+});

--- a/tests/interface/witness.test.ts
+++ b/tests/interface/witness.test.ts
@@ -388,3 +388,132 @@ test('byte-stable: unwitnessed YAML omits the field (round-trip clean)', (t) => 
   const yaml = readFileSync(join(dir, `${id}.yaml`), 'utf8');
   assert.doesNotMatch(yaml, /witnesses/);
 });
+
+// Asteria finding A (#244 follow-up): hand-edited YAML with duplicate
+// witnesses entries must be deduped on hydrate (the domain treats the
+// array as a set ordered by first registration), and the migration
+// must surface via onMalformed so it isn't silent. Without this fix,
+// `unwitness` would have to be invoked twice to clear a duplicated
+// entry, with the actor's name still visible on `show` between calls.
+test('hydrate dedup: duplicate witnesses in YAML are collapsed and warned', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'asteria']);
+  const dir = join(root, 'requests', 'pending');
+  mkdirSync(dir, { recursive: true });
+  const forged = `id: 2026-01-02-001
+from: alice
+action: dup test
+reason: forged duplicates
+state: pending
+created_at: '2026-01-02T00:00:00.000Z'
+status_log:
+  - state: pending
+    by: alice
+    at: '2026-01-02T00:00:00.000Z'
+    note: created
+reviews: []
+witnesses:
+  - asteria
+  - asteria
+`;
+  writeFileSync(join(dir, '2026-01-02-001.yaml'), forged);
+
+  const r = run(root, ['show', '2026-01-02-001', '--format', 'json']);
+  assert.equal(r.status, 0, `show failed: ${r.stderr}`);
+  const j = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.deepEqual(
+    j['witnesses'],
+    ['asteria'],
+    'duplicate witnesses must be collapsed to first occurrence',
+  );
+  assert.match(
+    r.stderr,
+    /witnesses array contained 1 duplicate/,
+    'dedup migration must surface via onMalformed (warn: ...)',
+  );
+
+  // And one unwitness call (not two) suffices to clear it.
+  const u = run(root, ['unwitness', '2026-01-02-001', '--by', 'asteria']);
+  assert.equal(u.status, 0, `unwitness failed: ${u.stderr}`);
+  const j2 = readShowJson(root, '2026-01-02-001');
+  assert.equal(j2['witnesses'], undefined, 'single unwitness should clear');
+});
+
+// Asteria finding B (#244 follow-up): a former witness running a
+// defensive cleanup pass on a terminal record (where auto-reset has
+// already cleared the list) needs a distinguishable error from the
+// real typo case. The `is not a witness` text is reserved for the
+// live-window states; terminal records get a "no action needed"
+// explanation that names the auto-reset behavior.
+test('unwitness on terminal: error message is auto-reset-aware', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice', 'leysia');
+
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+  assert.equal(run(root, ['approve', id, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['complete', id, '--by', 'leysia']).status, 0);
+
+  // miki, formerly a witness, runs cleanup on the (now completed)
+  // record. Auto-reset has already cleared the list, so this is the
+  // benign "nothing to do" path — message must say so.
+  const r = run(root, ['unwitness', id, '--by', 'miki']);
+  assert.equal(r.status, 1, 'unwitness on cleared list still throws');
+  assert.match(
+    r.stderr,
+    /state=completed/,
+    'terminal-aware error must name the state',
+  );
+  assert.match(
+    r.stderr,
+    /auto-released on terminal transitions/,
+    'terminal-aware error must explain why nothing remains',
+  );
+  assert.match(
+    r.stderr,
+    /No action needed/,
+    'terminal-aware error must signal the no-op intent',
+  );
+  // And it must NOT use the live-window typo phrasing.
+  assert.doesNotMatch(
+    r.stderr,
+    /unwitness only removes the caller's own witness/,
+    'live-window typo phrasing is reserved for non-terminal states',
+  );
+});
+
+// Companion to finding B: the live-window states (pending/approved/
+// executing) must still emit the original typo-oriented message — the
+// terminal branch is additive, not a rewrite.
+test('unwitness on live-window: error message is the typo-oriented form', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+
+  // pending
+  const idPending = newRequest(root, 'alice');
+  let r = run(root, ['unwitness', idPending, '--by', 'miki']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unwitness only removes the caller's own witness/);
+  assert.doesNotMatch(r.stderr, /auto-released on terminal/);
+
+  // approved
+  const idApproved = newRequest(root, 'alice', 'leysia');
+  assert.equal(run(root, ['approve', idApproved, '--by', 'eris']).status, 0);
+  r = run(root, ['unwitness', idApproved, '--by', 'miki']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unwitness only removes the caller's own witness/);
+  assert.doesNotMatch(r.stderr, /auto-released on terminal/);
+
+  // executing
+  const idExecuting = newRequest(root, 'alice', 'leysia');
+  assert.equal(run(root, ['approve', idExecuting, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', idExecuting, '--by', 'leysia']).status, 0);
+  r = run(root, ['unwitness', idExecuting, '--by', 'miki']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unwitness only removes the caller's own witness/);
+  assert.doesNotMatch(r.stderr, /auto-released on terminal/);
+});

--- a/tests/interface/witnessConcurrency.test.ts
+++ b/tests/interface/witnessConcurrency.test.ts
@@ -1,0 +1,430 @@
+// True-concurrency coverage for witness / unwitness / claim
+// (issue #244 Devil REJECT root-cause regression suite).
+//
+// The pre-fix bug:
+//   - claim, witness, unwitness mutate state without appending to
+//     status_log / reviews / thanks. The optimistic-lock token was
+//     defined as the sum of those three array lengths, so two
+//     concurrent witnesses BOTH read the same length, both passed
+//     the lock check, and last-writer-wins atomic rename silently
+//     dropped one of the two writes.
+//   - Devil's repro: 4 parallel witnesses → only 1 in the array.
+//                    parallel unwitness → loser silently dropped.
+//                    claim ⊥ witness mixed → both lost intermittently.
+//
+// The fix:
+//   - mutation_seq: number monotonic counter on Request, bumped on
+//     every real claim/witness/unwitness mutation (and per cleared
+//     actor on terminal auto-reset). computeVersion adds it. The
+//     repository's optimistic-lock check now sees the bump and
+//     throws RequestVersionConflict on a true race.
+//   - The use case (RequestUseCases.{claim,witness,unwitness}) wraps
+//     the load → mutate → save in a bounded retry on
+//     RequestVersionConflict. Domain verbs are idempotent on no-op
+//     and refuse on genuine conflict, so retry is safe.
+//
+// Why this lives below the gate CLI layer:
+//   `withGuildLock` (#155) serialises CLI writes at the file lock,
+//   so two concurrent CLI invocations on the same content root never
+//   actually race save() — the loser exits with lock_busy. The
+//   optimistic-lock + mutation_seq fix is defence-in-depth: it
+//   protects scenarios that bypass the file lock (in-process batch
+//   ops, future lock-free fast paths, lock metadata corruption,
+//   plus the lock_busy-retry post-release window). The tests below
+//   exercise the save() race directly so the bug is reproducible.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { GuildConfig } from '../../src/infrastructure/config/GuildConfig.js';
+import { YamlRequestRepository } from '../../src/infrastructure/persistence/YamlRequestRepository.js';
+import { Request } from '../../src/domain/request/Request.js';
+import { RequestId } from '../../src/domain/request/RequestId.js';
+import { MemberName } from '../../src/domain/member/MemberName.js';
+import {
+  RequestVersionConflict,
+} from '../../src/application/ports/RequestRepository.js';
+
+interface Harness {
+  root: string;
+  repo: YamlRequestRepository;
+  cleanup: () => void;
+}
+
+function bootstrap(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'witness-conc-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  const cfg = GuildConfig.load(root, () => {});
+  const repo = new YamlRequestRepository(cfg);
+  return { root, repo, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+async function newRequestOnDisk(
+  repo: YamlRequestRepository,
+  seq: number,
+): Promise<string> {
+  const id = RequestId.generate(new Date('2026-05-08T00:00:00Z'), seq);
+  const r = Request.create({ id, from: 'alice', action: 'a', reason: 'r' });
+  await repo.saveNew(r);
+  return id.value;
+}
+
+// Mirrors the use-case retry helper exactly: load → mutate → save,
+// retry on RequestVersionConflict. Inlined here so the test itself
+// drives the race (separate concurrent callers each running this loop)
+// without coupling to RequestUseCases construction (which depends on
+// member/inbox repos this test doesn't need).
+async function applyMutationWithRetry(
+  repo: YamlRequestRepository,
+  id: string,
+  mutate: (r: Request) => boolean /* true if the mutation should save */,
+): Promise<void> {
+  const maxAttempts = 16;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const r = await repo.findById(RequestId.of(id));
+      if (!r) throw new Error(`Request not found: ${id}`);
+      const shouldSave = mutate(r);
+      if (shouldSave) await repo.save(r);
+      return;
+    } catch (e) {
+      if (!(e instanceof RequestVersionConflict)) throw e;
+      lastErr = e;
+      // Tiny stagger to spread contention.
+      await new Promise((res) => setTimeout(res, 2 * (attempt + 1)));
+    }
+  }
+  throw lastErr;
+}
+
+test('concurrent witness: 4 parallel witnesses all land (no silent drop)', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 1);
+
+  // Pre-fix: each loaded copy saw the same status_log+reviews+thanks
+  // length and the optimistic-lock check passed every save; last-
+  // writer-wins kept exactly one in the array. Post-fix: the first
+  // save bumps mutation_seq and the next three see
+  // RequestVersionConflict — the retry helper reloads and re-applies.
+  await Promise.all(
+    ['a', 'b', 'c', 'd'].map((name) =>
+      applyMutationWithRetry(h.repo, id, (r) => {
+        const before = r.witnesses.length;
+        r.witness(MemberName.of(name));
+        return r.witnesses.length !== before;
+      }),
+    ),
+  );
+
+  const final = (await h.repo.findById(RequestId.of(id)))!;
+  const witnesses = final.witnesses.map((m) => m.value).sort();
+  assert.deepEqual(
+    witnesses,
+    ['a', 'b', 'c', 'd'],
+    'all 4 concurrent witnesses must coexist (the #244 core promise)',
+  );
+});
+
+test('concurrent unwitness: two actors removing themselves both reflect', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 2);
+
+  // Pre-state (sequential): a, b, c all witnessing.
+  for (const name of ['a', 'b', 'c']) {
+    await applyMutationWithRetry(h.repo, id, (r) => {
+      r.witness(MemberName.of(name));
+      return true;
+    });
+  }
+
+  // Concurrent unwitness: b and c each remove themselves. Pre-fix
+  // both pass the length-only lock and last-writer-wins drops one
+  // removal — final array would be {a, b} or {a, c} instead of {a}.
+  await Promise.all(
+    ['b', 'c'].map((name) =>
+      applyMutationWithRetry(h.repo, id, (r) => {
+        r.unwitness(MemberName.of(name));
+        return true;
+      }),
+    ),
+  );
+
+  const final = (await h.repo.findById(RequestId.of(id)))!;
+  assert.deepEqual(
+    final.witnesses.map((m) => m.value),
+    ['a'],
+    'both unwitness calls must land — only "a" should remain',
+  );
+});
+
+test('concurrent claim ⊥ witness: claim and witness coexist (#244 core promise)', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 3);
+
+  // Mixed race: one claim + three witnesses, all in parallel. The
+  // #244 core promise is "witness coexists with any claim" — pre-fix
+  // any of these could vanish under last-writer-wins on the same
+  // length-version token.
+  await Promise.all([
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.claimedBy?.value;
+      r.claim(MemberName.of('claimant'), new Date().toISOString());
+      return r.claimedBy?.value !== before;
+    }),
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.witnesses.length;
+      r.witness(MemberName.of('w1'));
+      return r.witnesses.length !== before;
+    }),
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.witnesses.length;
+      r.witness(MemberName.of('w2'));
+      return r.witnesses.length !== before;
+    }),
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.witnesses.length;
+      r.witness(MemberName.of('w3'));
+      return r.witnesses.length !== before;
+    }),
+  ]);
+
+  const final = (await h.repo.findById(RequestId.of(id)))!;
+  assert.equal(
+    final.claimedBy?.value,
+    'claimant',
+    'claim must survive concurrent witness writes',
+  );
+  const witnesses = final.witnesses.map((m) => m.value).sort();
+  assert.deepEqual(
+    witnesses,
+    ['w1', 'w2', 'w3'],
+    'all witnesses must coexist with the claim — #244 core promise',
+  );
+});
+
+test('concurrent claim: two different actors race — exactly one wins, other refuses', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 4);
+
+  // Both a and b try to claim simultaneously. claim is exclusive —
+  // exactly one must succeed; the other must surface the domain
+  // conflict ("already claimed by") rather than a silent overwrite.
+  // Pre-fix the version-lock could pass both, and last-writer-wins
+  // would seat whichever raced last with the first claim's record
+  // silently overwritten.
+  const settled = await Promise.allSettled([
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.claimedBy?.value;
+      r.claim(MemberName.of('a'), new Date().toISOString());
+      return r.claimedBy?.value !== before;
+    }),
+    applyMutationWithRetry(h.repo, id, (r) => {
+      const before = r.claimedBy?.value;
+      r.claim(MemberName.of('b'), new Date().toISOString());
+      return r.claimedBy?.value !== before;
+    }),
+  ]);
+  const fulfilled = settled.filter((s) => s.status === 'fulfilled');
+  const rejected = settled.filter((s) => s.status === 'rejected');
+  assert.equal(fulfilled.length, 1, 'exactly one claim must succeed');
+  assert.equal(rejected.length, 1, 'the other must refuse');
+  const reason = (rejected[0] as PromiseRejectedResult).reason as Error;
+  assert.match(
+    reason.message,
+    /already claimed/,
+    'the loser must see the domain conflict — not a silent drop or generic version error',
+  );
+
+  const final = (await h.repo.findById(RequestId.of(id)))!;
+  const claimedBy = final.claimedBy?.value;
+  assert.ok(
+    claimedBy === 'a' || claimedBy === 'b',
+    `claimant must be one of the racers: ${claimedBy}`,
+  );
+});
+
+test('concurrent same-actor re-witness: idempotent under concurrency (no duplicates)', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 5);
+
+  // Four parallel witness calls by the SAME actor. The first lands
+  // and bumps mutation_seq; the others reload, see "already
+  // witnessing", and no-op. None should duplicate.
+  await Promise.all(
+    [0, 1, 2, 3].map(() =>
+      applyMutationWithRetry(h.repo, id, (r) => {
+        const before = r.witnesses.length;
+        r.witness(MemberName.of('a'));
+        return r.witnesses.length !== before;
+      }),
+    ),
+  );
+
+  const final = (await h.repo.findById(RequestId.of(id)))!;
+  assert.deepEqual(
+    final.witnesses.map((m) => m.value),
+    ['a'],
+    'idempotent re-witness must not duplicate under concurrency',
+  );
+});
+
+test('mutation_seq is monotonic across the witness/claim lifecycle', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 6);
+
+  const seq = async () => (await h.repo.findById(RequestId.of(id)))!.mutationSeq;
+
+  assert.equal(await seq(), 0, 'fresh request must have mutation_seq=0');
+
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.witness(MemberName.of('a'));
+    return true;
+  });
+  assert.equal(await seq(), 1, 'first witness bumps to 1');
+
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.witness(MemberName.of('b'));
+    return true;
+  });
+  assert.equal(await seq(), 2, 'second witness bumps to 2');
+
+  // Re-witness same actor — domain no-op, save skipped, mutation_seq
+  // must NOT bump.
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    const before = r.witnesses.length;
+    r.witness(MemberName.of('a'));
+    return r.witnesses.length !== before;
+  });
+  assert.equal(
+    await seq(),
+    2,
+    'idempotent re-witness must not bump mutation_seq',
+  );
+
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.claim(MemberName.of('a'), new Date().toISOString());
+    return true;
+  });
+  assert.equal(await seq(), 3, 'first claim bumps to 3');
+
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.unwitness(MemberName.of('b'));
+    return true;
+  });
+  assert.equal(await seq(), 4, 'unwitness bumps to 4');
+});
+
+test('byte-stable: pre-#244-fix records (no mutation_seq field) round-trip clean', async (t) => {
+  // A never-mediated record (mutation_seq=0) must NOT emit the field
+  // in YAML — pre-#244 records on disk lack the field entirely, and
+  // a fresh post-fix record must round-trip identically so dogfooded
+  // records don't churn diffs.
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 7);
+  const yamlPath = join(h.root, 'requests', 'pending', `${id}.yaml`);
+  const yaml = readFileSync(yamlPath, 'utf8');
+  assert.doesNotMatch(
+    yaml,
+    /mutation_seq/,
+    'never-mediated record must omit mutation_seq for byte-stable round-trip with pre-#244 YAML',
+  );
+});
+
+test('mutation_seq emitted in YAML only after first mutation', async (t) => {
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 8);
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.witness(MemberName.of('observer'));
+    return true;
+  });
+
+  const yamlPath = join(h.root, 'requests', 'pending', `${id}.yaml`);
+  const yaml = readFileSync(yamlPath, 'utf8');
+  assert.match(
+    yaml,
+    /mutation_seq:\s*1/,
+    'after one mutation, mutation_seq: 1 must surface in YAML',
+  );
+});
+
+test('repo: stale-load + concurrent witness throws RequestVersionConflict', async (t) => {
+  // Belt-and-braces: a stale-loaded request that tries to save AFTER
+  // a concurrent mutation must throw RequestVersionConflict (the
+  // signal the retry helper relies on). Exercises the repo directly,
+  // past the retry, to confirm the optimistic-lock check sees
+  // mutation_seq movement — without this the retry helper would loop
+  // forever on a silent overwrite.
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 9);
+
+  // Snapshot 1: load fresh (loadedVersion = create's status_log = 1).
+  const snapshot = (await h.repo.findById(RequestId.of(id)))!;
+  // Concurrent path: a different agent witnesses and saves first.
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.witness(MemberName.of('a'));
+    return true;
+  });
+  // Now `snapshot` is stale. Try to mutate and save it.
+  snapshot.witness(MemberName.of('b'));
+  await assert.rejects(
+    () => h.repo.save(snapshot),
+    (e: unknown) => e instanceof RequestVersionConflict,
+    'save() on a stale aggregate after a concurrent witness must throw RequestVersionConflict — that is the signal the retry helper relies on',
+  );
+});
+
+test('terminal auto-reset bumps mutation_seq per cleared actor', async (t) => {
+  // Per-actor accounting: a terminal frontier collapsing one claim
+  // and N witnesses bumps mutation_seq by 1 + N (one for the claim,
+  // one per witness). The test sets up "claim + 3 witnesses" then
+  // walks to a terminal state and asserts the delta — keeps "how
+  // many actors were mediating at close" recoverable from the seq.
+  const h = bootstrap();
+  t.after(h.cleanup);
+  const id = await newRequestOnDisk(h.repo, 10);
+
+  for (const name of ['w1', 'w2', 'w3']) {
+    await applyMutationWithRetry(h.repo, id, (r) => {
+      r.witness(MemberName.of(name));
+      return true;
+    });
+  }
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.claim(MemberName.of('c'), new Date().toISOString());
+    return true;
+  });
+
+  const before = (await h.repo.findById(RequestId.of(id)))!.mutationSeq;
+  assert.equal(before, 4, '3 witnesses + 1 claim = 4 mutation_seq');
+
+  // Walk to denied (terminal) — releases claim and resets witnesses.
+  await applyMutationWithRetry(h.repo, id, (r) => {
+    r.deny(MemberName.of('eris'), 'no');
+    return true;
+  });
+
+  const after = (await h.repo.findById(RequestId.of(id)))!;
+  assert.equal(
+    after.mutationSeq,
+    before + 1 /* claim cleared */ + 3 /* witnesses cleared */,
+    'terminal auto-reset must bump per-actor (claim +1, each witness +1)',
+  );
+  assert.equal(after.claimedBy, undefined);
+  assert.equal(after.witnesses.length, 0);
+});


### PR DESCRIPTION
## Summary

- `gate witness <id> --by <actor>` / `gate unwitness <id> --by <actor>` — non-exclusive observation primitive (#226 phase 2、closes #244)
- claim verb (#243) と対称、ただし state-guard が executing も許可 / array なので re-witness は `some()` 重複 check / unwitness は missing-actor で throw
- **mutation_seq counter** 新設 — claim / witness / unwitness / terminal auto-reset で per-actor +1。`computeVersion` に算入されて optimistic-lock token として機能
- `RequestUseCases.retryOnVersionConflict` ヘルパー — bounded 8回 + stagger backoff、idempotent ⊥ refuse の domain 契約により retry safe
- `gate show` text/json 両 surface に `witnesses` 表示（空時 omit）
- `gate boot` は #234 の役割なので非介入

## なぜ mutation_seq？

初回実装時 (`0d21f88`) は Devil 最終ゲートで **REJECT 致命 3**：

1. 4 並列 witness → 3 名 silently drop (`computeVersion` が witnesses 算入なし)
2. 並列 unwitness で write loss
3. claim ⊥ witness mixed で片方消失 — phase 2 の core promise 破壊

`computeVersion = statusLogLen + reviewsLen + thanksLen` が append-only count を前提としていたが、claim/witnesses は削除あり (terminal auto-reset / unwitness) なので length 和では monotonicity が壊れる。

→ `mutation_seq: number` 単調カウンタを別フィールドで持たせ、mutation 毎に +1。`computeVersion = ... + mutationSeq` に拡張して optimistic-lock token として機能させた。byte-stable: `mutation_seq: 0` は YAML omit、pre-#244 record と round-trip clean。

## 検証

- Asteria T1-T9 PASS (基本動作 / 複数 actor / claim 共存 / re-witness 冪等 / state-guard / unwitness 権限 / byte-stable / hydrate tolerance / claim+witness terminal)
- Asteria 指摘 A/B fix (`524a052`): hydrate dedup + terminal-aware unwitness error
- **真並走 concurrency test 10 件新規** (`tests/interface/witnessConcurrency.test.ts`、Promise.all + repo.save() 直叩き)
- pre-fix sabotage (`bumpMutationSeq` を no-op) で 10 中 8 deterministic fail → fix 効果実証
- 全体 **1264/1264 GREEN**

## Devil 再ゲート: ratify (致命ゼロ)

5 lense で blocker なし、3 件は記録のみの将来負債：
1. 新 mutation verb 追加時の bump 忘れ防止（人間 review 依存）
2. retry 発火の観測性欠落（swarm 高頻度化で効く）
3. retry bound (8回×16ms) config 化なし

## Scope-out (follow-up)

- #245 (render UX: claim/witnesses 行が status_log 内に見える、claim から踏襲)
- #246 (--note on stake verbs design)

## Test plan

- [x] `npm run build && npm test` 全 GREEN (1264/1264)
- [x] witness 28 単体テスト + concurrency 10 真並走テスト
- [x] pre-fix sabotage で fix 効果実証
- [x] byte-stable: pre-#244 record と round-trip clean を実 YAML grep で確認
- [x] CHANGELOG `[Unreleased]` に concurrency 契約 + mutation_seq 説明追加

Closes #244, #226 (phase 2 完結)

🤖 Generated with [Claude Code](https://claude.com/claude-code)