### PR TITLE
feat(gate): profile-gated self_approve { allowed | warn | forbidden } (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   optional fields use. `fast-track` is unaffected (orthogonal verb,
   never gated). Non-self approve is also unaffected regardless of
   profile/policy — the gate is self-only.
+  + Self-detection is now performed on the canonical actor
+    representation (case-fold + trim, via `MemberName`) rather than
+    the raw CLI argument. Pre-fix, daily typing habits like `--by
+    ALICE` or `--by 'alice '` slipped past the swarm `forbidden`
+    gate even though the persisted record collapsed both to `alice`
+    — a critical bypass surfaced by Asteria during cross-review.
+    The same normalization is applied to all handler-side
+    self-detection sites (review's self-review warning, thank's
+    self-thank notice, message's self-message advisory) and to the
+    `# verb id: invoked by X on behalf of Y` surface line, so
+    whitespace no longer leaks into the audit trail.
 - **`gate witness <id> --by <actor>` / `gate unwitness <id> --by <actor>`
   for non-exclusive cross-session observation**
   ([#244](https://github.com/eris-ths/guild-cli/issues/244),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`features.self_approve: { allowed | warn | forbidden }` —
+  profile-gated self-approve policy on `gate approve`**
+  ([#233](https://github.com/eris-ths/guild-cli/issues/233)).
+  Tri-state config gates the case where `--by` matches the request
+  author. Three states (not a boolean) because failure modes differ:
+  `allowed` passes silently for deployments that actively rely on
+  self-approve, `warn` passes with a stderr notice pointing at
+  fast-track (the historical default), `forbidden` refuses with exit
+  1 and an actionable error naming three recovery paths
+  (`gate fast-track`, another actor approving, or switching profile /
+  setting `self_approve: warn`). Profile defaults: `warn` under
+  `standard` (preserves current behaviour), `forbidden` under `swarm`
+  (parallel waves require bias-checked approvals — same shape as
+  `worktree_required_for_parallel`). An explicit
+  `features.self_approve` always overrides the profile default so a
+  deployment can opt in/out without flipping the whole profile.
+  Malformed values (non-string, or string outside the enum) surface
+  via `onMalformed` and fall back to the profile default rather than
+  rejecting the config — same conservative read pattern other
+  optional fields use. `fast-track` is unaffected (orthogonal verb,
+  never gated). Non-self approve is also unaffected regardless of
+  profile/policy — the gate is self-only.
 - **`gate witness <id> --by <actor>` / `gate unwitness <id> --by <actor>`
   for non-exclusive cross-session observation**
   ([#244](https://github.com/eris-ths/guild-cli/issues/244),

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -33,6 +33,26 @@ export const defaultOnMalformed: OnMalformed = (source, msg) => {
  */
 export type GuildProfile = 'standard' | 'swarm';
 
+/**
+ * Tri-state policy for self-approval on `gate approve` (#233).
+ *
+ *   - `allowed`   : pass silently (no notice). For deployments that
+ *                   actively rely on self-approve as a primitive.
+ *   - `warn`      : pass, emit a stderr notice pointing at fast-track.
+ *                   The historical default — preserved under
+ *                   profile=standard so existing flows keep working.
+ *   - `forbidden` : refuse with an actionable error. Default under
+ *                   profile=swarm, where parallel waves and
+ *                   bias-checked approvals are the explicit point.
+ *
+ * Three states (not a boolean) because the failure modes differ:
+ * `allowed` removes the audit notice for callers who deliberately
+ * accept the risk, and `forbidden` is a hard stop with a recovery
+ * hint, not a softer noticed pass. Collapsing to two would either
+ * lose the silent-allow surface or muddle the swarm error path.
+ */
+export type SelfApprovePolicy = 'allowed' | 'warn' | 'forbidden';
+
 export interface GuildFeatures {
   /**
    * When true, parallel waves (multi-executor requests) carry a
@@ -43,6 +63,13 @@ export interface GuildFeatures {
    * in/out without flipping the whole profile.
    */
   worktreeRequiredForParallel: boolean;
+  /**
+   * Tri-state self-approve policy on `gate approve` (#233). Profile
+   * default: `warn` under standard, `forbidden` under swarm. An
+   * explicit `features.self_approve` always overrides the profile
+   * default — same opt-in/opt-out shape as worktree_required_for_parallel.
+   */
+  selfApprove: SelfApprovePolicy;
 }
 
 export interface GuildConfigProps {
@@ -161,9 +188,30 @@ export class GuildConfig implements GuildConfigProps {
       typeof featuresRaw.worktree_required_for_parallel === 'boolean'
         ? featuresRaw.worktree_required_for_parallel
         : undefined;
+    // self_approve (#233): tri-state with profile-derived default.
+    // Malformed values (non-string, or string outside the enum) fall
+    // back to the profile default with an onMalformed notice — same
+    // conservative read pattern other optional fields use.
+    const selfApproveDefault: SelfApprovePolicy =
+      profile === 'swarm' ? 'forbidden' : 'warn';
+    let selfApprove: SelfApprovePolicy = selfApproveDefault;
+    if (featuresRaw.self_approve !== undefined) {
+      const v = featuresRaw.self_approve;
+      if (v === 'allowed' || v === 'warn' || v === 'forbidden') {
+        selfApprove = v;
+      } else {
+        onMalformed(
+          configPath,
+          `unknown features.self_approve ${JSON.stringify(v)} — ` +
+            `falling back to profile default '${selfApproveDefault}'. ` +
+            `Valid: allowed | warn | forbidden.`,
+        );
+      }
+    }
     const features: GuildFeatures = {
       worktreeRequiredForParallel:
         explicitWorktreeRequired ?? (profile === 'swarm'),
+      selfApprove,
     };
     return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, profile, features, onMalformed, configPath);
   }
@@ -186,7 +234,7 @@ export class GuildConfig implements GuildConfigProps {
       [...DEFAULT_LENSES],
       [],
       'standard',
-      { worktreeRequiredForParallel: false },
+      { worktreeRequiredForParallel: false, selfApprove: 'warn' },
       onMalformed,
       null,
     );

--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -3,6 +3,7 @@ import { resolve as resolvePath } from 'node:path';
 import { buildContainer } from '../../shared/container.js';
 import { optionalOption, ParsedArgs } from '../../shared/parseArgs.js';
 import { RequestJSON } from '../voices.js';
+import { MemberName } from '../../../domain/member/MemberName.js';
 
 /**
  * Shared private helpers for gate command handlers.
@@ -57,6 +58,31 @@ export async function readStdin(): Promise<string> {
  * record) and you need to pass the value into the use case before
  * emitting the user-facing delegation notice.
  */
+/**
+ * Normalize a raw CLI `--by` / `--from` actor string to its canonical
+ * form (case-fold + trim, matching `MemberName.of()`'s value rules).
+ *
+ * Why this exists separately from `MemberName.of`: handlers compare a
+ * raw CLI argument against the canonical `request.from.value`
+ * (already lowercased/trimmed by the domain VO at write time). A naive
+ * string compare lets `--by ALICE` or `--by 'alice '` slip past
+ * self-detection — a CRITICAL bypass on the swarm `forbidden` policy
+ * (#233 follow-up: Asteria-found bypass on 50c9af1). Reusing the VO
+ * keeps a single source of truth for what "same actor" means and
+ * surfaces invalid actors with the same domain error the rest of the
+ * stack already raises.
+ *
+ * Rejects invalid input (empty / regex-failing / reserved) by letting
+ * `MemberName.of` throw — the handler entry already trusts that
+ * validation has happened upstream OR will happen, so an early throw
+ * here is preferable to a silent fall-through that lands a bad actor
+ * in YAML. Use this anywhere a handler needs to compare or display
+ * `by` before the use case has had a chance to canonicalize.
+ */
+export function normalizeActor(raw: string): string {
+  return MemberName.of(raw).value;
+}
+
 export function deriveInvokedBy(by: string): string | undefined {
   const envActor = resolveGuildActor();
   if (!envActor || envActor.length === 0) return undefined;

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -10,6 +10,7 @@ import {
   deriveInvokedBy,
   emitInvokedByNotice,
   readStdin,
+  normalizeActor,
 } from './internal.js';
 import { InboxMessage } from '../../../application/ports/NotificationPort.js';
 
@@ -60,8 +61,13 @@ const INBOX_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 
 export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, MESSAGE_SEND_KNOWN_FLAGS, 'message');
-  const from = requireOption(args, 'from', '<m>', 'GUILD_ACTOR');
-  const to = requireOption(args, 'to', '<m>');
+  // Canonicalize both sides of the self-message compare for the same
+  // reason as thank/approve: raw CLI args bypass the lowercase/trim
+  // collapse the persisted record applies.
+  const from = normalizeActor(
+    requireOption(args, 'from', '<m>', 'GUILD_ACTOR'),
+  );
+  const to = normalizeActor(requireOption(args, 'to', '<m>'));
   let text = requireOption(args, 'text', '"..."');
   // `--text -` reads from stdin — same sentinel as `gate issues note
   // --text -` and `gate review --comment -`. Heredoc bodies for long
@@ -116,7 +122,9 @@ export async function msgSend(c: C, args: ParsedArgs): Promise<number> {
 
 export async function msgBroadcast(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, MESSAGE_BROADCAST_KNOWN_FLAGS, 'broadcast');
-  const from = requireOption(args, 'from', '<m>', 'GUILD_ACTOR');
+  const from = normalizeActor(
+    requireOption(args, 'from', '<m>', 'GUILD_ACTOR'),
+  );
   let text = requireOption(args, 'text', '"..."');
   if (text === '-') text = (await readStdin()).trim();
   const type = optionalOption(args, 'type');

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -617,12 +617,32 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'approve', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
+  // Self-approve gate (#233). The detect runs BEFORE applying the
+  // transition: under `forbidden` we must not mutate the record. The
+  // `from` field is the canonical author (immutable post-creation);
+  // comparing on string value matches the historical notice path.
+  const prior = await c.requestUC.show(id);
+  const isSelf = prior !== null && by === prior.from.value;
+  if (isSelf) {
+    const policy = c.config.features.selfApprove;
+    if (policy === 'forbidden') {
+      const profile = c.config.profile;
+      process.stderr.write(
+        `error: self-approve forbidden in this profile (${profile}).\n` +
+          `  Options:\n` +
+          `    - Use \`gate fast-track <id>\` for legitimate single-step self-flow\n` +
+          `    - Have another actor approve: \`gate approve <id> --by <other>\`\n` +
+          `    - Switch profile to \`standard\` or set \`self_approve: warn\` if this guild allows self-approve\n`,
+      );
+      return 1;
+    }
+  }
   const r = await c.requestUC.approve(id, by, note, invokedBy);
-  // Self-approval is policy-allowed but worth flagging on stderr so
-  // the no-second-pair-of-eyes case never happens silently. Use the
-  // on-record actor (`by`), not GUILD_ACTOR — invoked_by is already
-  // surfaced separately by resolveInvokedBy above.
-  if (by === r.from.value) {
+  // Self-approval notice. Suppressed under `allowed` (deployments that
+  // actively rely on self-approve and don't want the audit line).
+  // Preserved under `warn` — the historical default — so the
+  // no-second-pair-of-eyes case never happens silently.
+  if (by === r.from.value && c.config.features.selfApprove === 'warn') {
     process.stderr.write(
       `notice: ${by} approved their own request ${id} ` +
         `(no second reviewer; for a single-step self-flow use ` +

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -100,12 +100,15 @@ import {
   resolveInvokedBy,
   isDryRun,
   emitDryRunPreview,
+  normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
 export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, REQUEST_CREATE_KNOWN_FLAGS, 'request');
-  const from = requireOption(args, 'from', '<m>', 'GUILD_ACTOR');
+  const from = normalizeActor(
+    requireOption(args, 'from', '<m>', 'GUILD_ACTOR'),
+  );
   const action = requireOption(args, 'action', '"..."');
   let reason = requireOption(args, 'reason', '"..."');
   // `--reason -` reads from stdin — parity with `gate review --comment -`.
@@ -606,7 +609,15 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, APPROVE_KNOWN_FLAGS, 'approve');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate approve <id> --by <m> [--dry-run]');
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  // Canonicalize `--by` BEFORE the self-detection compare and BEFORE
+  // any user-facing notice/invoked-by line is emitted. The raw CLI
+  // arg (`ALICE`, `alice `, etc.) survives into the comparison
+  // otherwise — `prior.from.value` was canonicalized at create time,
+  // so a raw compare let `--by ALICE` slip past the swarm
+  // `forbidden` policy (#233 follow-up Asteria critical bypass).
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'approve', id);
   if (isDryRun(args)) {
@@ -663,7 +674,9 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
         dashedValueHint(args, ['reason', 'note']),
     );
   }
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const invokedBy = resolveInvokedBy(by, 'deny', id);
   if (isDryRun(args)) {
     const prior = await c.requestUC.show(id);
@@ -683,7 +696,9 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   const id = args.positional[0];
   if (!id)
     throw new Error('Usage: gate execute <id> --by <m> [--cwd <path>] [--dry-run]');
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const note = optionalOption(args, 'note');
   // --cwd lets a caller declare "I'm running from THIS filesystem"
   // explicitly. Defaults to process.cwd() because every real call
@@ -788,7 +803,9 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, COMPLETE_KNOWN_FLAGS, 'complete');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate complete <id> --by <m> [--dry-run]');
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const note = optionalOption(args, 'note');
   const invokedBy = resolveInvokedBy(by, 'complete', id);
   if (isDryRun(args)) {
@@ -823,7 +840,9 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
         dashedValueHint(args, ['reason', 'note']),
     );
   }
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const invokedBy = resolveInvokedBy(by, 'fail', id);
   if (isDryRun(args)) {
     const prior = await c.requestUC.show(id);
@@ -929,7 +948,13 @@ async function resolveReason(args: ParsedArgs, _verb: string): Promise<string> {
 
 export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, FAST_TRACK_KNOWN_FLAGS, 'fast-track');
-  const from = requireOption(args, 'from', '<m>', 'GUILD_ACTOR');
+  // Canonicalize the author once at entry so every downstream use
+  // (executor defaulting, invoked-by surface, env-actor compare) sees
+  // the same value as `Request.from` will after MemberName.of()
+  // normalizes it inside the use case.
+  const from = normalizeActor(
+    requireOption(args, 'from', '<m>', 'GUILD_ACTOR'),
+  );
   const action = requireOption(args, 'action', '"..."');
   let reason = requireOption(args, 'reason', '"..."');
   if (reason === '-') reason = (await readStdin()).trim();

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -11,6 +11,7 @@ import {
   resolveInvokedBy,
   isDryRun,
   emitDryRunPreview,
+  normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
@@ -32,7 +33,12 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
         '[--comment <s> | --comment - | <comment>]',
     );
   }
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  // Canonicalize before downstream compares (`updated.from.value === by`
+  // is the self-review trigger and was vulnerable to the same case-fold
+  // / trim bypass that #233's self_approve gate had).
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
   const lense = requireOption(args, 'lense', '<l>');
   const verdict = requireOption(args, 'verdict', '<ok|concern|reject>');
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -790,7 +790,12 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'approve',
     category: 'write',
-    summary: 'transition pending → approved',
+    summary:
+      'transition pending → approved. Self-approve (by === request.from) ' +
+      'is gated by `features.self_approve` { allowed | warn | forbidden } ' +
+      '(#233). Profile defaults: warn under standard (notice + pass), ' +
+      'forbidden under swarm (exit 1 + actionable error). fast-track is ' +
+      'unaffected — use it for legitimate single-step self-flow.',
     input: {
       type: 'object',
       properties: {

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -10,6 +10,7 @@ import {
   resolveInvokedBy,
   isDryRun,
   emitDryRunPreview,
+  normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
@@ -39,14 +40,20 @@ const THANK_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  */
 export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, THANK_KNOWN_FLAGS, 'thank');
-  const to = args.positional[0];
-  if (!to) {
+  const toRaw = args.positional[0];
+  if (!toRaw) {
     throw new Error(
       'Usage: gate thank <to> --for <id> [--reason <s>] [--dry-run]',
     );
   }
   const id = requireOption(args, 'for', '<request-id>');
-  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  // Canonicalize both sides of the self-thank compare: raw CLI input
+  // would let `--by ALICE --to alice` slip past `by === to` even
+  // though the persisted record collapses both to `alice`.
+  const by = normalizeActor(
+    requireOption(args, 'by', '<m>', 'GUILD_ACTOR'),
+  );
+  const to = normalizeActor(toRaw);
   let reason = optionalOption(args, 'reason');
   if (reason === '-') reason = (await readStdin()).trim();
   const invokedBy = resolveInvokedBy(by, 'thank', id);

--- a/tests/interface/selfApprove.test.ts
+++ b/tests/interface/selfApprove.test.ts
@@ -1,0 +1,245 @@
+// Self-approve policy gate (#233).
+//
+// Tri-state `features.self_approve` { allowed | warn | forbidden }
+// gates `gate approve` when the approver matches the request author.
+// Profile defaults: warn under standard (historical behaviour),
+// forbidden under swarm (parallel waves require bias-checked
+// approvals). An explicit features.self_approve always wins, so a
+// deployment can opt in/out without flipping the whole profile.
+//
+// Surface contract verified here:
+//   - swarm  + self-approve              → exit 1 + actionable error
+//                                          (fast-track / other actor /
+//                                          profile change all named)
+//   - standard + self-approve            → notice + pass (current default)
+//   - features.self_approve: allowed     → pass silently (no notice)
+//   - swarm + features.self_approve: warn override → notice + pass
+//   - fast-track is unaffected           (orthogonal verb, never gated)
+//   - non-self approve                   → no notice, no error,
+//                                          regardless of profile/policy
+//   - malformed self_approve string      → onMalformed warn + profile
+//                                          default (forbidden under swarm)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function mkdtempReal(prefix: string): string {
+  return realpathSync(mkdtempSync(prefix));
+}
+
+interface Bootstrap {
+  root: string;
+  cleanup: () => void;
+}
+
+function bootstrap(yaml: string): Bootstrap {
+  const root = mkdtempReal(join(tmpdir(), 'guild-selfapprove-'));
+  writeFileSync(join(root, 'guild.config.yaml'), yaml);
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  actor?: string,
+): { stdout: string; stderr: string; status: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (actor !== undefined) env['GUILD_ACTOR'] = actor;
+  else delete env['GUILD_ACTOR'];
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function registerAll(root: string, names: string[]): void {
+  for (const n of names) {
+    run(root, ['register', '--name', n]);
+  }
+}
+
+function createRequest(
+  root: string,
+  args: { from: string; executors?: string[] },
+): string {
+  const cliArgs = [
+    'request',
+    '--from',
+    args.from,
+    '--action',
+    'do thing',
+    '--reason',
+    'r',
+    '--format',
+    'json',
+  ];
+  if (args.executors && args.executors.length > 0) {
+    cliArgs.push('--executors', args.executors.join(','));
+  }
+  const r = run(root, cliArgs);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  return (JSON.parse(r.stdout) as { id: string }).id;
+}
+
+test('swarm profile: self-approve is forbidden with actionable error', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  assert.equal(ap.status, 1, `should refuse self-approve: stderr=${ap.stderr}`);
+  assert.match(ap.stderr, /self-approve forbidden/);
+  assert.match(ap.stderr, /\(swarm\)/);
+  assert.match(ap.stderr, /fast-track/);
+  assert.match(ap.stderr, /--by <other>/);
+  assert.match(ap.stderr, /self_approve: warn/);
+});
+
+test('standard profile: self-approve emits notice but passes (historical default)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  assert.equal(ap.status, 0, `should pass: stderr=${ap.stderr}`);
+  assert.match(ap.stderr, /approved their own request/);
+});
+
+test('features.self_approve: allowed → pass silently (no notice)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n' +
+      'features:\n  self_approve: allowed\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  assert.equal(ap.status, 0, `should pass: stderr=${ap.stderr}`);
+  assert.doesNotMatch(
+    ap.stderr,
+    /approved their own request/,
+    `expected NO self-approve notice under 'allowed': ${ap.stderr}`,
+  );
+});
+
+test('swarm + features.self_approve: warn override → notice + pass', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n' +
+      'features:\n  self_approve: warn\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  assert.equal(
+    ap.status,
+    0,
+    `explicit warn should override swarm default: stderr=${ap.stderr}`,
+  );
+  assert.match(ap.stderr, /approved their own request/);
+});
+
+test('fast-track is unaffected by self_approve policy (swarm)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+
+  const ft = run(root, [
+    'fast-track',
+    '--from',
+    'alice',
+    '--action',
+    'quick',
+    '--reason',
+    'r',
+  ]);
+  assert.equal(
+    ft.status,
+    0,
+    `fast-track must pass under swarm regardless of self_approve: ${ft.stderr}`,
+  );
+});
+
+test('non-self approve passes without notice under standard', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'bob']);
+  assert.equal(ap.status, 0, `non-self approve should pass: ${ap.stderr}`);
+  assert.doesNotMatch(
+    ap.stderr,
+    /approved their own request/,
+    `non-self approve must not emit self-approve notice: ${ap.stderr}`,
+  );
+});
+
+test('non-self approve passes under swarm (forbidden gate is self-only)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'bob']);
+  assert.equal(
+    ap.status,
+    0,
+    `non-self approve must pass under swarm: ${ap.stderr}`,
+  );
+  assert.doesNotMatch(ap.stderr, /self-approve forbidden/);
+});
+
+test('malformed features.self_approve → onMalformed warn + profile default applies', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n' +
+      'features:\n  self_approve: yes\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice']);
+  // onMalformed message surfaces on stderr (defaultOnMalformed writes there).
+  assert.match(
+    ap.stderr,
+    /unknown features\.self_approve/,
+    `expected onMalformed warn for malformed value: ${ap.stderr}`,
+  );
+  // Profile default applies → swarm → forbidden.
+  assert.equal(
+    ap.status,
+    1,
+    `swarm default should still apply after malformed value: ${ap.stderr}`,
+  );
+  assert.match(ap.stderr, /self-approve forbidden/);
+});

--- a/tests/interface/selfApprove.test.ts
+++ b/tests/interface/selfApprove.test.ts
@@ -219,6 +219,129 @@ test('non-self approve passes under swarm (forbidden gate is self-only)', (t) =>
   assert.doesNotMatch(ap.stderr, /self-approve forbidden/);
 });
 
+// Asteria-found CRITICAL bypass (#233 follow-up): the original
+// self-detection compared raw `--by` against the canonical
+// `request.from.value` (lowercased+trimmed by MemberName at create
+// time). Daily typing habits — `--by ALICE`, `--by 'alice '` — slipped
+// past the swarm `forbidden` policy and landed in YAML as `by: alice`
+// without ever firing the gate. These tests pin the contract at the
+// CLI surface: actor representation must be normalized BEFORE the
+// self-detection compare so `forbidden` is not bypassable by
+// case/whitespace.
+
+test('swarm + --by ALICE (uppercase): self-approve forbidden (case bypass closed)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'ALICE']);
+  assert.equal(
+    ap.status,
+    1,
+    `uppercase --by must NOT bypass swarm forbidden: stderr=${ap.stderr}`,
+  );
+  assert.match(ap.stderr, /self-approve forbidden/);
+});
+
+test("swarm + --by 'alice ' (trailing space): self-approve forbidden (whitespace bypass closed)", (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'alice ']);
+  assert.equal(
+    ap.status,
+    1,
+    `trailing whitespace --by must NOT bypass swarm forbidden: stderr=${ap.stderr}`,
+  );
+  assert.match(ap.stderr, /self-approve forbidden/);
+});
+
+test("swarm + --by ' alice' (leading space): self-approve forbidden", (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: swarm\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', ' alice']);
+  assert.equal(
+    ap.status,
+    1,
+    `leading whitespace --by must NOT bypass swarm forbidden: stderr=${ap.stderr}`,
+  );
+  assert.match(ap.stderr, /self-approve forbidden/);
+});
+
+test('standard + --by ALICE: notice fires (warn path also normalizes)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'ALICE']);
+  assert.equal(ap.status, 0, `should pass: stderr=${ap.stderr}`);
+  assert.match(
+    ap.stderr,
+    /approved their own request/,
+    `warn-path notice must fire on case-only typo: ${ap.stderr}`,
+  );
+});
+
+test('allowed override + --by ALICE: silent pass (no notice, but normalized)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n' +
+      'features:\n  self_approve: allowed\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  const ap = run(root, ['approve', id, '--by', 'ALICE']);
+  assert.equal(ap.status, 0, `should pass: stderr=${ap.stderr}`);
+  assert.doesNotMatch(
+    ap.stderr,
+    /approved their own request/,
+    `allowed must stay silent even on case-typo: ${ap.stderr}`,
+  );
+});
+
+test('invoked-by surface: trailing whitespace --by does not leak into the notice line', (t) => {
+  // The "# verb id: invoked by X on behalf of Y" line takes `by` from
+  // the same source as self-detection. Pre-fix this leaked the raw
+  // string ("on behalf of alice ") which made grep / golden-string
+  // checks fragile and broke the human-readable surface.
+  const { root, cleanup } = bootstrap(
+    'content_root: .\nhost_names: [eris]\nprofile: standard\n',
+  );
+  t.after(cleanup);
+  registerAll(root, ['alice', 'bob']);
+  const id = createRequest(root, { from: 'alice', executors: ['bob'] });
+
+  // GUILD_ACTOR=charlie + --by 'alice ' triggers the invoked-by line.
+  const ap = run(root, ['approve', id, '--by', 'alice '], 'charlie');
+  // The line lands when env != by; whitespace must not survive.
+  assert.doesNotMatch(
+    ap.stderr,
+    /on behalf of alice $/m,
+    `--by trailing space leaked into invoked-by surface: ${ap.stderr}`,
+  );
+  assert.doesNotMatch(
+    ap.stderr,
+    /on behalf of alice \n/,
+    `--by trailing space leaked into invoked-by surface: ${ap.stderr}`,
+  );
+});
+
 test('malformed features.self_approve → onMalformed warn + profile default applies', (t) => {
   const { root, cleanup } = bootstrap(
     'content_root: .\nhost_names: [eris]\nprofile: swarm\n' +

--- a/tests/interface/worktreeIsolation.test.ts
+++ b/tests/interface/worktreeIsolation.test.ts
@@ -55,9 +55,15 @@ interface Bootstrap {
 
 function bootstrap(profile: 'standard' | 'swarm'): Bootstrap {
   const root = mkdtempReal(join(tmpdir(), `guild-wti-${profile}-`));
+  // Pin self_approve: warn so this suite stays focused on worktree
+  // isolation. #233 makes swarm forbid self-approve by default; the
+  // helper `createApproved` below self-approves to set up the wave,
+  // and asserting that orthogonal policy here would muddy what these
+  // tests actually verify.
   writeFileSync(
     join(root, 'guild.config.yaml'),
-    `content_root: .\nhost_names: [eris]\nprofile: ${profile}\n`,
+    `content_root: .\nhost_names: [eris]\nprofile: ${profile}\n` +
+      `features:\n  self_approve: warn\n`,
   );
   mkdirSync(join(root, 'members'));
   return {


### PR DESCRIPTION
## Summary

- `features.self_approve: 'allowed' | 'warn' | 'forbidden'` 三値、profile による default (swarm→forbidden / standard→warn)
- `gate approve` の self-detect → policy 分岐（forbidden は use case 呼ぶ前に refuse、record mutate なし）
- error message に三本柱の recovery hint：fast-track / 別 reviewer / profile or feature 切替
- CRITICAL bypass fix: `--by ALICE` (大文字) / `--by 'alice '` (whitespace) で forbidden 回避できた問題を `normalizeActor()` helper で塞いだ
- normalize は handler 層全体に展開（reqCreate/reqApprove/reqDeny/reqExecute/reqComplete/reqFail/reqFastTrack/reqReview/reqThank/msgSend/msgBroadcast）— invoked-by 表示の trailing-space leak も同時 fix
- malformed value (`self_approve: yes` 等) は onMalformed warn + profile default に縮退

## なぜ tri-state？

boolean だと `allowed` の silent surface か `forbidden` の hard stop どちらかが死ぬ。`warn` は現行互換で pre-#233 の振る舞いそのまま、`allowed`/`forbidden` は明示的 opt-in。TypeScript literal union で型レベル網羅性を保証。

## Asteria 検証 + Devil 再ゲート (post-fix)

- Asteria 9/9 仕様 PASS + edge 6 件 PASS + **CRITICAL bypass 発見** → Miki が `normalizeActor` で fix
- Devil ratify: Unicode/homoglyph/whitespace 系攻撃面は `MemberName.of` の二段ガード (trim+lowercase + ASCII regex `/^[a-z][a-z0-9_-]{0,31}$/`) で全て throw に落ちる構造を確認、policy ordering 安全、後方互換 preserved

## Test plan

- [x] `npm run build && npm test` 全 GREEN (1278/1278、selfApprove.test.ts 14 件新規)
- [x] swarm forbidden / standard warn / allowed silent / swarm+warn override / fast-track 直交性 / non-self pass / malformed fallback
- [x] bypass: ALICE / trailing-space / leading-space / invoked-by leak
- [x] 後方互換: profile/features 不在で現行通り

## Scope-out (Devil 指摘の follow-up)

- 読み取り側フィルタの canonicalization 不揃い (`gate status/board/list/resume/boot/unresponded --for/--from` が trim 欠落) — silently-empty result の touch-feel issue、別 PR 推奨
- `gate claim/witness` の success message の display drift (`by ALICE` echo) — 軽微 display only

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)