### PR TITLE
feat(gate): --from-agora <play_id> bridges agora play into request (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,34 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate request --from-agora <play_id>` bridges agora play
+  cliff/invitation into request action/reason**
+  ([#232](https://github.com/eris-ths/guild-cli/issues/232)).
+  Surfaces the substrate-side link from agora (suspended-conversation
+  passage) into gate (request passage) without forcing the operator
+  to copy/paste prose between two CLIs. Lift policy: `action ←
+  invitation` (the "what to do next" half of the cliff), `reason ←
+  cliff` (the "what was happening" half); either flag may still be
+  passed explicitly to override its corresponding lift while the other
+  axis stays bridged. The play id is stamped structurally on
+  `Request.sourceAgoraPlay` (YAML key `source_agora_play`) so
+  `gate chain`-style walks see the agora→gate edge without scanning
+  free-form text. `--game <slug>` disambiguates cross-game play-id
+  collisions (each agora game sequences plays independently per day);
+  passing `--game` without `--from-agora` is refused as a flag-shaped
+  error rather than silently ignored. Refusal cases each carry an
+  actionable `next:` hint: concluded plays (terminal — open a fresh
+  play or file without `--from-agora`); playing-but-never-suspended
+  plays (no cliff to bridge — `agora suspend` first); not-found play
+  ids (surfaces the agora content_root the bridge consulted, so a
+  multi-root operator sees which tree rejected the lookup); invalid
+  id shape (names the YYYY-MM-DD-NNN format). Profile-agnostic — works
+  identically under `standard` and `swarm`. Byte-stable persistence:
+  `source_agora_play` is omitted from YAML when unset (every plain
+  `gate request` and every pre-#232 record); hydrate tolerates the
+  absence by leaving the field undefined. `gate show` renders
+  `source_agora_play: <id>` in text mode (next to `created:`) and
+  exposes the same key under the JSON payload.
 - **`features.self_approve: { allowed | warn | forbidden }` —
   profile-gated self-approve policy on `gate approve`**
   ([#233](https://github.com/eris-ths/guild-cli/issues/233)).

--- a/src/application/request/AgoraPlayBridge.ts
+++ b/src/application/request/AgoraPlayBridge.ts
@@ -1,0 +1,163 @@
+// AgoraPlayBridge — read-only query that resolves a play id into the
+// cliff/invitation prose used by `gate request --from-agora <play_id>`
+// (#232).
+//
+// Lives in the gate's application layer (not the agora passage's)
+// because the consumer is the gate request handler, and the lift
+// rules (which suspension entry to pick, which states to refuse,
+// what error message to show) are gate-side bridge policy — not
+// agora-side play semantics. The agora repository stays the source of
+// truth for the data; this service is the policy that maps Play → the
+// two strings the request needs.
+//
+// Why a thin service instead of inlining into request.ts:
+//   - the parse → resolve → state-check → suspension-pick chain has 4
+//     distinct refusal reasons (ambiguous id, not found, concluded,
+//     no-suspension-yet) and writing them as 4 if-branches inside
+//     reqCreate would crowd the create path
+//   - tests can target the bridge directly without spawning the CLI
+//   - if a future verb (e.g. fast-track --from-agora) wants the same
+//     lift, it has one place to call
+
+import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
+import { Play, parsePlayId } from '../../passages/agora/domain/Play.js';
+import { resolvePlayForVerb } from '../../passages/agora/interface/handlers/resolvePlay.js';
+import { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
+
+/**
+ * Refusal kinds the bridge can surface. Each carries enough structure
+ * for the interface layer to render an actionable error with a
+ * `next:` hint without re-parsing prose.
+ */
+export type AgoraBridgeRefusal =
+  | { kind: 'invalid_id'; raw: string; detail: string }
+  | { kind: 'not_found'; playId: string; agoraRoot: string }
+  | { kind: 'concluded'; playId: string; game: string }
+  | { kind: 'no_suspension'; playId: string; game: string; state: string };
+
+/**
+ * Successful resolution. `cliff` and `invitation` come from the most
+ * recent suspension entry — the same entry `agora cliff` returns. The
+ * play id is echoed back so the handler can stamp it into
+ * `Request.sourceAgoraPlay` without re-parsing.
+ */
+export interface AgoraBridgeResolution {
+  readonly playId: string;
+  readonly game: string;
+  readonly state: 'playing' | 'suspended';
+  readonly cliff: string;
+  readonly invitation: string;
+  readonly suspendedAt: string;
+  readonly suspendedBy: string;
+}
+
+export type AgoraBridgeResult =
+  | { ok: true; value: AgoraBridgeResolution }
+  | { ok: false; refusal: AgoraBridgeRefusal };
+
+/**
+ * Resolve a `<play_id>` from an agora play into bridge inputs for
+ * `gate request --from-agora`.
+ *
+ * Acceptance rules (per #232 spec):
+ *   - state = `concluded` → refuse (terminal — bridging into a closed
+ *     thread would mis-represent the request as following a live
+ *     conversation).
+ *   - state = `playing` or `suspended` → accept, BUT only if the play
+ *     actually has at least one suspension on record. A `playing`
+ *     play that has never been suspended has no cliff/invitation, so
+ *     bridging would fabricate the prose; refuse with a hint pointing
+ *     at `agora suspend`.
+ *   - id with cross-game collision → resolvePlayForVerb throws
+ *     PlayIdAmbiguous; the caller's outer-catch surfaces it via the
+ *     normal error envelope (not handled here — same contract as
+ *     `agora cliff`).
+ *
+ * Suspension picking: most recent entry, regardless of whether it has
+ * been resumed. The same choice `agora cliff` makes — "what was the
+ * conversation about most recently" matches the request author's
+ * intent ("I want to act on the latest cliff").
+ */
+export class AgoraPlayBridge {
+  constructor(
+    private readonly plays: PlayRepository,
+    private readonly config: GuildConfig,
+  ) {}
+
+  /**
+   * Resolve `playIdRaw` to bridge inputs. `gameFilter` disambiguates
+   * cross-game id collisions (mirrors `agora cliff --game <slug>`);
+   * undefined means "scan all games and surface the unique match
+   * (or throw PlayIdAmbiguous on collision)".
+   *
+   * Throws PlayIdAmbiguous on cross-game collision (same as
+   * resolvePlayForVerb). All other failures return a refusal so the
+   * handler can render a tailored error per kind.
+   */
+  async resolve(
+    playIdRaw: string,
+    gameFilter: string | undefined,
+  ): Promise<AgoraBridgeResult> {
+    let playId: string;
+    try {
+      playId = parsePlayId(playIdRaw);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return { ok: false, refusal: { kind: 'invalid_id', raw: playIdRaw, detail } };
+    }
+
+    const play: Play | null = await resolvePlayForVerb(
+      this.plays,
+      playId,
+      gameFilter,
+    );
+    if (play === null) {
+      return {
+        ok: false,
+        refusal: {
+          kind: 'not_found',
+          playId,
+          // Surface the agora root the bridge looked under so the
+          // operator sees WHICH content_root rejected the lookup
+          // (multi-root setups occasionally cross paths). Mirrors the
+          // shape `agora cliff` uses when not_found bubbles up.
+          agoraRoot: this.config.contentRoot,
+        },
+      };
+    }
+
+    if (play.state === 'concluded') {
+      return {
+        ok: false,
+        refusal: { kind: 'concluded', playId: play.id, game: play.game },
+      };
+    }
+
+    const lastSuspension = play.suspensions[play.suspensions.length - 1];
+    if (!lastSuspension) {
+      return {
+        ok: false,
+        refusal: {
+          kind: 'no_suspension',
+          playId: play.id,
+          game: play.game,
+          state: play.state,
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      value: {
+        playId: play.id,
+        game: play.game,
+        // Narrow the type: state was already filtered to non-concluded.
+        state: play.state as 'playing' | 'suspended',
+        cliff: lastSuspension.cliff,
+        invitation: lastSuspension.invitation,
+        suspendedAt: lastSuspension.at,
+        suspendedBy: lastSuspension.by,
+      },
+    };
+  }
+}

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -64,6 +64,11 @@ export class RequestUseCases {
      *  when profile=swarm + executors.length > 1. Persisted only
      *  when true; absence reads as false. */
     requiresWorktreeIsolation?: boolean;
+    /** Source agora play id (#232). Set by the `--from-agora` bridge
+     *  in the interface layer when the request action/reason were
+     *  derived from an agora play's invitation/cliff. Persisted only
+     *  when set (absence is the common case). */
+    sourceAgoraPlay?: string;
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -123,6 +128,8 @@ export class RequestUseCases {
       createArgs.promotedFrom = input.promotedFrom;
     if (input.requiresWorktreeIsolation === true)
       createArgs.requiresWorktreeIsolation = true;
+    if (input.sourceAgoraPlay !== undefined)
+      createArgs.sourceAgoraPlay = input.sourceAgoraPlay;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -95,6 +95,21 @@ export interface RequestProps {
    */
   promotedFrom?: string;
   /**
+   * Tool-generated structured link to the agora play this request was
+   * derived from (via `gate request --from-agora <play_id>`). Populated
+   * by the `--from-agora` bridge orchestration in the interface layer;
+   * undefined for plain `gate request` calls. Distinct from text mentions
+   * of a play id in action/reason: `--from-agora` lifts the play's
+   * cliff/invitation prose into the action+reason fields, AND records
+   * the play id structurally here so `gate chain`-style walks can
+   * traverse the agora→gate edge without scanning free-form text.
+   *
+   * Same shape as `promotedFrom` (the issue→request equivalent). Issue
+   * #232 — surfaces "this request came out of <play>" without forcing
+   * the operator to remember to mention the id in prose.
+   */
+  sourceAgoraPlay?: string;
+  /**
    * Worktree-isolation requirement (issue #231). When true, parallel
    * `gate execute` invocations on the same target from the SAME
    * filesystem cwd are refused — the second `execute` errors out so
@@ -240,6 +255,10 @@ export class Request {
     /** See RequestProps.promotedFrom — issue id this request was
      *  promoted from. Populated by `gate issues promote` only. */
     promotedFrom?: string;
+    /** See RequestProps.sourceAgoraPlay — agora play id this request
+     *  was bridged from (via `gate request --from-agora <play_id>`).
+     *  Populated by the --from-agora orchestration only. Issue #232. */
+    sourceAgoraPlay?: string;
     /** See RequestProps.requiresWorktreeIsolation — set by the
      *  interface layer when profile=swarm + executors.length > 1.
      *  Persisted as `requires_worktree_isolation: true` only when
@@ -337,6 +356,14 @@ export class Request {
     if (input.promotedFrom !== undefined) {
       props.promotedFrom = input.promotedFrom;
     }
+    if (input.sourceAgoraPlay !== undefined) {
+      // sanitizeText guards length/charset the same way action/reason
+      // are guarded — a malformed play id smuggled into the field at
+      // a non-CLI entry point still gets normalized. The interface
+      // layer pre-validates with parsePlayId, so this is the second
+      // line of defence.
+      props.sourceAgoraPlay = sanitizeText(input.sourceAgoraPlay, 'sourceAgoraPlay');
+    }
     // Worktree-isolation: persist only when explicitly true. The
     // false case is represented by field absence on disk so the YAML
     // surface stays minimal (matches `depth`, `with`, `target` etc).
@@ -409,6 +436,14 @@ export class Request {
   }
   get promotedFrom(): string | undefined {
     return this.props.promotedFrom;
+  }
+  /** Issue #232 — agora play id this request was bridged from via
+   *  `gate request --from-agora <play_id>`. Undefined for plain
+   *  requests (the common case). Read surface used by `formatRequestText`
+   *  to render the source-play line and by JSON consumers reading
+   *  `source_agora_play` directly. */
+  get sourceAgoraPlay(): string | undefined {
+    return this.props.sourceAgoraPlay;
   }
   get with(): readonly MemberName[] {
     return this.props.with ?? [];
@@ -851,6 +886,12 @@ export class Request {
       out['with'] = this.props.with.map((m) => m.value);
     if (this.props.promotedFrom !== undefined)
       out['promoted_from'] = this.props.promotedFrom;
+    // source_agora_play (#232). Surface only when set — the field
+    // is absent on every plain `gate request` and on every pre-#232
+    // record. Byte-stable round-trip: omit-when-undefined matches the
+    // hydrate "absent ⇒ undefined" branch below.
+    if (this.props.sourceAgoraPlay !== undefined)
+      out['source_agora_play'] = this.props.sourceAgoraPlay;
     // Worktree isolation requirement (#231). Surface only when true —
     // the YAML stays minimal and pre-#231 records remain byte-stable
     // on round-trip (false-by-absence is the load tolerance).

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -538,6 +538,16 @@ function hydrate(
     if (typeof obj['promoted_from'] === 'string') {
       props.promotedFrom = obj['promoted_from'] as string;
     }
+    // source_agora_play (#232). Tolerated as a string only — anything
+    // else is dropped silently following the same conservative read
+    // pattern as `promoted_from`. Pre-#232 records simply lack the
+    // field; treated as absent. Records-outlive-writers (principle 04):
+    // we never reject, only ignore. The interface layer validates
+    // play-id shape on the write path, so a hydrated value is trusted
+    // as-is here.
+    if (typeof obj['source_agora_play'] === 'string') {
+      props.sourceAgoraPlay = obj['source_agora_play'] as string;
+    }
     // requires_worktree_isolation (#231). Tolerated as a strict boolean
     // only — anything else (string "true", number 1) is dropped silently
     // following the same conservative read pattern as `depth`. Pre-#231

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -25,6 +25,19 @@ const REQUEST_CREATE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'auto-review',
   'with',
   'format',
+  // from-agora <play_id> bridges an agora-play most-recent suspension
+  // cliff/invitation into action/reason (issue #232). The `game` flag
+  // disambiguates cross-game play-id collisions (each agora game uses
+  // its own per-day sequence, so two games can both produce a
+  // YYYY-MM-DD-001) — same shape as the agora cliff verb game flag.
+  // (Apostrophes and backticks intentionally avoided in this comment:
+  // the schema drift detector parses Set-body string literals via a
+  // quote-pair regex (single, double, OR backtick), so any quote
+  // character in a comment can pair with one further down and slurp
+  // the in-between text into a fake flag entry. See
+  // schemaInputDriftDetector.test.ts.)
+  'from-agora',
+  'game',
 ]);
 const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -91,6 +104,8 @@ const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'fields',
 ]);
 import { Request } from '../../../domain/request/Request.js';
+import { AgoraPlayBridge } from '../../../application/request/AgoraPlayBridge.js';
+import { PlayIdAmbiguous } from '../../../passages/agora/interface/handlers/resolvePlay.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import {
   C,
@@ -109,17 +124,118 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
   const from = normalizeActor(
     requireOption(args, 'from', '<m>', 'GUILD_ACTOR'),
   );
-  const action = requireOption(args, 'action', '"..."');
-  let reason = requireOption(args, 'reason', '"..."');
+  // --from-agora <play_id> (#232): when present, lifts the play's
+  // most-recent cliff/invitation into action/reason. Either flag may
+  // still be supplied explicitly to override the corresponding lift
+  // (action override → invitation lift dropped; reason override →
+  // cliff lift dropped). Plain `gate request` (no --from-agora) keeps
+  // the historical require-both contract.
+  const fromAgoraRaw = optionalOption(args, 'from-agora');
+  const gameFilter = optionalOption(args, 'game');
+  // --game without --from-agora is meaningless on `gate request`
+  // (the gate request surface has no other use for a game qualifier).
+  // Refuse up front rather than silently ignoring — silent ignore is
+  // the same fail-open class rejectUnknownFlags exists to prevent.
+  if (gameFilter !== undefined && fromAgoraRaw === undefined) {
+    process.stderr.write(
+      `error: --game requires --from-agora <play_id> ` +
+        `(--game disambiguates cross-game play-id collisions; it has ` +
+        `no meaning on a plain gate request).\n`,
+    );
+    return 1;
+  }
+
+  const actionRaw = optionalOption(args, 'action');
+  let reasonRaw = optionalOption(args, 'reason');
   // `--reason -` reads from stdin — parity with `gate review --comment -`.
   // Trim because heredoc / echo append a trailing newline that clutters
   // the rendered status_log note.
-  if (reason === '-') reason = (await readStdin()).trim();
+  if (reasonRaw === '-') reasonRaw = (await readStdin()).trim();
+
+  let action: string;
+  let reason: string;
+  let sourceAgoraPlay: string | undefined;
+
+  if (fromAgoraRaw !== undefined) {
+    const bridge = new AgoraPlayBridge(c.playRepo, c.config);
+    let result;
+    try {
+      result = await bridge.resolve(fromAgoraRaw, gameFilter);
+    } catch (err) {
+      if (err instanceof PlayIdAmbiguous) {
+        // Surface the same shape `agora cliff` does on cross-game
+        // collision — let the caller's outer envelope catch it. Re-
+        // throwing keeps a single source of truth for the message.
+        throw err;
+      }
+      throw err;
+    }
+    if (!result.ok) {
+      const r = result.refusal;
+      switch (r.kind) {
+        case 'invalid_id':
+          process.stderr.write(
+            `error: --from-agora "${r.raw}": ${r.detail}\n` +
+              `  hint: play ids look like 2026-05-08-001 (YYYY-MM-DD-NNN).\n`,
+          );
+          return 1;
+        case 'not_found':
+          process.stderr.write(
+            `error: --from-agora ${r.playId}: play not found in ${r.agoraRoot}/agora.\n` +
+              `  next: list candidates with \`agora list\` or check the play id.\n`,
+          );
+          return 1;
+        case 'concluded':
+          process.stderr.write(
+            `error: --from-agora ${r.playId}: play is concluded (game=${r.game}); ` +
+              `cannot bridge a closed thread into a new request.\n` +
+              `  next: open a fresh play (\`agora play --game ${r.game}\`) or ` +
+              `file the request without --from-agora.\n`,
+          );
+          return 1;
+        case 'no_suspension':
+          process.stderr.write(
+            `error: --from-agora ${r.playId}: play has no suspension on record ` +
+              `(state=${r.state}, game=${r.game}); nothing to bridge.\n` +
+              `  next: \`agora suspend ${r.playId} --cliff "..." --invitation "..."\` ` +
+              `to record a cliff first, or file the request without --from-agora.\n`,
+          );
+          return 1;
+      }
+    }
+    const lift = result.value;
+    sourceAgoraPlay = lift.playId;
+    // Lift policy (#232):
+    //   action  ← invitation  (the "what to do next" half — matches
+    //                          gate request's action semantics)
+    //   reason  ← cliff       (the "why / what was happening" half —
+    //                          matches gate request's reason semantics)
+    // Either explicit flag overrides its corresponding lift; the lifted
+    // half on the other axis is preserved. The structural sourceAgoraPlay
+    // record is kept regardless of overrides because the link is the
+    // point of the bridge — a request derived from a play stays linked
+    // even when the operator rewrote both fields.
+    action = actionRaw !== undefined && actionRaw.trim().length > 0
+      ? actionRaw
+      : lift.invitation;
+    reason = reasonRaw !== undefined && reasonRaw.trim().length > 0
+      ? reasonRaw
+      : lift.cliff;
+  } else {
+    // Plain `gate request` — action/reason are both required, same
+    // contract as before #232. requireOption surfaces the usage hint
+    // when missing; we re-call it here so the error message stays
+    // identical to the historical one.
+    action = requireOption(args, 'action', '"..."');
+    reason = requireOption(args, 'reason', '"..."');
+    if (reason === '-') reason = (await readStdin()).trim();
+  }
   const input: Parameters<typeof c.requestUC.create>[0] = {
     from,
     action,
     reason,
   };
+  if (sourceAgoraPlay !== undefined) input.sourceAgoraPlay = sourceAgoraPlay;
   const executor = optionalOption(args, 'executor');
   const executorsRaw = optionalOption(args, 'executors');
   const target = optionalOption(args, 'target');
@@ -474,6 +590,13 @@ function formatRequestText(r: Request): string {
   }
   if (j['promoted_from']) {
     lines.push(`  promoted_from: ${j['promoted_from']}`);
+  }
+  // source_agora_play (#232) — agora play this request was bridged
+  // from via `gate request --from-agora`. Rendered next to
+  // promoted_from because both are tool-stamped backlinks ("this came
+  // out of <X>") and a reader scanning the header pairs them mentally.
+  if (j['source_agora_play']) {
+    lines.push(`  source_agora_play: ${j['source_agora_play']}`);
   }
   lines.push(`  created:  ${j['created_at']}`);
   lines.push('');

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -754,8 +754,16 @@ const VERBS: readonly VerbSchema[] = [
       type: 'object',
       properties: {
         from: strOpt('author (defaults to $GUILD_ACTOR)'),
-        action: str,
-        reason: str,
+        action: strOpt(
+          'request action. Required UNLESS --from-agora is supplied; ' +
+            'with --from-agora the play\'s suspension `invitation` is ' +
+            'used as action (override by passing --action explicitly).',
+        ),
+        reason: strOpt(
+          'request reason. Required UNLESS --from-agora is supplied; ' +
+            'with --from-agora the play\'s suspension `cliff` is used ' +
+            'as reason (override by passing --reason explicitly).',
+        ),
         executor: strOpt('single executor (mutually exclusive with --executors)'),
         executors: strOpt(
           'comma-separated executor list, whitespace-trimmed per entry, ' +
@@ -781,9 +789,33 @@ const VERBS: readonly VerbSchema[] = [
         },
         'auto-review': strOpt('member assigned as critic'),
         with: strOpt('comma-separated dialogue partners (pair-mode)'),
+        'from-agora': strOpt(
+          'agora play id (YYYY-MM-DD-NNN) to bridge into this request ' +
+            '(#232). Lifts the play\'s most-recent suspension cliff into ' +
+            '--reason and invitation into --action; either flag may still ' +
+            'be passed explicitly to override the corresponding lift. ' +
+            'Stamps source_agora_play on the record so `gate chain`-style ' +
+            'walks see the agora→gate edge. Refuses on concluded plays ' +
+            'and on plays with no suspension on record (state=playing, ' +
+            'never suspended).',
+        ),
+        game: strOpt(
+          'agora game slug; only meaningful with --from-agora (#232). ' +
+            'Disambiguates cross-game play-id collisions (each game ' +
+            'sequences plays independently per day). Errors when passed ' +
+            'without --from-agora.',
+        ),
         format: formatField,
       },
-      required: ['action', 'reason'],
+      // action/reason are conditionally required. JSON Schema can't
+      // express the "required iff --from-agora is absent" branch in
+      // a single `required:` array without `oneOf`; rather than add
+      // the conditional shape (and force every existing JSON consumer
+      // through an `oneOf` walk), we drop the unconditional require
+      // and rely on the runtime handler — `requireOption` surfaces
+      // the same usage error for plain `gate request` callers, and
+      // the description on each field names the conditional contract.
+      required: [],
     },
     output: writeResponseSchema,
   },

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -35,6 +35,7 @@ type JsonSchema = {
   enum?: string[];
   description?: string;
   items?: JsonSchema;
+  oneOf?: JsonSchema[];
 };
 
 interface VerbSchema {
@@ -807,15 +808,19 @@ const VERBS: readonly VerbSchema[] = [
         ),
         format: formatField,
       },
-      // action/reason are conditionally required. JSON Schema can't
-      // express the "required iff --from-agora is absent" branch in
-      // a single `required:` array without `oneOf`; rather than add
-      // the conditional shape (and force every existing JSON consumer
-      // through an `oneOf` walk), we drop the unconditional require
-      // and rely on the runtime handler — `requireOption` surfaces
-      // the same usage error for plain `gate request` callers, and
-      // the description on each field names the conditional contract.
+      // action/reason are conditionally required: required iff
+      // --from-agora is absent. `oneOf` expresses the two-shape
+      // contract for JSON Schema consumers (codegen, form-builders,
+      // AI tool-use schemas) so they don't read action as
+      // unconditionally optional. Either shape A (`action`+`reason`,
+      // no agora bridge) or shape B (`from-agora`, lifts both) is
+      // valid; the runtime handler enforces the same branch via
+      // `requireOption`.
       required: [],
+      oneOf: [
+        { required: ['action', 'reason'] },
+        { required: ['from-agora'] },
+      ],
     },
     output: writeResponseSchema,
   },

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -16,6 +16,8 @@ import { RepairUseCases } from '../../application/repair/RepairUseCases.js';
 import { UnrespondedConcernsQuery } from '../../application/concern/UnrespondedConcernsQuery.js';
 import { SafeFsQuarantineStore } from '../../infrastructure/persistence/SafeFsQuarantineStore.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
+import { YamlPlayRepository } from '../../passages/agora/infrastructure/YamlPlayRepository.js';
+import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
 
 export interface Container {
   config: GuildConfig;
@@ -26,6 +28,16 @@ export interface Container {
   diagnosticUC: DiagnosticUseCases;
   repairUC: RepairUseCases;
   unrespondedConcernsQ: UnrespondedConcernsQuery;
+  /**
+   * Agora play storage adapter (#232). Wired into the gate container
+   * so the `--from-agora <play_id>` bridge in `gate request` can lift
+   * a play's cliff/invitation into the request action/reason without a
+   * second top-level container or a cross-process shell-out. Both
+   * passages share the same `content_root`, so re-using the gate's
+   * GuildConfig means the bridge sees the same agora directory the
+   * `agora` CLI verbs read/write.
+   */
+  playRepo: PlayRepository;
 }
 
 export interface BuildContainerOpts {
@@ -71,5 +83,6 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     ),
     repairUC: new RepairUseCases(quarantine),
     unrespondedConcernsQ: new UnrespondedConcernsQuery(requests, issues),
+    playRepo: new YamlPlayRepository(config),
   };
 }

--- a/tests/interface/gateRequestFromAgora.test.ts
+++ b/tests/interface/gateRequestFromAgora.test.ts
@@ -1,0 +1,413 @@
+// gate request --from-agora <play_id> — bridge from agora play
+// suspension cliff/invitation into request action/reason (issue #232).
+//
+// Pins the substrate-level contract:
+//   1. Plain bridge: action ← invitation, reason ← cliff. The
+//      structural source_agora_play stamp lands on the YAML record.
+//   2. --action override: explicit --action wins; cliff still lifts
+//      into reason; structural stamp still lands.
+//   3. --reason override: explicit --reason wins; invitation still
+//      lifts into action; structural stamp still lands.
+//   4. State refusal: concluded plays refuse with an actionable hint
+//      (next: open a fresh play, or file without --from-agora).
+//   5. State refusal: a playing-but-never-suspended play refuses with
+//      a hint pointing at agora suspend.
+//   6. Not-found refusal: unknown play id surfaces the agora root the
+//      bridge consulted, so a multi-root operator sees which one
+//      rejected the lookup.
+//   7. Byte-stable YAML: the field is omitted when --from-agora is
+//      not used (no source_agora_play key on plain requests).
+//   8. Hydrate tolerance: a request YAML written before #232 (no
+//      source_agora_play field) loads cleanly.
+//   9. JSON show surface: source_agora_play is exposed under the
+//      same key in the JSON payload.
+//  10. --game without --from-agora: refused with a flag-shaped error
+//      (no silent ignore — same fail-open class rejectUnknownFlags
+//      exists to prevent).
+//
+// What this test does NOT pin: the agora handler's own behaviour
+// (suspend / resume / conclude). Those contracts live in their own
+// passage tests; here we only set up plays as fixture YAML and
+// exercise the gate-side bridge.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Fixture {
+  root: string;
+  cleanup: () => void;
+}
+
+function bootstrap(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), 'gate-fromagora-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  // Agora layout: plays live under <content_root>/agora/plays/<game-slug>/
+  mkdirSync(join(root, 'agora', 'games'), { recursive: true });
+  mkdirSync(join(root, 'agora', 'plays', 'quest-1'), { recursive: true });
+  writeFileSync(
+    join(root, 'agora', 'games', 'quest-1.yaml'),
+    [
+      'slug: quest-1',
+      'kind: quest',
+      'title: smoke quest',
+      'created_at: 2026-05-01T00:00:00.000Z',
+      'created_by: alice',
+      '',
+    ].join('\n'),
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function writePlay(root: string, opts: {
+  id: string;
+  state: 'playing' | 'suspended' | 'concluded';
+  suspensions?: Array<{ cliff: string; invitation: string; at?: string; by?: string }>;
+  resumes?: Array<{ at?: string; by?: string }>;
+  concluded?: { at?: string; by?: string; note?: string };
+}): void {
+  const lines: string[] = [
+    `id: ${opts.id}`,
+    'game: quest-1',
+    `state: ${opts.state}`,
+    'started_at: 2026-05-08T00:00:00.000Z',
+    'started_by: alice',
+    'moves: []',
+  ];
+  if (opts.suspensions && opts.suspensions.length > 0) {
+    lines.push('suspensions:');
+    for (const s of opts.suspensions) {
+      lines.push(`  - at: ${s.at ?? '2026-05-08T01:00:00.000Z'}`);
+      lines.push(`    by: ${s.by ?? 'alice'}`);
+      lines.push(`    cliff: ${s.cliff}`);
+      lines.push(`    invitation: ${s.invitation}`);
+    }
+  } else {
+    lines.push('suspensions: []');
+  }
+  if (opts.resumes && opts.resumes.length > 0) {
+    lines.push('resumes:');
+    for (const r of opts.resumes) {
+      lines.push(`  - at: ${r.at ?? '2026-05-08T02:00:00.000Z'}`);
+      lines.push(`    by: ${r.by ?? 'alice'}`);
+    }
+  } else {
+    lines.push('resumes: []');
+  }
+  if (opts.concluded) {
+    lines.push(`concluded_at: ${opts.concluded.at ?? '2026-05-08T03:00:00.000Z'}`);
+    lines.push(`concluded_by: ${opts.concluded.by ?? 'alice'}`);
+    lines.push(`concluded_note: ${opts.concluded.note ?? 'done'}`);
+  }
+  lines.push('');
+  writeFileSync(
+    join(root, 'agora', 'plays', 'quest-1', `${opts.id}.yaml`),
+    lines.join('\n'),
+  );
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'alice', ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function extractRequestId(out: string): string {
+  const m = out.match(/(\d{4}-\d{2}-\d{2}-\d{4})/);
+  if (!m) throw new Error(`no request id in output: ${out}`);
+  return m[0] as string;
+}
+
+function readPendingYaml(root: string, id: string): string {
+  return readFileSync(join(root, 'requests', 'pending', `${id}.yaml`), 'utf8');
+}
+
+test('--from-agora: lifts invitation→action and cliff→reason; stamps source_agora_play', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'suspended',
+    suspensions: [
+      {
+        cliff: 'noir contradicted herself about the substrate purpose',
+        invitation: 'pick up the contradiction and either reconcile or escalate',
+      },
+    ],
+  });
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+  ]);
+  assert.equal(r.status, 0, `expected success; stderr=${r.stderr}`);
+  const id = extractRequestId(r.stdout);
+  const yaml = readPendingYaml(root, id);
+  assert.match(yaml, /^action: pick up the contradiction/m);
+  assert.match(yaml, /^reason: noir contradicted herself/m);
+  assert.match(yaml, /^source_agora_play: 2026-05-08-001$/m);
+});
+
+test('--from-agora + --action: action overrides invitation; cliff still lifts into reason; stamp lands', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'suspended',
+    suspensions: [
+      { cliff: 'cliff prose here', invitation: 'invitation prose here' },
+    ],
+  });
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+    '--action',
+    'do this exact thing instead',
+  ]);
+  assert.equal(r.status, 0, `expected success; stderr=${r.stderr}`);
+  const id = extractRequestId(r.stdout);
+  const yaml = readPendingYaml(root, id);
+  assert.match(yaml, /^action: do this exact thing instead$/m);
+  assert.match(yaml, /^reason: cliff prose here$/m);
+  assert.match(yaml, /^source_agora_play: 2026-05-08-001$/m);
+});
+
+test('--from-agora + --reason: reason overrides cliff; invitation still lifts into action; stamp lands', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'suspended',
+    suspensions: [
+      { cliff: 'cliff prose here', invitation: 'invitation prose here' },
+    ],
+  });
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+    '--reason',
+    'a fresh reason that overrides the cliff',
+  ]);
+  assert.equal(r.status, 0, `expected success; stderr=${r.stderr}`);
+  const id = extractRequestId(r.stdout);
+  const yaml = readPendingYaml(root, id);
+  assert.match(yaml, /^action: invitation prose here$/m);
+  assert.match(yaml, /^reason: a fresh reason that overrides the cliff$/m);
+  assert.match(yaml, /^source_agora_play: 2026-05-08-001$/m);
+});
+
+test('--from-agora: concluded play refused with actionable hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'concluded',
+    suspensions: [{ cliff: 'c', invitation: 'i' }],
+    concluded: { note: 'wrapped up' },
+  });
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /play is concluded/);
+  assert.match(r.stderr, /next:/);
+  assert.match(r.stderr, /game=quest-1/);
+});
+
+test('--from-agora: playing-but-never-suspended play refused with suspend-first hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-002',
+    state: 'playing',
+    // no suspensions
+  });
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-002',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /no suspension on record/);
+  assert.match(r.stderr, /agora suspend 2026-05-08-002/);
+});
+
+test('--from-agora: not-found play surfaces the agora root the bridge consulted', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // No plays written.
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-999',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /play not found/);
+  // The bridge surfaces the resolved content_root so the operator
+  // can verify they pointed at the right tree. realpath canonicalises
+  // /tmp → /private/tmp on darwin, so we just check the basename.
+  assert.match(r.stderr, /agora/);
+});
+
+test('byte-stable: plain gate request omits source_agora_play from YAML', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'plain action',
+    '--reason',
+    'plain reason',
+  ]);
+  assert.equal(r.status, 0, `expected success; stderr=${r.stderr}`);
+  const id = extractRequestId(r.stdout);
+  const yaml = readPendingYaml(root, id);
+  assert.doesNotMatch(yaml, /source_agora_play/);
+});
+
+test('hydrate tolerance: pre-#232 YAML (no source_agora_play) loads without error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Hand-write a request YAML in the legacy shape — no
+  // source_agora_play field at all. `gate show` must read it cleanly.
+  mkdirSync(join(root, 'requests', 'pending'), { recursive: true });
+  writeFileSync(
+    join(root, 'requests', 'pending', '2026-05-01-0001.yaml'),
+    [
+      'id: 2026-05-01-0001',
+      'from: alice',
+      'action: legacy action',
+      'reason: legacy reason',
+      'state: pending',
+      'created_at: 2026-05-01T00:00:00.000Z',
+      'status_log:',
+      '  - state: pending',
+      '    by: alice',
+      '    at: 2026-05-01T00:00:00.000Z',
+      '    note: created',
+      'reviews: []',
+      '',
+    ].join('\n'),
+  );
+  const r = run(root, ['show', '2026-05-01-0001', '--format', 'json']);
+  assert.equal(r.status, 0, `expected success; stderr=${r.stderr}`);
+  const payload = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.equal(payload['id'], '2026-05-01-0001');
+  // Field is absent on the JSON payload too — undefined means the
+  // hydrate path saw "no field" and the toJSON serialiser preserved
+  // that absence end-to-end.
+  assert.equal(payload['source_agora_play'], undefined);
+});
+
+test('JSON show surface: source_agora_play exposed under the same key', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'suspended',
+    suspensions: [{ cliff: 'c', invitation: 'i' }],
+  });
+  const created = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+  ]);
+  assert.equal(created.status, 0, `expected success; stderr=${created.stderr}`);
+  const id = extractRequestId(created.stdout);
+  const shown = run(root, ['show', id, '--format', 'json']);
+  assert.equal(shown.status, 0, `expected success; stderr=${shown.stderr}`);
+  const payload = JSON.parse(shown.stdout) as Record<string, unknown>;
+  assert.equal(payload['source_agora_play'], '2026-05-08-001');
+});
+
+test('--game without --from-agora: refused with flag-shaped error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--action',
+    'a',
+    '--reason',
+    'b',
+    '--game',
+    'quest-1',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--game requires --from-agora/);
+});
+
+test('text show surface: source_agora_play rendered next to created line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  writePlay(root, {
+    id: '2026-05-08-001',
+    state: 'suspended',
+    suspensions: [{ cliff: 'c', invitation: 'i' }],
+  });
+  const created = run(root, [
+    'request',
+    '--from',
+    'alice',
+    '--from-agora',
+    '2026-05-08-001',
+  ]);
+  assert.equal(created.status, 0);
+  const id = extractRequestId(created.stdout);
+  const shown = run(root, ['show', id, '--format', 'text']);
+  assert.equal(shown.status, 0);
+  assert.match(shown.stdout, /source_agora_play: 2026-05-08-001/);
+});


### PR DESCRIPTION
## Summary

- `gate request --from-agora <play_id>` で agora play の最新 suspension から `cliff` を `--reason`、`invitation` を `--action` に lift
- `--from-agora` + `--action`/`--reason` 併用で個別 override 可、両方明示で完全 override
- `--game <slug>` で cross-game play-id collision 解消 (agora 側の契約継承)
- record schema 拡張: `Request.sourceAgoraPlay: string | undefined` (byte-stable: 空時 YAML omit、hydrate tolerance、claim/witness pattern 踏襲)
- state guard: suspended / playing+suspensions の lift accept、concluded / playing+no-suspensions / not-found を refuse with actionable hint
- `gate show` text/json 両 surface に `source_agora_play` 表示 (空時 omit)
- profile 関係なく両 profile で動く (additive)
- schema `oneOf` で `action`+`reason` か `from-agora` の二択を機械可読契約として表現 (devil concern fix)

## Multi-actor real dogfood (第一試行)

本 PR は **subagent が gate verb を打って record に attribute する** dogfood 試験運用：

```
gate request --from eris --action ... --executor miki  # eris 起票
gate approve <id> --by eris                             # eris approve
# → Miki が claim+execute+review を gate verb で
gate claim <id> --by miki     ← Miki agent
gate execute <id> --by miki   ← Miki agent  
gate review <id> --by miki --comment "実装完了 ..." --lense layer --verdict ok
```

wave `2026-05-08-0013` に痕跡残存。multi-actor の足跡が record 上に物質化される（従来は eris が単独で全部叩いた record だった）。

## Asteria 検証 → OK to ship (8/8 PASS、blocker なし)
- happy / action override / reason override / concluded refuse / playing fallback / not found / pre-#232 hydrate / show text+json / profile 両方
- tests 1289/1289 GREEN

## Devil 最終ゲート: concerns → ratify (post-fix)
- 当初 concerns 1件: schema `required: []` が「条件付き必須」を機械可読契約として表現できてない (description 降格)
- post-fix: `oneOf: [{required:['action','reason']}, {required:['from-agora']}]` で二択契約を pin、JsonSchema 型に `oneOf` 追加。tests 1289/1289 維持

## Scope-out (follow-up issue 候補)

Asteria + Devil の low-priority 観測：

1. 空文字 / whitespace override が silent に "no override" 扱い (`--action ""` で agora invitation 採用) → 明示 reject か warn で pin
2. 同 play から N 個 request 起票可 (idempotency なし) → design doc 化
3. null byte 入り play_id のエラー文言が誤誘導 (`Invalid sequence: 10000`) — 別経路の調査必要
4. agora root unreadable directory が "play not found" に着弾 (warn なし)
5. dead try/catch in `reqCreate` `--from-agora` 経路 (PlayIdAmbiguous 特別扱いが no-op)
6. interface-level test 欠落: `invalid_id` / `PlayIdAmbiguous` cross-game collision
7. schemaInputDriftDetector: `oneOf` 追加で false-positive が出ないか runtime 確認 (本 PR では既存 1289 tests GREEN なので問題なし)

## Test plan

- [x] `npm run build && npm test` 全 GREEN (1289/1289)
- [x] 8 happy/refuse/override ケース
- [x] hydrate tolerance + byte-stable round-trip (md5 confirmed by Asteria)
- [x] state guard 三値 (suspended/playing/concluded)
- [x] schema oneOf 追加で既存 schema test も GREEN
- [x] CHANGELOG `[Unreleased]` entry 追加

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)