### PR TITLE
feat(gate templates): wave-brief template registry — list / show / --template skeleton expansion (#235)

### DIFF
--- a/.tmp-asteria-235/data/guild/templates/wave-brief/compare-and-ratify.md
+++ b/.tmp-asteria-235/data/guild/templates/wave-brief/compare-and-ratify.md
@@ -1,0 +1,13 @@
+---
+template_name: compare-and-ratify
+template_version: 2
+intended_use: Compare parallel attempts and ratify a winner
+gate_required: true
+---
+# Compare and Ratify Brief
+
+## Inputs
+- Two or more candidate implementations
+
+## Decision criteria
+- correctness, simplicity, perf

--- a/.tmp-asteria-235/data/guild/templates/wave-brief/parallel-impl.md
+++ b/.tmp-asteria-235/data/guild/templates/wave-brief/parallel-impl.md
@@ -1,0 +1,14 @@
+---
+template_name: parallel-impl
+template_version: 1
+intended_use: Run two or more independent implementations in parallel; pick the better one
+gate_required: true
+---
+# Parallel Implementation Brief
+
+## Goals
+- Two independent attempts at the same target
+- Compare-and-ratify after both complete
+
+## Executors
+- a, b

--- a/.tmp-asteria-235/data/guild/templates/wave-brief/research-wave.md
+++ b/.tmp-asteria-235/data/guild/templates/wave-brief/research-wave.md
@@ -1,0 +1,11 @@
+---
+template_name: research-wave
+template_version: 1
+intended_use: Investigate options before committing to an implementation path
+gate_required: true
+---
+# Research Wave
+
+## Outputs
+- Comparison matrix
+- Recommendation

--- a/.tmp-asteria-235/data/guild/templates/wave-brief/single-impl.md
+++ b/.tmp-asteria-235/data/guild/templates/wave-brief/single-impl.md
@@ -1,0 +1,10 @@
+---
+template_name: single-impl
+template_version: 1
+intended_use: Single executor implementation
+gate_required: false
+---
+# Single Implementation
+
+## Goal
+- One executor, one attempt

--- a/.tmp-asteria-235/data/guild/templates/wave-brief/verification.md
+++ b/.tmp-asteria-235/data/guild/templates/wave-brief/verification.md
@@ -1,0 +1,12 @@
+---
+template_name: verification
+template_version: 1
+intended_use: Verification / dogfood pass on a recently-merged feature
+gate_required: true
+---
+# Verification Brief
+
+## Coverage
+- Happy path
+- Edge cases
+- Adversarial cases

--- a/.tmp-asteria-235/guild.config.yaml
+++ b/.tmp-asteria-235/guild.config.yaml
@@ -1,0 +1,3 @@
+profile: swarm
+host_names:
+  - eris

--- a/.tmp-asteria-235/requests/approved/2026-05-08-9999.yaml
+++ b/.tmp-asteria-235/requests/approved/2026-05-08-9999.yaml
@@ -1,0 +1,17 @@
+id: 2026-05-08-9999
+from: asteria
+action: pre-235 record
+reason: simulating hydrate of a record from before template fields existed
+state: approved
+created_at: 2026-04-01T00:00:00.000Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-04-01T00:00:00.000Z
+    note: created
+  - state: approved
+    by: eris
+    at: 2026-05-08T11:20:17.555Z
+reviews: []
+executors:
+  - asteria

--- a/.tmp-asteria-235/requests/pending/2026-05-08-0001.yaml
+++ b/.tmp-asteria-235/requests/pending/2026-05-08-0001.yaml
@@ -1,0 +1,17 @@
+id: 2026-05-08-0001
+from: asteria
+action: "wave-brief: single-impl"
+reason: Single executor implementation
+state: pending
+created_at: 2026-05-08T11:17:48.659Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-05-08T11:17:48.659Z
+    note: created
+reviews: []
+executors:
+  - asteria
+template: single-impl
+template_version: 1
+gate_required_acknowledged: true

--- a/.tmp-asteria-235/requests/pending/2026-05-08-0002.yaml
+++ b/.tmp-asteria-235/requests/pending/2026-05-08-0002.yaml
@@ -1,0 +1,17 @@
+id: 2026-05-08-0002
+from: asteria
+action: custom action override
+reason: Run two or more independent implementations in parallel; pick the better one
+state: pending
+created_at: 2026-05-08T11:18:10.292Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-05-08T11:18:10.292Z
+    note: created
+reviews: []
+executors:
+  - asteria
+template: parallel-impl
+template_version: 1
+gate_required_acknowledged: true

--- a/.tmp-asteria-235/requests/pending/2026-05-08-0003.yaml
+++ b/.tmp-asteria-235/requests/pending/2026-05-08-0003.yaml
@@ -1,0 +1,17 @@
+id: 2026-05-08-0003
+from: asteria
+action: "wave-brief: parallel-impl"
+reason: custom reason
+state: pending
+created_at: 2026-05-08T11:18:15.677Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-05-08T11:18:15.677Z
+    note: created
+reviews: []
+executors:
+  - asteria
+template: parallel-impl
+template_version: 1
+gate_required_acknowledged: true

--- a/.tmp-asteria-235/requests/pending/2026-05-08-0004.yaml
+++ b/.tmp-asteria-235/requests/pending/2026-05-08-0004.yaml
@@ -1,0 +1,16 @@
+id: 2026-05-08-0004
+from: asteria
+action: test
+reason: test
+state: pending
+created_at: 2026-05-08T11:18:26.991Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-05-08T11:18:26.991Z
+    note: created
+reviews: []
+executors:
+  - asteria
+  - noir
+requires_worktree_isolation: true

--- a/.tmp-asteria-235/requests/pending/2026-05-08-0005.yaml
+++ b/.tmp-asteria-235/requests/pending/2026-05-08-0005.yaml
@@ -1,0 +1,19 @@
+id: 2026-05-08-0005
+from: asteria
+action: "wave-brief: parallel-impl"
+reason: Run two or more independent implementations in parallel; pick the better one
+state: pending
+created_at: 2026-05-08T11:18:27.062Z
+status_log:
+  - state: pending
+    by: asteria
+    at: 2026-05-08T11:18:27.062Z
+    note: created
+reviews: []
+executors:
+  - asteria
+  - noir
+requires_worktree_isolation: true
+template: parallel-impl
+template_version: 1
+gate_required_acknowledged: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,42 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   `gate request` and every pre-#232 record); hydrate tolerates the
   absence by leaving the field undefined. `gate show` renders
   `source_agora_play: <id>` in text mode (next to `created:`) and
-  exposes the same key under the JSON payload.
+  exposes the same key under the JSON payload. Mutually exclusive
+  with `--template` (#235) at the interface layer — both supply
+  action/reason defaults, so combining them is rejected with a
+  flag-shaped error rather than silently picking one.
+- **`feat(gate templates): wave-brief template registry — list / show /
+  --template skeleton expansion
+  ([#235](https://github.com/eris-ths/guild-cli/issues/235))**.
+  Adds two read subverbs (`gate templates list` / `gate templates show
+  <name>`) over a per-instance template SOT at
+  `<content_root>/data/guild/templates/wave-brief/`, and threads
+  `gate request --template <name>` through to stamp three new fields
+  on the request record (`template`, `template_version`,
+  `gate_required_acknowledged`). The skeleton expansion populates
+  `--action` / `--reason` from the template's frontmatter when the
+  caller omits them; explicit overrides win and the template stamp
+  survives. Templates are markdown files with YAML frontmatter
+  (`template_name` / `template_version` / `intended_use` /
+  `gate_required`); malformed frontmatter routes through the
+  conventional `onMalformed` warn-and-skip path so one bad file
+  doesn't take the registry offline. The public `guild-cli` repo does
+  NOT ship templates — each guild instance keeps its own brief
+  catalogue under `content_root`, and a missing dir is the legitimate
+  empty-registry case (the `list` surface emits a single-line advisory
+  rather than failing). Profile=swarm gating for parallel-executor
+  waves is in stub form for this phase: when `executors.length > 1`
+  is supplied without `--template`, a stderr notice points at the
+  registry and `gate templates list`, but the request still lands.
+  Enforcement (refuse without `--template` for parallel waves) is the
+  follow-up issue. Pre-#235 records lack all three template fields
+  and round-trip clean (records-outlive-writers, principle 04). Schema
+  declares the new `templates` verb under category `read` with a
+  `subcommand` discriminator; the schema-drift detector treats it as
+  a subcommand umbrella alongside `issues` and `inbox`. Mutually
+  exclusive with `--from-agora` (#232) at the interface layer (both
+  supply action/reason defaults).
+
 - **`features.self_approve: { allowed | warn | forbidden }` —
   profile-gated self-approve policy on `gate approve`**
   ([#233](https://github.com/eris-ths/guild-cli/issues/233)).

--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -69,6 +69,16 @@ export class RequestUseCases {
      *  derived from an agora play's invitation/cliff. Persisted only
      *  when set (absence is the common case). */
     sourceAgoraPlay?: string;
+    /** Wave-brief template stamp (#235). Threads through from the
+     *  interface layer's `--template` flag. The trio (template name,
+     *  version, gate_required acknowledgement) moves together; if the
+     *  caller supplies `template`, the version defaults to 1 and
+     *  acknowledgement to true. Mutually exclusive with
+     *  `sourceAgoraPlay` at the interface layer (both supply
+     *  action/reason defaults). */
+    template?: string;
+    templateVersion?: number;
+    gateRequiredAcknowledged?: boolean;
   }): Promise<Request> {
     const { requests, members, clock } = this.deps;
     const from = await assertActor(input.from, '--from', members);
@@ -130,6 +140,13 @@ export class RequestUseCases {
       createArgs.requiresWorktreeIsolation = true;
     if (input.sourceAgoraPlay !== undefined)
       createArgs.sourceAgoraPlay = input.sourceAgoraPlay;
+    if (input.template !== undefined) {
+      createArgs.template = input.template;
+      if (input.templateVersion !== undefined)
+        createArgs.templateVersion = input.templateVersion;
+      if (input.gateRequiredAcknowledged !== undefined)
+        createArgs.gateRequiredAcknowledged = input.gateRequiredAcknowledged;
+    }
 
     for (let attempt = 0; attempt < 10; attempt++) {
       createArgs.id = RequestId.generate(now, seq);

--- a/src/application/template/TemplateUseCases.ts
+++ b/src/application/template/TemplateUseCases.ts
@@ -1,0 +1,55 @@
+// Wave-brief template registry use cases (#235).
+//
+// Thin orchestration over `TemplateRepository`. Two read verbs in
+// scope: list every available template, and show one by name. Write
+// path lives in `gate request --template <name>` (handlers/request.ts);
+// this module is a read-only port consumer.
+
+import {
+  TemplateRepository,
+  ParsedTemplate,
+} from '../../infrastructure/template/TemplateRepository.js';
+
+export interface TemplateSummary {
+  readonly name: string;
+  readonly version: number;
+  readonly intendedUse: string;
+  readonly gateRequired: boolean;
+}
+
+export class TemplateUseCases {
+  constructor(private readonly repo: TemplateRepository) {}
+
+  /** Return every parseable template, sorted by name. */
+  list(): TemplateSummary[] {
+    return this.repo.list().map(toSummary);
+  }
+
+  /** Return one template by name, or null when unknown. The full
+   *  `ParsedTemplate` (including body) is exposed so `gate templates
+   *  show` can render the markdown verbatim. */
+  show(name: string): ParsedTemplate | null {
+    return this.repo.find(name);
+  }
+
+  /** True when the templates dir exists. False is the legitimate
+   *  empty-registry case (fresh install / public-repo clone). */
+  registryExists(): boolean {
+    return this.repo.exists;
+  }
+
+  /** Filesystem path of the templates dir — surfaced in error
+   *  messages so the operator can find the SOT. */
+  registryDir(): string {
+    return this.repo.dir;
+  }
+}
+
+function toSummary(t: ParsedTemplate): TemplateSummary {
+  return {
+    name: t.name,
+    version: t.version,
+    intendedUse: t.intendedUse,
+    gateRequired: t.gateRequired,
+  };
+}

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -121,6 +121,30 @@ export interface RequestProps {
    * record, including all pre-#231 history.
    */
   requiresWorktreeIsolation?: boolean;
+  /**
+   * Wave-brief template registry (#235). When the request was created
+   * via `gate request --template <name>`, the chosen template name is
+   * stamped here so downstream consumers can recover "which brief did
+   * this wave start from?" without re-parsing free-text fields.
+   *
+   * Persistence: `template` / `template_version` / `gate_required_acknowledged`
+   * are emitted only when `template` is set (the trio moves together —
+   * if you stamped a template, the version and gate-acknowledgement
+   * round-trip with it). Pre-#235 records lack all three fields and
+   * hydrate as undefined (template-less). Byte-stable round-trip for
+   * non-template records. */
+  template?: string;
+  /** Template version (#235). Currently always 1; bumps if a template's
+   *  intended_use or skeleton meaningfully changes. Paired with
+   *  `template`; if `template` is set, this is set too. */
+  templateVersion?: number;
+  /** Acknowledgement that the template's `gate_required: true` contract
+   *  was honoured at request-creation time (#235). Always recorded as
+   *  true on a templated request — phase-1 is "we shipped via the
+   *  template path". A future release may surface a `--no-gate` opt-out
+   *  for stub experiments; until then the field's presence is a
+   *  positive assertion, not a toggle. */
+  gateRequiredAcknowledged?: boolean;
   state: RequestState;
   createdAt: string;
   reviews: Review[];
@@ -265,6 +289,14 @@ export class Request {
      *  truthy; older / single-executor / standard-profile records
      *  carry no field at all (false-by-absence). Issue #231. */
     requiresWorktreeIsolation?: boolean;
+    /** Template stamp (#235). If `template` is set, `templateVersion`
+     *  must be a positive integer and `gateRequiredAcknowledged` is
+     *  recorded as true. The interface layer is the only legitimate
+     *  caller that supplies these; non-CLI callers may pass them too
+     *  if they're enforcing the same contract. */
+    template?: string;
+    templateVersion?: number;
+    gateRequiredAcknowledged?: boolean;
   }): Request {
     const from = MemberName.of(input.from);
     const action = sanitizeText(input.action, 'action');
@@ -371,6 +403,34 @@ export class Request {
     if (input.requiresWorktreeIsolation === true) {
       props.requiresWorktreeIsolation = true;
     }
+    // Template stamp (#235). Persist all three fields together when a
+    // template was chosen — version and gate-required acknowledgement
+    // are meaningless without the template name. Validation: name must
+    // be a non-empty string (the interface layer also pre-checks
+    // against the registry); version must be a positive integer.
+    if (input.template !== undefined) {
+      const name = String(input.template).trim();
+      if (name.length === 0) {
+        throw new DomainError(
+          'template name must be a non-empty string',
+          'template',
+        );
+      }
+      const version = input.templateVersion ?? 1;
+      if (!Number.isInteger(version) || version < 1) {
+        throw new DomainError(
+          `template_version must be a positive integer, got ${version}`,
+          'templateVersion',
+        );
+      }
+      props.template = name;
+      props.templateVersion = version;
+      // Phase 1: presence of `template` implies the gate-required
+      // contract was honoured — there is no opt-out yet. Record as
+      // true unconditionally so a hydrate-then-resave round-trip
+      // produces byte-stable YAML even if the input arg was omitted.
+      props.gateRequiredAcknowledged = input.gateRequiredAcknowledged ?? true;
+    }
     // New requests have no on-disk predecessor; loadedVersion=0 marks
     // "never seen" for the optimistic-lock check in save().
     return new Request(props, 0);
@@ -455,6 +515,17 @@ export class Request {
    *  the gate execute handler to gate the cwd-collision check. */
   get requiresWorktreeIsolation(): boolean {
     return this.props.requiresWorktreeIsolation === true;
+  }
+  /** Template registry stamp (#235). Undefined when the request was
+   *  created without `--template`; pre-#235 records always undefined. */
+  get template(): string | undefined {
+    return this.props.template;
+  }
+  get templateVersion(): number | undefined {
+    return this.props.templateVersion;
+  }
+  get gateRequiredAcknowledged(): boolean | undefined {
+    return this.props.gateRequiredAcknowledged;
   }
   /** Most recent `executing` status_log entry's cwd, or undefined
    *  when the request has never been executed (or when the on-disk
@@ -897,6 +968,17 @@ export class Request {
     // on round-trip (false-by-absence is the load tolerance).
     if (this.props.requiresWorktreeIsolation === true) {
       out['requires_worktree_isolation'] = true;
+    }
+    // Template registry stamp (#235). The trio (template,
+    // template_version, gate_required_acknowledged) moves together —
+    // all-set or all-absent. Pre-#235 records and template-less post-
+    // #235 records both emit byte-identical YAML on round-trip.
+    if (this.props.template !== undefined) {
+      out['template'] = this.props.template;
+      out['template_version'] = this.props.templateVersion ?? 1;
+      if (this.props.gateRequiredAcknowledged !== undefined) {
+        out['gate_required_acknowledged'] = this.props.gateRequiredAcknowledged;
+      }
     }
     // Cross-session claim (issue #226). Both fields move together —
     // present-when-set, omitted-when-clear — so YAML stays byte-stable

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -556,6 +556,36 @@ function hydrate(
     if (obj['requires_worktree_isolation'] === true) {
       props.requiresWorktreeIsolation = true;
     }
+    // Template stamp (#235). Hydrate when `template` is present and a
+    // non-empty string. `template_version` is tolerated as a positive
+    // integer (default 1 if absent / malformed); `gate_required_acknowledged`
+    // is tolerated as boolean (default true since presence of `template`
+    // is the positive assertion in phase 1). Pre-#235 records lack all
+    // three fields and round-trip clean. Records-outlive-writers
+    // (principle 04): malformed values degrade to defaults rather than
+    // dropping the whole record.
+    if (typeof obj['template'] === 'string' && (obj['template'] as string).length > 0) {
+      props.template = obj['template'] as string;
+      const rawVer = obj['template_version'];
+      if (typeof rawVer === 'number' && Number.isFinite(rawVer) && rawVer >= 1) {
+        props.templateVersion = Math.floor(rawVer);
+      } else {
+        if (rawVer !== undefined) {
+          onMalformed(
+            source,
+            `template_version is not a positive integer (got ${typeof rawVer === 'number' ? String(rawVer) : typeof rawVer}); defaulting to 1`,
+          );
+        }
+        props.templateVersion = 1;
+      }
+      const rawAck = obj['gate_required_acknowledged'];
+      if (typeof rawAck === 'boolean') {
+        props.gateRequiredAcknowledged = rawAck;
+      } else {
+        // presence of `template` implies acknowledgement in phase 1
+        props.gateRequiredAcknowledged = true;
+      }
+    }
     // Cross-session claim (issue #226). Restore only when BOTH fields
     // are present and well-typed — a record with one of the two is
     // structurally inconsistent (claim should never be half-set) and

--- a/src/infrastructure/template/TemplateRepository.ts
+++ b/src/infrastructure/template/TemplateRepository.ts
@@ -1,0 +1,199 @@
+// Wave-brief template registry (#235).
+//
+// Reads frontmatter+body markdown templates from
+// `<content_root>/data/guild/templates/wave-brief/<name>.md`. The
+// templates SOT is per-instance (each guild keeps its own brief
+// catalogue under content_root); the public guild-cli repo does NOT
+// ship templates, so missing dir → "empty registry" is the legitimate
+// default for fresh installs.
+//
+// Frontmatter is a YAML block delimited by lines containing exactly
+// `---` at file start and end of the metadata section. Body is
+// everything after the closing `---`. Malformed frontmatter routes
+// through `onMalformed` (warn + skip the entry); the rest of the
+// catalogue stays available.
+
+import { join } from 'node:path';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import YAML from 'yaml';
+import { listDirSafe } from '../persistence/safeFs.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
+
+/** Parsed wave-brief template. `body` is the markdown after the
+ *  frontmatter block, trimmed at neither end (callers may render or
+ *  embed verbatim). `frontmatter` carries every key parsed from the
+ *  YAML block — `template_name`, `template_version`, `intended_use`,
+ *  `gate_required` are the canonical four; additional keys are
+ *  tolerated and surfaced for forward-compat consumers. */
+export interface ParsedTemplate {
+  readonly name: string;
+  readonly version: number;
+  readonly intendedUse: string;
+  readonly gateRequired: boolean;
+  readonly body: string;
+  readonly frontmatter: Record<string, unknown>;
+  /** Absolute path of the source file (for diagnostics). */
+  readonly source: string;
+}
+
+export interface TemplateRepository {
+  /** List every parseable template in the registry. Returns [] when
+   *  the templates dir does not exist. */
+  list(): ParsedTemplate[];
+  /** Find a single template by name. Returns null if no file matches
+   *  `<name>.md` or if the file failed to parse (caller should treat
+   *  null as "unknown name" — a parse failure already routed through
+   *  onMalformed). */
+  find(name: string): ParsedTemplate | null;
+  /** Filesystem path of the templates directory (informational; used
+   *  by handlers to surface the SOT location in error messages). */
+  readonly dir: string;
+  /** True when the templates dir exists on disk. False is the legitimate
+   *  fresh-install / public-repo case. */
+  readonly exists: boolean;
+}
+
+const TEMPLATE_FILE_PATTERN = /^[a-z][a-z0-9_-]*\.md$/;
+
+/**
+ * Filesystem-backed template repo. Path is resolved from the content
+ * root: `<contentRoot>/data/guild/templates/wave-brief/`. The fixed
+ * subdirectory is intentional — different brief categories (e.g.
+ * `code-review/`, `incident/`) would each get their own subdir under
+ * `data/guild/templates/`, but only `wave-brief` is in scope for #235.
+ */
+export class FsTemplateRepository implements TemplateRepository {
+  readonly dir: string;
+  constructor(
+    contentRoot: string,
+    private readonly onMalformed: OnMalformed,
+  ) {
+    this.dir = join(contentRoot, 'data', 'guild', 'templates', 'wave-brief');
+  }
+
+  get exists(): boolean {
+    if (!existsSync(this.dir)) return false;
+    try {
+      return statSync(this.dir).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  list(): ParsedTemplate[] {
+    if (!this.exists) return [];
+    // listDirSafe expects a base + relative; since `dir` is already
+    // absolute and outside the request layout's safety domain, use
+    // it as the base directly. Templates dir is read-only.
+    const files = listDirSafe(this.dir, '.').filter((f) =>
+      TEMPLATE_FILE_PATTERN.test(f),
+    );
+    const out: ParsedTemplate[] = [];
+    for (const f of files.sort()) {
+      const parsed = this.readFile(join(this.dir, f));
+      if (parsed) out.push(parsed);
+    }
+    return out;
+  }
+
+  find(name: string): ParsedTemplate | null {
+    if (!this.exists) return null;
+    if (!TEMPLATE_FILE_PATTERN.test(`${name}.md`)) {
+      // Defensive: an attacker-controlled `name` could attempt path
+      // traversal through `--template ../../../etc/passwd`. We refuse
+      // anything that doesn't fit the simple slug shape rather than
+      // letting the filesystem decide. The list() filter uses the
+      // same regex, so the two surfaces stay consistent.
+      return null;
+    }
+    const path = join(this.dir, `${name}.md`);
+    if (!existsSync(path)) return null;
+    return this.readFile(path);
+  }
+
+  private readFile(path: string): ParsedTemplate | null {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.onMalformed(path, `template read failed: ${msg}`);
+      return null;
+    }
+    return parseTemplate(raw, path, this.onMalformed);
+  }
+}
+
+/**
+ * Pure parser for a wave-brief template file. Exported (not just
+ * `FsTemplateRepository`-private) so the test suite can exercise the
+ * frontmatter edge cases without round-tripping through the
+ * filesystem.
+ */
+export function parseTemplate(
+  raw: string,
+  source: string,
+  onMalformed: OnMalformed,
+): ParsedTemplate | null {
+  // Frontmatter delimiter: a line containing just `---` at the very
+  // start of the file, then a closing `---` on its own line. Anything
+  // before the opening delimiter (including leading whitespace) is
+  // refused — the convention is exact start.
+  if (!raw.startsWith('---\n') && !raw.startsWith('---\r\n')) {
+    onMalformed(source, 'template missing opening frontmatter delimiter (---)');
+    return null;
+  }
+  // Skip the opening delimiter line, then find the closing one.
+  const afterOpen = raw.replace(/^---\r?\n/, '');
+  const closeIdx = afterOpen.search(/^---\r?\n/m);
+  if (closeIdx < 0) {
+    onMalformed(source, 'template missing closing frontmatter delimiter (---)');
+    return null;
+  }
+  const fmText = afterOpen.slice(0, closeIdx);
+  const body = afterOpen.slice(closeIdx).replace(/^---\r?\n/, '');
+
+  let fm: unknown;
+  try {
+    fm = YAML.parse(fmText);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    onMalformed(source, `template frontmatter yaml parse failed: ${msg.split('\n').join(' ')}`);
+    return null;
+  }
+  if (fm === null || typeof fm !== 'object' || Array.isArray(fm)) {
+    onMalformed(source, 'template frontmatter is not a mapping');
+    return null;
+  }
+  const fmObj = fm as Record<string, unknown>;
+  const name = fmObj['template_name'];
+  if (typeof name !== 'string' || name.length === 0) {
+    onMalformed(source, 'template frontmatter missing template_name');
+    return null;
+  }
+  const rawVer = fmObj['template_version'];
+  let version = 1;
+  if (typeof rawVer === 'number' && Number.isFinite(rawVer) && rawVer >= 1) {
+    version = Math.floor(rawVer);
+  } else if (rawVer !== undefined) {
+    onMalformed(
+      source,
+      `template_version is not a positive integer (got ${typeof rawVer === 'number' ? String(rawVer) : typeof rawVer}); defaulting to 1`,
+    );
+  }
+  const intendedUseRaw = fmObj['intended_use'];
+  const intendedUse = typeof intendedUseRaw === 'string' ? intendedUseRaw : '';
+  const gateRequiredRaw = fmObj['gate_required'];
+  const gateRequired =
+    typeof gateRequiredRaw === 'boolean' ? gateRequiredRaw : true;
+
+  return {
+    name,
+    version,
+    intendedUse,
+    gateRequired,
+    body,
+    frontmatter: fmObj,
+    source,
+  };
+}

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -38,6 +38,11 @@ const REQUEST_CREATE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   // schemaInputDriftDetector.test.ts.)
   'from-agora',
   'game',
+  // #235 wave-brief template registry: --template name expands a brief
+  // skeleton; explicit --action and --reason override the defaults.
+  // Mutually exclusive with --from-agora (both supply action/reason
+  // defaults; combining them would make precedence ambiguous).
+  'template',
 ]);
 const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -145,6 +150,50 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
     return 1;
   }
 
+  // #235 — wave-brief template skeleton expansion.
+  // When `--template <name>` is supplied, the template's `intended_use`
+  // becomes the default `--reason`, and a `wave-brief: <name>` summary
+  // becomes the default `--action`. Explicit `--action` / `--reason`
+  // override the skeleton; the template stamp itself (template name,
+  // version, gate-required acknowledgement) survives caller overrides.
+  //
+  // Mutex with --from-agora: both supply action/reason defaults, so
+  // combining them would make precedence ambiguous (does the play's
+  // invitation win, or the template's wave-brief stub?). Refuse up
+  // front rather than silently picking one — same fail-open class
+  // rejectUnknownFlags is built to prevent.
+  const templateName = optionalOption(args, 'template');
+  if (templateName !== undefined && fromAgoraRaw !== undefined) {
+    process.stderr.write(
+      `error: --template and --from-agora are mutually exclusive ` +
+        `(both supply default --action / --reason; precedence would be ` +
+        `ambiguous). Pick one: use --template <name> for a wave-brief ` +
+        `skeleton, or --from-agora <play_id> to bridge an agora play.\n`,
+    );
+    return 1;
+  }
+  let templateMeta:
+    | { name: string; version: number; intendedUse: string; gateRequired: boolean }
+    | undefined;
+  if (templateName !== undefined) {
+    const t = c.templateUC.show(templateName);
+    if (!t) {
+      const available = c.templateUC.list().map((s) => s.name);
+      const hint =
+        available.length === 0
+          ? `  (registry empty at ${c.templateUC.registryDir()})`
+          : `  available: ${available.join(', ')}`;
+      process.stderr.write(`error: unknown template "${templateName}"\n${hint}\n`);
+      return 1;
+    }
+    templateMeta = {
+      name: t.name,
+      version: t.version,
+      intendedUse: t.intendedUse,
+      gateRequired: t.gateRequired,
+    };
+  }
+
   const actionRaw = optionalOption(args, 'action');
   let reasonRaw = optionalOption(args, 'reason');
   // `--reason -` reads from stdin — parity with `gate review --comment -`.
@@ -221,6 +270,22 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
     reason = reasonRaw !== undefined && reasonRaw.trim().length > 0
       ? reasonRaw
       : lift.cliff;
+  } else if (templateMeta !== undefined) {
+    // #235 — template skeleton path. Defaults derive from the template;
+    // explicit --action / --reason override. The template stamp itself
+    // (name + version + gate_required ack) is set further below and
+    // survives any caller override of action/reason.
+    action =
+      actionRaw !== undefined && actionRaw.trim().length > 0
+        ? actionRaw
+        : `wave-brief: ${templateMeta.name}`;
+    if (reasonRaw !== undefined && reasonRaw.trim().length > 0) {
+      reason = reasonRaw;
+    } else if (templateMeta.intendedUse.length > 0) {
+      reason = templateMeta.intendedUse;
+    } else {
+      reason = `wave-brief template ${templateMeta.name} (v${templateMeta.version})`;
+    }
   } else {
     // Plain `gate request` — action/reason are both required, same
     // contract as before #232. requireOption surfaces the usage hint
@@ -236,6 +301,11 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
     reason,
   };
   if (sourceAgoraPlay !== undefined) input.sourceAgoraPlay = sourceAgoraPlay;
+  if (templateMeta !== undefined) {
+    input.template = templateMeta.name;
+    input.templateVersion = templateMeta.version;
+    input.gateRequiredAcknowledged = true;
+  }
   const executor = optionalOption(args, 'executor');
   const executorsRaw = optionalOption(args, 'executors');
   const target = optionalOption(args, 'target');
@@ -285,6 +355,25 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
           `in guild.config.yaml to enforce per-cwd isolation.\n`,
       );
     }
+  }
+  // #235 — profile=swarm gating for parallel-shaped templates. Stub:
+  // the brief catalogue carries `template_name` like `parallel-impl`
+  // / `compare-and-ratify` that imply >1 executor; under swarm we
+  // *should* require `--template` for parallel-executor waves so the
+  // brief is on record. Phase 1 emits a warning notice only;
+  // enforcement (refuse without --template) is the follow-up. Single-
+  // executor and standard-profile callers are silent.
+  if (
+    c.config.profile === 'swarm' &&
+    parallelExecutors &&
+    templateMeta === undefined
+  ) {
+    process.stderr.write(
+      `notice: parallel executors under profile=swarm without --template ` +
+        `(#235 phase 1: warning only; enforcement is follow-up). ` +
+        `Consider \`gate templates list\` to find a wave-brief template, ` +
+        `or pass --template <name> when filing this request.\n`,
+    );
   }
   // depth (issue #221): pre-check at the interface boundary so the
   // caller sees a flag-shaped error before the domain layer fires.

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -744,6 +744,16 @@ function formatRequestText(r: Request): string {
       const names = (j['witnesses'] as unknown[]).map((w) => String(w)).join(', ');
       lines.push(`    witnesses: ${names}`);
     }
+    // Template stamp (issue #235). Rendered when the request was
+    // bootstrapped from a wave-brief template. Surfaces on the same
+    // axis as claim/witness so readers see "this wave's framing is
+    // canon-blessed" without dipping into JSON.
+    if (typeof j['template'] === 'string') {
+      const v =
+        typeof j['template_version'] === 'number' ? ` (v${j['template_version']})` : '';
+      const ack = j['gate_required_acknowledged'] === true ? ' [gate-ack]' : '';
+      lines.push(`    template: ${j['template']}${v}${ack}`);
+    }
   }
 
   const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -807,22 +807,50 @@ const VERBS: readonly VerbSchema[] = [
             'without --from-agora.',
         ),
         format: formatField,
+        template: strOpt(
+          'wave-brief template name (#235). Expands a brief skeleton ' +
+            'into action/reason defaults; explicit --action / --reason ' +
+            "override. The template name + version are stamped onto the " +
+            'request record (template / template_version / ' +
+            'gate_required_acknowledged). Use `gate templates list` to ' +
+            'see the catalogue.',
+        ),
       },
-      // action/reason are conditionally required: required iff
-      // --from-agora is absent. `oneOf` expresses the two-shape
-      // contract for JSON Schema consumers (codegen, form-builders,
-      // AI tool-use schemas) so they don't read action as
-      // unconditionally optional. Either shape A (`action`+`reason`,
-      // no agora bridge) or shape B (`from-agora`, lifts both) is
-      // valid; the runtime handler enforces the same branch via
-      // `requireOption`.
+      // action/reason are conditionally required: required unless one
+      // of `--from-agora` (#232) or `--template` (#235) is supplied,
+      // each of which provides its own action/reason defaults. `oneOf`
+      // expresses the three-shape contract for JSON Schema consumers
+      // (codegen, form-builders, AI tool-use schemas) so they don't
+      // read action as unconditionally optional. The runtime handler
+      // enforces the same branches via `requireOption`, and rejects
+      // `--from-agora` + `--template` as mutually exclusive (both
+      // supply defaults; precedence would be ambiguous).
       required: [],
       oneOf: [
         { required: ['action', 'reason'] },
         { required: ['from-agora'] },
+        { required: ['template'] },
       ],
     },
     output: writeResponseSchema,
+  },
+  {
+    name: 'templates',
+    category: 'read',
+    summary:
+      'wave-brief template registry (#235). Subcommands: list (catalogue), show <name> (full body). The template SOT lives at <content_root>/data/guild/templates/wave-brief/; missing dir is the legitimate empty-registry case (public-repo / fresh-install).',
+    input: {
+      type: 'object',
+      properties: {
+        subcommand: {
+          type: 'string',
+          enum: ['list', 'show'],
+        },
+        name: strOpt('template name (positional, `show` only)'),
+        format: formatField,
+      },
+    },
+    output: { type: 'object' },
   },
   {
     name: 'approve',

--- a/src/interface/gate/handlers/templates.ts
+++ b/src/interface/gate/handlers/templates.ts
@@ -1,0 +1,157 @@
+// `gate templates` — wave-brief template registry surface (#235).
+//
+// Two read subverbs:
+//   - `gate templates list`         → name + intended_use catalogue
+//   - `gate templates show <name>`  → full markdown body (text mode)
+//                                    or {frontmatter, body} (json mode)
+//
+// The write side (consume a template via `gate request --template <n>`)
+// lives in handlers/request.ts. This module is read-only.
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+
+const TEMPLATES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+const TEMPLATES_SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+export async function templatesCmd(c: C, args: ParsedArgs): Promise<number> {
+  const sub = args.positional[0];
+  if (sub === undefined) {
+    process.stderr.write(
+      'gate templates needs a subcommand:\n' +
+        '  gate templates list                # available wave-brief templates\n' +
+        '  gate templates show <name>         # render one template\n',
+    );
+    return 1;
+  }
+  if (sub === 'list') {
+    return await templatesList(c, shiftPositional(args));
+  }
+  if (sub === 'show') {
+    return await templatesShow(c, shiftPositional(args));
+  }
+  process.stderr.write(
+    `unknown subcommand: gate templates ${sub}\n` +
+      `  see 'gate templates' for the available subverbs.\n`,
+  );
+  return 1;
+}
+
+function shiftPositional(args: ParsedArgs): ParsedArgs {
+  // Drop the first positional (the subverb itself) so downstream
+  // handlers see `<name>` at positional[0]. Mirrors how `issuesCmd`
+  // handles its own subverb dispatch via raw positional inspection;
+  // we shift here because templatesShow uses `positional[0]`.
+  return { ...args, positional: args.positional.slice(1) };
+}
+
+async function templatesList(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, TEMPLATES_LIST_KNOWN_FLAGS, 'templates list');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  const items = c.templateUC.list();
+  const exists = c.templateUC.registryExists();
+  const dir = c.templateUC.registryDir();
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          templates: items.map((t) => ({
+            name: t.name,
+            version: t.version,
+            intended_use: t.intendedUse,
+            gate_required: t.gateRequired,
+          })),
+          _meta: { dir, exists },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+  if (!exists) {
+    // Empty / missing dir — print a single advisory line so an
+    // operator on a fresh checkout (or the public guild-cli repo)
+    // sees why the catalogue is empty rather than a blank stdout.
+    process.stdout.write(
+      `(empty: templates dir not found at ${dir})\n`,
+    );
+    return 0;
+  }
+  if (items.length === 0) {
+    process.stdout.write(
+      `(no templates found in ${dir})\n`,
+    );
+    return 0;
+  }
+  // Pad name column for readable alignment. Same shape as
+  // computeReviewMarkerWidth — measure the catalogue once.
+  const nameWidth = Math.max(...items.map((t) => t.name.length));
+  for (const t of items) {
+    const padded = t.name.padEnd(nameWidth);
+    const lock = t.gateRequired ? '[gate-required]' : '[no-gate]';
+    process.stdout.write(
+      `${padded}  v${t.version}  ${lock}  ${t.intendedUse}\n`,
+    );
+  }
+  return 0;
+}
+
+async function templatesShow(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, TEMPLATES_SHOW_KNOWN_FLAGS, 'templates show');
+  const name = args.positional[0];
+  if (!name) {
+    throw new Error(
+      'Usage: gate templates show <name> [--format json|text]',
+    );
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  const t = c.templateUC.show(name);
+  if (!t) {
+    const available = c.templateUC.list().map((s) => s.name);
+    const hint =
+      available.length === 0
+        ? `  (registry is empty at ${c.templateUC.registryDir()})`
+        : `  available: ${available.join(', ')}`;
+    process.stderr.write(`unknown template: ${name}\n${hint}\n`);
+    return 1;
+  }
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          name: t.name,
+          version: t.version,
+          intended_use: t.intendedUse,
+          gate_required: t.gateRequired,
+          frontmatter: t.frontmatter,
+          body: t.body,
+          source: t.source,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+  // Text mode: emit the raw markdown including frontmatter so the
+  // output is a faithful copy of the source file. Operators piping
+  // to a file get a working `.md` they can edit and re-import if
+  // they ever want to fork a template.
+  const fmKeys = Object.entries(t.frontmatter)
+    .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+    .join('\n');
+  process.stdout.write(`---\n${fmKeys}\n---\n${t.body}`);
+  if (!t.body.endsWith('\n')) process.stdout.write('\n');
+  return 0;
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -45,6 +45,7 @@ import { transcriptCmd } from './handlers/transcript.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
+import { templatesCmd } from './handlers/templates.js';
 import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
@@ -273,6 +274,7 @@ const KNOWN_COMMANDS = [
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
   'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
   'unresponded',
+  'templates',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -418,6 +420,8 @@ async function dispatch(
       return await schemaCmd(c, args);
     case 'unresponded':
       return await unrespondedCmd(c, args);
+    case 'templates':
+      return await templatesCmd(c, args);
     default: {
       const hint = nearestCommand(cmd, KNOWN_COMMANDS);
       const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -36,6 +36,7 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'resume',
   'schema',
   'unresponded',
+  'templates',
 ]);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set([

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -18,6 +18,8 @@ import { SafeFsQuarantineStore } from '../../infrastructure/persistence/SafeFsQu
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
 import { YamlPlayRepository } from '../../passages/agora/infrastructure/YamlPlayRepository.js';
 import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
+import { FsTemplateRepository } from '../../infrastructure/template/TemplateRepository.js';
+import { TemplateUseCases } from '../../application/template/TemplateUseCases.js';
 
 export interface Container {
   config: GuildConfig;
@@ -38,6 +40,13 @@ export interface Container {
    * `agora` CLI verbs read/write.
    */
   playRepo: PlayRepository;
+  /**
+   * Wave-brief template registry adapter (#235). Wired so
+   * `gate templates list/show` and `gate request --template <name>`
+   * read from the per-instance template SOT under
+   * `<content_root>/data/guild/templates/wave-brief/`.
+   */
+  templateUC: TemplateUseCases;
 }
 
 export interface BuildContainerOpts {
@@ -84,5 +93,8 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     repairUC: new RepairUseCases(quarantine),
     unrespondedConcernsQ: new UnrespondedConcernsQuery(requests, issues),
     playRepo: new YamlPlayRepository(config),
+    templateUC: new TemplateUseCases(
+      new FsTemplateRepository(config.contentRoot, config.onMalformed),
+    ),
   };
 }

--- a/tests/interface/schemaInputDriftDetector.test.ts
+++ b/tests/interface/schemaInputDriftDetector.test.ts
@@ -67,6 +67,11 @@ const GATE = resolve(here, '../../../bin/gate.mjs');
 const SUBCOMMAND_UMBRELLAS: ReadonlySet<string> = new Set([
   'issues',
   'inbox', // inbox umbrella has mark-read sub-handler with separate flags
+  // templates (#235): same shape as issues — `templates list` and
+  // `templates show` carry separate KNOWN_FLAGS sets, but the schema
+  // collapses them into a single `templates` entry with a `subcommand`
+  // discriminator. Skip in line with the policy comment above.
+  'templates',
 ]);
 
 // `gate help` and the very top-level positional verb dispatcher

--- a/tests/interface/templates.test.ts
+++ b/tests/interface/templates.test.ts
@@ -1,0 +1,356 @@
+// `gate templates` + `gate request --template` (#235).
+//
+// Coverage:
+//   - templates list: dir present (sandbox fixtures) + dir absent
+//   - templates show: known + unknown name
+//   - request --template <known>: skeleton expansion populates
+//     action/reason and stamps template/template_version/
+//     gate_required_acknowledged on the record
+//   - request --template <known> --action / --reason: explicit
+//     overrides win, template stamp survives
+//   - request --template <unknown>: exits 1, lists available
+//   - frontmatter malformed: surfaces via onMalformed warn + skip
+//   - profile=swarm + parallel executors without --template:
+//     warning notice (phase-1 stub)
+//   - byte-stable round-trip: a templated record reloads cleanly
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Bootstrapped {
+  root: string;
+  templatesDir: string;
+  cleanup: () => void;
+}
+
+function bootstrap(opts: { profile?: 'standard' | 'swarm' } = {}): Bootstrapped {
+  const root = mkdtempSync(join(tmpdir(), 'guild-templates-'));
+  const profileLine = opts.profile ? `profile: ${opts.profile}\n` : '';
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    `content_root: .\nhost_names: [eris]\n${profileLine}`,
+  );
+  mkdirSync(join(root, 'members'));
+  const templatesDir = join(root, 'data', 'guild', 'templates', 'wave-brief');
+  return {
+    root,
+    templatesDir,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  actor?: string,
+): { stdout: string; stderr: string; status: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (actor !== undefined) env['GUILD_ACTOR'] = actor;
+  else delete env['GUILD_ACTOR'];
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function registerAll(root: string, names: string[]): void {
+  for (const n of names) {
+    run(root, ['register', '--name', n]);
+  }
+}
+
+function writeTemplate(
+  templatesDir: string,
+  name: string,
+  body: { intendedUse?: string; gateRequired?: boolean; version?: number; markdown?: string },
+): void {
+  mkdirSync(templatesDir, { recursive: true });
+  const ver = body.version ?? 1;
+  const intended = body.intendedUse ?? `intended use of ${name}`;
+  const gateReq = body.gateRequired ?? true;
+  const md = body.markdown ?? `# Wave Brief: ${name}\n\nbody content for ${name}.\n`;
+  // Quote intended_use defensively — prose may contain `:` which YAML
+  // would parse as a nested mapping in flow-form.
+  const intendedQuoted = JSON.stringify(intended);
+  const content =
+    `---\n` +
+    `template_name: ${name}\n` +
+    `template_version: ${ver}\n` +
+    `intended_use: ${intendedQuoted}\n` +
+    `gate_required: ${gateReq}\n` +
+    `---\n` +
+    md;
+  writeFileSync(join(templatesDir, `${name}.md`), content);
+}
+
+// ---------------- templates list ----------------
+
+test('gate templates list: empty dir → advisory line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'list']);
+  assert.equal(r.status, 0, `list failed: ${r.stderr}`);
+  assert.match(r.stdout, /empty: templates dir not found/);
+});
+
+test('gate templates list: dir with templates → catalogue', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {
+    intendedUse: 'parallel implementation wave',
+  });
+  writeTemplate(templatesDir, 'verification', {
+    intendedUse: 'verification wave',
+  });
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'list']);
+  assert.equal(r.status, 0, `list failed: ${r.stderr}`);
+  assert.match(r.stdout, /parallel-impl/);
+  assert.match(r.stdout, /verification/);
+  assert.match(r.stdout, /v1/);
+  assert.match(r.stdout, /\[gate-required\]/);
+});
+
+test('gate templates list --format json: structured payload', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'single-impl', { intendedUse: 'single' });
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'list', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const j = JSON.parse(r.stdout) as { templates: Array<Record<string, unknown>>; _meta: Record<string, unknown> };
+  assert.equal(j.templates.length, 1);
+  assert.equal(j.templates[0]!['name'], 'single-impl');
+  assert.equal(j.templates[0]!['version'], 1);
+  assert.equal(j.templates[0]!['gate_required'], true);
+  assert.equal(j._meta['exists'], true);
+});
+
+// ---------------- templates show ----------------
+
+test('gate templates show <known>: emits markdown body', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {
+    markdown: '# Wave Brief: parallel-impl\n\nspecial-marker-XYZ\n',
+  });
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'show', 'parallel-impl']);
+  assert.equal(r.status, 0, `show failed: ${r.stderr}`);
+  assert.match(r.stdout, /special-marker-XYZ/);
+  assert.match(r.stdout, /^---/);
+});
+
+test('gate templates show <unknown>: exits 1, lists available', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'single-impl', {});
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'show', 'no-such-template']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unknown template/);
+  assert.match(r.stderr, /single-impl/);
+});
+
+test('gate templates show --format json: frontmatter + body', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'verification', {
+    intendedUse: 'verify the artefact',
+    markdown: 'body line one\nbody line two\n',
+  });
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'show', 'verification', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const j = JSON.parse(r.stdout) as Record<string, unknown>;
+  assert.equal(j['name'], 'verification');
+  assert.equal(j['intended_use'], 'verify the artefact');
+  assert.match(String(j['body']), /body line one/);
+  assert.equal(typeof j['frontmatter'], 'object');
+});
+
+// ---------------- request --template ----------------
+
+test('gate request --template <known>: skeleton expansion + record stamp', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {
+    intendedUse: 'parallel implementation: 2+ executors',
+  });
+  registerAll(root, ['miki', 'leysia']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--template', 'parallel-impl',
+    '--format', 'json',
+  ]);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+  // Inspect the persisted record.
+  const show = run(root, ['show', id, '--format', 'json']);
+  const j = JSON.parse(show.stdout) as Record<string, unknown>;
+  assert.equal(j['template'], 'parallel-impl');
+  assert.equal(j['template_version'], 1);
+  assert.equal(j['gate_required_acknowledged'], true);
+  assert.match(String(j['action']), /parallel-impl/);
+  assert.match(String(j['reason']), /parallel implementation/);
+});
+
+test('gate request --template <known> --action --reason: overrides survive, stamp persists', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {
+    intendedUse: 'parallel implementation',
+  });
+  registerAll(root, ['miki']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--template', 'parallel-impl',
+    '--action', 'custom-action-XYZ',
+    '--reason', 'custom-reason-ABC',
+    '--format', 'json',
+  ]);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  const id = (JSON.parse(r.stdout) as { id: string }).id;
+  const show = run(root, ['show', id, '--format', 'json']);
+  const j = JSON.parse(show.stdout) as Record<string, unknown>;
+  assert.equal(j['action'], 'custom-action-XYZ');
+  assert.equal(j['reason'], 'custom-reason-ABC');
+  // Stamp survives.
+  assert.equal(j['template'], 'parallel-impl');
+  assert.equal(j['template_version'], 1);
+});
+
+test('gate request --template <unknown>: exits 1, surfaces available list', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'single-impl', {});
+  registerAll(root, ['miki']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--template', 'no-such',
+    '--action', 'a', '--reason', 'b',
+  ]);
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}: ${r.stdout}`);
+  assert.match(r.stderr, /unknown template/);
+  assert.match(r.stderr, /single-impl/);
+});
+
+test('templates: malformed frontmatter → onMalformed warn, skip in list', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Write a good template, then a bad one with no closing delimiter.
+  writeTemplate(templatesDir, 'good', {});
+  mkdirSync(templatesDir, { recursive: true });
+  writeFileSync(
+    join(templatesDir, 'bad.md'),
+    '---\ntemplate_name: bad\n(no closing delimiter)\n',
+  );
+  registerAll(root, ['miki']);
+  const r = run(root, ['templates', 'list']);
+  assert.equal(r.status, 0, `list failed: ${r.stderr}`);
+  // Good template is listed; bad one is dropped (malformed → skipped).
+  assert.match(r.stdout, /good/);
+  // The malformed warning routes through onMalformed (stderr).
+  assert.match(r.stderr, /missing closing frontmatter|template/i);
+});
+
+// ---------------- profile=swarm gating (phase-1 stub) ----------------
+
+test('profile=swarm + parallel executors without --template: warning notice', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap({ profile: 'swarm' });
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {});
+  registerAll(root, ['miki', 'leysia']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--executors', 'miki,leysia',
+    '--target', 'sometarget',
+    '--action', 'do parallel work',
+    '--reason', 'reason',
+    '--format', 'json',
+  ]);
+  // Phase-1 stub: warning only, the request still lands.
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  assert.match(
+    r.stderr,
+    /parallel executors under profile=swarm without --template/,
+  );
+});
+
+test('profile=swarm + parallel executors WITH --template: no swarm-template warning', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap({ profile: 'swarm' });
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', {});
+  registerAll(root, ['miki', 'leysia']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--executors', 'miki,leysia',
+    '--target', 'sometarget',
+    '--template', 'parallel-impl',
+    '--format', 'json',
+  ]);
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  assert.doesNotMatch(
+    r.stderr,
+    /parallel executors under profile=swarm without --template/,
+  );
+});
+
+// ---------------- byte-stable round-trip ----------------
+
+test('templated record: pre-#235 record (no template fields) round-trips clean', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['miki']);
+  // Hand-write a pre-#235 record (no template fields).
+  const reqDir = join(root, 'requests', 'pending');
+  mkdirSync(reqDir, { recursive: true });
+  const id = '2026-05-08-9999';
+  const yaml =
+    `id: ${id}\n` +
+    `from: miki\n` +
+    `action: pre-235 action\n` +
+    `reason: pre-235 reason\n` +
+    `state: pending\n` +
+    `created_at: 2026-05-08T00:00:00.000Z\n` +
+    `status_log:\n` +
+    `  - state: pending\n` +
+    `    by: miki\n` +
+    `    at: 2026-05-08T00:00:00.000Z\n` +
+    `    note: created\n` +
+    `reviews: []\n`;
+  writeFileSync(join(reqDir, `${id}.yaml`), yaml);
+  const show = run(root, ['show', id, '--format', 'json']);
+  assert.equal(show.status, 0, `show failed: ${show.stderr}`);
+  const j = JSON.parse(show.stdout) as Record<string, unknown>;
+  // No template fields surface.
+  assert.equal(j['template'], undefined);
+  assert.equal(j['template_version'], undefined);
+  assert.equal(j['gate_required_acknowledged'], undefined);
+});

--- a/tests/interface/templates.test.ts
+++ b/tests/interface/templates.test.ts
@@ -215,6 +215,11 @@ test('gate request --template <known>: skeleton expansion + record stamp', (t) =
   assert.equal(j['gate_required_acknowledged'], true);
   assert.match(String(j['action']), /parallel-impl/);
   assert.match(String(j['reason']), /parallel implementation/);
+  // Asteria #8: text mode must surface the template stamp too,
+  // not only json. Renders on the claim/witness axis as
+  // `template: <name> (vN) [gate-ack]`.
+  const showText = run(root, ['show', id, '--format', 'text']);
+  assert.match(showText.stdout, /template: parallel-impl \(v1\) \[gate-ack\]/);
 });
 
 test('gate request --template <known> --action --reason: overrides survive, stamp persists', (t) => {

--- a/tests/interface/templates.test.ts
+++ b/tests/interface/templates.test.ts
@@ -359,3 +359,36 @@ test('templated record: pre-#235 record (no template fields) round-trips clean',
   assert.equal(j['template_version'], undefined);
   assert.equal(j['gate_required_acknowledged'], undefined);
 });
+
+// ---------------- mutex with --from-agora (#232 ↔ #235) ----------------
+
+// `--template` (#235) and `--from-agora` (#232) both supply default
+// action/reason. Combining them would make precedence ambiguous (does
+// the play's invitation win, or the template's wave-brief stub?). The
+// interface layer rejects up-front rather than silently picking one —
+// same fail-open class rejectUnknownFlags is built to prevent. The
+// error mentions both flags so the operator sees which combination
+// tripped, and the request is NOT created (no record on disk).
+test('gate request --template + --from-agora: mutex, exits 1, no record written', (t) => {
+  const { root, templatesDir, cleanup } = bootstrap();
+  t.after(cleanup);
+  writeTemplate(templatesDir, 'parallel-impl', { intendedUse: 'parallel impl' });
+  registerAll(root, ['miki']);
+  const r = run(root, [
+    'request',
+    '--from', 'miki',
+    '--template', 'parallel-impl',
+    '--from-agora', '2026-05-08-001',
+  ]);
+  assert.notEqual(r.status, 0, `expected non-zero exit, got ${r.status}`);
+  assert.match(
+    r.stderr,
+    /--template and --from-agora are mutually exclusive/,
+    `expected mutex error, got: ${r.stderr}`,
+  );
+  // Confirm the request was not created (no .yaml under requests/).
+  const list = run(root, ['list', '--state', 'pending', '--format', 'json']);
+  assert.equal(list.status, 0);
+  const lj = JSON.parse(list.stdout) as { requests: unknown[] };
+  assert.equal(lj.requests.length, 0, 'mutex error must not create a record');
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -42,7 +42,7 @@ const GATE_ALL = [
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
-  'schema', 'unresponded',
+  'schema', 'unresponded', 'templates',
 ] as const;
 
 const AGORA_ALL = [


### PR DESCRIPTION
## Summary

- `gate templates list` → 5 種列挙 + `[gate-required]` flag 表示
- `gate templates show <name>` → frontmatter + body raw markdown (text)、structured (json)
- `gate request --template <name>` → action/reason の skeleton 自動展開、record に `template / template_version / gate_required_acknowledged` 永続化
- `--template` + `--action`/`--reason` 併用で個別 override
- **mutex**: `--template` と `--from-agora` (#232) は同時指定禁止 (両者が action/reason の default を提供するため優先順位が曖昧 → 明示 reject)
- profile=swarm + parallel executors + no template → warning notice (本 PR は **stub**、enforcement は follow-up)
- byte-stable: pre-#235 record 欠落フィールド round-trip clean、空時 YAML omit
- show text/json 両 surface に template stamp 表示 (Asteria #8 finding fix)

## Multi-actor real dogfood (第二試行)

```
gate request --from eris --action "ship #235 ..." --executor miki  # eris 起票
gate approve <id> --by eris                                          # eris approve
gate claim <id> --by miki                                            # Miki claim
gate execute <id> --by miki                                          # Miki execute
gate review <id> --by miki --comment "..." --lense layer --verdict ok  # Miki review
```

wave `2026-05-08-0014` に Miki 当事者の足跡記録。`--note` ではなく `--comment` を使う必要があった (Miki 報告)が、これは #228 (PR #250) で deprecated alias 化されたばかり、本 PR の dogfood 中の friction 観測。

## Asteria 検証 → OK to ship (10/10 PASS、blocker なし、#8 fix 済)
- list happy / list empty / show known/unknown / request --template / override / schema round-trip / show text+json / profile=swarm warning stub / frontmatter malformed
- path traversal / unicode / 大文字 / 空文字 / symlink dir / 0 byte / 5MB body / frontmatter 重複 すべて適切に handle
- finding #8 (text mode で template 表示欠落) は本 PR 内で fix `cf2473f`、regression test pin

## Devil 確認事項

事前 trap 照会 + #228/#232 で Devil が指摘した同型 trap がないか確認推奨：
- `mutation_seq` への影響 (template stamp は append-only、削除なし、影響なし)
- schema `oneOf` 三択化 (`action+reason` / `from-agora` / `template`) の機械可読契約
- filename ↔ frontmatter `template_name` 不一致 trap (Asteria 指摘、follow-up issue 候補)

## Scope-out (follow-up issue 候補)

Asteria 指摘のうち本 PR では未対応：
1. filename ↔ frontmatter `template_name` 不一致時の onMalformed warn (lying.md trap)
2. templates dir 内エントリの symlink 検査 (信頼境界、低 severity)
3. `list()` がボディ全体を読む点 / `show <unknown>` が再 list を呼ぶ点 (大規模 registry 性能)
4. `--game` + `--template` の組み合わせ (現状 `--game requires --from-agora` で先に弾かれる)
5. profile=swarm の enforcement (本 PR は warning stub のみ)

## Test plan

- [x] `npm run build && npm test` 全 GREEN (1312/1312)
- [x] templates 13 ケース新規 + mutex 1 ケース + text mode regression 1 ケース
- [x] CHANGELOG `[Unreleased]` entry 追加

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)