### PR TITLE
test: shared makeTempRoot() helper to prevent realpath-flake regression (#241)

### DIFF
--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -8,16 +8,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import {
-  mkdtempSync,
-  writeFileSync,
-  rmSync,
-  mkdirSync,
-  realpathSync,
-} from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 // At runtime this file lives under dist/tests/interface/, so we walk
 // three levels up (interface → tests → dist → repo root) to reach bin/.
@@ -25,10 +20,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  // realpathSync resolves macOS's /var → /private/var symlink so the
-  // root we use in regex assertions matches what subprocesses see when
-  // they resolve their own cwd. See darwin path-comparison fix (#238).
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-boot-')));
+  const root = makeTempRoot('guild-boot-');
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -377,8 +369,7 @@ test('gate boot text: no-config-found case discloses cwd-as-fallback', () => {
   // fallback root)`. The misconfigured_cwd block (no-config + no-
   // data) keeps its bigger warning; this fires for the no-config
   // + has-data case (someone deliberately using cwd as root).
-  // realpathSync — see #238 / bootstrap() comment above.
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-boot-nocfg-')));
+  const root = makeTempRoot('guild-boot-nocfg-');
   try {
     // Plant a member so we're past the misconfigured_cwd trigger.
     mkdirSync(join(root, 'members'));

--- a/tests/interface/doctorContentRoot.test.ts
+++ b/tests/interface/doctorContentRoot.test.ts
@@ -28,20 +28,17 @@ import {
   writeFileSync,
   rmSync,
   mkdirSync,
-  realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  // realpathSync resolves macOS's /var → /private/var symlink so the
-  // root we use in regex assertions matches what subprocesses see when
-  // they resolve their own cwd. See darwin path-comparison fix (#238).
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-doc-cr-')));
+  const root = makeTempRoot('guild-doc-cr-');
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -112,8 +109,7 @@ test('doctor text: no-config-found case discloses cwd-as-fallback (totals > 0)',
   // cwd as implicit content_root (no parent config) gets the
   // `(config: none — cwd used as fallback root)` segment naming
   // the implicit default.
-  // realpathSync — see #238 / bootstrap() comment above.
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-doc-cr-nocfg-')));
+  const root = makeTempRoot('guild-doc-cr-nocfg-');
   try {
     mkdirSync(join(root, 'members'));
     writeFileSync(

--- a/tests/interface/register.test.ts
+++ b/tests/interface/register.test.ts
@@ -10,26 +10,21 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
-  mkdtempSync,
   writeFileSync,
   readFileSync,
   existsSync,
   rmSync,
   mkdirSync,
-  realpathSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  // realpathSync resolves macOS's /var → /private/var symlink so the
-  // root we use in regex assertions matches what subprocesses see when
-  // they resolve their own cwd. See darwin path-comparison fix (#238).
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-register-')));
+  const root = makeTempRoot('guild-register-');
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',
@@ -436,8 +431,7 @@ test('register: no-config fallback path surfaces "config: none" so the implicit-
   // used as content_root with no warning. Post-fix the notice
   // names it (`config: none — cwd used as fallback root`) so the
   // agent learns the implicit default exists.
-  // realpathSync — see #238 / bootstrap() comment above.
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'guild-register-nocfg-')));
+  const root = makeTempRoot('guild-register-nocfg-');
   try {
     const r = runGate(root, ['register', '--name', 'cwdsolo']);
     assert.equal(r.status, 0);

--- a/tests/interface/selfApprove.test.ts
+++ b/tests/interface/selfApprove.test.ts
@@ -23,17 +23,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, realpathSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
-
-function mkdtempReal(prefix: string): string {
-  return realpathSync(mkdtempSync(prefix));
-}
 
 interface Bootstrap {
   root: string;
@@ -41,7 +37,7 @@ interface Bootstrap {
 }
 
 function bootstrap(yaml: string): Bootstrap {
-  const root = mkdtempReal(join(tmpdir(), 'guild-selfapprove-'));
+  const root = makeTempRoot('guild-selfapprove-');
   writeFileSync(join(root, 'guild.config.yaml'), yaml);
   mkdirSync(join(root, 'members'));
   return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };

--- a/tests/interface/worktreeIsolation.test.ts
+++ b/tests/interface/worktreeIsolation.test.ts
@@ -21,32 +21,19 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
-  mkdtempSync,
   writeFileSync,
   rmSync,
   mkdirSync,
   readFileSync,
   readdirSync,
-  realpathSync,
   symlinkSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
-
-// Wrap mkdtempSync so every test directory is canonical. On darwin
-// `os.tmpdir()` returns `/var/folders/...` which is itself a symlink
-// to `/private/var/folders/...`; passing the symlink form into the
-// CLI and asserting against the realpath form (or vice-versa) is the
-// exact ambiguity #231 had to resolve — pin tests to canonical to
-// avoid co-mingling that with the actual collision logic. (Pattern
-// established in #238 for the same reason.)
-function mkdtempReal(prefix: string): string {
-  return realpathSync(mkdtempSync(prefix));
-}
 
 interface Bootstrap {
   root: string;
@@ -54,7 +41,7 @@ interface Bootstrap {
 }
 
 function bootstrap(profile: 'standard' | 'swarm'): Bootstrap {
-  const root = mkdtempReal(join(tmpdir(), `guild-wti-${profile}-`));
+  const root = makeTempRoot(`guild-wti-${profile}-`);
   // Pin self_approve: warn so this suite stays focused on worktree
   // isolation. #233 makes swarm forbid self-approve by default; the
   // helper `createApproved` below self-approves to set up the wave,
@@ -228,8 +215,8 @@ test('profile=swarm + parallel executors + DIFFERENT cwds: both execute', (t) =>
   // Simulate separate worktrees by passing different --cwd values.
   // The collision check compares the resolved absolute paths, so any
   // two distinct directories suffice.
-  const wt1 = mkdtempReal(join(tmpdir(), 'wti-wt1-'));
-  const wt2 = mkdtempReal(join(tmpdir(), 'wti-wt2-'));
+  const wt1 = makeTempRoot('wti-wt1-');
+  const wt2 = makeTempRoot('wti-wt2-');
   t.after(() => {
     rmSync(wt1, { recursive: true, force: true });
     rmSync(wt2, { recursive: true, force: true });
@@ -366,7 +353,7 @@ test('execute --cwd stamps executing_at_cwd into the status_log entry', (t) => {
   const id = (JSON.parse(r.stdout) as { id: string }).id;
   run(root, ['approve', id, '--by', 'alice']);
 
-  const wt = mkdtempReal(join(tmpdir(), 'wti-stamp-'));
+  const wt = makeTempRoot('wti-stamp-');
   t.after(() => rmSync(wt, { recursive: true, force: true }));
   const ex = run(root, ['execute', id, '--by', 'miki', '--cwd', wt]);
   assert.equal(ex.status, 0, ex.stderr);
@@ -409,8 +396,8 @@ test('Devil HIGH-1: symlink form of an already-executing cwd is canonicalised an
   // symlink form. With realpath canonicalisation, both flatten to
   // the same identity → refuse. Without it (pre-fix) the second
   // would have passed.
-  const realWt = mkdtempReal(join(tmpdir(), 'wti-real-'));
-  const linkParent = mkdtempReal(join(tmpdir(), 'wti-link-'));
+  const realWt = makeTempRoot('wti-real-');
+  const linkParent = makeTempRoot('wti-link-');
   const linkWt = join(linkParent, 'symlinked-worktree');
   symlinkSync(realWt, linkWt, 'dir');
   t.after(() => {
@@ -452,8 +439,8 @@ test('Devil HIGH-1: symmetric — first via symlink, second via realpath also re
     target: 'shared-target',
   });
 
-  const realWt = mkdtempReal(join(tmpdir(), 'wti-real2-'));
-  const linkParent = mkdtempReal(join(tmpdir(), 'wti-link2-'));
+  const realWt = makeTempRoot('wti-real2-');
+  const linkParent = makeTempRoot('wti-link2-');
   const linkWt = join(linkParent, 'symlinked-worktree');
   symlinkSync(realWt, linkWt, 'dir');
   t.after(() => {

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -17,17 +17,15 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
-  mkdtempSync,
   writeFileSync,
   readFileSync,
   rmSync,
   mkdirSync,
   existsSync,
-  realpathSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 // At runtime this file lives under dist/tests/passages/agora/, so we
@@ -37,10 +35,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const AGORA = resolve(here, '../../../../bin/agora.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  // realpathSync resolves macOS's /var → /private/var symlink so the
-  // root we use in regex assertions matches what subprocesses see when
-  // they resolve their own cwd. See darwin path-comparison fix (#238).
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'agora-new-')));
+  const root = makeTempRoot('agora-new-');
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',

--- a/tests/passages/agora/play.test.ts
+++ b/tests/passages/agora/play.test.ts
@@ -16,27 +16,22 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import {
-  mkdtempSync,
   writeFileSync,
   readFileSync,
   rmSync,
   mkdirSync,
   existsSync,
   readdirSync,
-  realpathSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const AGORA = resolve(here, '../../../../bin/agora.mjs');
 
 function bootstrap(): { root: string; cleanup: () => void } {
-  // realpathSync resolves macOS's /var → /private/var symlink so the
-  // root we use in regex assertions matches what subprocesses see when
-  // they resolve their own cwd. See darwin path-comparison fix (#238).
-  const root = realpathSync(mkdtempSync(join(tmpdir(), 'agora-play-')));
+  const root = makeTempRoot('agora-play-');
   writeFileSync(
     join(root, 'guild.config.yaml'),
     'content_root: .\nhost_names: [human]\n',

--- a/tests/util/tempRoot.ts
+++ b/tests/util/tempRoot.ts
@@ -1,0 +1,22 @@
+// Shared test helper: canonical temp-root creation.
+//
+// On darwin `os.tmpdir()` returns `/var/folders/...` which is itself
+// a symlink to `/private/var/folders/...`. Subprocesses spawned with
+// the symlinked cwd resolve their own cwd through the symlink and
+// emit the canonical form, so any test that asserts on path strings
+// the subprocess produced has to compare against the canonical root,
+// not the symlinked one returned by `mkdtempSync`. Wrapping with
+// `realpathSync` collapses both forms to the canonical one.
+//
+// History: PR #240 (#238) wrapped each test bootstrap individually
+// to resolve 12 darwin flakes. This helper is the follow-up (#241):
+// one central wrap so the next test author can't reintroduce the
+// flake by writing `mkdtempSync(...)` directly without realpath.
+
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function makeTempRoot(prefix: string): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+}


### PR DESCRIPTION
## Summary

Closes #241.

PR #240 (#238) wrapped each test bootstrap's `mkdtempSync(...)` in `realpathSync` individually to resolve 12 darwin flakes. That fix lives at the call-site, so a future test author copying the bootstrap pattern but writing `mkdtempSync` directly would silently reintroduce the flake.

This PR centralizes the wrap in `tests/util/tempRoot.ts` (`makeTempRoot(prefix)`) and replaces the seven scattered call-sites — the five touched by #240 plus two later additions in `selfApprove` / `worktreeIsolation` tests that grew their own local `mkdtempReal` helpers (duplicate work).

Per #241's recommendation, this is option (a) only. Option (b) (ESLint `no-restricted-syntax` to forbid bare `mkdtempSync` in tests) is deferred to a follow-up PR.

## Files

- `tests/util/tempRoot.ts` (new — `makeTempRoot`)
- `tests/interface/boot.test.ts` (bootstrap + nocfg)
- `tests/interface/doctorContentRoot.test.ts` (bootstrap + nocfg)
- `tests/interface/register.test.ts` (bootstrap + nocfg)
- `tests/interface/selfApprove.test.ts` (drop local `mkdtempReal`)
- `tests/interface/worktreeIsolation.test.ts` (drop local `mkdtempReal`, 7 call-sites)
- `tests/passages/agora/new.test.ts` (bootstrap)
- `tests/passages/agora/play.test.ts` (bootstrap)

Net: +48 / -72 across 8 files.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1312/1312 pass on linux
- [ ] Verify on darwin: 1312/1312 pass (the original flake surface — same `realpathSync` semantics, so should remain green)

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_