### PR TITLE
fix(gate show): lift stake markers + template out of status_log (#245)

### DIFF
--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -728,32 +728,41 @@ function formatRequestText(r: Request): string {
       );
       prevAt = at;
     }
-    // Cross-session claim (issue #226). Surfaced just below the state
-    // log because logically it sits on the same axis as transitions:
-    // "who has this right now". Only rendered when set — unclaimed is
-    // the common case and a `(no claim)` line would clutter every
-    // show. JSON consumers read the structured fields directly.
-    if (typeof j['claimed_by'] === 'string' && typeof j['claimed_at'] === 'string') {
+  }
+
+  // Stake markers (issues #226 / #244): claim and witnesses sit on
+  // the "who has this right now / who has eyes on it" axis. Rendered
+  // as their own sub-section below status_log so they don't read as
+  // a transition entry — same indentation under the same header was
+  // misleading scanners (#245). Only emitted when at least one is
+  // set; an unstaked record produces no `stake:` block.
+  const hasClaim =
+    typeof j['claimed_by'] === 'string' && typeof j['claimed_at'] === 'string';
+  const hasWitnesses =
+    Array.isArray(j['witnesses']) && (j['witnesses'] as unknown[]).length > 0;
+  if (hasClaim || hasWitnesses) {
+    lines.push('');
+    lines.push('  stake:');
+    if (hasClaim) {
       lines.push(`    claimed by: ${j['claimed_by']} at ${j['claimed_at']}`);
     }
-    // Witnesses (issue #244). Surfaced just below the claim line —
-    // both share the "who has eyes on this right now" axis. Only
-    // rendered when non-empty; an unwitnessed record is the common
-    // case and an empty `witnesses:` line would clutter every show.
-    if (Array.isArray(j['witnesses']) && j['witnesses'].length > 0) {
-      const names = (j['witnesses'] as unknown[]).map((w) => String(w)).join(', ');
+    if (hasWitnesses) {
+      const names = (j['witnesses'] as unknown[])
+        .map((w) => String(w))
+        .join(', ');
       lines.push(`    witnesses: ${names}`);
     }
-    // Template stamp (issue #235). Rendered when the request was
-    // bootstrapped from a wave-brief template. Surfaces on the same
-    // axis as claim/witness so readers see "this wave's framing is
-    // canon-blessed" without dipping into JSON.
-    if (typeof j['template'] === 'string') {
-      const v =
-        typeof j['template_version'] === 'number' ? ` (v${j['template_version']})` : '';
-      const ack = j['gate_required_acknowledged'] === true ? ' [gate-ack]' : '';
-      lines.push(`    template: ${j['template']}${v}${ack}`);
-    }
+  }
+
+  // Template stamp (issue #235): wave-brief provenance. Lifted out
+  // of status_log alongside the stake markers (#245) — the same
+  // "looks like a log entry" anti-pattern applied here.
+  if (typeof j['template'] === 'string') {
+    const v =
+      typeof j['template_version'] === 'number' ? ` (v${j['template_version']})` : '';
+    const ack = j['gate_required_acknowledged'] === true ? ' [gate-ack]' : '';
+    lines.push('');
+    lines.push(`  template: ${j['template']}${v}${ack}`);
   }
 
   const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];

--- a/tests/interface/witness.test.ts
+++ b/tests/interface/witness.test.ts
@@ -338,6 +338,38 @@ test('gate show text: witnesses line surfaces below the claim line', (t) => {
   );
 });
 
+test('gate show text: claim + witnesses render under a stake: sub-section, not inside status_log (#245)', (t) => {
+  // Before #245 the lines were emitted at status_log's 4-space
+  // entry indent, directly under `status_log (1):`. Read scans
+  // saw "witnesses: ..." as a transition entry. The fix lifts
+  // them into their own `stake:` subsection between status_log
+  // and reviews. This test pins the new structural contract.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['claim', id, '--by', 'leysia']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki']).status, 0);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+
+  // The `stake:` header exists, sits at section indent, and
+  // appears after status_log but before its own line items.
+  const idxLog = r.stdout.indexOf('status_log');
+  const idxStake = r.stdout.indexOf('\n  stake:\n');
+  const idxClaim = r.stdout.indexOf('claimed by:');
+  const idxWit = r.stdout.indexOf('witnesses:');
+  assert.ok(idxLog >= 0, 'status_log section is rendered');
+  assert.ok(idxStake > idxLog, 'stake: header appears after status_log');
+  assert.ok(idxClaim > idxStake, 'claimed by: line is inside stake: section');
+  assert.ok(idxWit > idxClaim, 'witnesses: line follows claimed by: inside stake:');
+
+  // The stake lines are at the section-item 4-space indent.
+  assert.match(r.stdout, /\n {4}claimed by: leysia at /);
+  assert.match(r.stdout, /\n {4}witnesses: miki\n/);
+});
+
 test('gate show text: unwitnessed record omits the witnesses line', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
@@ -347,6 +379,10 @@ test('gate show text: unwitnessed record omits the witnesses line', (t) => {
   const r = run(root, ['show', id, '--format', 'text']);
   assert.equal(r.status, 0);
   assert.doesNotMatch(r.stdout, /witnesses:/);
+  // An unstaked record (no claim, no witnesses) emits no
+  // `stake:` block at all. This is the (#245) fix's empty-case
+  // contract — don't clutter every show with an empty header.
+  assert.doesNotMatch(r.stdout, /\n  stake:\n/);
 });
 
 test('hydrate tolerance: legacy record (no witnesses field) loads as unwitnessed', (t) => {


### PR DESCRIPTION
## Summary

Closes #245.

`gate show <id> --format text` rendered `claimed by:` (#243), `witnesses:` (#244), and `template:` (#235) at the status_log entry indent, directly under the `status_log (N):` header. Read-scans saw "witnesses: ..." as a transition entry — the visual contradicted the intent (the comment that landed with #243 said "the same axis as transitions", but log entries and stake markers are different axes).

Per #245's option (a), move the three lines into their own sub-sections below status_log, each separated by a blank line.

## Before / After

**Before:**
```
  status_log (1):
    2026-05-08T08:06:49.521Z  pending  by eris — created
    claimed by: miki at 2026-05-08T08:06:53.703Z
    witnesses: asteria, miki
```

**After:**
```
  status_log (1):
    2026-05-08T08:06:49.521Z  pending  by eris — created

  stake:
    claimed by: miki at 2026-05-08T08:06:53.703Z
    witnesses: asteria, miki

  template: parallel-impl (v1) [gate-ack]
```

## Scope choice

The issue called out claim/witness explicitly. Template (#235) was added later with the same anti-pattern (rendered inside the `status_log` block, comment intentionally cited "same axis as claim/witness"). Fixing only claim/witness would have left template stranded both semantically (the axis it tracked moved out) and aesthetically (still looks like a log entry). Lifting all three together is the consistent move.

JSON mode unchanged — top-level fields are already structurally distinct (issue scope notes this).

## Empty-case contracts (preserved)

- No claim and no witnesses → no `stake:` block (no header line clutter)
- No template stamp → no `template:` line

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1313/1313 pass on linux (1 new test)
  - new: pins `stake:` header position + 4-space-indented items
  - new: unstaked record emits no `stake:` block
  - existing claim/witness order assertions still hold (loose `indexOf` checks)
- [x] Visual sanity check — confirmed live `gate show` output matches the design

## Files

- `src/interface/gate/handlers/request.ts` — `formatRequestText` lifts the three lines out of the status_log block
- `tests/interface/witness.test.ts` — new structural pin + empty-case assertion

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_