### PR TITLE
feat(gate boot): surface overlapping-target active waves (#234 phase 1)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -86,6 +86,55 @@ export type BootSuggestedNextOrPendingResponse =
   | BootBroadcastPendingResponse;
 
 /**
+ * Surface for active (non-terminal) requests sharing a target.
+ *
+ * Two or more `pending` / `approved` / `executing` requests pointing
+ * at the same `target` string indicate cross-session race risk:
+ * substrate-experiment 5 saw an independent session pre-empt our
+ * #221 implementation because nobody booted into "someone else is
+ * already working on that target".
+ *
+ * Detection is exact-match on the freeform `target` field. Fuzzy
+ * grouping (startsWith / contains) would false-positive on common
+ * path prefixes (`src/`, `data/guild/templates`) and is deferred —
+ * see issue #234 "overlap 検知ロジック".
+ *
+ * Profile gating: phase 1 surfaces overlaps as a notice on every
+ * profile. The harder enforcement (`profile: swarm` refuses
+ * unclaimed overlapping requests at create time) is the parent
+ * epic's territory (#227) and not in this slot.
+ *
+ * Empty array when no active group has size ≥ 2; readers should
+ * gate text rendering on `length > 0` to avoid emitting a noise
+ * section in the common "no overlap" case.
+ */
+export interface BootActiveOverlap {
+  /** The shared target string, verbatim. */
+  target: string;
+  /**
+   * The active requests sharing the target, in id ascending order
+   * (deterministic across runs so an agent doing diff reasoning
+   * over successive boots sees stable membership).
+   */
+  requests: ReadonlyArray<{
+    id: string;
+    state: 'pending' | 'approved' | 'executing';
+    /** Recorded executors. May be empty (none assigned yet). */
+    executors: readonly string[];
+    /**
+     * Member who staked an exclusive claim via `gate claim` (#226
+     * phase 1). Omitted when nobody has claimed — absence on read
+     * is the unclaimed signal, mirroring the omit-when-undefined
+     * convention used elsewhere on this payload (e.g.
+     * `inbox_unread[].expects_response`). Renders as `claim_held`
+     * in text mode so a coordinating actor sees who currently owns
+     * the wave at a glance.
+     */
+    claimed_by?: string;
+  }>;
+}
+
+/**
  * gate boot [--format json|text] [--tail <N>] [--utterances <N>]
  *
  * Single-command session orientation for agents. Composes the
@@ -194,6 +243,15 @@ interface BootPayload {
    * findable on re-entry, not just present on disk.
    */
   cross_passage: Record<string, PassageOrientationSummary>;
+  /**
+   * Active (non-terminal) requests sharing a target, surfaced for
+   * cross-session race detection (issue #234). Empty array when no
+   * group has size ≥ 2. Each entry's `requests` list carries enough
+   * for an agent to decide whether to coordinate via `gate claim` /
+   * `gate witness` (#226) or proceed in parallel. See
+   * BootActiveOverlap for the per-entry contract.
+   */
+  active_overlapping_targets: ReadonlyArray<BootActiveOverlap>;
   /**
    * Discoverability hint: what verbs are applicable right now?
    *
@@ -452,6 +510,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   }
 
   const crossPassage = await collectCrossPassage(c.config);
+  const activeOverlappingTargets = computeActiveOverlappingTargets(allRequests);
 
   const payload: BootPayload = {
     actor,
@@ -469,6 +528,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
       content_root_health: contentRootHealth,
     },
     cross_passage: crossPassage,
+    active_overlapping_targets: activeOverlappingTargets,
     suggested_next: suggestedNext,
     verbs_available_now: verbsAvailableNow,
   };
@@ -891,6 +951,65 @@ function actionableTransitions(
  * UTC-Z formatted (the only shape Request.ts emits, see Thank.ts:43,
  * Review.ts and StatusLog entry.at).
  */
+/**
+ * Group active (non-terminal) requests by their `target` and surface
+ * groups with size ≥ 2 as overlap warnings. See BootActiveOverlap
+ * for the surface contract and issue #234 for the parent context
+ * (substrate-experiment 5: independent sessions silently raced on
+ * the same wave because the substrate had no "someone else is on
+ * it" surface at boot).
+ *
+ * Active = `pending` | `approved` | `executing`. Terminal states
+ * (`completed` | `failed` | `denied`) are skipped — a completed
+ * wave on the same target is not a race; it is history.
+ *
+ * Targets that are unset, empty, or whitespace-only are skipped:
+ * "two requests with no target" is not a coordination signal.
+ *
+ * Per-group output is sorted by id ascending so consecutive boots
+ * agree on member order (an agent diff-reasoning over the field
+ * across runs sees stable composition); the overall list is sorted
+ * by target so the same property holds across multiple groups.
+ */
+export function computeActiveOverlappingTargets(
+  allRequests: ReadonlyArray<Request>,
+): BootActiveOverlap[] {
+  const ACTIVE: ReadonlySet<string> = new Set([
+    'pending',
+    'approved',
+    'executing',
+  ]);
+  const groups = new Map<string, Request[]>();
+  for (const r of allRequests) {
+    if (!ACTIVE.has(r.state)) continue;
+    const target = r.target;
+    if (target === undefined || target.trim() === '') continue;
+    const arr = groups.get(target);
+    if (arr) arr.push(r);
+    else groups.set(target, [r]);
+  }
+  const overlaps: BootActiveOverlap[] = [];
+  for (const [target, reqs] of groups) {
+    if (reqs.length < 2) continue;
+    const sorted = [...reqs].sort((a, b) =>
+      a.id.value < b.id.value ? -1 : a.id.value > b.id.value ? 1 : 0,
+    );
+    overlaps.push({
+      target,
+      requests: sorted.map((r) => ({
+        id: r.id.value,
+        state: r.state as 'pending' | 'approved' | 'executing',
+        executors: r.executors.map((e) => e.value),
+        ...(r.claimedBy !== undefined ? { claimed_by: r.claimedBy.value } : {}),
+      })),
+    });
+  }
+  overlaps.sort((a, b) =>
+    a.target < b.target ? -1 : a.target > b.target ? 1 : 0,
+  );
+  return overlaps;
+}
+
 export function computeLastAuthoredWriteAt(
   actor: string,
   allRequests: ReadonlyArray<Request>,
@@ -1157,6 +1276,29 @@ function renderBootText(p: BootPayload): string {
           : '';
       lines.push(`${s.passage}: ${s.open} open${suspendedNote}${lastNote}`);
     }
+  }
+
+  // Cross-session race surface (issue #234). Only rendered when at
+  // least one target has ≥ 2 active requests; the empty case stays
+  // silent so the common "no overlap" boot doesn't carry an empty
+  // header line. JSON consumers read `active_overlapping_targets`
+  // directly — text mode here is the human-readable projection.
+  if (p.active_overlapping_targets.length > 0) {
+    lines.push('');
+    lines.push('active waves with overlapping target:');
+    for (const o of p.active_overlapping_targets) {
+      for (const r of o.requests) {
+        const exec =
+          r.executors.length > 0 ? r.executors.join(',') : '(no executor)';
+        const claim = r.claimed_by !== undefined ? ', claim_held' : '';
+        lines.push(
+          `  - ${r.id} (${exec}, ${r.state}${claim}) — target: ${o.target}`,
+        );
+      }
+    }
+    lines.push(
+      '  ⚠ overlap detected. coordinate via `gate witness <id>` or `gate claim <id>`.',
+    );
   }
 
   if (p.tail.length > 0) {

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -271,6 +271,41 @@ const VERBS: readonly VerbSchema[] = [
             'across session boundaries (records-outlive-writers requires ' +
             'records also be findable on re-entry).',
         },
+        active_overlapping_targets: {
+          type: 'array',
+          description:
+            'Cross-session race detection (issue #234). Active ' +
+            "(pending|approved|executing) requests sharing a `target` " +
+            'string, grouped by target, surfaced when any group has ' +
+            'size ≥ 2. Exact-match grouping; fuzzy variants are out of ' +
+            'scope per the issue. Empty array in the no-overlap common ' +
+            'case. Per-entry: { target, requests: [{ id, state, ' +
+            'executors[], claimed_by | null }] }; per-target requests ' +
+            'are sorted by id ascending. Phase 1 surfaces the warning ' +
+            'on every profile (the swarm-side refuse-on-create lives ' +
+            "with the parent epic #227, not in this slot).",
+          items: {
+            type: 'object',
+            properties: {
+              target: { type: 'string' },
+              requests: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                    state: {
+                      type: 'string',
+                      enum: ['pending', 'approved', 'executing'],
+                    },
+                    executors: { type: 'array', items: { type: 'string' } },
+                    claimed_by: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
         suggested_next: {
           type: 'object',
           description:

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -53,6 +53,7 @@ test('gate boot: JSON top-level keys are stable', () => {
     assert.deepEqual(
       keys,
       [
+        'active_overlapping_targets',
         'actor',
         'cross_passage',
         'hints',
@@ -869,4 +870,186 @@ test('computeLastAuthoredWriteAt aggregates across status_log, reviews, and than
     stubs as unknown as Parameters<typeof computeLastAuthoredWriteAt>[1],
   );
   assert.equal(lastNobody, null);
+});
+
+// active_overlapping_targets — cross-session race surface (#234).
+//
+// Surfaces active (pending|approved|executing) requests that share
+// the same `target` so a booting agent sees "someone else is on
+// it" before pre-empting. Phase 1: detection + warning, no refuse.
+// Refuse-on-create lives with #227 (swarm profile epic).
+
+function registerMember(root: string, name: string): void {
+  runGate(root, ['register', '--name', name]);
+}
+
+function makeRequestWithTarget(
+  root: string,
+  from: string,
+  action: string,
+  target: string,
+): string {
+  const r = spawnSync(
+    process.execPath,
+    [
+      GATE,
+      'request',
+      '--from', from,
+      '--action', action,
+      '--reason', 'overlap test',
+      '--target', target,
+      '--format', 'json',
+    ],
+    { cwd: root, env: { ...process.env }, encoding: 'utf8' },
+  );
+  if (r.status !== 0) {
+    throw new Error(`gate request failed: ${r.stderr}`);
+  }
+  const j = JSON.parse(r.stdout);
+  return j.id ?? j.request_id;
+}
+
+test('gate boot: active_overlapping_targets surfaces two pending requests on the same target', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    registerMember(root, 'leysia');
+    const id1 = makeRequestWithTarget(root, 'alice', 'work A', 'data/guild/templates');
+    const id2 = makeRequestWithTarget(root, 'leysia', 'work B', 'data/guild/templates');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.equal(Array.isArray(payload.active_overlapping_targets), true);
+    assert.equal(payload.active_overlapping_targets.length, 1);
+    const entry = payload.active_overlapping_targets[0];
+    assert.equal(entry.target, 'data/guild/templates');
+    assert.equal(entry.requests.length, 2);
+    // Sorted by id ascending — deterministic across boots.
+    assert.deepEqual(
+      entry.requests.map((r: { id: string }) => r.id),
+      [id1, id2].sort(),
+    );
+    // Each entry carries state + executors[]. claimed_by is omitted
+    // for unclaimed waves (omit-when-undefined convention).
+    for (const r of entry.requests) {
+      assert.ok(['pending', 'approved', 'executing'].includes(r.state));
+      assert.ok(Array.isArray(r.executors));
+      assert.equal('claimed_by' in r, false);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: active_overlapping_targets is empty when targets differ', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    registerMember(root, 'leysia');
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/foo');
+    makeRequestWithTarget(root, 'leysia', 'work B', 'src/bar');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(payload.active_overlapping_targets, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: active_overlapping_targets ignores requests with no target', () => {
+  // Two requests, both untargeted → no group key → no overlap.
+  // Untargeted overlap is not a coordination signal (the freeform
+  // target is the only handle for "same wave").
+  const { root, cleanup } = bootstrap();
+  try {
+    registerMember(root, 'leysia');
+    const r1 = spawnSync(
+      process.execPath,
+      [GATE, 'request', '--from', 'alice', '--action', 'a', '--reason', 'r', '--format', 'json'],
+      { cwd: root, env: { ...process.env }, encoding: 'utf8' },
+    );
+    assert.equal(r1.status, 0, r1.stderr);
+    const r2 = spawnSync(
+      process.execPath,
+      [GATE, 'request', '--from', 'leysia', '--action', 'b', '--reason', 'r', '--format', 'json'],
+      { cwd: root, env: { ...process.env }, encoding: 'utf8' },
+    );
+    assert.equal(r2.status, 0, r2.stderr);
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.deepEqual(payload.active_overlapping_targets, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: active_overlapping_targets carries claim_held marker for claimed wave', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    registerMember(root, 'leysia');
+    // Use --executor to populate the executors[] slot the surface
+    // renders (matching the issue's example output shape, which
+    // names the executor next to the id).
+    const r1 = spawnSync(
+      process.execPath,
+      [
+        GATE, 'request',
+        '--from', 'alice',
+        '--executor', 'alice',
+        '--action', 'work A',
+        '--reason', 'overlap test',
+        '--target', 'shared/path',
+        '--format', 'json',
+      ],
+      { cwd: root, env: { ...process.env }, encoding: 'utf8' },
+    );
+    assert.equal(r1.status, 0, r1.stderr);
+    const id1 = JSON.parse(r1.stdout).id;
+    const r2 = spawnSync(
+      process.execPath,
+      [
+        GATE, 'request',
+        '--from', 'leysia',
+        '--executor', 'leysia',
+        '--action', 'work B',
+        '--reason', 'overlap test',
+        '--target', 'shared/path',
+        '--format', 'json',
+      ],
+      { cwd: root, env: { ...process.env }, encoding: 'utf8' },
+    );
+    assert.equal(r2.status, 0, r2.stderr);
+
+    // Stake an exclusive claim on the first request.
+    const claim = runGate(root, ['claim', id1, '--by', 'alice']);
+    assert.equal(claim.status, 0);
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    const claimed = entry.requests.find((r: { id: string }) => r.id === id1);
+    assert.equal(claimed.claimed_by, 'alice');
+    // Text mode renders the marker too (`claim_held` flag).
+    const t = runGate(root, ['boot', '--format', 'text']);
+    assert.match(t.stdout, /active waves with overlapping target:/);
+    assert.match(t.stdout, new RegExp(`${id1} \\(alice, pending, claim_held\\)`));
+    assert.match(t.stdout, /target: shared\/path/);
+    assert.match(t.stdout, /coordinate via .gate witness/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: active_overlapping_targets text section is omitted when no overlap', () => {
+  // Voice budget — fresh roots / single-wave roots should not see
+  // the warning header line. Empty array is a JSON contract; text
+  // mode silences entirely.
+  const { root, cleanup } = bootstrap();
+  try {
+    const t = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(t.status, 0);
+    assert.doesNotMatch(t.stdout, /active waves with overlapping target/);
+  } finally {
+    cleanup();
+  }
 });


### PR DESCRIPTION
## Summary

Closes #234 phase 1.

Active (`pending` / `approved` / `executing`) requests sharing a `target` string indicate cross-session race risk. substrate-experiment 5 saw an independent session pre-empt our #221 implementation because nobody booted into "someone else is already on it."

Add a new top-level `active_overlapping_targets` field on `gate boot` that groups active requests by exact-match target and surfaces groups of size ≥ 2.

## Output (text mode)

```
active waves with overlapping target:
  - 2026-05-08-0001 (alice, pending, claim_held) — target: data/guild/templates
  - 2026-05-08-0002 (leysia, pending) — target: data/guild/templates
  ⚠ overlap detected. coordinate via `gate witness <id>` or `gate claim <id>`.
```

## JSON shape

```json
"active_overlapping_targets": [
  {
    "target": "data/guild/templates",
    "requests": [
      { "id": "2026-05-08-0001", "state": "pending", "executors": ["alice"], "claimed_by": "alice" },
      { "id": "2026-05-08-0002", "state": "pending", "executors": ["leysia"] }
    ]
  }
]
```

## Empty-case contracts

- No overlap → empty array (JSON), section omitted (text)
- Untargeted requests skipped (target undefined or whitespace-only — no coordination signal without a handle)
- Terminal requests (`completed` / `failed` / `denied`) skipped — completed waves on the same target are history, not race
- `claimed_by` omitted when no claim is held (omit-when-undefined convention used elsewhere on the boot payload)

## Determinism

- Per-target requests sorted by id ascending
- Overall list sorted by target

Both keep agent diff-reasoning across consecutive boots stable.

## Out of scope (intentional)

Per the issue:
- **Profile gating** for refuse-on-create (`profile: swarm` rejects unclaimed overlap when filing): lives with parent epic #227, not this slot. Phase 1 is detection + warning.
- **Fuzzy matching** (startsWith / contains): deferred — common path prefixes (`src/`, `data/...`) would false-positive. Issue calls this out as a `--check-overlap fuzzy` opt-in.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1318/1318 pass on linux (5 new tests)
  - top-level keys pin updated (1 new key)
  - overlap surfaced when two pending requests share target
  - empty when targets differ
  - empty when both untargeted
  - claim_held marker rendered in JSON + text when claim exists
  - text section omitted entirely when array is empty
- [x] Visual sanity check — confirmed live `gate boot --format text` output matches the issue's spec

## Files

- `src/interface/gate/handlers/boot.ts` — new `BootActiveOverlap` interface, `computeActiveOverlappingTargets` helper, payload field, text rendering
- `src/interface/gate/handlers/schema.ts` — boot output schema entry for the new field
- `tests/interface/boot.test.ts` — 5 new tests + key pin update

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_