### PR TITLE
feat(gate stake verbs): tight-scope --note on claim / witness (#246)

### DIFF
--- a/src/application/request/RequestUseCases.ts
+++ b/src/application/request/RequestUseCases.ts
@@ -332,6 +332,7 @@ export class RequestUseCases {
   async claim(input: {
     id: string;
     by: string;
+    note?: string;
     dryRun?: boolean;
   }): Promise<{ request: Request; mutated: boolean }> {
     const actor = await assertActor(input.by, '--by', this.deps.members);
@@ -344,9 +345,14 @@ export class RequestUseCases {
     // safe and bounded.
     return retryOnVersionConflict('claim', input.id, async () => {
       const req = await this.loadOrThrow(input.id);
-      const before = req.claimedBy?.value;
-      req.claim(actor, this.deps.clock.now().toISOString());
-      const mutated = before !== req.claimedBy?.value;
+      // mutationSeq is the canonical "real change happened" witness —
+      // covers the (#246) case where a same-actor re-claim with a
+      // divergent --note is a real mutation even though claimedBy
+      // didn't change. Pre-#246 the claimedBy delta sufficed; under
+      // notes, it doesn't.
+      const before = req.mutationSeq;
+      req.claim(actor, this.deps.clock.now().toISOString(), input.note);
+      const mutated = req.mutationSeq !== before;
       if (mutated && !input.dryRun) await this.deps.requests.save(req);
       return { request: req, mutated };
     });
@@ -363,14 +369,18 @@ export class RequestUseCases {
   async witness(input: {
     id: string;
     by: string;
+    note?: string;
     dryRun?: boolean;
   }): Promise<{ request: Request; mutated: boolean }> {
     const actor = await assertActor(input.by, '--by', this.deps.members);
     return retryOnVersionConflict('witness', input.id, async () => {
       const req = await this.loadOrThrow(input.id);
-      const before = req.witnesses.length;
-      req.witness(actor);
-      const mutated = before !== req.witnesses.length;
+      // mutationSeq tracks both first-time witness and same-actor
+      // re-witness with a divergent note (#246) — the latter doesn't
+      // change witnesses.length but is a real mutation.
+      const before = req.mutationSeq;
+      req.witness(actor, input.note);
+      const mutated = req.mutationSeq !== before;
       if (mutated && !input.dryRun) await this.deps.requests.save(req);
       return { request: req, mutated };
     });

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -15,6 +15,15 @@ const MAX_TEXT = 4096;
 const MAX_REVIEWS = 50;
 const MAX_THANKS = 50;
 const MAX_STATUS_LOG = 100;
+/**
+ * Stake-note ceiling (issue #246). Single short string per claim or
+ * per witness — terminal-friendly, fits one line in `gate show` and
+ * resists the "let's discuss it here" drift that motivated the
+ * silent-stake principle in the first place. Wider context belongs
+ * in agora plays; the note is metadata for the stake event, not
+ * commentary on lifecycle.
+ */
+const MAX_STAKE_NOTE = 80;
 
 export interface StatusLogEntry {
   state: RequestState;
@@ -175,6 +184,29 @@ export interface RequestProps {
    *  fields move together — set together, cleared together. */
   claimedAt?: string;
   /**
+   * Optional short metadata attached to the claim (issue #246).
+   *
+   * Tight-scope: a single string up to MAX_STAKE_NOTE chars,
+   * overwritten on re-claim by the same actor. Sanitized via the
+   * shared text path (control chars stripped, trim, length capped),
+   * so empty / whitespace-only input lands as undefined. Cleared
+   * with the rest of the claim on terminal auto-reset and on
+   * different-actor refusal (the latter doesn't reach the field
+   * because the throw happens first — but the rule is symmetric
+   * with `claimedBy` for the future explicit-release verb).
+   *
+   * NOT a discussion forum: the schema description names this
+   * "metadata, not commentary" so the surface stays thin. Cross-
+   * actor talk belongs in agora plays; the elements that warrant
+   * a stake note are things like "watching for the dedup fix" or
+   * "blocked on review #233" — single-line context that scoped to
+   * the current stake event.
+   *
+   * Persistence: omitted from YAML when undefined (byte-stable
+   * round-trip with pre-#246 records).
+   */
+  claimNote?: string;
+  /**
    * Cross-session non-exclusive observers (issue #226 phase 2 / #244).
    * Sibling primitive to `claimedBy`: where claim is "I'm working on
    * this right now, do not double-stake" (exclusive, refuses on
@@ -190,6 +222,21 @@ export interface RequestProps {
    * terminal record carries no further race signal.
    */
   witnesses?: MemberName[];
+  /**
+   * Per-witness short metadata (issue #246). Map keyed by lowercase
+   * actor name, mirroring `witnesses[]`. Same tight-scope rules as
+   * `claimNote`: single string ≤ MAX_STAKE_NOTE chars, overwrite-on-
+   * re-witness, sanitized empty → omitted. Witnesses without notes
+   * are simply absent from the map; an unannotated witness list with
+   * no notes round-trips as the field being undefined. unwitness
+   * removes both the witness entry and (if present) its note.
+   *
+   * NOT a discussion forum — same caveat as `claimNote`. The map
+   * shape was chosen over a parallel-array-of-objects so byte-stable
+   * round-trip stays trivial: pre-#246 records have neither field;
+   * post-#246 records that nobody noted on still have neither field.
+   */
+  witnessNotes?: Map<string, string>;
   /**
    * Monotonic mutation counter for cross-session-mutating verbs that
    * are NOT append-only on a recorded array (issue #244 follow-up;
@@ -661,6 +708,19 @@ export class Request {
   get claimedBy(): MemberName | undefined {
     return this.props.claimedBy;
   }
+  /** Optional metadata attached to the current claim. Undefined when
+   *  unclaimed or when the claimer didn't supply a --note. Issue #246. */
+  get claimNote(): string | undefined {
+    return this.props.claimNote;
+  }
+  /**
+   * Per-witness notes keyed by lowercase actor name. Empty map when
+   * no witness has noted; absent witnesses simply have no entry.
+   * Returned as a read-only view. Issue #246.
+   */
+  get witnessNotes(): ReadonlyMap<string, string> {
+    return this.props.witnessNotes ?? new Map();
+  }
   /** ISO timestamp matched with `claimedBy`. Undefined when unclaimed. */
   get claimedAt(): string | undefined {
     return this.props.claimedAt;
@@ -686,7 +746,7 @@ export class Request {
    * State guard is checked here (domain invariant) rather than only at
    * the use case so non-CLI callers can't bypass it.
    */
-  claim(by: MemberName, at: string): void {
+  claim(by: MemberName, at: string, note?: string): void {
     if (this.props.state !== 'pending' && this.props.state !== 'approved') {
       throw new DomainError(
         `Cannot claim a request in state "${this.props.state}"; ` +
@@ -695,10 +755,36 @@ export class Request {
         'state',
       );
     }
+    // Optional stake-note (issue #246). Sanitize at the boundary so
+    // empty / whitespace-only input lands as undefined, the cap
+    // throws if exceeded, and the value stored is identical to what
+    // round-trip emits. Per the tight-scope rule the note is metadata
+    // for THIS stake event — re-claim by the same actor with a new
+    // note overwrites; absence on re-claim leaves the prior note in
+    // place (doesn't clear it — clearing requires a release/terminal).
+    let cleanedNote: string | undefined;
+    if (note !== undefined) {
+      cleanedNote = sharedSanitizeText(note, 'claim_note', {
+        maxLen: MAX_STAKE_NOTE,
+        requireNonEmpty: false,
+      });
+      if (cleanedNote.length === 0) cleanedNote = undefined;
+    }
     const existing = this.props.claimedBy;
     if (existing !== undefined) {
       if (existing.value === by.value) {
-        // Idempotent re-claim — see method doc. No mutation, no log.
+        // Same-actor re-claim. Idempotent on the (claim, claimedBy,
+        // claimedAt) pair — re-stamping the timestamp would muddy
+        // "when did this stake first land". The note is the only
+        // field that may genuinely differ session-to-session, so it
+        // updates if and only if the caller supplied one and it
+        // diverges from what's stored. Empty/whitespace --note is
+        // already collapsed to undefined above, so a bare re-claim
+        // (no flag) is a true no-op.
+        if (cleanedNote !== undefined && cleanedNote !== this.props.claimNote) {
+          this.props.claimNote = cleanedNote;
+          this.bumpMutationSeq();
+        }
         return;
       }
       throw new DomainError(
@@ -711,6 +797,7 @@ export class Request {
     }
     this.props.claimedBy = by;
     this.props.claimedAt = at;
+    if (cleanedNote !== undefined) this.props.claimNote = cleanedNote;
     // Real mutation — bump so the optimistic-lock token moves and a
     // concurrent claim by another actor (which would race past the
     // status_log+reviews+thanks length check, since claim doesn't
@@ -728,6 +815,10 @@ export class Request {
     if (this.props.claimedBy === undefined) return;
     delete this.props.claimedBy;
     delete this.props.claimedAt;
+    // claim_note (issue #246) moves with the claim — terminal
+    // auto-reset clears it alongside, so a closed record never
+    // carries a stale stake note.
+    delete this.props.claimNote;
     // Per-actor accounting: a terminal frontier that clears one claim
     // counts as one mutation. See `RequestProps.mutationSeq` for the
     // rationale (observability of how many actors were mediating at
@@ -760,7 +851,7 @@ export class Request {
    * this" signal, whereas claim on `executing` would be too late to
    * mediate the cross-session race claim is designed for.
    */
-  witness(by: MemberName): void {
+  witness(by: MemberName, note?: string): void {
     if (
       this.props.state !== 'pending' &&
       this.props.state !== 'approved' &&
@@ -773,13 +864,42 @@ export class Request {
         'state',
       );
     }
+    // Optional stake-note (issue #246) — same tight-scope rules as
+    // claim's. Sanitized empty → undefined; whitespace-only --note is
+    // a true no-op on the note dimension (re-witness with bare flag
+    // doesn't fire a mutation just to clear an absent note).
+    let cleanedNote: string | undefined;
+    if (note !== undefined) {
+      cleanedNote = sharedSanitizeText(note, 'witness_note', {
+        maxLen: MAX_STAKE_NOTE,
+        requireNonEmpty: false,
+      });
+      if (cleanedNote.length === 0) cleanedNote = undefined;
+    }
     const list = this.props.witnesses ?? [];
-    if (list.some((m) => m.value === by.value)) {
-      // Idempotent re-witness — already observing, no mutation.
+    const actorKey = by.value;
+    if (list.some((m) => m.value === actorKey)) {
+      // Same-actor re-witness. Update the note if and only if the
+      // caller supplied one and it diverges from what's stored —
+      // mirrors claim's overwrite-only-on-divergence rule. A bare
+      // `gate witness <id>` re-run stays a true no-op.
+      const notes = this.props.witnessNotes;
+      const current = notes?.get(actorKey);
+      if (cleanedNote !== undefined && cleanedNote !== current) {
+        const map = notes ?? new Map<string, string>();
+        map.set(actorKey, cleanedNote);
+        this.props.witnessNotes = map;
+        this.bumpMutationSeq();
+      }
       return;
     }
     list.push(by);
     this.props.witnesses = list;
+    if (cleanedNote !== undefined) {
+      const map = this.props.witnessNotes ?? new Map<string, string>();
+      map.set(actorKey, cleanedNote);
+      this.props.witnessNotes = map;
+    }
     // Real mutation — bump for the same reason claim does. See
     // `bumpMutationSeq` doc and `RequestProps.mutationSeq`.
     this.bumpMutationSeq();
@@ -831,6 +951,17 @@ export class Request {
     } else {
       this.props.witnesses = list;
     }
+    // Drop the per-actor note (issue #246) alongside the witness
+    // entry. unwitness is a removal of the stake; the note is
+    // metadata for that stake and has no meaning once the actor is
+    // gone from the list. If this leaves the map empty, drop the
+    // map prop entirely so YAML round-trips byte-identically to a
+    // record that never had any witness notes.
+    const notes = this.props.witnessNotes;
+    if (notes !== undefined) {
+      notes.delete(by.value);
+      if (notes.size === 0) delete this.props.witnessNotes;
+    }
     // Real mutation — bump so two concurrent unwitness calls by
     // different actors don't both pass the optimistic-lock check
     // (which sees identical pre-mutation length on both sides) and
@@ -849,6 +980,10 @@ export class Request {
     if (list === undefined || list.length === 0) return;
     const cleared = list.length;
     delete this.props.witnesses;
+    // Per-witness notes (issue #246) move with the witnesses on
+    // terminal auto-reset, same rationale as claim_note: closed
+    // records carry no stake metadata.
+    delete this.props.witnessNotes;
     // Per-actor accounting: bump once per cleared witness so a
     // terminal frontier collapsing N witnesses contributes +N to the
     // version token. Keeps "how many actors were observing at close"
@@ -990,6 +1125,12 @@ export class Request {
     if (this.props.claimedBy !== undefined && this.props.claimedAt !== undefined) {
       out['claimed_by'] = this.props.claimedBy.value;
       out['claimed_at'] = this.props.claimedAt;
+      // Optional metadata for the claim (issue #246). Surface only
+      // when set so pre-#246 records and noteless claims both emit
+      // byte-identical YAML on round-trip.
+      if (this.props.claimNote !== undefined) {
+        out['claim_note'] = this.props.claimNote;
+      }
     }
     // Witnesses (issue #244). Surface only when non-empty — empty
     // witnesses is the common case and an empty array would clutter
@@ -999,6 +1140,19 @@ export class Request {
     const witnessList = this.props.witnesses ?? [];
     if (witnessList.length > 0) {
       out['witnesses'] = witnessList.map((m) => m.value);
+    }
+    // Per-witness metadata (issue #246). Map keyed by lowercase
+    // actor name. Surfaced as a plain object for YAML — ordered
+    // implicitly by Map insertion (mirroring witness registration
+    // order). Omitted entirely when no witness has noted, so a
+    // post-#246 record with no notes round-trips byte-identically
+    // to a pre-#246 record.
+    if (this.props.witnessNotes !== undefined && this.props.witnessNotes.size > 0) {
+      const notes: Record<string, string> = {};
+      for (const [actor, note] of this.props.witnessNotes) {
+        notes[actor] = note;
+      }
+      out['witness_notes'] = notes;
     }
     // mutation_seq (issue #244 follow-up). Surface only when > 0 so
     // pre-#244 records and never-mediated post-#244 records both emit

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -598,6 +598,20 @@ function hydrate(
     ) {
       props.claimedBy = MemberName.of(obj['claimed_by']);
       props.claimedAt = obj['claimed_at'] as string;
+      // claim_note (issue #246). Tolerated only as a non-empty
+      // string — empty / non-string values fall through to "no
+      // note", matching the domain rule that whitespace-only input
+      // collapses to undefined. Length cap is enforced on the next
+      // save; a hand-edited YAML carrying an over-long note hydrates
+      // verbatim so reads stay non-destructive (Devil-style "the
+      // record always wins on read"), and the next mutation that
+      // touches the note path goes through sanitizeText.
+      if (
+        typeof obj['claim_note'] === 'string' &&
+        obj['claim_note'].length > 0
+      ) {
+        props.claimNote = obj['claim_note'];
+      }
     }
     // Witnesses (issue #244). Restore only well-typed string entries;
     // anything else (objects, numbers) is dropped silently following
@@ -634,6 +648,33 @@ function hydrate(
         );
       }
       if (observers.length > 0) props.witnesses = observers;
+    }
+    // witness_notes (issue #246). Map keyed by lowercase actor name.
+    // Restored only when the field is a plain object whose values are
+    // non-empty strings; entries pointing at non-string or empty
+    // values are dropped silently (same tolerance as the witnesses
+    // array). Notes for actors NOT in `witnesses[]` are also dropped
+    // — a stray note has no anchor to attach to, and silently keeping
+    // it would muddy the next save's byte-stability. Pre-#246
+    // records and post-#246 records with no notes both lack the
+    // field and hydrate as undefined.
+    if (
+      obj['witness_notes'] !== null &&
+      typeof obj['witness_notes'] === 'object' &&
+      !Array.isArray(obj['witness_notes'])
+    ) {
+      const validActors = new Set(
+        (props.witnesses ?? []).map((m) => m.value),
+      );
+      const notes = new Map<string, string>();
+      for (const [actor, raw] of Object.entries(
+        obj['witness_notes'] as Record<string, unknown>,
+      )) {
+        if (typeof raw !== 'string' || raw.length === 0) continue;
+        if (!validActors.has(actor)) continue;
+        notes.set(actor, raw);
+      }
+      if (notes.size > 0) props.witnessNotes = notes;
     }
     // mutation_seq (issue #244 follow-up; Devil REJECT root cause).
     // Counter for cross-session-mutating verbs (claim/witness/

--- a/src/interface/gate/handlers/claim.ts
+++ b/src/interface/gate/handlers/claim.ts
@@ -1,5 +1,6 @@
 import {
   ParsedArgs,
+  optionalOption,
   requireOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
@@ -35,6 +36,7 @@ import { emitWriteResponse, parseFormat } from './writeFormat.js';
 //     follow-up alongside witness.
 const CLAIM_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
+  'note',
   'dry-run',
   'format',
 ]);
@@ -43,11 +45,23 @@ export async function reqClaim(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, CLAIM_KNOWN_FLAGS, 'claim');
   const id = args.positional[0];
   if (!id) {
-    throw new Error('Usage: gate claim <id> --by <m> [--dry-run]');
+    throw new Error('Usage: gate claim <id> --by <m> [--note <text>] [--dry-run]');
   }
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  // Optional stake-note (issue #246). Tight-scope: single short
+  // string ≤ 80 chars, sanitized at the domain boundary; empty /
+  // whitespace-only collapses to undefined so a bare `--note ""`
+  // is a true no-op on the note dimension. Discussion belongs in
+  // agora plays — the schema description names this "metadata,
+  // not commentary".
+  const note = optionalOption(args, 'note');
   if (isDryRun(args)) {
-    const { request } = await c.requestUC.claim({ id, by, dryRun: true });
+    const { request } = await c.requestUC.claim({
+      id,
+      by,
+      ...(note !== undefined ? { note } : {}),
+      dryRun: true,
+    });
     // Claim doesn't transition lifecycle state — the verb is orthogonal
     // to pending/approved/etc — so omit `would_transition`. The preview
     // payload carries the prospective claimed_by/at via toRenderJSON.
@@ -60,7 +74,11 @@ export async function reqClaim(c: C, args: ParsedArgs): Promise<number> {
     });
     return 0;
   }
-  const { request, mutated } = await c.requestUC.claim({ id, by });
+  const { request, mutated } = await c.requestUC.claim({
+    id,
+    by,
+    ...(note !== undefined ? { note } : {}),
+  });
   // Re-claim message is distinct so a caller that re-runs claim (e.g.
   // a session restart) sees that the call was idempotent rather than
   // wondering whether anything changed. The state of the record is

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -744,12 +744,30 @@ function formatRequestText(r: Request): string {
     lines.push('');
     lines.push('  stake:');
     if (hasClaim) {
-      lines.push(`    claimed by: ${j['claimed_by']} at ${j['claimed_at']}`);
+      // Optional claim_note (issue #246) appended after an em-dash
+      // separator. Stays on one line so the stake block scans
+      // compactly even with several witnesses.
+      const claimNote =
+        typeof j['claim_note'] === 'string' && j['claim_note'].length > 0
+          ? ` — ${j['claim_note']}`
+          : '';
+      lines.push(`    claimed by: ${j['claimed_by']} at ${j['claimed_at']}${claimNote}`);
     }
     if (hasWitnesses) {
-      const names = (j['witnesses'] as unknown[])
-        .map((w) => String(w))
-        .join(', ');
+      // Per-witness notes (issue #246) emitted inline as
+      // `name (note)` so a 5-witness wave with mixed annotations
+      // reads naturally:  `witnesses: alice (watching dedup), bob, carol (perf)`.
+      const witnessNotes =
+        j['witness_notes'] && typeof j['witness_notes'] === 'object' && !Array.isArray(j['witness_notes'])
+          ? (j['witness_notes'] as Record<string, string>)
+          : {};
+      const names = (j['witnesses'] as unknown[]).map((w) => {
+        const name = String(w);
+        const note = witnessNotes[name];
+        return typeof note === 'string' && note.length > 0
+          ? `${name} (${note})`
+          : name;
+      }).join(', ');
       lines.push(`    witnesses: ${names}`);
     }
   }

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1023,6 +1023,15 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: strOpt('claimant (defaults to $GUILD_ACTOR)'),
+        note: strOpt(
+          'optional stake metadata (issue #246). Single short string ' +
+            '≤ 80 chars — metadata for THIS stake event, not commentary. ' +
+            'Cross-actor discussion belongs in agora plays; the note is ' +
+            'for context like "watching the dedup fix" or "blocked on ' +
+            'review #233". Same-actor re-claim with a divergent --note ' +
+            'overwrites the previous note (single value per claim). ' +
+            'Auto-cleared on terminal transitions and on release.',
+        ),
         format: formatField,
         'dry-run': dryRunField,
       },
@@ -1044,6 +1053,14 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: strOpt('observer (defaults to $GUILD_ACTOR)'),
+        note: strOpt(
+          'optional per-witness metadata (issue #246). Single short string ' +
+            '≤ 80 chars — metadata for THIS stake event, not commentary. ' +
+            'Cross-actor discussion belongs in agora plays. Same-actor ' +
+            're-witness with a divergent --note overwrites the previous ' +
+            'note (single value per witness). Auto-cleared on terminal ' +
+            'transitions and on unwitness.',
+        ),
         format: formatField,
         'dry-run': dryRunField,
       },

--- a/src/interface/gate/handlers/witness.ts
+++ b/src/interface/gate/handlers/witness.ts
@@ -1,5 +1,6 @@
 import {
   ParsedArgs,
+  optionalOption,
   requireOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
@@ -33,7 +34,16 @@ import { emitWriteResponse, parseFormat } from './writeFormat.js';
 //   - Auto-reset to [] lives in `Request.transition` for completed/
 //     failed/denied — same terminal frontier as claim.
 
+// witness accepts --note for the per-witness stake metadata
+// (issue #246). unwitness does NOT — it removes a stake, and a
+// note has no anchor when the witness entry is gone.
 const WITNESS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'dry-run',
+  'format',
+]);
+const UNWITNESS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
   'dry-run',
   'format',
@@ -43,11 +53,20 @@ export async function reqWitness(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, WITNESS_KNOWN_FLAGS, 'witness');
   const id = args.positional[0];
   if (!id) {
-    throw new Error('Usage: gate witness <id> --by <m> [--dry-run]');
+    throw new Error('Usage: gate witness <id> --by <m> [--note <text>] [--dry-run]');
   }
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  // Optional stake-note (issue #246) — same tight-scope contract as
+  // claim's. Domain sanitizes empty / whitespace-only to undefined,
+  // so a bare `--note ""` is a true no-op on the note dimension.
+  const note = optionalOption(args, 'note');
   if (isDryRun(args)) {
-    const { request } = await c.requestUC.witness({ id, by, dryRun: true });
+    const { request } = await c.requestUC.witness({
+      id,
+      by,
+      ...(note !== undefined ? { note } : {}),
+      dryRun: true,
+    });
     // Witness doesn't transition lifecycle state — orthogonal to
     // pending/approved/executing — so omit `would_transition`.
     emitDryRunPreview({
@@ -59,7 +78,11 @@ export async function reqWitness(c: C, args: ParsedArgs): Promise<number> {
     });
     return 0;
   }
-  const { request, mutated } = await c.requestUC.witness({ id, by });
+  const { request, mutated } = await c.requestUC.witness({
+    id,
+    by,
+    ...(note !== undefined ? { note } : {}),
+  });
   // Re-witness message is distinct so the caller can tell whether
   // anything landed (idempotent re-run is legitimate; we just want
   // to make the no-op visible).
@@ -71,7 +94,7 @@ export async function reqWitness(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export async function reqUnwitness(c: C, args: ParsedArgs): Promise<number> {
-  rejectUnknownFlags(args, WITNESS_KNOWN_FLAGS, 'unwitness');
+  rejectUnknownFlags(args, UNWITNESS_KNOWN_FLAGS, 'unwitness');
   const id = args.positional[0];
   if (!id) {
     throw new Error('Usage: gate unwitness <id> --by <m> [--dry-run]');

--- a/tests/interface/witness.test.ts
+++ b/tests/interface/witness.test.ts
@@ -561,3 +561,149 @@ test('unwitness on live-window: error message is the typo-oriented form', (t) =>
   assert.match(r.stderr, /unwitness only removes the caller's own witness/);
   assert.doesNotMatch(r.stderr, /auto-released on terminal/);
 });
+
+// --- issue #246: tight-scope --note on claim/witness (NOT unwitness) ---
+
+test('gate witness --note: stamps witness_note inline in show text', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  const r = run(root, ['witness', id, '--by', 'leysia', '--note', 'watching the dedup fix']);
+  assert.equal(r.status, 0);
+
+  const show = run(root, ['show', id, '--format', 'text']);
+  assert.equal(show.status, 0);
+  assert.match(show.stdout, /witnesses: leysia \(watching the dedup fix\)/);
+
+  // Same in JSON: top-level witness_notes map carries the entry.
+  const showJson = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(showJson.stdout);
+  assert.deepEqual(payload.witness_notes, { leysia: 'watching the dedup fix' });
+});
+
+test('gate claim --note: stamps claim_note on the claim line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  const r = run(root, ['claim', id, '--by', 'leysia', '--note', 'starting now']);
+  assert.equal(r.status, 0);
+
+  const show = run(root, ['show', id, '--format', 'text']);
+  assert.match(show.stdout, /claimed by: leysia at \d{4}-\d{2}-\d{2}T.*— starting now/);
+
+  const showJson = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(showJson.stdout);
+  assert.equal(payload.claim_note, 'starting now');
+});
+
+test('gate witness --note: same-actor re-witness with divergent note overwrites', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia', '--note', 'first take']).status, 0);
+  // Divergent note → mutation, overwrite.
+  const r = run(root, ['witness', id, '--by', 'leysia', '--note', 'second take']);
+  assert.equal(r.status, 0);
+  // Message should reflect mutation (not the no-op variant).
+  assert.match(r.stdout, /✓ witnessed:/);
+
+  const show = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  assert.deepEqual(payload.witness_notes, { leysia: 'second take' });
+});
+
+test('gate witness: bare --note "" is a true no-op on the note dimension', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  // First witness with a note.
+  assert.equal(run(root, ['witness', id, '--by', 'leysia', '--note', 'kept']).status, 0);
+  // Re-witness with empty --note: per the spec, whitespace-only
+  // input collapses to undefined, which means no overwrite — the
+  // original note survives.
+  const r = run(root, ['witness', id, '--by', 'leysia', '--note', '   ']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /already witnessing.*no change/);
+
+  const show = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  assert.deepEqual(payload.witness_notes, { leysia: 'kept' });
+});
+
+test('gate claim --note: rejects > 80 chars', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  const longNote = 'x'.repeat(81);
+  const r = run(root, ['claim', id, '--by', 'leysia', '--note', longNote]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /claim_note too long \(max 80 chars\)/);
+});
+
+test('gate unwitness: --note flag is rejected', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+  // unwitness is a removal, not a stake — the note has no anchor.
+  const r = run(root, ['unwitness', id, '--by', 'leysia', '--note', 'leaving']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /unwitness: unknown flag: --note/);
+});
+
+test('gate witness --note: terminal auto-reset clears witness_notes', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice', 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia', '--note', 'soon-cleared']).status, 0);
+  // Drive the request to completed.
+  assert.equal(run(root, ['approve', id, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', id, '--by', 'alice']).status, 0);
+  assert.equal(run(root, ['complete', id, '--by', 'alice', '--note', 'done']).status, 0);
+
+  const show = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  // witnesses[] auto-resets on terminal; witness_notes goes with it.
+  assert.equal(payload.witnesses, undefined);
+  assert.equal(payload.witness_notes, undefined);
+});
+
+test('gate claim --note: terminal auto-reset clears claim_note', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const id = newRequest(root, 'alice', 'alice');
+  assert.equal(run(root, ['claim', id, '--by', 'alice', '--note', 'soon-cleared']).status, 0);
+  assert.equal(run(root, ['approve', id, '--by', 'eris']).status, 0);
+  assert.equal(run(root, ['execute', id, '--by', 'alice']).status, 0);
+  assert.equal(run(root, ['complete', id, '--by', 'alice', '--note', 'done']).status, 0);
+
+  const show = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  assert.equal(payload.claimed_by, undefined);
+  assert.equal(payload.claim_note, undefined);
+});
+
+test('gate unwitness: drops the actor\'s witness_note alongside the witness entry', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia', '--note', 'leysia note']).status, 0);
+  assert.equal(run(root, ['witness', id, '--by', 'miki', '--note', 'miki note']).status, 0);
+  // Drop leysia.
+  assert.equal(run(root, ['unwitness', id, '--by', 'leysia']).status, 0);
+
+  const show = run(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  assert.deepEqual(payload.witnesses, ['miki']);
+  // leysia's note removed; miki's preserved.
+  assert.deepEqual(payload.witness_notes, { miki: 'miki note' });
+});


### PR DESCRIPTION
## Summary

Closes #246 with option (b), tight-scope variant.

The "verb itself is the signal, not commentary" principle is half-right: it correctly says stake events shouldn't become discussion threads, but blocking *any* annotation overshoots — lifecycle verbs (`approve` / `deny` / `complete`) already balance "tight metadata" against "don't become a forum" without drifting into chat surfaces. Issue #246's concrete failure mode (5-witness wave, all silent → "why each actor is watching" disperses into chat history and agora plays) is a real records-outlive-writers tension.

Allow `--note <text>` on `gate claim` and `gate witness`. Tight scope so the silent-stake principle's intent is preserved.

## Tight-scope rules

- **Max 80 chars** (terminal-friendly, fits one line)
- **One note per actor per request** — overwrite-on-divergence, no append, no thread
- **Sanitized** through the shared text path (control chars stripped, trim, length cap enforced at domain boundary)
- **Whitespace-only `--note` collapses to undefined** — a true no-op (so `--note ""` doesn't accidentally clear or churn)
- **Auto-cleared on terminal transitions** alongside claim/witnesses
- **`unwitness` does NOT accept `--note`** — removal events have no stake to attach a note to

Schema descriptions explicitly name this "metadata, not commentary" + "cross-actor discussion belongs in agora plays" so the surface's intent is in the contract, not just code comments.

## Output (text mode, #245's stake: section)

```
  stake:
    claimed by: alice at 2026-05-08T16:09:37Z — starting now
    witnesses: leysia (watching the dedup fix), miki, asteria (for the perf review)
```

## Storage

```yaml
claimed_by: alice
claimed_at: 2026-05-08T...
claim_note: starting now              # optional, omit if absent

witnesses: [leysia, miki, asteria]
witness_notes:                         # optional, omit when empty
  leysia: watching the dedup fix
  asteria: for the perf review
  # miki has no note → absent from map
```

Pre-#246 records and post-#246 records where no actor has noted on both lack the fields and round-trip byte-identically.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1327/1327 pass on linux (9 new tests)
  - claim --note stamps claim_note inline (text + JSON)
  - witness --note stamps witness_note inline (mixed annotations)
  - re-witness with divergent note overwrites
  - re-witness with whitespace-only `--note` is a true no-op
  - claim --note rejects > 80 chars
  - unwitness --note rejected at flag layer
  - terminal auto-reset clears claim_note + witness_notes
  - unwitness drops the actor's witness_note alongside the entry
- [x] Visual sanity check on a 4-actor mixed-annotation wave

## Files

- `src/domain/request/Request.ts` — `claimNote` / `witnessNotes` props, `MAX_STAKE_NOTE = 80`, claim/witness method extensions, terminal auto-reset, toJSON
- `src/infrastructure/persistence/YamlRequestRepository.ts` — hydrate with tolerance for stray entries
- `src/application/request/RequestUseCases.ts` — `note?` plumbed through; `mutationSeq` becomes the canonical "did anything change" witness
- `src/interface/gate/handlers/claim.ts` — `--note` on KNOWN_FLAGS + handler
- `src/interface/gate/handlers/witness.ts` — `--note` on witness only; unwitness has its own KNOWN_FLAGS
- `src/interface/gate/handlers/schema.ts` — schema descriptions name the principle ("metadata, not commentary")
- `src/interface/gate/handlers/request.ts` — `gate show` text rendering for inline notes
- `tests/interface/witness.test.ts` — 9 new tests

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_