### PR TITLE
docs + groundwork: plugin stability / trust model / VerbSchema source (#36 Phase 1 step 1-3)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -141,13 +141,64 @@ For full details: `src/passages/devil/README.md`,
   editor command is **not validated** — the tool trusts the local
   environment. In multi-user or container environments, restrict
   environment variable mutation or avoid interactive review.
-- **Doctor plugins.** Plugins listed in `guild.config.yaml`
-  `doctor.plugins` are ES modules executed **in the main process**
-  with full Node.js capabilities. Only load plugins from trusted
-  sources. There is no sandboxing.
+- **Plugin trust model.** See "Plugin trust model" below for the
+  full surface (currently doctor plugins; verb / hook / transform
+  plugins planned under [#36](https://github.com/eris-ths/guild-cli/issues/36)).
 - **MCP server (gate_mcp.py).** Spawns `gate` as a subprocess via
   `asyncio.create_subprocess_exec` (array form, no shell expansion).
   Project name validation blocks path traversal (`/`, `\`, `.`, `..`).
+
+## Plugin trust model
+
+`guild-cli` allows operators to extend the CLI through plugins listed
+in `guild.config.yaml`. Today only **doctor plugins** are loaded; the
+**verb / lifecycle-hook / content-transform** plugins specified in
+[#36](https://github.com/eris-ths/guild-cli/issues/36) Phase 1 will
+share the same trust model when they ship.
+
+**Execution context.** Every plugin is loaded as an ES module via
+Node's `import()` and runs **in the main process** with full
+Node.js capabilities — file system, network, child processes,
+environment access. There is **no sandboxing**. A malicious plugin
+has the same authority as the user running `gate` / `guild` /
+`agora` / `devil` / `ctx`.
+
+**Consent surface — `trusted: true` guard.** `guild.config.yaml`
+must declare `doctor.trusted: true` (and, when the broader
+plugin-loader ships, the equivalent `plugins.trusted: true`) before
+plugin paths under that section are loaded. Without the trust
+declaration, the loader **warns and skips** every plugin path
+listed under it — the YAML alone is not consent. This is the same
+guard added in [#90](https://github.com/eris-ths/guild-cli/issues/90)
+for doctor plugins (`src/infrastructure/config/GuildConfig.ts`).
+Rationale: a teammate's `git pull` should not silently start
+running new code on your machine just because a `plugins:` entry
+landed in the config.
+
+**Origin discipline.** Load plugins only from sources you would
+type credentials for. The model is "whitelist by author", not
+"vet by review" — code review of plugin diffs at PR time is a
+useful *backstop*, not a *substitute*, for knowing the author.
+
+**Plugin loader failure is non-fatal.** A plugin path that fails to
+load (missing file, syntax error, throw on import) surfaces as a
+`gate doctor` finding rather than crashing the CLI. The same
+behaviour will apply to verb / hook / transform plugins when their
+loader ships — read verbs (`gate boot`, `gate show`, etc.) must
+remain available even when an extension is broken.
+
+**Source discrimination via `gate schema`.** Every verb in the
+`gate schema` output carries `source: 'core' | 'plugin'` so an MCP
+wiring or LLM tool layer can filter built-in verbs from extensions.
+The discriminator is part of the schema contract (see
+[`docs/POLICY.md`](docs/POLICY.md) § "Plugin stability") — a
+consumer that whitelists `source: 'core'` is guaranteed to get the
+built-in surface only.
+
+**What this is NOT.** Trusted-plugin loading is not a security
+boundary against the plugin author; it is a deliberate handoff of
+authority from the operator to the plugin code. Untrusted code
+should not be run as a plugin under any configuration.
 
 ## Known hardening items (not yet addressed)
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -144,6 +144,41 @@ When a stable surface element is scheduled for removal:
 2. The deprecation is announced in `CHANGELOG.md` under the minor release that introduces the warning.
 3. The element is removed **no earlier than one minor release later** in the 0.x line (or one major in 1.x).
 
+## Plugin stability
+
+`guild-cli` exposes extension surfaces — currently **doctor plugins**
+(implemented; see `src/application/diagnostic/DiagnosticUseCases.ts`)
+and the planned **verb / lifecycle-hook / content-transform** surfaces
+tracked under [#36](https://github.com/eris-ths/guild-cli/issues/36)
+Phase 1. The same versioning contract applies to all of them:
+
+- **Plugin contracts are additive within a 0.x line.** Hook signatures
+  (the parameter shape passed to a plugin) and verb-plugin export
+  shapes (`{ name, category, summary, input, output, run(c, args) }`)
+  MAY gain optional fields in any minor release. They MUST NOT be
+  renamed or removed without a minor bump and a `BREAKING` entry in
+  `CHANGELOG.md`.
+- **Hook firing order is part of the contract.** "Fire `before:approve`
+  before the state mutation" is a guarantee a plugin can rely on.
+  Reordering existing hooks (e.g. moving a hook to fire after a
+  different stage of the transition) is a breaking change.
+- **`gate schema` exposes the `source` discriminator.** Every verb in
+  the schema payload carries `source: 'core' | 'plugin'` so an MCP
+  wiring or LLM tool layer can tell built-in verbs from extensions.
+  Built-in verbs are `source: 'core'`; verb plugins (when the loader
+  ships) emit `source: 'plugin'`. The discriminator is a stability
+  guarantee, not a hint — consumers may filter on it without
+  cross-checking some other source of truth.
+- **Plugin failures are non-fatal.** `gate doctor` reports plugin
+  load errors as findings (the existing pattern for doctor plugins,
+  to be carried forward to verb / hook / transform plugins). A
+  broken plugin must not break the CLI's read verbs.
+
+The trust model for plugins is documented in
+[`SECURITY.md`](../SECURITY.md) § "Plugin trust model" — plugins run
+in-process with full Node.js capabilities, and the `trusted: true`
+guard on `guild.config.yaml` is the consent surface.
+
 ## Security fixes
 
 Security patches may ship in any release type (patch, minor, major).

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -44,6 +44,16 @@ interface VerbSchema {
   readonly category: 'read' | 'write' | 'admin' | 'meta';
   readonly input: JsonSchema;
   readonly output: JsonSchema;
+  /**
+   * Origin discriminator (issue #36 Phase 1 groundwork). Built-in
+   * verbs declared in this file omit the field and are emitted as
+   * `source: 'core'` by `schemaCmd`'s default. The forthcoming
+   * verb-plugin loader will register schemas with `source: 'plugin'`
+   * so MCP wirings and LLM tool layers can filter built-in surface
+   * from extensions without cross-checking another source of truth.
+   * Stability contract: `docs/POLICY.md` § "Plugin stability".
+   */
+  readonly source?: 'core' | 'plugin';
 }
 
 const str: JsonSchema = { type: 'string' };
@@ -1326,6 +1336,13 @@ export async function schemaCmd(_c: C, args: ParsedArgs): Promise<number> {
     verbs: verbs.map((v) => ({
       name: v.name,
       category: v.category,
+      // `source` defaults to 'core' when the VerbSchema entry omits
+      // it — the built-in VERBS table never sets it explicitly so a
+      // future loader landing 'plugin' is the only signal worth
+      // emitting verbatim. Always emitted on the wire so consumers
+      // never see undefined and can filter unconditionally. See
+      // VerbSchema interface comment for the discrimination contract.
+      source: v.source ?? 'core',
       summary: v.summary,
       input: v.input,
       output: v.output,
@@ -1337,7 +1354,13 @@ export async function schemaCmd(_c: C, args: ParsedArgs): Promise<number> {
     const lines: string[] = [];
     for (const v of verbs) {
       const req = v.input.required?.join(', ') ?? '';
-      lines.push(`${v.name} [${v.category}] — ${v.summary}`);
+      // `source` is rendered only for plugin verbs — every built-in
+      // verb is `core` and a `[core]` tag on every line would just
+      // be noise (voice budget). The plugin marker calls attention
+      // to extensions because filtering by it is the typical reason
+      // a reader would consult `gate schema --format text`.
+      const src = v.source === 'plugin' ? ' [plugin]' : '';
+      lines.push(`${v.name} [${v.category}]${src} — ${v.summary}`);
       if (req) lines.push(`  required: ${req}`);
     }
     process.stdout.write(lines.join('\n') + '\n');

--- a/tests/interface/schema.test.ts
+++ b/tests/interface/schema.test.ts
@@ -7,12 +7,22 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { VERBS } from '../../src/interface/gate/handlers/schema.js';
+import { makeTempRoot } from '../util/tempRoot.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrapMinimal(prefix: string): { root: string; cleanup: () => void } {
+  const root = makeTempRoot(prefix);
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [human]\n');
+  mkdirSync(join(root, 'members'), { recursive: true });
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
 
 test('gate schema: every VERBS entry matches a case in index.ts dispatch', () => {
   const indexPath = join(here, '../../../src/interface/gate/index.ts');
@@ -84,4 +94,49 @@ test('gate schema: input required fields are a subset of declared properties', (
       );
     }
   }
+});
+
+// --- issue #36 Phase 1: source: 'core' | 'plugin' discriminator ---
+
+test('gate schema --format json: every verb carries source = "core" (built-in surface)', (t) => {
+  // The runtime payload must always emit `source` so consumers can
+  // filter built-in vs plugin verbs without cross-checking another
+  // source of truth. Built-in verbs default to 'core' regardless of
+  // whether the VerbSchema entry sets the field explicitly.
+  const { root, cleanup } = bootstrapMinimal('gate-schema-source-');
+  t.after(cleanup);
+
+  const r = spawnSync(process.execPath, [GATE, 'schema', '--format', 'json'], {
+    cwd: root,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(payload.verbs), 'verbs array present');
+  assert.ok(payload.verbs.length > 0, 'verbs array non-empty');
+  for (const v of payload.verbs) {
+    assert.equal(
+      v.source,
+      'core',
+      `verb ${v.name}: built-in surface must report source="core" (got ${JSON.stringify(v.source)})`,
+    );
+  }
+});
+
+test('gate schema --format text: built-in verbs render without [plugin] tag', (t) => {
+  // Voice budget: a [core] tag on every line would be noise. The
+  // tag fires only for plugin verbs (none today), so the text
+  // output stays compact for the built-in surface.
+  const { root, cleanup } = bootstrapMinimal('gate-schema-source-text-');
+  t.after(cleanup);
+
+  const r = spawnSync(process.execPath, [GATE, 'schema', '--format', 'text'], {
+    cwd: root,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout, /\[plugin\]/, 'no built-in verb should render the [plugin] tag');
+  assert.doesNotMatch(r.stdout, /\[core\]/, 'voice budget: [core] tag is suppressed for built-ins');
 });


### PR DESCRIPTION
## Summary

Steps 1–3 of #36 Phase 1's "Lightest-first work order". Sets up the documentation and `VerbSchema` discriminator that step 4 (the verb-plugin loader) will land against.

This is intentionally a doc + groundwork PR — no behavior change for existing verbs. The `source` field defaults to `'core'` on emission; once the loader ships, plugin schemas register with `source: 'plugin'` and the discrimination is already wired.

## Changes

### 1. `docs/POLICY.md` — Plugin stability section

- Plugin contracts are additive within a 0.x line; renaming or removing hook signatures / verb-plugin export shapes requires a minor bump + BREAKING marker
- Hook firing order is part of the contract
- `gate schema` exposes `source: 'core' | 'plugin'` discriminator as a stability guarantee
- Plugin failures are non-fatal (`gate doctor` surfaces them)

### 2. `SECURITY.md` — Plugin trust model section

Promotes the one-line "Doctor plugins" trust assumption into a full section covering the broader plugin model that #36 Phase 1 will introduce:

- Plugins run **in-process** with full Node capabilities — no sandbox
- `trusted: true` guard on `guild.config.yaml` is the consent surface ("yaml alone is not consent — a teammate's `git pull` should not silently start running new code")
- Origin discipline: whitelist by author, not by code review
- Plugin loader failure is non-fatal
- `gate schema`'s `source` field is the surface-discrimination contract for MCP wirings and LLM tool layers

### 3. `VerbSchema` — `source: 'core' | 'plugin'` marker

- Optional field on `VerbSchema`; built-in VERBS entries omit it
- `schemaCmd` defaults to `'core'` on emission so the wire shape is **always** present (consumers never see undefined)
- Text mode renders `[plugin]` tag for plugin verbs only; `[core]` suppressed (voice budget — would be noise on 37 verbs)
- Forward-compatible groundwork: when the loader lands in step 4, plugin verbs register with `source: 'plugin'` and the discrimination is already on the wire

## Output

```
$ gate schema --format json | jq '.verbs[0].source'
"core"

$ gate schema --format text | head -2
boot [read] — single-command session orientation ...
status [read] — pending/approved/executing counts ...
```

(No `[core]` tag — voice budget. `[plugin]` would appear when a plugin verb lands.)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1329/1329 pass on linux (2 new tests)
  - new: built-in verbs all report `source = 'core'` in JSON output
  - new: text output carries no `[plugin]` tag for built-ins
- [x] Visual sanity check — `gate schema --format json` and `--format text` both look right

## Files

- `docs/POLICY.md` — new "Plugin stability" section
- `SECURITY.md` — new "Plugin trust model" section
- `src/interface/gate/handlers/schema.ts` — optional `source` field + emission
- `tests/interface/schema.test.ts` — 2 new tests + shared `bootstrapMinimal` helper

## Next

Step 4 (verb-plugin loader) lands separately. The contract this PR pins down — that `source` is part of `gate schema` output, that `trusted: true` is the consent surface, that plugin failures are non-fatal — gives that PR a concrete shape to land into.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_