### PR TITLE
feat(gate): verb plugin loader (#36 Phase 1 step 4)

### DIFF
--- a/examples/plugins/verbs/echo.mjs
+++ b/examples/plugins/verbs/echo.mjs
@@ -1,0 +1,59 @@
+// Example verb plugin (issue #36 Phase 1 step 4).
+//
+// `gate echo --text "hello"` prints the text and exits 0. Demonstrates
+// the minimum viable plugin shape:
+//   - default export carries `name`, `category`, `summary`, `input`,
+//     `output`, and `run`
+//   - `run(c, args)` returns a Promise<number> exit code
+//   - the plugin runs in-process — full Node capabilities — so it's
+//     gated on `plugins.trusted: true` in `guild.config.yaml`
+//
+// To enable:
+//
+//   # guild.config.yaml
+//   plugins:
+//     trusted: true
+//     verbs:
+//       - examples/plugins/verbs/echo.mjs
+//
+// Then `gate echo --text "hello"` works alongside the built-in verbs.
+// `gate schema --format json` reports it with `source: "plugin"`.
+
+export default {
+  name: 'echo',
+  category: 'meta',
+  summary: 'echo --text <s> back to stdout (example verb plugin from #36)',
+  input: {
+    type: 'object',
+    properties: {
+      text: { type: 'string', description: 'the string to echo' },
+      format: {
+        type: 'string',
+        enum: ['json', 'text'],
+        description: 'output format (default: text)',
+      },
+    },
+    required: ['text'],
+  },
+  output: {
+    type: 'object',
+    properties: {
+      ok: { type: 'boolean' },
+      text: { type: 'string' },
+    },
+  },
+  run: async (_c, args) => {
+    const text = args.options['text'];
+    if (typeof text !== 'string' || text.length === 0) {
+      process.stderr.write('error: --text <s> required\n');
+      return 1;
+    }
+    const format = args.options['format'] === 'json' ? 'json' : 'text';
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify({ ok: true, text }) + '\n');
+    } else {
+      process.stdout.write(text + '\n');
+    }
+    return 0;
+  },
+};

--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -52,11 +52,36 @@ export type DoctorPluginFn = (
   ctx: DoctorPluginContext,
 ) => Promise<DiagnosticFinding[]>;
 
+/**
+ * Verb-plugin load info, mirrored from the gate-side loader so
+ * doctor can fold a verb plugin's per-path outcome into the same
+ * `pluginsLoaded` + `findings (area: 'plugin')` channels doctor
+ * plugins already use. Kept structural here (no import from the
+ * gate side) so the application layer doesn't depend on the
+ * interface layer.
+ */
+export interface VerbPluginDiagnostics {
+  readonly pluginsLoaded: ReadonlyArray<{
+    path: string;
+    status: 'loaded' | 'error';
+  }>;
+  readonly errors: ReadonlyArray<{ path: string; reason: string }>;
+}
+
 export class DiagnosticUseCases {
   constructor(
     private readonly buildRepos: DiagnosticRepoFactory,
     private readonly pluginPaths: readonly string[] = [],
     private readonly pluginContext?: DoctorPluginContext,
+    /**
+     * Verb plugin load outcome (issue #36 Phase 1 step 4). Gate's
+     * `main()` runs the verb-plugin loader at startup and feeds the
+     * result into the container; doctor reads the result here so
+     * verb plugin failures surface alongside doctor plugin failures
+     * in the same report. Empty default keeps tests / non-gate
+     * containers (agora / devil / ctx) unaffected.
+     */
+    private readonly verbPlugins: VerbPluginDiagnostics = { pluginsLoaded: [], errors: [] },
   ) {}
 
   async run(): Promise<DiagnosticReport> {
@@ -159,6 +184,26 @@ export class DiagnosticUseCases {
       }
     }
 
+    // Verb plugin diagnostics (#36 Phase 1 step 4). Loader-supplied
+    // errors become findings under area='plugin' (same kind as
+    // doctor plugin errors); per-path outcomes are appended to the
+    // pluginsLoaded list so a single plugins-loaded section in the
+    // doctor renderer covers both kinds. The path differentiator is
+    // sufficient — doctor plugins are filesystem paths under root,
+    // verb plugins are too, and any path-shaped string is a path
+    // for display purposes.
+    for (const e of this.verbPlugins.errors) {
+      findings.push({
+        area: 'plugin',
+        source: e.path,
+        kind: 'unknown',
+        message: `verb plugin error: ${e.reason}`,
+      });
+    }
+    const allPluginsLoaded: PluginLoadInfo[] = [
+      ...pluginsLoaded,
+      ...this.verbPlugins.pluginsLoaded,
+    ];
     return new DiagnosticReport(
       {
         members: { total: members.length, malformed: memberMalformed },
@@ -166,7 +211,7 @@ export class DiagnosticUseCases {
         issues: { total: issues.length, malformed: issueMalformed },
       },
       findings,
-      pluginsLoaded,
+      allPluginsLoaded,
     );
   }
 }

--- a/src/application/plugin/VerbPlugin.ts
+++ b/src/application/plugin/VerbPlugin.ts
@@ -1,0 +1,70 @@
+// Verb plugin contract (issue #36 Phase 1 step 4).
+//
+// A verb plugin is an ES module whose default export carries the same
+// shape `VerbSchema` declares for built-in verbs PLUS a `run` function.
+// The loader (`src/infrastructure/plugin/VerbPluginLoader.ts`) imports
+// the module, validates the export shape, and adds the verb to the
+// dispatch fall-through after every built-in case.
+//
+// Trust model: plugins run in-process with full Node capabilities.
+// `guild.config.yaml` must declare `plugins.trusted: true` before any
+// path under `plugins.verbs` is loaded. See `SECURITY.md` § "Plugin
+// trust model".
+//
+// Stability: the export shape is part of the 0.x plugin contract
+// (`docs/POLICY.md` § "Plugin stability"). Renaming or removing a
+// field requires a minor bump + BREAKING marker; adding optional
+// fields is allowed in any release.
+
+import type { JsonSchema } from '../../interface/gate/handlers/schema.js';
+
+// Re-export-ish type for plugin authors. Kept minimal so a plugin
+// can construct it without importing internal infra.
+export type VerbCategory = 'read' | 'write' | 'admin' | 'meta';
+
+/**
+ * Plugin module's default export shape.
+ *
+ * `run` receives the full Container `c` (same value built-in handlers
+ * see) and the parsed args. Return value is the process exit code —
+ * 0 for success, non-zero for failure. Throwing is acceptable; the
+ * dispatcher's top-level catch turns it into an error envelope.
+ */
+export interface VerbPlugin {
+  readonly name: string;
+  readonly category: VerbCategory;
+  readonly summary: string;
+  readonly input: JsonSchema;
+  readonly output: JsonSchema;
+  // The runtime signature is held loose here because VerbPlugin lives
+  // in the application layer and Container is an interface-layer
+  // concept. The infrastructure loader narrows the type when it
+  // wires plugins into dispatch.
+  readonly run: (c: unknown, args: unknown) => Promise<number>;
+}
+
+/**
+ * One per failed plugin path. Surfaced via `gate doctor` so the
+ * operator sees broken plugins instead of silently losing a verb.
+ * Mirrors the doctor-plugin precedent in `DiagnosticUseCases.ts`.
+ */
+export interface VerbPluginLoadError {
+  readonly path: string;
+  readonly reason: string;
+}
+
+/**
+ * Result of a single load pass. Plugins and errors are disjoint —
+ * a path either contributes to `plugins` or to `errors`, never both.
+ * Built-in name collisions land in `errors` (the plugin is rejected).
+ *
+ * `pluginsLoaded` is the per-path loaded/error roll-up used by
+ * `gate doctor` to surface "what ran" — mirrors the
+ * `PluginLoadInfo[]` pattern doctor plugins already use, so the
+ * doctor renderer can treat verb plugin paths the same shape.
+ */
+export interface VerbPluginLoadResult {
+  readonly plugins: readonly VerbPlugin[];
+  readonly errors: readonly VerbPluginLoadError[];
+  readonly pluginsLoaded: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
+}

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -84,6 +84,15 @@ export interface GuildConfigProps {
   hostNames: readonly string[];
   lenses: readonly string[];
   doctorPlugins: readonly string[];
+  /**
+   * Absolute paths of verb plugins to load at CLI startup
+   * (issue #36 Phase 1 step 4). Populated only when `plugins.trusted:
+   * true` is set in `guild.config.yaml`; without that consent the
+   * loader skips every entry under `plugins.verbs` and emits an
+   * `onMalformed` notice. Same trust contract as `doctorPlugins` —
+   * see `SECURITY.md` § "Plugin trust model".
+   */
+  verbPluginPaths: readonly string[];
   profile: GuildProfile;
   features: GuildFeatures;
   onMalformed: OnMalformed;
@@ -105,6 +114,7 @@ export class GuildConfig implements GuildConfigProps {
     readonly hostNames: readonly string[],
     readonly lenses: readonly string[],
     readonly doctorPlugins: readonly string[],
+    readonly verbPluginPaths: readonly string[],
     readonly profile: GuildProfile,
     readonly features: GuildFeatures,
     readonly onMalformed: OnMalformed,
@@ -164,6 +174,28 @@ export class GuildConfig implements GuildConfigProps {
           'Add `trusted: true` under `doctor:` in guild.config.yaml to enable.',
       );
     }
+    // Verb plugins (#36 Phase 1 step 4). Separate consent gate from
+    // doctor.trusted: `plugins.trusted: true` lights up the unified
+    // `plugins:` section that future hook / transform extensions will
+    // share. Without it, every entry under `plugins.verbs` is dropped
+    // with an onMalformed notice. The trust model is identical to
+    // doctor's — plugins run in-process with full Node capabilities,
+    // and the YAML alone is not consent. See `SECURITY.md` § "Plugin
+    // trust model".
+    const pluginsRaw = raw.plugins ?? {};
+    const verbPluginsTrusted = pluginsRaw.trusted === true;
+    const verbPluginPaths = Array.isArray(pluginsRaw.verbs) && verbPluginsTrusted
+      ? pluginsRaw.verbs
+          .filter((x: unknown): x is string => typeof x === 'string')
+          .map((x: string) => resolveUnder(root, x))
+      : [];
+    if (Array.isArray(pluginsRaw.verbs) && pluginsRaw.verbs.length > 0 && !verbPluginsTrusted) {
+      onMalformed(
+        configPath,
+        'plugins.verbs present but plugins.trusted is not true — verb plugins will NOT be loaded. ' +
+          'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
+      );
+    }
     // Profile + features (#231). The two interact: `profile: swarm`
     // flips the default of `features.worktree_required_for_parallel`
     // to true, but an explicit `features:` block always wins so a
@@ -213,7 +245,7 @@ export class GuildConfig implements GuildConfigProps {
         explicitWorktreeRequired ?? (profile === 'swarm'),
       selfApprove,
     };
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, profile, features, onMalformed, configPath);
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, profile, features, onMalformed, configPath);
   }
 
   static default(
@@ -232,6 +264,7 @@ export class GuildConfig implements GuildConfigProps {
       },
       [...DEFAULT_HOSTS],
       [...DEFAULT_LENSES],
+      [],
       [],
       'standard',
       { worktreeRequiredForParallel: false, selfApprove: 'warn' },

--- a/src/infrastructure/plugin/VerbPluginLoader.ts
+++ b/src/infrastructure/plugin/VerbPluginLoader.ts
@@ -1,0 +1,138 @@
+// Verb plugin loader (issue #36 Phase 1 step 4).
+//
+// Reads paths from `guild.config.yaml`'s `plugins.verbs` (already
+// trust-gated by GuildConfig — see `plugins.trusted: true`) and
+// dynamically imports each as an ES module. Validates the export
+// shape, rejects collisions with built-in verb names, and collects
+// errors per path so a single broken plugin doesn't take the rest
+// of the loader down with it.
+//
+// Mirrors the doctor-plugin loader in
+// `src/application/diagnostic/DiagnosticUseCases.ts`:
+//   - `pathToFileURL` for cross-platform absolute imports (Windows
+//     ESM rejects bare `C:\...` paths)
+//   - `default ?? mod` to accept both `export default {...}` and
+//     `module.exports = {...}` shapes
+//   - errors become structured records, never thrown
+
+import { pathToFileURL } from 'node:url';
+import {
+  VerbPlugin,
+  VerbPluginLoadError,
+  VerbPluginLoadResult,
+  VerbCategory,
+} from '../../application/plugin/VerbPlugin.js';
+
+const VALID_CATEGORIES: ReadonlySet<VerbCategory> = new Set([
+  'read',
+  'write',
+  'admin',
+  'meta',
+]);
+
+/**
+ * Validate a freshly-imported module's default export against the
+ * VerbPlugin shape. Returns the plugin when valid, or a reason string
+ * when not. Pure — no side effects, no I/O — so the loader's error
+ * branch can be reasoned about line-by-line.
+ */
+function validatePluginShape(raw: unknown): { ok: true; plugin: VerbPlugin } | { ok: false; reason: string } {
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, reason: 'default export is not an object' };
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj['name'] !== 'string' || obj['name'].length === 0) {
+    return { ok: false, reason: 'name must be a non-empty string' };
+  }
+  if (!/^[a-z][a-z0-9-]*$/.test(obj['name'])) {
+    // Match the dispatch table's verb naming convention so plugin
+    // names land in shell-friendly territory and the same regex
+    // KNOWN_COMMANDS / `nearestCommand` use can find them.
+    return {
+      ok: false,
+      reason: `name "${obj['name']}" is not a valid verb (lowercase, digits, hyphens; must start with a letter)`,
+    };
+  }
+  if (typeof obj['category'] !== 'string' || !VALID_CATEGORIES.has(obj['category'] as VerbCategory)) {
+    return {
+      ok: false,
+      reason: `category must be one of ${Array.from(VALID_CATEGORIES).join(' | ')}, got: ${JSON.stringify(obj['category'])}`,
+    };
+  }
+  if (typeof obj['summary'] !== 'string' || obj['summary'].length === 0) {
+    return { ok: false, reason: 'summary must be a non-empty string' };
+  }
+  if (obj['input'] === null || typeof obj['input'] !== 'object') {
+    return { ok: false, reason: 'input must be a JsonSchema object' };
+  }
+  if (obj['output'] === null || typeof obj['output'] !== 'object') {
+    return { ok: false, reason: 'output must be a JsonSchema object' };
+  }
+  if (typeof obj['run'] !== 'function') {
+    return { ok: false, reason: 'run must be a function (c, args) => Promise<number>' };
+  }
+  return { ok: true, plugin: obj as unknown as VerbPlugin };
+}
+
+/**
+ * Load every path in `pluginPaths` as a verb plugin. Built-in verb
+ * names in `reservedNames` reject the plugin (collision is treated
+ * as an error, not a silent shadow — built-ins always win).
+ *
+ * Two plugins claiming the same name in the same load pass: the
+ * first wins, the rest are rejected. Order is the order of the
+ * `plugins.verbs` array in `guild.config.yaml`.
+ */
+export async function loadVerbPlugins(
+  pluginPaths: readonly string[],
+  reservedNames: ReadonlySet<string>,
+): Promise<VerbPluginLoadResult> {
+  const plugins: VerbPlugin[] = [];
+  const errors: VerbPluginLoadError[] = [];
+  const pluginsLoaded: Array<{ path: string; status: 'loaded' | 'error' }> = [];
+  const seenNames = new Set<string>();
+
+  for (const pluginPath of pluginPaths) {
+    let mod: { default?: unknown } & Record<string, unknown>;
+    try {
+      mod = await import(pathToFileURL(pluginPath).href);
+    } catch (e) {
+      errors.push({
+        path: pluginPath,
+        reason: `import failed: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    // Accept both `export default { ... }` and `module.exports = { ... }`
+    // forms — same tolerance the doctor-plugin loader uses.
+    const exportRoot = mod.default ?? mod;
+    const result = validatePluginShape(exportRoot);
+    if (!result.ok) {
+      errors.push({ path: pluginPath, reason: result.reason });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    const plugin = result.plugin;
+    if (reservedNames.has(plugin.name)) {
+      errors.push({
+        path: pluginPath,
+        reason: `verb "${plugin.name}" collides with a built-in — built-ins always win, plugin rejected`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    if (seenNames.has(plugin.name)) {
+      errors.push({
+        path: pluginPath,
+        reason: `verb "${plugin.name}" is already registered by an earlier plugin in this load pass`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    seenNames.add(plugin.name);
+    plugins.push(plugin);
+    pluginsLoaded.push({ path: pluginPath, status: 'loaded' });
+  }
+  return { plugins, errors, pluginsLoaded };
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -28,7 +28,7 @@ const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb']);
  *    consumable by any schema-aware LLM.
  */
 
-type JsonSchema = {
+export type JsonSchema = {
   type?: string;
   properties?: Record<string, JsonSchema>;
   required?: string[];
@@ -38,7 +38,7 @@ type JsonSchema = {
   oneOf?: JsonSchema[];
 };
 
-interface VerbSchema {
+export interface VerbSchema {
   readonly name: string;
   readonly summary: string;
   readonly category: 'read' | 'write' | 'admin' | 'meta';
@@ -1314,16 +1314,31 @@ const VERBS: readonly VerbSchema[] = [
   },
 ];
 
-export async function schemaCmd(_c: C, args: ParsedArgs): Promise<number> {
+export async function schemaCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SCHEMA_KNOWN_FLAGS, 'schema');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
   }
   const verbFilter = optionalOption(args, 'verb');
+  // Plugin verbs (#36 Phase 1 step 4) are spliced into the schema
+  // payload as siblings of built-ins. They carry `source: 'plugin'`
+  // so a consumer can filter on origin without a name lookup. Built-
+  // ins always come first — `gate schema --format text` reads
+  // top-down, and burying core surface under plugins would push the
+  // most-used verbs off-screen on small terminals.
+  const pluginVerbs: VerbSchema[] = c.verbPlugins.map((p) => ({
+    name: p.name,
+    category: p.category,
+    summary: p.summary,
+    input: p.input,
+    output: p.output,
+    source: 'plugin',
+  }));
+  const allVerbs: VerbSchema[] = [...VERBS, ...pluginVerbs];
   const verbs = verbFilter
-    ? VERBS.filter((v) => v.name === verbFilter)
-    : VERBS;
+    ? allVerbs.filter((v) => v.name === verbFilter)
+    : allVerbs;
   if (verbFilter && verbs.length === 0) {
     throw new Error(`unknown verb: ${verbFilter}`);
   }

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -1,4 +1,6 @@
 import { buildContainer } from '../shared/container.js';
+import { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
+import { loadVerbPlugins } from '../../infrastructure/plugin/VerbPluginLoader.js';
 import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
 import { nearestCommand } from '../shared/nearestCommand.js';
@@ -288,7 +290,23 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 0;
   }
   const args = parseArgs(rest);
-  const c = buildContainer();
+  // Verb plugins (#36 Phase 1 step 4). Loaded before buildContainer
+  // because dynamic ESM `import()` is async; the container itself
+  // stays synchronous so test bootstraps don't need to thread an
+  // async pre-pass through their helpers. Built-in command names
+  // are reserved — the loader rejects collisions, so a plugin can
+  // never shadow a core verb.
+  const config = GuildConfig.load();
+  const builtInNames = new Set<string>(KNOWN_COMMANDS);
+  const verbPluginLoad = await loadVerbPlugins(
+    config.verbPluginPaths,
+    builtInNames,
+  );
+  const c = buildContainer({
+    verbPlugins: verbPluginLoad.plugins,
+    verbPluginErrors: verbPluginLoad.errors,
+    verbPluginsLoaded: verbPluginLoad.pluginsLoaded,
+  });
   try {
     // #200: <write-verb> --help must not block on the lock. Help is
     // read-only; routing it through withEntryLock would surface
@@ -304,11 +322,24 @@ export async function main(argv: readonly string[]): Promise<number> {
     // --by/--from at the entry layer is intentionally out of scope
     // (deferred follow-up); this is a strictly diagnostic improvement.
     const actor = resolveGuildActor() ?? '(unset)';
+    // Augment the verb sets with the loaded plugins so the lock
+    // middleware classifies plugin verbs by their declared category
+    // rather than falling through to the unknown→write fail-safe.
+    // category 'meta' rides with READ (introspection); 'admin' rides
+    // with LOCK_EXEMPT (doctor / repair maintenance pattern).
+    const readSet = new Set<string>(READ_VERBS);
+    const writeSet = new Set<string>(WRITE_VERBS);
+    const exemptSet = new Set<string>(LOCK_EXEMPT_VERBS);
+    for (const p of c.verbPlugins) {
+      if (p.category === 'read' || p.category === 'meta') readSet.add(p.name);
+      else if (p.category === 'write') writeSet.add(p.name);
+      else if (p.category === 'admin') exemptSet.add(p.name);
+    }
     return await withEntryLock(
       c.config,
       'gate',
       cmd,
-      { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS },
+      { READ_VERBS: readSet, WRITE_VERBS: writeSet, LOCK_EXEMPT_VERBS: exemptSet },
       actor,
       () => dispatch(cmd, c, args),
     );
@@ -423,7 +454,24 @@ async function dispatch(
     case 'templates':
       return await templatesCmd(c, args);
     default: {
-      const hint = nearestCommand(cmd, KNOWN_COMMANDS);
+      // Verb plugin dispatch (#36 Phase 1 step 4). Built-in cases
+      // run first (the switch above); plugins are the fall-through
+      // step before "unknown command". Built-in name collisions are
+      // already filtered out in the loader, so a plugin reaching
+      // this point is guaranteed not to shadow core dispatch.
+      for (const p of c.verbPlugins) {
+        if (p.name === cmd) {
+          return await p.run(c, args);
+        }
+      }
+      // The did-you-mean hint searches both core verbs and loaded
+      // plugins so a typo against a plugin verb still gets a useful
+      // suggestion ("did you mean: gate myverb?").
+      const candidates = [
+        ...KNOWN_COMMANDS,
+        ...c.verbPlugins.map((p) => p.name),
+      ];
+      const hint = nearestCommand(cmd, candidates);
       const suggest = hint ? `\n  did you mean: gate ${hint}?` : '';
       process.stderr.write(
         `unknown command: ${cmd}${suggest}\n` +

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -20,6 +20,10 @@ import { YamlPlayRepository } from '../../passages/agora/infrastructure/YamlPlay
 import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
 import { FsTemplateRepository } from '../../infrastructure/template/TemplateRepository.js';
 import { TemplateUseCases } from '../../application/template/TemplateUseCases.js';
+import {
+  VerbPlugin,
+  VerbPluginLoadError,
+} from '../../application/plugin/VerbPlugin.js';
 
 export interface Container {
   config: GuildConfig;
@@ -47,6 +51,22 @@ export interface Container {
    * `<content_root>/data/guild/templates/wave-brief/`.
    */
   templateUC: TemplateUseCases;
+  /**
+   * Verb plugins loaded at CLI startup (issue #36 Phase 1 step 4).
+   * Empty array when `plugins.trusted: true` is absent from
+   * `guild.config.yaml` or no plugins are listed under `plugins.verbs`.
+   * Built-in verb names are reserved — collisions are rejected by the
+   * loader and surface as `verbPluginErrors` rather than overriding
+   * core dispatch.
+   */
+  verbPlugins: readonly VerbPlugin[];
+  /**
+   * Per-path load failures from the verb plugin loader. Surfaced via
+   * `gate doctor` so a broken plugin is visible to the operator
+   * instead of silently dropping the verb. Empty array on a clean
+   * load.
+   */
+  verbPluginErrors: readonly VerbPluginLoadError[];
 }
 
 export interface BuildContainerOpts {
@@ -56,6 +76,27 @@ export interface BuildContainerOpts {
    * (issue #155 PR-B pin test); production never sets this.
    */
   cwd?: string;
+  /**
+   * Pre-loaded verb plugins (issue #36 Phase 1 step 4). main() loads
+   * them via `loadVerbPlugins` before constructing the container —
+   * dynamic ESM import is async, so the loading can't live inside
+   * the synchronous `buildContainer` call. Defaults to `[]` so tests
+   * and use-cases that don't care about plugins stay unchanged.
+   */
+  verbPlugins?: readonly VerbPlugin[];
+  /**
+   * Per-path load errors collected by the verb plugin loader.
+   * Defaults to `[]`. `gate doctor` reads this list and surfaces
+   * each entry as a finding (`area: 'plugin'`).
+   */
+  verbPluginErrors?: readonly VerbPluginLoadError[];
+  /**
+   * Per-path load outcome (success + failure) from the verb plugin
+   * loader. Mirrors the `PluginLoadInfo[]` shape doctor plugins use
+   * so the doctor renderer can display verb plugin paths in the
+   * same "plugins loaded" section. Defaults to `[]`.
+   */
+  verbPluginsLoaded?: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
 }
 
 export function buildContainer(opts: BuildContainerOpts = {}): Container {
@@ -89,6 +130,18 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
       buildDiagRepos,
       config.doctorPlugins,
       { root: config.root, contentRoot: config.contentRoot },
+      {
+        // Surface every loader path (success + failure) so doctor
+        // displays "what ran" identically to doctor plugins. Falls
+        // back to a derived list when only `verbPlugins` was passed
+        // (test convenience), but production main() always provides
+        // both arrays explicitly via opts.
+        pluginsLoaded: opts.verbPluginsLoaded ?? [],
+        errors: (opts.verbPluginErrors ?? []).map((e) => ({
+          path: e.path,
+          reason: e.reason,
+        })),
+      },
     ),
     repairUC: new RepairUseCases(quarantine),
     unrespondedConcernsQ: new UnrespondedConcernsQuery(requests, issues),
@@ -96,5 +149,7 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     templateUC: new TemplateUseCases(
       new FsTemplateRepository(config.contentRoot, config.onMalformed),
     ),
+    verbPlugins: opts.verbPlugins ?? [],
+    verbPluginErrors: opts.verbPluginErrors ?? [],
   };
 }

--- a/tests/interface/verbPluginLoader.test.ts
+++ b/tests/interface/verbPluginLoader.test.ts
@@ -1,0 +1,233 @@
+// Verb plugin loader (issue #36 Phase 1 step 4).
+//
+// End-to-end tests via the gate CLI:
+//   - successful load: a valid plugin's verb dispatches and `gate
+//     schema` lists it with `source: "plugin"`
+//   - name collision with built-in: rejected, surfaces via `gate
+//     doctor` as a finding (area: 'plugin')
+//   - missing file: same — error finding, CLI keeps working
+//   - broken module (syntax error): error finding, no crash
+//   - no `plugins.trusted: true`: paths are silently skipped (with
+//     onMalformed notice on stderr)
+//
+// The unit-level shape validation lives inline in the loader itself
+// and is exercised here via the broken-shape test (export not an
+// object → error finding).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+interface Bootstrap {
+  root: string;
+  pluginDir: string;
+  cleanup: () => void;
+}
+
+function bootstrap(extraConfig = ''): Bootstrap {
+  const root = makeTempRoot('gate-vp-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n' + extraConfig,
+  );
+  mkdirSync(join(root, 'members'));
+  mkdirSync(join(root, 'plugins'));
+  return {
+    root,
+    pluginDir: join(root, 'plugins'),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+const VALID_PLUGIN = `export default {
+  name: 'myverb',
+  category: 'meta',
+  summary: 'plugin test verb',
+  input: { type: 'object', properties: { text: { type: 'string' } } },
+  output: { type: 'object' },
+  run: async (_c, args) => {
+    process.stdout.write('plugin ran with text=' + args.options['text'] + '\\n');
+    return 0;
+  },
+};`;
+
+test('verb plugin: loads + dispatches when plugins.trusted: true', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/myverb.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'myverb.mjs'), VALID_PLUGIN);
+
+  const r = runGate(root, ['myverb', '--text', 'hello']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /plugin ran with text=hello/);
+});
+
+test('verb plugin: gate schema lists the plugin verb with source="plugin"', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/myverb.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'myverb.mjs'), VALID_PLUGIN);
+
+  const r = runGate(root, ['schema', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const myverb = (payload.verbs as Array<{ name: string; source: string }>).find(
+    (v) => v.name === 'myverb',
+  );
+  assert.ok(myverb, 'plugin verb is in the schema payload');
+  assert.equal(myverb!.source, 'plugin');
+});
+
+test('verb plugin: gate schema --format text tags the plugin verb [plugin]', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/myverb.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'myverb.mjs'), VALID_PLUGIN);
+
+  const r = runGate(root, ['schema', '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /myverb \[meta\] \[plugin\] — plugin test verb/);
+});
+
+test('verb plugin: name collision with built-in is rejected, error surfaces via gate doctor', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/colliding.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'colliding.mjs'),
+    VALID_PLUGIN.replace("name: 'myverb'", "name: 'request'"),
+  );
+
+  // Built-in `request` verb still works — plugin shadow rejected.
+  // (No need to actually invoke it — the schema check is sufficient
+  // to confirm dispatch wasn't hijacked.)
+  const schema = runGate(root, ['schema', '--format', 'json', '--verb', 'request']);
+  assert.equal(schema.status, 0);
+  const payload = JSON.parse(schema.stdout);
+  const requestVerb = payload.verbs.find((v: { name: string }) => v.name === 'request');
+  assert.equal(requestVerb.source, 'core', 'built-in `request` was not shadowed');
+
+  // doctor surfaces the collision as a plugin-area finding.
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /collides with a built-in/.test(f.message),
+  );
+  assert.ok(finding, `expected collision finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('verb plugin: missing file surfaces as gate doctor finding (CLI keeps working)', (t) => {
+  const { root, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/does-not-exist.mjs\n',
+  );
+  t.after(cleanup);
+
+  // Read verbs still work despite the broken plugin path.
+  const status = runGate(root, ['status']);
+  assert.equal(status.status, 0);
+
+  // doctor surfaces the load failure.
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /import failed/.test(f.message),
+  );
+  assert.ok(finding, `expected import-failed finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('verb plugin: broken shape (export not an object) is rejected with a finding', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n    - plugins/broken.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'broken.mjs'), `export default 42;`);
+
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /default export is not an object/.test(f.message),
+  );
+  assert.ok(finding, `expected shape-error finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('verb plugin: plugins.trusted absent → loader skips with onMalformed notice', (t) => {
+  // No `trusted: true` → plugin paths drop with an onMalformed
+  // notice. This is the consent gate: the YAML alone is not
+  // consent. See SECURITY.md § "Plugin trust model".
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  verbs:\n    - plugins/myverb.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'myverb.mjs'), VALID_PLUGIN);
+
+  // The plugin verb is NOT registered.
+  const schema = runGate(root, ['schema', '--format', 'json']);
+  assert.equal(schema.status, 0);
+  const payload = JSON.parse(schema.stdout);
+  const found = payload.verbs.find((v: { name: string }) => v.name === 'myverb');
+  assert.equal(found, undefined, 'plugin verb must not register without plugins.trusted: true');
+
+  // The notice surfaces on stderr (somewhere — gate verbs all share
+  // the GuildConfig.load path that emits onMalformed). Pick a quiet
+  // verb whose stderr is empty in the clean case.
+  const status = runGate(root, ['status']);
+  assert.equal(status.status, 0);
+  assert.match(
+    status.stderr,
+    /plugins\.verbs present but plugins\.trusted is not true/,
+  );
+});
+
+test('verb plugin: duplicate names within one load pass — first wins, rest rejected', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  verbs:\n' +
+      '    - plugins/first.mjs\n' +
+      '    - plugins/second.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'first.mjs'), VALID_PLUGIN);
+  // Both export the same `name: 'myverb'`.
+  writeFileSync(join(pluginDir, 'second.mjs'), VALID_PLUGIN);
+
+  const schema = runGate(root, ['schema', '--format', 'json']);
+  const payload = JSON.parse(schema.stdout);
+  const myverbs = payload.verbs.filter((v: { name: string }) => v.name === 'myverb');
+  assert.equal(myverbs.length, 1, 'only the first registration wins');
+
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const dup = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /already registered by an earlier plugin/.test(f.message),
+  );
+  assert.ok(dup, 'second registration is rejected with a finding');
+});


### PR DESCRIPTION
## Summary

Step 4 of #36 Phase 1's "Lightest-first work order" — the verb plugin loader. Operators can now ship custom `gate <verb>` implementations without forking the core, gated on explicit consent (`plugins.trusted: true`).

Lands cleanly into the contract step 1–3 set up (PR #257): VerbSchema's `source: 'core' | 'plugin'` discriminator, the `plugins.trusted: true` consent surface, and "plugin failures are non-fatal" all become operationally real here.

## Operator surface

```yaml
# guild.config.yaml
plugins:
  trusted: true              # consent gate — yaml alone is not consent
  verbs:
    - plugins/echo.mjs
```

```js
// plugins/echo.mjs
export default {
  name: 'echo',
  category: 'meta',
  summary: 'echo --text <s> back to stdout',
  input:  { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
  output: { type: 'object', properties: { ok: { type: 'boolean' }, text: { type: 'string' } } },
  run: async (c, args) => {
    process.stdout.write(args.options['text'] + '\n');
    return 0;
  },
};
```

```
$ gate echo --text 'hello world'
hello world

$ gate schema --format json --verb echo | jq '.verbs[0].source'
"plugin"

$ gate schema --format text | grep echo
echo [meta] [plugin] — echo --text <s> back to stdout (example verb plugin from #36)

$ gate doctor --format text | tail -3
plugins loaded: 1
    ✓ [loaded] /path/to/plugins/echo.mjs

✓ clean — no malformed records detected
```

## Pipeline

- **`main()`** loads plugins via `loadVerbPlugins()` before `buildContainer` (dynamic ESM import is async; container stays sync)
- **`dispatch()`** falls through to plugin map after every built-in case; built-in collisions are already rejected by the loader, so a plugin can **never** shadow a core verb
- **did-you-mean hint** searches both core verbs and plugin names
- **Lock middleware** classifies plugin verbs by their declared category (`read` / `meta` → no lock, `write` → lock, `admin` → exempt)
- **`gate schema`** emits each plugin verb with `source: 'plugin'`; text mode tags it `[plugin]`
- **`gate doctor`** surfaces load errors as findings (`area: 'plugin'`) and adds successful loads to the "plugins loaded" list

## Trust contract

Already documented in #36 step 1+2 (PR #257). Operationalized here:
- Plugins run **in-process** with full Node capabilities — no sandbox
- `plugins.trusted: true` is the operator consent surface; a config listing plugins **without** the trust declaration drops them with an `onMalformed` notice on stderr ("yaml alone is not consent")
- Plugin failures are non-fatal — broken plugins surface as doctor findings but never crash the CLI
- Built-in name collisions reject the plugin (built-ins always win)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1337/1337 pass on linux (8 new tests)
  - load + dispatch end-to-end via spawned gate
  - `gate schema` lists plugin verb with `source: 'plugin'`
  - text mode tags plugin verb as `[plugin]`
  - name collision with built-in → rejected, doctor finding
  - missing file → loader error finding, CLI keeps running
  - broken shape (export not an object) → finding
  - `plugins.trusted` absent → silent skip + onMalformed notice
  - duplicate names within one load pass → first wins, rest rejected
- [x] Visual sanity check on a live plugin loaded under content_root

## Files

- `src/application/plugin/VerbPlugin.ts` — `VerbPlugin` interface + `VerbPluginLoadResult`
- `src/infrastructure/plugin/VerbPluginLoader.ts` — async loader with shape validation + collision check
- `src/infrastructure/config/GuildConfig.ts` — `plugins.verbs` + `plugins.trusted` parsing
- `src/interface/shared/container.ts` — Container carries `verbPlugins` / `verbPluginErrors` / `verbPluginsLoaded`
- `src/interface/gate/index.ts` — load → dispatch fall-through, dynamic verb-set augmentation
- `src/interface/gate/handlers/schema.ts` — splice plugin verbs into the schema payload
- `src/application/diagnostic/DiagnosticUseCases.ts` — fold verb plugin errors into doctor findings
- `examples/plugins/verbs/echo.mjs` — minimum viable plugin example
- `tests/interface/verbPluginLoader.test.ts` — 8 new tests

## Next

Steps 5 (lifecycle hooks `before:` / `after:`), 6 (content transforms `on:save` / `on:load`), 7 (`examples/plugins/` end-to-end suite) remain for future PRs. The contract this PR pins down — that plugins go through `plugins.trusted`, that load errors are non-fatal, that `source: 'plugin'` discriminates schema entries — gives those follow-ups a stable foundation.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_