### PR TITLE
feat(gate): lifecycle hooks bus (#36 Phase 1 step 5)

### DIFF
--- a/examples/plugins/hooks/audit-log.mjs
+++ b/examples/plugins/hooks/audit-log.mjs
@@ -1,0 +1,58 @@
+// Example hook plugin (issue #36 Phase 1 step 5).
+//
+// Subscribes to every `after:` event and appends an audit-log line
+// to a file under content_root. Demonstrates:
+//   - multi-event subscription via the array form of `on`
+//   - the `after:` shape — observation only, no veto
+//   - reading the request through `ctx.request` (post-mutation
+//     snapshot for after-events)
+//
+// To enable:
+//
+//   # guild.config.yaml
+//   plugins:
+//     trusted: true
+//     hooks:
+//       - examples/plugins/hooks/audit-log.mjs
+//
+// Each transition appends one JSON line to `audit.log` next to
+// guild.config.yaml:
+//
+//   {"at":"2026-...","event":"after:approve","id":"2026-...","by":"alice","state":"approved"}
+
+import { appendFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Resolve the audit log next to THIS plugin file. Real deployments
+// might want to honour a content-root-relative path or environment
+// override; the example keeps it simple.
+const here = dirname(fileURLToPath(import.meta.url));
+const AUDIT_LOG = join(here, '..', '..', '..', '..', 'audit.log');
+
+export default {
+  on: [
+    'after:approve',
+    'after:deny',
+    'after:execute',
+    'after:complete',
+    'after:fail',
+    'after:review',
+  ],
+  run: async (ctx) => {
+    const line = JSON.stringify({
+      at: new Date().toISOString(),
+      event: ctx.event,
+      id: ctx.request.id.value,
+      by: ctx.actor,
+      state: ctx.request.state,
+    });
+    try {
+      appendFileSync(AUDIT_LOG, line + '\n', 'utf8');
+    } catch {
+      // Per the contract: after-hook errors are warnings, not faults.
+      // Swallowing here means the audit logger is best-effort by
+      // design — a full disk shouldn't take down the lifecycle.
+    }
+  },
+};

--- a/src/application/diagnostic/DiagnosticUseCases.ts
+++ b/src/application/diagnostic/DiagnosticUseCases.ts
@@ -192,12 +192,19 @@ export class DiagnosticUseCases {
     // sufficient — doctor plugins are filesystem paths under root,
     // verb plugins are too, and any path-shaped string is a path
     // for display purposes.
+    // Caller (`buildContainer` for the gate entry) prefixes the
+    // reason with the plugin kind ("verb plugin: ..." / "hook
+    // plugin: ...") before passing in, so this layer doesn't need
+    // to discriminate. Keeping the formatting at the wiring layer
+    // means future plugin kinds (transforms, etc.) only need to
+    // rename their own prefix without revisiting the diagnostic
+    // domain.
     for (const e of this.verbPlugins.errors) {
       findings.push({
         area: 'plugin',
         source: e.path,
         kind: 'unknown',
-        message: `verb plugin error: ${e.reason}`,
+        message: e.reason,
       });
     }
     const allPluginsLoaded: PluginLoadInfo[] = [

--- a/src/application/plugin/HookBus.ts
+++ b/src/application/plugin/HookBus.ts
@@ -1,0 +1,118 @@
+// Hook dispatch helpers (issue #36 Phase 1 step 5).
+//
+// Two entry points the lifecycle handlers call:
+//
+//   `fireBeforeHook(subs, event, request, actor)` → HookVeto | null
+//     Runs every subscriber to `before:<event>` in registration order.
+//     First veto wins — remaining hooks do NOT run after a veto.
+//     A hook that throws is treated as a veto (fail-closed) — a buggy
+//     security policy hook should block the transition, not silently
+//     pass it through.
+//
+//   `fireAfterHook(subs, event, request, actor)` → void
+//     Runs every subscriber to `after:<event>` in order. Errors are
+//     written to stderr but never propagate; the transition has
+//     already succeeded by this point and the response is about to
+//     be emitted, so a failing hook is a warning, not a fault.
+
+import {
+  HookContext,
+  HookEvent,
+  HookFn,
+  HookVeto,
+} from './HookPlugin.js';
+import type { Request } from '../../domain/request/Request.js';
+
+export type HookSubscriptions = ReadonlyMap<HookEvent, readonly HookFn[]>;
+
+/**
+ * The verb half of a hook event. Used by handlers to compose
+ * `before:<verb>` / `after:<verb>` without typo risk on the prefix.
+ */
+export type LifecycleVerb =
+  | 'approve'
+  | 'deny'
+  | 'execute'
+  | 'complete'
+  | 'fail'
+  | 'review';
+
+function toEvent(prefix: 'before' | 'after', verb: LifecycleVerb): HookEvent {
+  return `${prefix}:${verb}` as HookEvent;
+}
+
+/**
+ * Fire every `before:<verb>` subscriber in order. Returns the first
+ * veto seen, or null if all hooks passed (or none subscribed). Hook
+ * errors are converted to vetoes — see file header for rationale.
+ */
+export async function fireBeforeHook(
+  subs: HookSubscriptions,
+  verb: LifecycleVerb,
+  request: Request,
+  actor: string,
+  extra?: HookContext['extra'],
+): Promise<HookVeto | null> {
+  const event = toEvent('before', verb);
+  const fns = subs.get(event);
+  if (!fns || fns.length === 0) return null;
+  const ctx: HookContext = extra !== undefined
+    ? { event, request, actor, extra }
+    : { event, request, actor };
+  for (const fn of fns) {
+    let result: void | HookVeto;
+    try {
+      result = await fn(ctx);
+    } catch (e) {
+      return {
+        allow: false,
+        reason: `hook threw on ${event}: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+    if (result && typeof result === 'object' && (result as HookVeto).allow === false) {
+      return result as HookVeto;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fire every `after:<verb>` subscriber in order. Hooks errors are
+ * written to stderr as warnings; they never break the handler.
+ */
+export async function fireAfterHook(
+  subs: HookSubscriptions,
+  verb: LifecycleVerb,
+  request: Request,
+  actor: string,
+  extra?: HookContext['extra'],
+): Promise<void> {
+  const event = toEvent('after', verb);
+  const fns = subs.get(event);
+  if (!fns || fns.length === 0) return;
+  const ctx: HookContext = extra !== undefined
+    ? { event, request, actor, extra }
+    : { event, request, actor };
+  for (const fn of fns) {
+    try {
+      await fn(ctx);
+    } catch (e) {
+      process.stderr.write(
+        `warning: hook threw on ${event}: ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+    }
+  }
+}
+
+/**
+ * Render a veto into the standard handler stderr format and return
+ * exit code 1. Centralised so every lifecycle handler emits the same
+ * shape — an operator's grep for "hook vetoed" finds the entry
+ * regardless of which verb tripped.
+ */
+export function emitHookVeto(verb: LifecycleVerb, id: string, veto: HookVeto): number {
+  process.stderr.write(
+    `error: hook vetoed ${verb} on ${id}: ${veto.reason}\n`,
+  );
+  return 1;
+}

--- a/src/application/plugin/HookPlugin.ts
+++ b/src/application/plugin/HookPlugin.ts
@@ -1,0 +1,131 @@
+// Lifecycle hook plugin contract (issue #36 Phase 1 step 5).
+//
+// A hook plugin subscribes to one or more lifecycle events and runs
+// at the corresponding point in the dispatch pipeline. There are two
+// flavours:
+//
+//   `before:<verb>`  — runs after argument validation, before the
+//                      mutation. May veto by returning
+//                      `{ allow: false, reason }`. A veto blocks the
+//                      transition; the handler returns exit code 1 and
+//                      writes the reason to stderr. First veto wins —
+//                      remaining `before:` hooks for the same event
+//                      do NOT run after a veto, so an order-sensitive
+//                      "deny everything else" hook can sit at the end.
+//
+//   `after:<verb>`   — runs after the mutation succeeded, before the
+//                      handler emits its write response. Cannot veto
+//                      (the transition already happened). Errors are
+//                      logged to stderr but never break the handler.
+//                      Use for audit trails / external notification /
+//                      derived index rebuilds.
+//
+// Events covered in phase 1 (request lifecycle + review):
+//   before/after:approve, deny, execute, complete, fail, review
+//
+// Hooks run in the order their plugin paths appear in
+// `plugins.hooks` in `guild.config.yaml`. Same trust model as verb
+// plugins: `plugins.trusted: true` is the consent gate, plugins
+// run in-process with full Node capabilities. See `SECURITY.md`
+// § "Plugin trust model".
+
+import type { Request } from '../../domain/request/Request.js';
+import type { DevilReview } from '../../passages/devil/domain/DevilReview.js';
+
+/**
+ * The lifecycle events a hook can subscribe to. Phase 1 covers the
+ * five request transitions plus review. fast-track / claim / witness
+ * / unwitness / thank are intentionally out of scope for v1 — they
+ * either compose multiple events (fast-track) or sit on a different
+ * axis from state transitions (the stake/observe verbs). Adding
+ * those is additive within the 0.x line per `docs/POLICY.md`
+ * § "Plugin stability".
+ */
+export type HookEvent =
+  | 'before:approve' | 'after:approve'
+  | 'before:deny'    | 'after:deny'
+  | 'before:execute' | 'after:execute'
+  | 'before:complete' | 'after:complete'
+  | 'before:fail'    | 'after:fail'
+  | 'before:review'  | 'after:review';
+
+export const ALL_HOOK_EVENTS: readonly HookEvent[] = [
+  'before:approve', 'after:approve',
+  'before:deny',    'after:deny',
+  'before:execute', 'after:execute',
+  'before:complete', 'after:complete',
+  'before:fail',    'after:fail',
+  'before:review',  'after:review',
+];
+
+/**
+ * Per-event context the hook receives. The `request` is the
+ * pre-mutation snapshot for `before:` events (so a veto sees the
+ * original state) and the post-mutation snapshot for `after:`
+ * events (so an audit hook sees the new state). `actor` is the
+ * canonicalised `--by` / `--from` invoker.
+ *
+ * `extra` carries event-specific payload — currently only `review`
+ * uses it (carries the DevilReview-like record). Kept as an
+ * optional discriminated field so phase-2 events can extend without
+ * a breaking change to the base shape.
+ */
+export interface HookContext {
+  readonly event: HookEvent;
+  readonly request: Request;
+  readonly actor: string;
+  readonly extra?: { readonly review?: DevilReview | unknown };
+}
+
+/**
+ * Veto result from a `before:` hook. Returning this from a `before:`
+ * hook blocks the transition; the handler exits 1 and writes the
+ * reason to stderr.
+ */
+export interface HookVeto {
+  readonly allow: false;
+  readonly reason: string;
+}
+
+/**
+ * Hook function shape. Async to accommodate plugins that need I/O
+ * (audit trail write, external notification). Per the issue's
+ * "must not block the transition on slow I/O" rule, hooks should
+ * keep blocking work small — for unbounded work, spawn and return.
+ */
+export type HookFn = (ctx: HookContext) => Promise<void | HookVeto> | void | HookVeto;
+
+/**
+ * Plugin module's default export shape for hook plugins.
+ *
+ * `on` may name a single event or an array of events; the bus
+ * subscribes the same `run` function to each entry. Use the array
+ * form when one piece of logic spans multiple lifecycle points
+ * (e.g. an audit hook covering `after:approve` / `after:complete`
+ * / `after:fail` / `after:deny`).
+ */
+export interface HookPlugin {
+  readonly on: HookEvent | readonly HookEvent[];
+  readonly run: HookFn;
+}
+
+/**
+ * Per-path load failure. Same shape as `VerbPluginLoadError`,
+ * surfaced through `gate doctor` as an `area: 'plugin'` finding.
+ */
+export interface HookPluginLoadError {
+  readonly path: string;
+  readonly reason: string;
+}
+
+/**
+ * Result of a single load pass. `subscriptions` is the resolved
+ * map from event → ordered list of HookFn (one entry per (plugin,
+ * event) pair, in plugin-path order). Empty arrays for unsubscribed
+ * events are omitted — readers `.get(event) ?? []`.
+ */
+export interface HookPluginLoadResult {
+  readonly subscriptions: ReadonlyMap<HookEvent, readonly HookFn[]>;
+  readonly errors: readonly HookPluginLoadError[];
+  readonly pluginsLoaded: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
+}

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -93,6 +93,15 @@ export interface GuildConfigProps {
    * see `SECURITY.md` § "Plugin trust model".
    */
   verbPluginPaths: readonly string[];
+  /**
+   * Absolute paths of hook plugins to load at CLI startup
+   * (issue #36 Phase 1 step 5). Same trust gate as verb plugins
+   * (`plugins.trusted: true`). Each plugin subscribes to one or
+   * more lifecycle events (`before:approve`, `after:complete`, etc.)
+   * and runs at the corresponding fire point. See `HookPlugin.ts`
+   * for the full event list and contract.
+   */
+  hookPluginPaths: readonly string[];
   profile: GuildProfile;
   features: GuildFeatures;
   onMalformed: OnMalformed;
@@ -115,6 +124,7 @@ export class GuildConfig implements GuildConfigProps {
     readonly lenses: readonly string[],
     readonly doctorPlugins: readonly string[],
     readonly verbPluginPaths: readonly string[],
+    readonly hookPluginPaths: readonly string[],
     readonly profile: GuildProfile,
     readonly features: GuildFeatures,
     readonly onMalformed: OnMalformed,
@@ -196,6 +206,26 @@ export class GuildConfig implements GuildConfigProps {
           'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
       );
     }
+    // Hook plugins (#36 Phase 1 step 5). Shares the `plugins.trusted`
+    // consent gate with verb plugins — one declaration unlocks every
+    // plugin kind. The model is unified: the operator either trusts
+    // the source of every plugin in `plugins:` or trusts none of
+    // them. Per-kind trust would multiply the consent surface
+    // without adding meaningful precision (a hostile hook plugin
+    // can do everything a hostile verb plugin can — they're both
+    // arbitrary in-process code).
+    const hookPluginPaths = Array.isArray(pluginsRaw.hooks) && verbPluginsTrusted
+      ? pluginsRaw.hooks
+          .filter((x: unknown): x is string => typeof x === 'string')
+          .map((x: string) => resolveUnder(root, x))
+      : [];
+    if (Array.isArray(pluginsRaw.hooks) && pluginsRaw.hooks.length > 0 && !verbPluginsTrusted) {
+      onMalformed(
+        configPath,
+        'plugins.hooks present but plugins.trusted is not true — hook plugins will NOT be loaded. ' +
+          'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
+      );
+    }
     // Profile + features (#231). The two interact: `profile: swarm`
     // flips the default of `features.worktree_required_for_parallel`
     // to true, but an explicit `features:` block always wins so a
@@ -245,7 +275,7 @@ export class GuildConfig implements GuildConfigProps {
         explicitWorktreeRequired ?? (profile === 'swarm'),
       selfApprove,
     };
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, profile, features, onMalformed, configPath);
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, profile, features, onMalformed, configPath);
   }
 
   static default(
@@ -264,6 +294,7 @@ export class GuildConfig implements GuildConfigProps {
       },
       [...DEFAULT_HOSTS],
       [...DEFAULT_LENSES],
+      [],
       [],
       [],
       'standard',

--- a/src/infrastructure/plugin/HookPluginLoader.ts
+++ b/src/infrastructure/plugin/HookPluginLoader.ts
@@ -1,0 +1,102 @@
+// Hook plugin loader (issue #36 Phase 1 step 5).
+//
+// Reads paths from `guild.config.yaml`'s `plugins.hooks` (already
+// trust-gated by GuildConfig — see `plugins.trusted: true`) and
+// dynamically imports each as an ES module. Validates the export
+// shape, resolves multi-event subscriptions, and collects errors
+// per path. Mirrors the verb plugin loader pattern.
+//
+// Output shape: `subscriptions: Map<HookEvent, HookFn[]>` — one
+// entry per (plugin, event) pair, ordered by plugin path then
+// (when a single plugin subscribes to multiple events) by the
+// `on:` array order.
+
+import { pathToFileURL } from 'node:url';
+import {
+  HookPlugin,
+  HookFn,
+  HookEvent,
+  ALL_HOOK_EVENTS,
+  HookPluginLoadError,
+  HookPluginLoadResult,
+} from '../../application/plugin/HookPlugin.js';
+
+const VALID_EVENTS: ReadonlySet<string> = new Set<string>(ALL_HOOK_EVENTS);
+
+function validateHookShape(raw: unknown): { ok: true; plugin: HookPlugin } | { ok: false; reason: string } {
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, reason: 'default export is not an object' };
+  }
+  const obj = raw as Record<string, unknown>;
+  const onRaw = obj['on'];
+  // `on` is required and may be a single event string or a non-empty
+  // array of event strings. Empty arrays are rejected — a hook that
+  // subscribes to nothing is dead code, surfacing as an explicit
+  // configuration error is more useful than silently ignoring it.
+  let events: readonly string[];
+  if (typeof onRaw === 'string') {
+    events = [onRaw];
+  } else if (Array.isArray(onRaw)) {
+    if (onRaw.length === 0) {
+      return { ok: false, reason: '`on` must name at least one event' };
+    }
+    if (!onRaw.every((e) => typeof e === 'string')) {
+      return { ok: false, reason: '`on` array must contain only strings' };
+    }
+    events = onRaw;
+  } else {
+    return { ok: false, reason: '`on` must be an event name or an array of event names' };
+  }
+  for (const e of events) {
+    if (!VALID_EVENTS.has(e)) {
+      return {
+        ok: false,
+        reason: `unknown event "${e}"; valid: ${ALL_HOOK_EVENTS.join(', ')}`,
+      };
+    }
+  }
+  if (typeof obj['run'] !== 'function') {
+    return { ok: false, reason: 'run must be a function' };
+  }
+  return { ok: true, plugin: obj as unknown as HookPlugin };
+}
+
+export async function loadHookPlugins(
+  pluginPaths: readonly string[],
+): Promise<HookPluginLoadResult> {
+  const subscriptions = new Map<HookEvent, HookFn[]>();
+  const errors: HookPluginLoadError[] = [];
+  const pluginsLoaded: Array<{ path: string; status: 'loaded' | 'error' }> = [];
+
+  for (const pluginPath of pluginPaths) {
+    let mod: { default?: unknown } & Record<string, unknown>;
+    try {
+      mod = await import(pathToFileURL(pluginPath).href);
+    } catch (e) {
+      errors.push({
+        path: pluginPath,
+        reason: `import failed: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    const exportRoot = mod.default ?? mod;
+    const result = validateHookShape(exportRoot);
+    if (!result.ok) {
+      errors.push({ path: pluginPath, reason: result.reason });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    const plugin = result.plugin;
+    const events: readonly HookEvent[] = Array.isArray(plugin.on)
+      ? (plugin.on as readonly HookEvent[])
+      : [plugin.on as HookEvent];
+    for (const ev of events) {
+      const arr = subscriptions.get(ev);
+      if (arr) arr.push(plugin.run);
+      else subscriptions.set(ev, [plugin.run]);
+    }
+    pluginsLoaded.push({ path: pluginPath, status: 'loaded' });
+  }
+  return { subscriptions, errors, pluginsLoaded };
+}

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -8,6 +8,11 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { notFoundMessage } from '../../shared/notFoundHint.js';
+import {
+  fireBeforeHook,
+  fireAfterHook,
+  emitHookVeto,
+} from '../../../application/plugin/HookBus.js';
 
 // Known flags per write-verb. Silent-ignore of unknown flags (e.g.
 // `--executr noir` instead of `--executor noir`) would let a typo
@@ -922,7 +927,17 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
       return 1;
     }
   }
+  // Lifecycle hook fire point (#36 Phase 1 step 5). `before:approve`
+  // sees the pre-mutation request snapshot; a veto blocks the
+  // transition. Fired AFTER the built-in self-approve check because
+  // a hook policy that depends on actor identity should compose with
+  // (not duplicate) the hard-coded gate.
+  if (prior !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'approve', prior, by);
+    if (veto) return emitHookVeto('approve', id, veto);
+  }
   const r = await c.requestUC.approve(id, by, note, invokedBy);
+  await fireAfterHook(c.hookSubscriptions, 'approve', r, by);
   // Self-approval notice. Suppressed under `allowed` (deployments that
   // actively rely on self-approve and don't want the audit line).
   // Preserved under `warn` — the historical default — so the
@@ -960,7 +975,13 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'deny', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
+  const priorDeny = await c.requestUC.show(id);
+  if (priorDeny !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'deny', priorDeny, by);
+    if (veto) return emitHookVeto('deny', id, veto);
+  }
   const r = await c.requestUC.deny(id, by, reason, invokedBy);
+  await fireAfterHook(c.hookSubscriptions, 'deny', r, by);
   emitWriteResponse(parseFormat(args), r, `✓ denied: ${id}`, c.config);
   return 0;
 }
@@ -1044,7 +1065,12 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'execute', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
+  if (target !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'execute', target, by);
+    if (veto) return emitHookVeto('execute', id, veto);
+  }
   const r = await c.requestUC.execute(id, by, note, invokedBy, { cwd });
+  await fireAfterHook(c.hookSubscriptions, 'execute', r, by);
   // `--executor` / `--executors` is informational, not access
   // control: the substrate records both the assignment and the actual
   // actor, but does not refuse a mismatched execute. Surface a notice
@@ -1090,7 +1116,13 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'complete', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
+  const priorComplete = await c.requestUC.show(id);
+  if (priorComplete !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'complete', priorComplete, by);
+    if (veto) return emitHookVeto('complete', id, veto);
+  }
   const r = await c.requestUC.complete(id, by, note, invokedBy);
+  await fireAfterHook(c.hookSubscriptions, 'complete', r, by);
   const extraLines: string[] = [];
   if (r.autoReview) {
     const reviewer = r.autoReview.value;
@@ -1126,7 +1158,13 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'fail', id, by, fromState, toState: r.state, after: r, format: parseFormat(args) });
     return 0;
   }
+  const priorFail = await c.requestUC.show(id);
+  if (priorFail !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'fail', priorFail, by);
+    if (veto) return emitHookVeto('fail', id, veto);
+  }
   const r = await c.requestUC.fail(id, by, reason, invokedBy);
+  await fireAfterHook(c.hookSubscriptions, 'fail', r, by);
   emitWriteResponse(parseFormat(args), r, `✓ failed: ${id}`, c.config);
   return 0;
 }

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -14,6 +14,11 @@ import {
   normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import {
+  fireBeforeHook,
+  fireAfterHook,
+  emitHookVeto,
+} from '../../../application/plugin/HookBus.js';
 
 // Friction bundle (#228 sub-task 1): `--note` is the canonical comment
 // flag across every write verb (approve / deny / execute / complete /
@@ -158,6 +163,14 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     emitDryRunPreview({ verb: 'review', id, by, after: updated, format: parseFormat(args) });
     return 0;
   }
+  // Lifecycle hook fire point (#36 Phase 1 step 5). `before:review`
+  // sees the pre-review request snapshot; a veto blocks the append.
+  // Useful for policy hooks like "this lense is reserved to hosts".
+  const priorReview = await c.requestUC.show(id);
+  if (priorReview !== null) {
+    const veto = await fireBeforeHook(c.hookSubscriptions, 'review', priorReview, by);
+    if (veto) return emitHookVeto('review', id, veto);
+  }
   const updated = await c.requestUC.review({
     id,
     by,
@@ -166,6 +179,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     comment,
     ...(invokedBy !== undefined ? { invokedBy } : {}),
   });
+  await fireAfterHook(c.hookSubscriptions, 'review', updated, by);
   // Self-review warning. The tool permits `--by` to equal the
   // request author (the YAML is just an append-only record and
   // doesn't know intent), but the Two-Persona Devil frame is

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -1,6 +1,7 @@
 import { buildContainer } from '../shared/container.js';
 import { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
 import { loadVerbPlugins } from '../../infrastructure/plugin/VerbPluginLoader.js';
+import { loadHookPlugins } from '../../infrastructure/plugin/HookPluginLoader.js';
 import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
 import { nearestCommand } from '../shared/nearestCommand.js';
@@ -302,10 +303,19 @@ export async function main(argv: readonly string[]): Promise<number> {
     config.verbPluginPaths,
     builtInNames,
   );
+  // Hook plugins (#36 Phase 1 step 5). Loaded in parallel with verb
+  // plugins because the two are independent; sequential here only
+  // because the await contract is simpler. Container exposes the
+  // resulting subscription map and load errors to handlers and
+  // doctor respectively.
+  const hookPluginLoad = await loadHookPlugins(config.hookPluginPaths);
   const c = buildContainer({
     verbPlugins: verbPluginLoad.plugins,
     verbPluginErrors: verbPluginLoad.errors,
     verbPluginsLoaded: verbPluginLoad.pluginsLoaded,
+    hookSubscriptions: hookPluginLoad.subscriptions,
+    hookPluginErrors: hookPluginLoad.errors,
+    hookPluginsLoaded: hookPluginLoad.pluginsLoaded,
   });
   try {
     // #200: <write-verb> --help must not block on the lock. Help is

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -24,6 +24,8 @@ import {
   VerbPlugin,
   VerbPluginLoadError,
 } from '../../application/plugin/VerbPlugin.js';
+import type { HookSubscriptions } from '../../application/plugin/HookBus.js';
+import type { HookPluginLoadError } from '../../application/plugin/HookPlugin.js';
 
 export interface Container {
   config: GuildConfig;
@@ -67,6 +69,18 @@ export interface Container {
    * load.
    */
   verbPluginErrors: readonly VerbPluginLoadError[];
+  /**
+   * Hook plugin subscriptions (#36 Phase 1 step 5). Empty map when no
+   * hook plugins are loaded. Lifecycle handlers (`approve`, `deny`,
+   * `execute`, `complete`, `fail`, `review`) call `fireBeforeHook` /
+   * `fireAfterHook` against this map at fire points.
+   */
+  hookSubscriptions: HookSubscriptions;
+  /**
+   * Per-path hook plugin load errors. Surfaced via `gate doctor` as
+   * `area: 'plugin'` findings, same channel as verb plugin errors.
+   */
+  hookPluginErrors: readonly HookPluginLoadError[];
 }
 
 export interface BuildContainerOpts {
@@ -97,6 +111,21 @@ export interface BuildContainerOpts {
    * same "plugins loaded" section. Defaults to `[]`.
    */
   verbPluginsLoaded?: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
+  /**
+   * Pre-loaded hook plugin subscription map (#36 Phase 1 step 5).
+   * main() builds it via `loadHookPlugins`. Defaults to an empty
+   * Map.
+   */
+  hookSubscriptions?: HookSubscriptions;
+  /**
+   * Per-path hook plugin load errors. Defaults to `[]`.
+   */
+  hookPluginErrors?: readonly HookPluginLoadError[];
+  /**
+   * Per-path load outcome (success + failure) from the hook plugin
+   * loader. Mirrors `verbPluginsLoaded`.
+   */
+  hookPluginsLoaded?: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
 }
 
 export function buildContainer(opts: BuildContainerOpts = {}): Container {
@@ -136,11 +165,20 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
         // back to a derived list when only `verbPlugins` was passed
         // (test convenience), but production main() always provides
         // both arrays explicitly via opts.
-        pluginsLoaded: opts.verbPluginsLoaded ?? [],
-        errors: (opts.verbPluginErrors ?? []).map((e) => ({
-          path: e.path,
-          reason: e.reason,
-        })),
+        pluginsLoaded: [
+          ...(opts.verbPluginsLoaded ?? []),
+          ...(opts.hookPluginsLoaded ?? []),
+        ],
+        errors: [
+          ...(opts.verbPluginErrors ?? []).map((e) => ({
+            path: e.path,
+            reason: `verb plugin: ${e.reason}`,
+          })),
+          ...(opts.hookPluginErrors ?? []).map((e) => ({
+            path: e.path,
+            reason: `hook plugin: ${e.reason}`,
+          })),
+        ],
       },
     ),
     repairUC: new RepairUseCases(quarantine),
@@ -151,5 +189,7 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     ),
     verbPlugins: opts.verbPlugins ?? [],
     verbPluginErrors: opts.verbPluginErrors ?? [],
+    hookSubscriptions: opts.hookSubscriptions ?? new Map(),
+    hookPluginErrors: opts.hookPluginErrors ?? [],
   };
 }

--- a/tests/interface/hookPluginLoader.test.ts
+++ b/tests/interface/hookPluginLoader.test.ts
@@ -1,0 +1,322 @@
+// Hook plugin loader (issue #36 Phase 1 step 5).
+//
+// End-to-end tests via the gate CLI:
+//   - subscription: an after-hook fires after a successful approve
+//   - veto: a before-hook returning { allow: false } blocks the
+//     transition (exit 1, stderr message, no record mutation)
+//   - multi-event: one plugin subscribing to multiple events fires
+//     for each
+//   - after-error: a throwing after-hook is logged but doesn't
+//     break the handler
+//   - before-error: a throwing before-hook is treated as a veto
+//     (fail-closed)
+//   - missing file / broken shape: surface as gate doctor findings
+//   - plugins.trusted absent: hooks dropped with onMalformed notice
+//   - first-veto-wins: a second before-hook is not invoked after a
+//     first one already vetoed
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}) {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+interface Bootstrap {
+  root: string;
+  pluginDir: string;
+  cleanup: () => void;
+}
+
+function bootstrap(extraConfig = ''): Bootstrap {
+  const root = makeTempRoot('gate-hp-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n' + extraConfig,
+  );
+  mkdirSync(join(root, 'members'));
+  // Two members so we can approve as a different actor than --from.
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins'));
+  return {
+    root,
+    pluginDir: join(root, 'plugins'),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function makeRequest(root: string): string {
+  const r = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--action', 'do thing',
+    '--reason', 'because',
+    '--format', 'json',
+  ]);
+  if (r.status !== 0) throw new Error(`request failed: ${r.stderr}`);
+  return JSON.parse(r.stdout).id;
+}
+
+test('hook plugin: after:approve fires once on a successful approve', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit.mjs\n',
+  );
+  t.after(cleanup);
+  // Hook writes one line to a side-effect file in cwd. Using an
+  // absolute path under root keeps the test self-contained.
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'audit.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'after:approve',
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)}, ctx.event + ':' + ctx.actor + ':' + ctx.request.state + '\\n');
+       },
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(existsSync(trace), 'hook should have written to trace');
+  assert.equal(readFileSync(trace, 'utf8'), 'after:approve:bob:approved\n');
+});
+
+test('hook plugin: before:approve veto blocks the transition', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/policy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'policy.mjs'),
+    `export default {
+       on: 'before:approve',
+       run: async (ctx) => ({ allow: false, reason: 'org policy: bob cannot approve' }),
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed approve on .+ org policy: bob cannot approve/);
+
+  // Record stays pending — no mutation occurred.
+  const show = runGate(root, ['show', id, '--format', 'json']);
+  const payload = JSON.parse(show.stdout);
+  assert.equal(payload.state, 'pending');
+});
+
+test('hook plugin: multi-event subscription fires for each registered event', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit-multi.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'audit-multi.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: ['after:approve', 'after:execute', 'after:complete'],
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)}, ctx.event + '\\n');
+       },
+     };`,
+  );
+
+  const id = makeRequest(root);
+  assert.equal(runGate(root, ['approve', id, '--by', 'bob']).status, 0);
+  assert.equal(runGate(root, ['execute', id, '--by', 'alice']).status, 0);
+  assert.equal(runGate(root, ['complete', id, '--by', 'alice', '--note', 'done']).status, 0);
+
+  assert.equal(
+    readFileSync(trace, 'utf8'),
+    'after:approve\nafter:execute\nafter:complete\n',
+  );
+});
+
+test('hook plugin: throwing after-hook is logged but does not break the handler', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/throwy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'throwy.mjs'),
+    `export default {
+       on: 'after:approve',
+       run: async () => { throw new Error('boom'); },
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(r.status, 0, 'after-hook error must NOT break the handler');
+  assert.match(r.stderr, /warning: hook threw on after:approve.*boom/);
+  // Transition still happened.
+  const show = runGate(root, ['show', id, '--format', 'json']);
+  assert.equal(JSON.parse(show.stdout).state, 'approved');
+});
+
+test('hook plugin: throwing before-hook is treated as a veto (fail-closed)', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/buggy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'buggy.mjs'),
+    `export default {
+       on: 'before:approve',
+       run: async () => { throw new Error('plugin bug'); },
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(r.status, 1, 'fail-closed: a buggy before-hook must block');
+  assert.match(r.stderr, /hook vetoed approve on .+plugin bug/);
+  const show = runGate(root, ['show', id, '--format', 'json']);
+  assert.equal(JSON.parse(show.stdout).state, 'pending');
+});
+
+test('hook plugin: first veto wins — later before-hooks do not run', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n' +
+      '    - plugins/first-veto.mjs\n' +
+      '    - plugins/second-trace.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'first-veto.mjs'),
+    `export default {
+       on: 'before:approve',
+       run: async () => ({ allow: false, reason: 'first' }),
+     };`,
+  );
+  writeFileSync(
+    join(pluginDir, 'second-trace.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'before:approve',
+       run: async () => { appendFileSync(${JSON.stringify(trace)}, 'second\\n'); },
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /first/);
+  // Second hook never ran.
+  assert.ok(!existsSync(trace), 'first veto must short-circuit subsequent hooks');
+});
+
+test('hook plugin: missing file surfaces as gate doctor finding', (t) => {
+  const { root, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/does-not-exist.mjs\n',
+  );
+  t.after(cleanup);
+
+  // Read verbs still work — broken hook plugin is non-fatal.
+  assert.equal(runGate(root, ['status']).status, 0);
+
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /hook plugin.*import failed/.test(f.message),
+  );
+  assert.ok(finding, `expected hook-plugin import-failed finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('hook plugin: broken shape (no `on`) is rejected with a finding', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/no-on.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(join(pluginDir, 'no-on.mjs'), `export default { run: () => {} };`);
+
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' &&
+      /must be an event name or an array of event names/.test(f.message),
+  );
+  assert.ok(finding, `expected shape-error finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('hook plugin: unknown event name is rejected with a finding', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/bogus-event.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'bogus-event.mjs'),
+    `export default { on: 'before:not-a-real-event', run: () => {} };`,
+  );
+
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  const report = JSON.parse(doctor.stdout);
+  const finding = report.findings.find(
+    (f: { area: string; message: string }) =>
+      f.area === 'plugin' && /unknown event "before:not-a-real-event"/.test(f.message),
+  );
+  assert.ok(finding, `expected unknown-event finding in:\n${JSON.stringify(report.findings, null, 2)}`);
+});
+
+test('hook plugin: plugins.trusted absent → hooks skipped + onMalformed notice', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  hooks:\n    - plugins/audit.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'audit.mjs'),
+    `export default { on: 'after:approve', run: async () => {} };`,
+  );
+
+  const status = runGate(root, ['status']);
+  assert.equal(status.status, 0);
+  assert.match(status.stderr, /plugins\.hooks present but plugins\.trusted is not true/);
+});
+
+test('hook plugin: before:review veto blocks review append', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/review-policy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'review-policy.mjs'),
+    `export default {
+       on: 'before:review',
+       run: async (ctx) => ({ allow: false, reason: 'review locked while pending host approval' }),
+     };`,
+  );
+
+  const id = makeRequest(root);
+  const r = runGate(root, ['review', id, '--by', 'bob', '--lense', 'devil', '--verdict', 'concern', '--note', 'should be blocked']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed review on .+review locked/);
+
+  const show = runGate(root, ['show', id, '--format', 'json']);
+  assert.equal(JSON.parse(show.stdout).reviews?.length ?? 0, 0);
+});


### PR DESCRIPTION
## Summary

Step 5 of #36 Phase 1's "Lightest-first work order" — the lifecycle hooks bus. Operators can now layer audit trails, policy gates, and external notification on top of the lifecycle without forking core handlers.

Builds on the verb plugin loader (PR #258, step 4): same `plugins.trusted: true` consent gate, same loader/diagnostic plumbing pattern, same "load failure is non-fatal" guarantee.

## Surface

```yaml
# guild.config.yaml
plugins:
  trusted: true              # shared with verb plugins
  hooks:
    - plugins/audit.mjs
```

```js
// plugins/audit.mjs
export default {
  on: ['after:approve', 'after:complete', 'after:fail'],
  run: async (ctx) => {
    // ctx.event = 'after:approve' | ...
    // ctx.request = post-mutation Request
    // ctx.actor = '--by' / '--from' invoker
    appendFileSync('audit.log', JSON.stringify({...}) + '\n');
  },
};
```

## Two flavours

| Flavour | Veto? | Errors |
|---------|-------|--------|
| `before:<verb>` | yes — `{ allow: false, reason }` | thrown → fail-closed veto |
| `after:<verb>` | no | thrown → stderr warning, transition succeeds |

**First veto wins.** Remaining `before:` hooks for the same event do NOT run after a veto — order-sensitive "deny everything else" hooks can sit at the end of the chain.

## Events covered

`before/after:` × `approve | deny | execute | complete | fail | review`.

`fast-track`, `claim`, `witness`, `unwitness`, `thank` are out of scope for v1 — `fast-track` composes multiple events, the stake/observe verbs sit on a different axis. Adding them later is additive within 0.x per `docs/POLICY.md` § "Plugin stability".

## Live demo

```
$ gate approve 2026-05-08-0001 --by bob
[audit] after:approve 2026-05-08-0001 by bob → approved
✓ approved: 2026-05-08-0001

$ gate execute 2026-05-08-0001 --by alice    # alice blocked by policy hook
error: hook vetoed execute on 2026-05-08-0001: alice cannot execute (demo policy)
```

## Pipeline

- `main()` loads hooks via `loadHookPlugins()` alongside verb plugins; both share the `plugins.trusted: true` declaration
- Container exposes `c.hookSubscriptions` (`Map<HookEvent, HookFn[]>`) + `c.hookPluginErrors`
- Each lifecycle handler now: `fireBeforeHook` → optional veto → mutation → `fireAfterHook`
- Veto path: `emitHookVeto()` writes a uniform stderr line and returns exit 1; record is **not** mutated
- `gate doctor` surfaces hook plugin load errors as `area: 'plugin'` findings (same channel as verb plugins; messages prefixed "hook plugin: ..." vs "verb plugin: ..." for source attribution)

## Trust contract

Already documented in #36 step 1+2 (PR #257). Operationalized here:
- Hooks run **in-process** with full Node capabilities — no sandbox
- The same `plugins.trusted: true` declaration that lights up verb plugins also lights up hooks (one consent surface per source-of-trust)
- YAML alone is not consent — listing `plugins.hooks` without `plugins.trusted` drops them with an `onMalformed` notice
- Hook plugin failures are non-fatal — broken hooks surface as doctor findings but never crash the CLI

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1348/1348 pass on linux (11 new tests)
  - `after:approve` fires once on a successful approve
  - `before:approve` veto blocks the transition (no mutation)
  - multi-event subscription fires for each registered event
  - throwing `after:` hook → warning, transition succeeds
  - throwing `before:` hook → fail-closed veto
  - first veto wins — second hook does not run
  - missing file → doctor finding, CLI keeps working
  - broken shape (no `on`) → doctor finding
  - unknown event name → doctor finding
  - `plugins.trusted` absent → silent skip + onMalformed notice
  - `before:review` veto blocks review append
- [x] Visual sanity check: live audit-log + veto-policy plugins under content_root

## Files

- `src/application/plugin/HookPlugin.ts` — `HookPlugin` / `HookContext` / `HookVeto` / `HookEvent` / `ALL_HOOK_EVENTS` / `HookPluginLoadResult`
- `src/application/plugin/HookBus.ts` — `fireBeforeHook` / `fireAfterHook` / `emitHookVeto` helpers
- `src/infrastructure/plugin/HookPluginLoader.ts` — async loader with shape validation
- `src/infrastructure/config/GuildConfig.ts` — `plugins.hooks` field parsing
- `src/interface/shared/container.ts` — Container carries `hookSubscriptions` + `hookPluginErrors`
- `src/interface/gate/index.ts` — load + plumb to container
- `src/interface/gate/handlers/request.ts` — fire points in approve/deny/execute/complete/fail
- `src/interface/gate/handlers/review.ts` — fire points in review
- `src/application/diagnostic/DiagnosticUseCases.ts` — leave the kind-prefix to the wiring layer (so verb / hook / future plugin kinds discriminate cleanly)
- `examples/plugins/hooks/audit-log.mjs` — minimum viable hook plugin
- `tests/interface/hookPluginLoader.test.ts` — 11 new tests

## Next

Steps 6 (content transforms `on:save` / `on:load`) and 7 (`examples/plugins/` end-to-end suite) remain. The contract this PR pins down — that hooks run through `plugins.trusted`, that vetoes are uniform `{ allow: false, reason }`, that load errors are non-fatal — gives those follow-ups a stable foundation.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_