### PR TITLE
feat(gate): gate rest — boundary record (#36 Phase 2 step 1)

### DIFF
--- a/src/application/session/SessionEventRepository.ts
+++ b/src/application/session/SessionEventRepository.ts
@@ -1,0 +1,19 @@
+import type { SessionEvent } from '../../domain/session/SessionEvent.js';
+
+/**
+ * Storage port for session-boundary records (#36 Phase 2).
+ *
+ * Mirrors the per-event YAML pattern other passages use:
+ *   - `nextSequence(dateKey)` — allocate the next per-day sequence
+ *     so callers can construct a `YYYY-MM-DD-NNN` id without
+ *     scanning the directory themselves.
+ *   - `save(event)` — write one file per event, id-keyed.
+ *   - `listAll()` — read every record (used by `gate boot` /
+ *     `gate resume` integration in follow-up PRs; not yet wired
+ *     in this PR).
+ */
+export interface SessionEventRepository {
+  nextSequence(dateKey: string): Promise<number>;
+  save(event: SessionEvent): Promise<void>;
+  listAll(): Promise<readonly SessionEvent[]>;
+}

--- a/src/application/session/SessionEventUseCases.ts
+++ b/src/application/session/SessionEventUseCases.ts
@@ -1,0 +1,51 @@
+import type { Clock } from '../ports/Clock.js';
+import type { MemberRepository } from '../ports/MemberRepository.js';
+import { SessionEvent, SessionKind } from '../../domain/session/SessionEvent.js';
+import { SessionEventRepository } from './SessionEventRepository.js';
+import { assertActor } from '../shared/assertActor.js';
+
+export interface RecordSessionEventInput {
+  readonly kind: SessionKind;
+  readonly by: string;
+  readonly note?: string;
+}
+
+export interface SessionEventUseCasesDeps {
+  readonly events: SessionEventRepository;
+  readonly members: MemberRepository;
+  readonly clock: Clock;
+}
+
+/**
+ * Use-cases for session-boundary records (#36 Phase 2).
+ *
+ * Phase 2's first slice (this PR) only wires `record({ kind: 'rest' })`
+ * via the `gate rest` handler. The interface accepts the full
+ * `SessionKind` union so the wake / farewell handlers in follow-up
+ * PRs can reuse `record()` without a domain change.
+ */
+export class SessionEventUseCases {
+  constructor(private readonly deps: SessionEventUseCasesDeps) {}
+
+  /**
+   * Record one boundary event. Allocates a per-day sequence id,
+   * stamps the system clock, and persists. Returns the saved
+   * record so the handler can emit it back to the caller.
+   */
+  async record(input: RecordSessionEventInput): Promise<SessionEvent> {
+    const actor = await assertActor(input.by, '--by', this.deps.members);
+    const at = this.deps.clock.now().toISOString();
+    const dateKey = at.slice(0, 10); // YYYY-MM-DD
+    const seq = await this.deps.events.nextSequence(dateKey);
+    const id = `${dateKey}-${String(seq).padStart(3, '0')}`;
+    const event = SessionEvent.create({
+      id,
+      kind: input.kind,
+      by: actor,
+      at,
+      ...(input.note !== undefined ? { note: input.note } : {}),
+    });
+    await this.deps.events.save(event);
+    return event;
+  }
+}

--- a/src/domain/session/SessionEvent.ts
+++ b/src/domain/session/SessionEvent.ts
@@ -1,0 +1,149 @@
+import { DomainError } from '../shared/DomainError.js';
+import { MemberName } from '../member/MemberName.js';
+import { sanitizeText } from '../shared/sanitizeText.js';
+
+/**
+ * Session-boundary event (#36 Phase 2 — time-aware verbs).
+ *
+ * Three boundary kinds the verb surface will eventually reach:
+ *
+ *   `rest`     — "I am putting this down now" (this PR).
+ *   `wake`     — "I am picking it back up" (follow-up PR).
+ *   `farewell` — "until next session" (follow-up PR; pairs with
+ *                `gate resume`).
+ *
+ * Phase 2's first slice ships `rest` only. The domain enum carries
+ * the full union from day one so the schema / repository / hydrate
+ * paths don't need a breaking change when the other two land —
+ * additive within the 0.x line per `docs/POLICY.md` § "Plugin
+ * stability". Records with `kind: wake` / `kind: farewell` written
+ * by a future version will still hydrate cleanly today (records-
+ * outlive-writers, principle 04).
+ *
+ * Why a boundary record at all: agents (human or AI) accumulate
+ * fatigue or context drift inside long sessions. Marking the
+ * boundaries in-band lets downstream verbs (`tail`, `voices`,
+ * `resume`) render the session with the boundaries visible, which
+ * changes how the next reader experiences the history. The length
+ * of a break is itself information, the way a commit timestamp is
+ * information — explicit `rest`/`wake` pairs let `gate resume`
+ * compute "you were away N hours" instead of "you last wrote N
+ * hours ago, unclear whether intentional".
+ *
+ * Storage: `<content_root>/sessions/<id>.yaml`, one file per event,
+ * id format `YYYY-MM-DD-NNN` (per-day sequence, mirroring the
+ * issue / request id shape minus the `i-` prefix).
+ */
+export const SESSION_KINDS = ['rest', 'wake', 'farewell'] as const;
+export type SessionKind = (typeof SESSION_KINDS)[number];
+
+export function parseSessionKind(value: string): SessionKind {
+  if ((SESSION_KINDS as readonly string[]).includes(value)) {
+    return value as SessionKind;
+  }
+  throw new DomainError(
+    `Invalid session kind: "${value}" — valid: ${SESSION_KINDS.join(', ')}`,
+    'kind',
+  );
+}
+
+const MAX_SESSION_NOTE = 240;
+
+export interface SessionEventProps {
+  readonly id: string;
+  readonly kind: SessionKind;
+  readonly by: MemberName;
+  readonly at: string;
+  readonly note?: string;
+}
+
+export interface CreateSessionEventInput {
+  readonly id: string;
+  readonly kind: SessionKind;
+  readonly by: MemberName;
+  readonly at: string;
+  readonly note?: string;
+}
+
+/**
+ * Aggregate root for a single boundary record. Immutable —
+ * boundaries are facts about a moment in time; later corrections
+ * are *new* records, not edits, mirroring the append-only stance
+ * Request takes on its status_log.
+ */
+export class SessionEvent {
+  private constructor(private readonly props: SessionEventProps) {}
+
+  static create(input: CreateSessionEventInput): SessionEvent {
+    if (!/^\d{4}-\d{2}-\d{2}-\d{3,4}$/.test(input.id)) {
+      throw new DomainError(
+        `Invalid session id: "${input.id}" — expected YYYY-MM-DD-NNN`,
+        'id',
+      );
+    }
+    if (!input.kind) {
+      throw new DomainError('kind required', 'kind');
+    }
+    parseSessionKind(input.kind); // validates enum
+    if (typeof input.at !== 'string' || input.at.length === 0) {
+      throw new DomainError('at required (ISO 8601 timestamp)', 'at');
+    }
+    let note: string | undefined;
+    if (input.note !== undefined) {
+      const cleaned = sanitizeText(input.note, 'note', {
+        maxLen: MAX_SESSION_NOTE,
+        requireNonEmpty: false,
+      });
+      if (cleaned.length > 0) note = cleaned;
+    }
+    return new SessionEvent({
+      id: input.id,
+      kind: input.kind,
+      by: input.by,
+      at: input.at,
+      ...(note !== undefined ? { note } : {}),
+    });
+  }
+
+  /** Hydrate from a YAML record. Distinct from `create` because
+   *  hydrate is permissive (records-outlive-writers): a future kind
+   *  unknown to this binary should NOT throw. The caller passes the
+   *  raw kind string and we accept any well-shaped value. */
+  static restore(props: SessionEventProps): SessionEvent {
+    return new SessionEvent({ ...props });
+  }
+
+  get id(): string {
+    return this.props.id;
+  }
+  get kind(): SessionKind {
+    return this.props.kind;
+  }
+  get by(): MemberName {
+    return this.props.by;
+  }
+  get at(): string {
+    return this.props.at;
+  }
+  get note(): string | undefined {
+    return this.props.note;
+  }
+
+  /**
+   * Wire-format projection. Top-level keys are snake_case to match
+   * the rest of the YAML surface (request, issue, agora play).
+   * `note` is omitted when undefined so a boundary record without a
+   * note round-trips byte-identically to a record where the field
+   * is absent on disk.
+   */
+  toJSON(): Record<string, unknown> {
+    const out: Record<string, unknown> = {
+      id: this.props.id,
+      kind: this.props.kind,
+      by: this.props.by.value,
+      at: this.props.at,
+    };
+    if (this.props.note !== undefined) out['note'] = this.props.note;
+    return out;
+  }
+}

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -80,6 +80,12 @@ export interface GuildConfigProps {
     requests: string;
     issues: string;
     inbox: string;
+    /**
+     * Per-event session-boundary records (`gate rest` /
+     * `gate wake` / `gate farewell`, #36 Phase 2). One YAML file
+     * per event under `<content_root>/sessions/<id>.yaml`.
+     */
+    sessions: string;
   };
   hostNames: readonly string[];
   lenses: readonly string[];
@@ -159,6 +165,7 @@ export class GuildConfig implements GuildConfigProps {
       requests: resolveUnder(contentRoot, p.requests ?? 'requests'),
       issues: resolveUnder(contentRoot, p.issues ?? 'issues'),
       inbox: resolveUnder(contentRoot, p.inbox ?? 'inbox'),
+      sessions: resolveUnder(contentRoot, p.sessions ?? 'sessions'),
     };
     const hostNames = Array.isArray(raw.host_names)
       ? raw.host_names
@@ -291,6 +298,7 @@ export class GuildConfig implements GuildConfigProps {
         requests: join(abs, 'requests'),
         issues: join(abs, 'issues'),
         inbox: join(abs, 'inbox'),
+        sessions: join(abs, 'sessions'),
       },
       [...DEFAULT_HOSTS],
       [...DEFAULT_LENSES],

--- a/src/infrastructure/persistence/YamlSessionEventRepository.ts
+++ b/src/infrastructure/persistence/YamlSessionEventRepository.ts
@@ -1,0 +1,116 @@
+import YAML from 'yaml';
+import { join } from 'node:path';
+import {
+  SessionEvent,
+  parseSessionKind,
+} from '../../domain/session/SessionEvent.js';
+import { MemberName } from '../../domain/member/MemberName.js';
+import { SessionEventRepository } from '../../application/session/SessionEventRepository.js';
+import { GuildConfig } from '../config/GuildConfig.js';
+import {
+  MAX_DIR_ENTRIES,
+  existsSafe,
+  listDirSafe,
+  readTextSafe,
+  writeTextSafe,
+} from './safeFs.js';
+import { parseYamlSafe } from './parseYamlSafe.js';
+
+// Session-event filename pattern. Same shape as request / issue
+// per-day sequence ids minus the entity prefix.
+const FILE_PATTERN = /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/;
+const SEQ_PATTERN = /^(\d{4}-\d{2}-\d{2})-(\d{3,4})\.yaml$/;
+
+export class YamlSessionEventRepository implements SessionEventRepository {
+  constructor(private readonly config: GuildConfig) {}
+
+  async nextSequence(dateKey: string): Promise<number> {
+    let max = 0;
+    for (const f of listDirSafe(this.config.paths.sessions, '.')) {
+      const m = f.match(SEQ_PATTERN);
+      if (m && m[1] === dateKey) {
+        const n = parseInt(m[2] as string, 10);
+        if (n > max) max = n;
+      }
+    }
+    return max + 1;
+  }
+
+  async save(event: SessionEvent): Promise<void> {
+    const rel = `${event.id}.yaml`;
+    if (existsSafe(this.config.paths.sessions, rel)) {
+      // ID collision is structural: nextSequence picks the smallest
+      // available number, so a collision means a concurrent writer
+      // wrote one between the allocation and this save. Surface the
+      // race as a domain-shaped error rather than silently
+      // overwriting — the caller can re-allocate and retry.
+      throw new Error(
+        `session event id collision: ${event.id} already exists. ` +
+          `A concurrent writer may have allocated the same sequence; retry.`,
+      );
+    }
+    const text = YAML.stringify(event.toJSON());
+    try {
+      writeTextSafe(this.config.paths.sessions, rel, text, {
+        createOnly: true,
+      });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error(
+          `session event id collision: ${event.id} already exists.`,
+        );
+      }
+      throw e;
+    }
+  }
+
+  async listAll(): Promise<readonly SessionEvent[]> {
+    const files = listDirSafe(this.config.paths.sessions, '.')
+      .filter((f) => FILE_PATTERN.test(f))
+      .slice(0, MAX_DIR_ENTRIES);
+    const out: SessionEvent[] = [];
+    for (const f of files) {
+      const raw = readTextSafe(this.config.paths.sessions, f);
+      const absSource = join(this.config.paths.sessions, f);
+      const parsed = parseYamlSafe(raw, absSource, this.config.onMalformed);
+      if (parsed === undefined) continue;
+      const event = hydrate(parsed, absSource, this.config.onMalformed);
+      if (event) out.push(event);
+    }
+    return out;
+  }
+}
+
+function hydrate(
+  data: unknown,
+  source: string,
+  onMalformed: (source: string, msg: string) => void,
+): SessionEvent | null {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    onMalformed(source, 'top-level YAML is not a mapping; skipping');
+    return null;
+  }
+  const obj = data as Record<string, unknown>;
+  try {
+    const id = String(obj['id'] ?? '');
+    const kind = parseSessionKind(String(obj['kind'] ?? ''));
+    const by = MemberName.of(obj['by']);
+    const at = String(obj['at'] ?? '');
+    const noteRaw = obj['note'];
+    return SessionEvent.restore({
+      id,
+      kind,
+      by,
+      at,
+      ...(typeof noteRaw === 'string' && noteRaw.length > 0
+        ? { note: noteRaw }
+        : {}),
+    });
+  } catch (e) {
+    onMalformed(
+      source,
+      `failed to hydrate session event: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return null;
+  }
+}

--- a/src/interface/gate/handlers/rest.ts
+++ b/src/interface/gate/handlers/rest.ts
@@ -1,0 +1,74 @@
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { parseFormat } from './writeFormat.js';
+
+/**
+ * gate rest [--by <m>] [--note <s>] [--format json|text]
+ *
+ * Boundary record — "I am putting this down now" (#36 Phase 2).
+ *
+ * Not a lifecycle toggle: `rest` doesn't transition any state, it
+ * just stamps a moment. The length of a break is itself information,
+ * the way a commit timestamp is — explicit `rest` markers let
+ * downstream verbs (`tail`, `voices`, `resume`) render the session
+ * with the boundary visible.
+ *
+ * Free-form `--note` is optional. Mandating one would turn the verb
+ * into "reflect" — a different shape with a different ergonomic
+ * cost. The verb's bare form (`gate rest`) must stay frictionless,
+ * so the agent reaches for it as easily as `git commit -m '.'`.
+ *
+ * The matching `gate wake` and `gate farewell` verbs land in
+ * follow-up PRs. Their record kinds are already in the domain enum
+ * — see `SessionEvent.ts` — so this PR's storage layer accepts
+ * them on read without a future migration.
+ */
+const REST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'format',
+]);
+
+export async function restCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REST_KNOWN_FLAGS, 'rest');
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const note = optionalOption(args, 'note');
+  const format = parseFormat(args);
+
+  const event = await c.sessionEventUC.record({
+    kind: 'rest',
+    by,
+    ...(note !== undefined ? { note } : {}),
+  });
+
+  const message = `✓ rested: ${event.id} by ${event.by.value}`;
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          ...event.toJSON(),
+          message,
+          // No suggested_next: the natural pair (`gate wake`) lands
+          // in a follow-up PR. Pre-suggesting a verb that doesn't
+          // exist yet would be a fake prescription. Once `wake`
+          // ships, this slot will name it.
+          suggested_next: null,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(message + '\n');
+    if (event.note !== undefined) {
+      process.stdout.write(`  note: ${event.note}\n`);
+    }
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -589,6 +589,33 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'rest',
+    category: 'write',
+    summary:
+      'boundary record (#36 Phase 2). Stamps a "putting this down now" timestamp; not a lifecycle toggle. Optional --note. The matching `gate wake` and `gate farewell` verbs ship in follow-up PRs.',
+    input: {
+      type: 'object',
+      properties: {
+        by: strOpt('actor (defaults to $GUILD_ACTOR)'),
+        note: strOpt('optional free-form context (≤ 240 chars)'),
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        id: { type: 'string', description: 'YYYY-MM-DD-NNN per-day sequence' },
+        kind: { type: 'string', enum: ['rest', 'wake', 'farewell'] },
+        by: str,
+        at: str,
+        note: strOpt(),
+        message: str,
+        suggested_next: { type: 'object' },
+      },
+    },
+  },
+  {
     name: 'whoami',
     category: 'read',
     summary: 'identity + recent utterances (requires GUILD_ACTOR)',

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -36,6 +36,7 @@ import { repairCmd } from './handlers/repair.js';
 import { bootCmd } from './handlers/boot.js';
 import { schemaCmd } from './handlers/schema.js';
 import { resumeCmd } from './handlers/resume.js';
+import { restCmd } from './handlers/rest.js';
 import { reqRegister } from './handlers/register.js';
 import {
   msgSend,
@@ -278,6 +279,7 @@ const KNOWN_COMMANDS = [
   'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
   'unresponded',
   'templates',
+  'rest',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -457,6 +459,8 @@ async function dispatch(
       return await whyCmd(c, args);
     case 'resume':
       return await resumeCmd(c, args);
+    case 'rest':
+      return await restCmd(c, args);
     case 'schema':
       return await schemaCmd(c, args);
     case 'unresponded':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -57,6 +57,7 @@ export const WRITE_VERBS: ReadonlySet<string> = new Set([
   'message',
   'broadcast',
   'inbox',
+  'rest',
 ]);
 
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set([

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -20,6 +20,8 @@ import { YamlPlayRepository } from '../../passages/agora/infrastructure/YamlPlay
 import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
 import { FsTemplateRepository } from '../../infrastructure/template/TemplateRepository.js';
 import { TemplateUseCases } from '../../application/template/TemplateUseCases.js';
+import { YamlSessionEventRepository } from '../../infrastructure/persistence/YamlSessionEventRepository.js';
+import { SessionEventUseCases } from '../../application/session/SessionEventUseCases.js';
 import {
   VerbPlugin,
   VerbPluginLoadError,
@@ -53,6 +55,14 @@ export interface Container {
    * `<content_root>/data/guild/templates/wave-brief/`.
    */
   templateUC: TemplateUseCases;
+  /**
+   * Session-boundary events (`gate rest` / `gate wake` /
+   * `gate farewell`, #36 Phase 2). Phase 2's first slice ships
+   * `gate rest` only; the use case accepts the full kind union so
+   * follow-up PRs add wake / farewell handlers without a domain
+   * change.
+   */
+  sessionEventUC: SessionEventUseCases;
   /**
    * Verb plugins loaded at CLI startup (issue #36 Phase 1 step 4).
    * Empty array when `plugins.trusted: true` is absent from
@@ -187,6 +197,11 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     templateUC: new TemplateUseCases(
       new FsTemplateRepository(config.contentRoot, config.onMalformed),
     ),
+    sessionEventUC: new SessionEventUseCases({
+      events: new YamlSessionEventRepository(config),
+      members,
+      clock,
+    }),
     verbPlugins: opts.verbPlugins ?? [],
     verbPluginErrors: opts.verbPluginErrors ?? [],
     hookSubscriptions: opts.hookSubscriptions ?? new Map(),

--- a/tests/interface/rest.test.ts
+++ b/tests/interface/rest.test.ts
@@ -1,0 +1,205 @@
+// gate rest — boundary record (#36 Phase 2).
+//
+// Pins:
+//   - JSON envelope shape (snake_case, suggested_next slot for the
+//     future wake/farewell pair)
+//   - text mode prints the success line and the optional note
+//   - file lands at <content_root>/sessions/<id>.yaml
+//   - id format YYYY-MM-DD-NNN per-day sequence
+//   - --note is sanitised and capped at 240 chars
+//   - missing --by + missing GUILD_ACTOR fails closed
+//   - hydrate tolerance: a future kind ('wake' / 'farewell') in the
+//     domain enum hydrates today without throwing
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('gate-rest-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+interface RunResult { stdout: string; stderr: string; status: number; }
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+test('gate rest: writes a session event YAML under <content_root>/sessions/', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /✓ rested: \d{4}-\d{2}-\d{2}-\d{3,4} by alice/);
+
+  const sessionsDir = join(root, 'sessions');
+  assert.ok(existsSync(sessionsDir), 'sessions/ directory exists');
+  const files = readdirSync(sessionsDir);
+  assert.equal(files.length, 1);
+  const file = files[0]!;
+  assert.match(file, /^\d{4}-\d{2}-\d{2}-\d{3,4}\.yaml$/);
+  const yaml = readFileSync(join(sessionsDir, file), 'utf8');
+  assert.match(yaml, /kind: rest/);
+  assert.match(yaml, /by: alice/);
+  assert.match(yaml, /at: \d{4}-\d{2}-\d{2}T/);
+  assert.doesNotMatch(yaml, /note:/, 'no --note → field omitted (byte-stable)');
+});
+
+test('gate rest --note: stamps the note in YAML and prints it in text mode', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest', '--by', 'alice', '--note', 'stepping away for lunch']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ rested: \d{4}-\d{2}-\d{2}-\d{3,4} by alice/);
+  assert.match(r.stdout, /note: stepping away for lunch/);
+
+  const file = readdirSync(join(root, 'sessions'))[0]!;
+  const yaml = readFileSync(join(root, 'sessions', file), 'utf8');
+  assert.match(yaml, /note: stepping away for lunch/);
+});
+
+test('gate rest --format json: emits the structured envelope', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest', '--by', 'alice', '--note', 'hello', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.kind, 'rest');
+  assert.equal(payload.by, 'alice');
+  assert.equal(payload.note, 'hello');
+  assert.match(payload.id, /^\d{4}-\d{2}-\d{2}-\d{3,4}$/);
+  assert.match(payload.at, /^\d{4}-\d{2}-\d{2}T/);
+  assert.match(payload.message, /✓ rested:/);
+  // suggested_next is null until `gate wake` ships — no fake
+  // prescription of a verb that doesn't exist.
+  assert.equal(payload.suggested_next, null);
+});
+
+test('gate rest: GUILD_ACTOR fallback when --by omitted', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /by alice/);
+});
+
+test('gate rest: missing --by and missing GUILD_ACTOR fails closed', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest'], { GUILD_ACTOR: '' });
+  assert.equal(r.status, 1);
+  // Standard "actor required" surface from requireOption.
+  assert.match(r.stderr, /--by/);
+});
+
+test('gate rest: per-day sequence increments', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r1 = JSON.parse(runGate(root, ['rest', '--by', 'alice', '--format', 'json']).stdout);
+  const r2 = JSON.parse(runGate(root, ['rest', '--by', 'alice', '--format', 'json']).stdout);
+  // Same date prefix, sequential suffix.
+  const date1 = r1.id.slice(0, 10);
+  const date2 = r2.id.slice(0, 10);
+  assert.equal(date1, date2);
+  const seq1 = parseInt(r1.id.slice(11), 10);
+  const seq2 = parseInt(r2.id.slice(11), 10);
+  assert.equal(seq2, seq1 + 1);
+});
+
+test('gate rest --note: rejected when > 240 chars', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const longNote = 'x'.repeat(241);
+  const r = runGate(root, ['rest', '--by', 'alice', '--note', longNote]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /note too long \(max 240 chars\)/);
+});
+
+test('gate rest --note: whitespace-only collapses to no-note (omit-when-empty)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest', '--by', 'alice', '--note', '   ', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.note, undefined);
+});
+
+test('gate rest: rejects unknown actor (canonical actor-validation surface)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['rest', '--by', 'nobody']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /nobody/);
+});
+
+test('gate rest: hydrate tolerance — wake / farewell records load without error', (t) => {
+  // Forge two records on disk that future `gate wake` / `gate farewell`
+  // would write. The current binary doesn't expose those verbs yet,
+  // but the domain enum already accepts them; reading must not throw.
+  // Pre-#36-Phase-2 records are simply absent (no `sessions/` dir at
+  // all); this test covers the OPPOSITE direction: a future writer's
+  // record reaches an older reader. Records-outlive-writers
+  // (principle 04).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  mkdirSync(join(root, 'sessions'));
+  writeFileSync(
+    join(root, 'sessions', '2099-01-01-001.yaml'),
+    'id: 2099-01-01-001\nkind: wake\nby: alice\nat: 2099-01-01T00:00:00.000Z\n',
+  );
+  writeFileSync(
+    join(root, 'sessions', '2099-01-01-002.yaml'),
+    'id: 2099-01-01-002\nkind: farewell\nby: alice\nat: 2099-01-01T01:00:00.000Z\nnote: see you tomorrow\n',
+  );
+
+  // gate doctor must read every YAML under content_root and not crash
+  // on the future kinds. A well-formed but unknown-kind record would
+  // surface via parseSessionKind throwing — we expect it to PASS today
+  // because wake / farewell are already in the enum.
+  const doctor = runGate(root, ['doctor', '--format', 'json']);
+  assert.equal(doctor.status, 0);
+  // No plugin-area finding referencing the session files.
+  const report = JSON.parse(doctor.stdout);
+  const sessionFinding = (report.findings as Array<{ source: string }>).find(
+    (f) => f.source.includes('sessions/'),
+  );
+  assert.equal(sessionFinding, undefined, 'session events must hydrate cleanly');
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -42,7 +42,7 @@ const GATE_ALL = [
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
-  'schema', 'unresponded', 'templates',
+  'schema', 'unresponded', 'templates', 'rest',
 ] as const;
 
 const AGORA_ALL = [


### PR DESCRIPTION
## Summary

First slice of #36 Phase 2 (time-aware verbs). `gate rest` stamps a "putting this down now" timestamp without transitioning any lifecycle state — boundary marker, not a toggle. The matching `gate wake` and `gate farewell` verbs land in follow-up PRs.

## Surface

```
$ gate rest --by alice
✓ rested: 2026-05-08-001 by alice

$ gate rest --by alice --note 'lunch break'
✓ rested: 2026-05-08-002 by alice
  note: lunch break

$ gate rest --by alice --format json
{
  "ok": true,
  "id": "2026-05-08-003",
  "kind": "rest",
  "by": "alice",
  "at": "2026-05-08T...",
  "message": "✓ rested: 2026-05-08-003 by alice",
  "suggested_next": null
}
```

## Storage

`<content_root>/sessions/<id>.yaml` — one file per event, id format `YYYY-MM-DD-NNN` (per-day sequence, same shape as request / issue ids minus the entity prefix).

## Why a boundary record

Agents (human or AI) accumulate fatigue or context drift inside long sessions. Marking the boundaries in-band lets downstream verbs (`tail`, `voices`, `resume`) render the session with the boundary visible — the length of a break is itself information, the way a commit timestamp is. Explicit `rest`/`wake` pairs let `gate resume` (in a future PR) compute "you were away N hours" instead of "you last wrote N hours ago, unclear whether intentional".

## Why optional `--note`

Mandating a wake-note would turn the verb into "reflect" — a different shape with a different ergonomic cost. The bare form `gate rest` must stay frictionless so an agent reaches for it as easily as `git commit -m '.'`.

`--note` is sanitised through the shared text path (control chars stripped, trim, max 240 chars). Whitespace-only collapses to undefined — bare `--note ""` is a true no-op.

## Forward-compat for the future siblings

Domain enum carries the full union from day one:

```ts
SESSION_KINDS = ['rest', 'wake', 'farewell']
```

The schema / repository / hydrate paths accept all three already, so when `gate wake` and `gate farewell` ship, no breaking change is needed. Records with `kind: wake` or `kind: farewell` written by a future version hydrate cleanly today (records-outlive-writers, principle 04). A test pins this contract.

`suggested_next` is `null` until `gate wake` ships — no fake prescription of a verb that doesn't exist. The slot will name `wake` once the follow-up PR lands.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1358/1358 pass on linux (10 new tests)
  - writes session event YAML under `<content_root>/sessions/`
  - `--note` stamps the note in YAML + prints it in text mode
  - `--format json` emits the structured envelope
  - `GUILD_ACTOR` fallback when `--by` omitted
  - missing `--by` + missing `GUILD_ACTOR` → fail-closed
  - per-day sequence increments
  - `--note` > 240 chars rejected
  - whitespace-only `--note` collapses to undefined
  - unknown actor rejected
  - hydrate tolerance: future `kind: wake` / `kind: farewell` records load without error
- [x] Visual sanity check on a live `gate rest` flow (3 calls, all 3 YAML files round-trip clean)

## Files

**New**:
- `src/domain/session/SessionEvent.ts` — `SessionEvent` aggregate, `SESSION_KINDS` enum, `parseSessionKind`
- `src/application/session/SessionEventRepository.ts` — repository port
- `src/application/session/SessionEventUseCases.ts` — `record({ kind, by, note? })`
- `src/infrastructure/persistence/YamlSessionEventRepository.ts` — YAML impl with per-day sequence allocation + hydrate tolerance
- `src/interface/gate/handlers/rest.ts` — `gate rest` handler
- `tests/interface/rest.test.ts` — 10 new tests

**Modified**:
- `src/infrastructure/config/GuildConfig.ts` — `paths.sessions` field (default `<content_root>/sessions`)
- `src/interface/shared/container.ts` — `c.sessionEventUC` wiring
- `src/interface/gate/index.ts` — dispatch case + KNOWN_COMMANDS entry
- `src/interface/gate/verbs.ts` — `WRITE_VERBS.add('rest')`
- `src/interface/gate/handlers/schema.ts` — schema entry for `gate rest`
- `tests/interface/verbs-consistency.test.ts` — `GATE_ALL` adds `'rest'`

## Next

- `gate wake` (#36 Phase 2 step 2) — pairing verb, fills the `suggested_next` slot
- `gate farewell` (#36 Phase 2 step 3) — ceremonial close, pairs with `gate resume` at next session start
- `gate resume` integration — surface `rest` / `wake` / `farewell` boundaries in the restoration prose so a returning session sees "you were away N hours" instead of guessing from the last utterance timestamp

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_