### PR TITLE
feat(gate): gate wake — pairing verb to rest (#36 Phase 2 step 2)

### DIFF
--- a/src/interface/gate/handlers/rest.ts
+++ b/src/interface/gate/handlers/rest.ts
@@ -54,11 +54,17 @@ export async function restCmd(c: C, args: ParsedArgs): Promise<number> {
           ok: true,
           ...event.toJSON(),
           message,
-          // No suggested_next: the natural pair (`gate wake`) lands
-          // in a follow-up PR. Pre-suggesting a verb that doesn't
-          // exist yet would be a fake prescription. Once `wake`
-          // ships, this slot will name it.
-          suggested_next: null,
+          // Rest → wake: the natural pair. The agent stamps a
+          // boundary now, picks the work back up later with
+          // `gate wake`. Both verbs are independent (wake doesn't
+          // require a prior rest, rest doesn't require a follow-
+          // up wake); the suggestion is advisory, not enforced.
+          suggested_next: {
+            verb: 'wake',
+            args: { by: event.by.value },
+            reason:
+              'When you return, `gate wake` stamps the matching boundary so the gap between rest and wake is recoverable from the record. Skip if the run is abandoned — wake is optional.',
+          },
         },
         null,
         2,

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -592,7 +592,34 @@ const VERBS: readonly VerbSchema[] = [
     name: 'rest',
     category: 'write',
     summary:
-      'boundary record (#36 Phase 2). Stamps a "putting this down now" timestamp; not a lifecycle toggle. Optional --note. The matching `gate wake` and `gate farewell` verbs ship in follow-up PRs.',
+      'boundary record (#36 Phase 2): stamps a "putting this down now" timestamp; not a lifecycle toggle. Optional --note. Pairs with `gate wake` — both verbs are independent, the relationship is observed by readers.',
+    input: {
+      type: 'object',
+      properties: {
+        by: strOpt('actor (defaults to $GUILD_ACTOR)'),
+        note: strOpt('optional free-form context (≤ 240 chars)'),
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        id: { type: 'string', description: 'YYYY-MM-DD-NNN per-day sequence' },
+        kind: { type: 'string', enum: ['rest', 'wake', 'farewell'] },
+        by: str,
+        at: str,
+        note: strOpt(),
+        message: str,
+        suggested_next: { type: 'object' },
+      },
+    },
+  },
+  {
+    name: 'wake',
+    category: 'write',
+    summary:
+      'boundary record (#36 Phase 2): stamps a "picking this back up" timestamp. Pairs with `gate rest` but does NOT require a prior rest record. Suggests `gate boot` next so a returning agent re-orients.',
     input: {
       type: 'object',
       properties: {

--- a/src/interface/gate/handlers/wake.ts
+++ b/src/interface/gate/handlers/wake.ts
@@ -1,0 +1,87 @@
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { parseFormat } from './writeFormat.js';
+
+/**
+ * gate wake [--by <m>] [--note <s>] [--format json|text]
+ *
+ * Pairing verb to `gate rest` — "I am picking this back up"
+ * (#36 Phase 2 step 2).
+ *
+ * Decoupled from rest by design: wake does NOT require a prior
+ * rest record. The two are independent boundary stamps; the
+ * relationship is observed by the reader (`gate resume` will
+ * compute "you were away N hours" by reading rest/wake pairs in
+ * a follow-up integration), not enforced by the writer. This
+ * keeps wake usable on its own when an agent forgot to rest, and
+ * keeps rest usable on its own when the next session never wakes
+ * (the run was abandoned).
+ *
+ * Like rest: not a lifecycle toggle, just a moment-stamp. The
+ * length of the interval between rest and wake is itself
+ * information — explicit pairs let downstream verbs render the
+ * session with the boundary visible. Optional `--note` follows
+ * the same tight-scope rules as rest's: ≤ 240 chars, sanitised,
+ * empty/whitespace collapses to undefined.
+ *
+ * Suggests `gate boot` next: by definition, wake means the agent
+ * just returned. Boot is the orientation lense for that moment —
+ * what changed in the inbox / queues / cross-passage state since
+ * the rest. (The opposite direction — rest suggests wake — lives
+ * in `rest.ts`.)
+ */
+const WAKE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'format',
+]);
+
+export async function wakeCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WAKE_KNOWN_FLAGS, 'wake');
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const note = optionalOption(args, 'note');
+  const format = parseFormat(args);
+
+  const event = await c.sessionEventUC.record({
+    kind: 'wake',
+    by,
+    ...(note !== undefined ? { note } : {}),
+  });
+
+  const message = `✓ woke: ${event.id} by ${event.by.value}`;
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          ...event.toJSON(),
+          message,
+          // Wake → boot: the agent just returned, so the natural
+          // next move is to orient against whatever changed during
+          // the break. Suggesting boot rather than a specific
+          // lifecycle verb keeps the prescription advisory — the
+          // agent reads the boot output and decides what to do.
+          suggested_next: {
+            verb: 'boot',
+            args: {},
+            reason:
+              'You just woke — boot surfaces the inbox / queues / cross-passage signals that landed during your rest, so you can pick up with full context.',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(message + '\n');
+    if (event.note !== undefined) {
+      process.stdout.write(`  note: ${event.note}\n`);
+    }
+  }
+  return 0;
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -37,6 +37,7 @@ import { bootCmd } from './handlers/boot.js';
 import { schemaCmd } from './handlers/schema.js';
 import { resumeCmd } from './handlers/resume.js';
 import { restCmd } from './handlers/rest.js';
+import { wakeCmd } from './handlers/wake.js';
 import { reqRegister } from './handlers/register.js';
 import {
   msgSend,
@@ -280,6 +281,7 @@ const KNOWN_COMMANDS = [
   'unresponded',
   'templates',
   'rest',
+  'wake',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -461,6 +463,8 @@ async function dispatch(
       return await resumeCmd(c, args);
     case 'rest':
       return await restCmd(c, args);
+    case 'wake':
+      return await wakeCmd(c, args);
     case 'schema':
       return await schemaCmd(c, args);
     case 'unresponded':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -58,6 +58,7 @@ export const WRITE_VERBS: ReadonlySet<string> = new Set([
   'broadcast',
   'inbox',
   'rest',
+  'wake',
 ]);
 
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set([

--- a/tests/interface/rest.test.ts
+++ b/tests/interface/rest.test.ts
@@ -102,9 +102,13 @@ test('gate rest --format json: emits the structured envelope', (t) => {
   assert.match(payload.id, /^\d{4}-\d{2}-\d{2}-\d{3,4}$/);
   assert.match(payload.at, /^\d{4}-\d{2}-\d{2}T/);
   assert.match(payload.message, /✓ rested:/);
-  // suggested_next is null until `gate wake` ships — no fake
-  // prescription of a verb that doesn't exist.
-  assert.equal(payload.suggested_next, null);
+  // Rest's natural pair is `gate wake` (#36 Phase 2 step 2).
+  // The suggestion is advisory — wake doesn't require a prior
+  // rest, but stamping the matching boundary makes the gap
+  // recoverable from the record.
+  assert.equal(payload.suggested_next.verb, 'wake');
+  assert.equal(payload.suggested_next.args.by, 'alice');
+  assert.match(payload.suggested_next.reason, /gap between rest and wake/);
 });
 
 test('gate rest: GUILD_ACTOR fallback when --by omitted', (t) => {

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -42,7 +42,7 @@ const GATE_ALL = [
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
-  'schema', 'unresponded', 'templates', 'rest',
+  'schema', 'unresponded', 'templates', 'rest', 'wake',
 ] as const;
 
 const AGORA_ALL = [

--- a/tests/interface/wake.test.ts
+++ b/tests/interface/wake.test.ts
@@ -1,0 +1,138 @@
+// gate wake — pairing verb to gate rest (#36 Phase 2 step 2).
+//
+// Pins:
+//   - JSON envelope shape (kind: 'wake', suggested_next → 'boot')
+//   - text mode prints the success line and the optional note
+//   - same storage path as rest (sessions/<id>.yaml, kind discriminator)
+//   - decoupled from rest: wake works WITHOUT a prior rest record
+//   - per-day sequence shares the same allocator as rest (one
+//     `sessions/` namespace, all kinds count toward the same seq)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  readdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('gate-wake-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+interface RunResult { stdout: string; stderr: string; status: number; }
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+test('gate wake: writes a session event YAML with kind: wake', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['wake', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /✓ woke: \d{4}-\d{2}-\d{2}-\d{3,4} by alice/);
+
+  const file = readdirSync(join(root, 'sessions'))[0]!;
+  const yaml = readFileSync(join(root, 'sessions', file), 'utf8');
+  assert.match(yaml, /kind: wake/);
+  assert.match(yaml, /by: alice/);
+});
+
+test('gate wake --format json: emits envelope with suggested_next → boot', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['wake', '--by', 'alice', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.kind, 'wake');
+  assert.equal(payload.by, 'alice');
+  // Wake → boot: the agent just returned; boot is the orientation
+  // lense for what changed during the rest.
+  assert.equal(payload.suggested_next.verb, 'boot');
+  assert.match(payload.suggested_next.reason, /just woke/);
+});
+
+test('gate wake: works without a prior rest record (decoupled by design)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  // No rest call before this wake — should still succeed.
+  const r = runGate(root, ['wake', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+});
+
+test('gate wake: rest + wake share the same per-day sequence allocator', (t) => {
+  // Both verbs write to the same sessions/ directory, so the
+  // sequence is contiguous across kinds — first rest gets 001,
+  // following wake gets 002, etc. This keeps the on-disk ordering
+  // chronological by id without a kind-aware tiebreaker.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r1 = JSON.parse(runGate(root, ['rest', '--by', 'alice', '--format', 'json']).stdout);
+  const r2 = JSON.parse(runGate(root, ['wake', '--by', 'alice', '--format', 'json']).stdout);
+  const seq1 = parseInt(r1.id.slice(11), 10);
+  const seq2 = parseInt(r2.id.slice(11), 10);
+  assert.equal(seq2, seq1 + 1);
+  assert.equal(r1.kind, 'rest');
+  assert.equal(r2.kind, 'wake');
+});
+
+test('gate wake --note: stamps the note in YAML and prints it in text mode', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['wake', '--by', 'alice', '--note', 'back from coffee']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /note: back from coffee/);
+
+  const file = readdirSync(join(root, 'sessions'))[0]!;
+  const yaml = readFileSync(join(root, 'sessions', file), 'utf8');
+  assert.match(yaml, /note: back from coffee/);
+});
+
+test('gate wake: missing --by + missing GUILD_ACTOR fails closed', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['wake'], { GUILD_ACTOR: '' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--by/);
+});
+
+test('gate wake --note: rejected when > 240 chars', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const longNote = 'x'.repeat(241);
+  const r = runGate(root, ['wake', '--by', 'alice', '--note', longNote]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /note too long \(max 240 chars\)/);
+});


### PR DESCRIPTION
## Summary

Second slice of #36 Phase 2 (time-aware verbs). `gate wake` stamps a "picking this back up" timestamp — the natural pair to `gate rest` (PR #261).

## Decoupled by design

Wake does **not** require a prior rest record. The two are independent boundary stamps; the relationship is observed by the reader (a future `gate resume` integration will compute "you were away N hours" by reading rest/wake pairs). This keeps wake usable on its own when an agent forgot to rest, and keeps rest usable on its own when the run was abandoned.

## Surface

```
$ gate rest --by alice --note 'lunch break'
✓ rested: 2026-05-08-001 by alice
  note: lunch break

$ gate wake --by alice
✓ woke: 2026-05-08-002 by alice

$ gate wake --format json
{
  "ok": true,
  "id": "2026-05-08-003",
  "kind": "wake",
  "by": "alice",
  "at": "2026-05-08T...",
  "message": "✓ woke: 2026-05-08-003 by alice",
  "suggested_next": {
    "verb": "boot",
    "args": {},
    "reason": "You just woke — boot surfaces the inbox / queues / cross-passage signals that landed during your rest, so you can pick up with full context."
  }
}
```

## suggested_next semantics

- **rest → wake** (updated this PR): "stamp the matching boundary so the gap is recoverable from the record. Skip if the run is abandoned — wake is optional."
- **wake → boot**: "the agent just returned; boot is the orientation lense for what changed during the rest."

Both suggestions are advisory — the verbs don't enforce the pair.

## Mechanics mirror rest

Same domain (`SessionEvent.kind: 'wake'` already in the enum from PR #261), same `SessionEventUseCases.record({kind, by, note?})`, same storage path (`<content_root>/sessions/<id>.yaml`), same per-day sequence allocator (rest + wake share the `sessions/` namespace, so seq is contiguous across kinds — chronological by id without a kind-aware tiebreaker), same `--note` tight-scope rules.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1365/1365 pass on linux (7 new + 1 updated)
  - new: writes a session event YAML with `kind: wake`
  - new: JSON envelope includes `suggested_next → boot`
  - new: works without a prior rest record (decoupled)
  - new: rest + wake share the same per-day sequence allocator
  - new: `--note` stamps the note in YAML and prints in text mode
  - new: missing `--by` + missing `GUILD_ACTOR` fails closed
  - new: `--note` > 240 chars rejected
  - updated: rest test (suggested_next was `null` in PR #261, now points at wake)
- [x] Visual sanity check on a live `gate rest` → `gate wake` flow

## Files

**New**:
- `src/interface/gate/handlers/wake.ts` — handler
- `tests/interface/wake.test.ts` — 7 new tests

**Modified**:
- `src/interface/gate/handlers/rest.ts` — `suggested_next` now points at `gate wake`
- `src/interface/gate/handlers/schema.ts` — schema entry for `gate wake`
- `src/interface/gate/index.ts` — dispatch case + KNOWN_COMMANDS
- `src/interface/gate/verbs.ts` — `WRITE_VERBS.add('wake')`
- `tests/interface/rest.test.ts` — pin the new rest → wake suggestion
- `tests/interface/verbs-consistency.test.ts` — `GATE_ALL` adds `'wake'`

## Next

- `gate farewell` (#36 Phase 2 step 3) — ceremonial close, pairs with `gate resume` at the next session start. Distinct from `rest` because it's "until next session" not "until later today".
- `gate resume` integration — surface `rest` / `wake` / `farewell` boundaries in restoration prose so a returning session sees "you were away N hours" instead of guessing from the last utterance timestamp.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_