### PR TITLE
feat(gate): gate farewell — ceremonial close (#36 Phase 2 step 3)

### DIFF
--- a/src/interface/gate/handlers/farewell.ts
+++ b/src/interface/gate/handlers/farewell.ts
@@ -1,0 +1,86 @@
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { parseFormat } from './writeFormat.js';
+
+/**
+ * gate farewell [--by <m>] [--note <s>] [--format json|text]
+ *
+ * Ceremonial close — "until next session" (#36 Phase 2 step 3).
+ *
+ * Distinct from `gate rest` ("until later today"): farewell is
+ * the boundary an agent stamps before the session ENDS, not before
+ * a break inside the same session. Pairs with `gate resume` at the
+ * next session start — the future `gate resume` integration will
+ * compose restoration prose around the most recent farewell, so the
+ * next session starts with "your last farewell at {timestamp},
+ * here's what was open at the time" rather than guessing from the
+ * tail of the activity log.
+ *
+ * Why two boundary verbs (rest / farewell) rather than one with a
+ * flag: ergonomics. The verb name carries the semantic — agents
+ * reach for `rest` mid-session and `farewell` at session-end
+ * naturally. A `--scope=session|day` flag on `rest` would push the
+ * decision into the call site every time. Two short verbs cost
+ * nothing on the dispatch table and stay frictionless.
+ *
+ * suggested_next is null: farewell is terminal in the session
+ * sense. The next call comes from a NEW session running
+ * `gate resume`. Pre-suggesting resume here would be a weird
+ * shape — the JSON consumer that just farewelled wouldn't run it.
+ * The advisory pointer at resume lives in the text-mode message
+ * footer instead, where a human reader sees it as a parting note.
+ */
+const FAREWELL_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+  'format',
+]);
+
+export async function farewellCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, FAREWELL_KNOWN_FLAGS, 'farewell');
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const note = optionalOption(args, 'note');
+  const format = parseFormat(args);
+
+  const event = await c.sessionEventUC.record({
+    kind: 'farewell',
+    by,
+    ...(note !== undefined ? { note } : {}),
+  });
+
+  const message = `✓ farewell: ${event.id} by ${event.by.value}`;
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          ...event.toJSON(),
+          message,
+          // Terminal in the session sense — see file header for
+          // why null here is the right shape.
+          suggested_next: null,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(message + '\n');
+    if (event.note !== undefined) {
+      process.stdout.write(`  note: ${event.note}\n`);
+    }
+    // Parting note — text-mode only, since the JSON envelope's
+    // suggested_next is structured advisory and a free-form
+    // "next time, do X" doesn't fit. Humans (or text-mode agents)
+    // reading farewell's output see the resume hint here.
+    process.stdout.write(
+      `  next session: \`gate resume\` will pick up around this farewell.\n`,
+    );
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -643,6 +643,33 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'farewell',
+    category: 'write',
+    summary:
+      'ceremonial close (#36 Phase 2): stamps an "until next session" timestamp. Distinct from `gate rest` — farewell ends the session, rest is a mid-session break. Pairs with `gate resume` at the next session start. suggested_next is null (terminal in the session sense).',
+    input: {
+      type: 'object',
+      properties: {
+        by: strOpt('actor (defaults to $GUILD_ACTOR)'),
+        note: strOpt('optional free-form context (≤ 240 chars)'),
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        ok: { type: 'boolean' },
+        id: { type: 'string', description: 'YYYY-MM-DD-NNN per-day sequence' },
+        kind: { type: 'string', enum: ['rest', 'wake', 'farewell'] },
+        by: str,
+        at: str,
+        note: strOpt(),
+        message: str,
+        suggested_next: { type: 'object' },
+      },
+    },
+  },
+  {
     name: 'whoami',
     category: 'read',
     summary: 'identity + recent utterances (requires GUILD_ACTOR)',

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -38,6 +38,7 @@ import { schemaCmd } from './handlers/schema.js';
 import { resumeCmd } from './handlers/resume.js';
 import { restCmd } from './handlers/rest.js';
 import { wakeCmd } from './handlers/wake.js';
+import { farewellCmd } from './handlers/farewell.js';
 import { reqRegister } from './handlers/register.js';
 import {
   msgSend,
@@ -282,6 +283,7 @@ const KNOWN_COMMANDS = [
   'templates',
   'rest',
   'wake',
+  'farewell',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -465,6 +467,8 @@ async function dispatch(
       return await restCmd(c, args);
     case 'wake':
       return await wakeCmd(c, args);
+    case 'farewell':
+      return await farewellCmd(c, args);
     case 'schema':
       return await schemaCmd(c, args);
     case 'unresponded':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -59,6 +59,7 @@ export const WRITE_VERBS: ReadonlySet<string> = new Set([
   'inbox',
   'rest',
   'wake',
+  'farewell',
 ]);
 
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set([

--- a/tests/interface/farewell.test.ts
+++ b/tests/interface/farewell.test.ts
@@ -1,0 +1,164 @@
+// gate farewell — ceremonial close (#36 Phase 2 step 3).
+//
+// Pins:
+//   - JSON envelope shape (kind: 'farewell', suggested_next: null)
+//   - text mode prints the success line + the next-session resume hint
+//   - same storage path as rest/wake (sessions/<id>.yaml,
+//     kind discriminator)
+//   - --note tight-scope (≤ 240 chars, sanitised, empty → omitted)
+//   - missing --by + missing GUILD_ACTOR → fail-closed
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  readdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('gate-farewell-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+interface RunResult { stdout: string; stderr: string; status: number; }
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+test('gate farewell: writes a session event YAML with kind: farewell', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['farewell', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /✓ farewell: \d{4}-\d{2}-\d{2}-\d{3,4} by alice/);
+
+  const file = readdirSync(join(root, 'sessions'))[0]!;
+  const yaml = readFileSync(join(root, 'sessions', file), 'utf8');
+  assert.match(yaml, /kind: farewell/);
+  assert.match(yaml, /by: alice/);
+});
+
+test('gate farewell text mode: prints next-session resume hint', (t) => {
+  // The advisory pointer at `gate resume` lives in text mode (not
+  // suggested_next) because the JSON consumer that just farewelled
+  // by definition won't run resume — it's the NEXT session's first
+  // call. Text mode is for the human reader who sees it as a
+  // parting note.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['farewell', '--by', 'alice']);
+  assert.match(r.stdout, /next session: `gate resume`/);
+});
+
+test('gate farewell --format json: suggested_next is null (terminal in session sense)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['farewell', '--by', 'alice', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.kind, 'farewell');
+  assert.equal(payload.by, 'alice');
+  // farewell ends the session — pre-suggesting resume here would
+  // be a weird shape since the consumer that just farewelled
+  // wouldn't immediately run resume. Null is the right shape.
+  assert.equal(payload.suggested_next, null);
+});
+
+test('gate farewell --note: stamps note + still prints resume hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, [
+    'farewell', '--by', 'alice',
+    '--note', 'shipping the wake/farewell PR',
+  ]);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /note: shipping the wake\/farewell PR/);
+  assert.match(r.stdout, /next session: `gate resume`/);
+
+  const file = readdirSync(join(root, 'sessions'))[0]!;
+  const yaml = readFileSync(join(root, 'sessions', file), 'utf8');
+  assert.match(yaml, /note: shipping the wake\/farewell PR/);
+});
+
+test('gate farewell: rest + wake + farewell share the same per-day sequence', (t) => {
+  // All three boundary verbs write to the same sessions/ directory;
+  // the per-day allocator counts every kind toward one chronological
+  // sequence. id ordering matches wall-clock ordering without a
+  // kind-aware tiebreaker.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r1 = JSON.parse(runGate(root, ['rest', '--by', 'alice', '--format', 'json']).stdout);
+  const r2 = JSON.parse(runGate(root, ['wake', '--by', 'alice', '--format', 'json']).stdout);
+  const r3 = JSON.parse(runGate(root, ['farewell', '--by', 'alice', '--format', 'json']).stdout);
+  const seq1 = parseInt(r1.id.slice(11), 10);
+  const seq2 = parseInt(r2.id.slice(11), 10);
+  const seq3 = parseInt(r3.id.slice(11), 10);
+  assert.equal(seq2, seq1 + 1);
+  assert.equal(seq3, seq2 + 1);
+  assert.equal(r1.kind, 'rest');
+  assert.equal(r2.kind, 'wake');
+  assert.equal(r3.kind, 'farewell');
+});
+
+test('gate farewell: missing --by + missing GUILD_ACTOR fails closed', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, ['farewell'], { GUILD_ACTOR: '' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /--by/);
+});
+
+test('gate farewell --note: rejected when > 240 chars', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const longNote = 'x'.repeat(241);
+  const r = runGate(root, ['farewell', '--by', 'alice', '--note', longNote]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /note too long \(max 240 chars\)/);
+});
+
+test('gate farewell --note: whitespace-only collapses to no-note', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+
+  const r = runGate(root, [
+    'farewell', '--by', 'alice',
+    '--note', '   ',
+    '--format', 'json',
+  ]);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.note, undefined);
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -42,7 +42,7 @@ const GATE_ALL = [
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
-  'schema', 'unresponded', 'templates', 'rest', 'wake',
+  'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
 ] as const;
 
 const AGORA_ALL = [


### PR DESCRIPTION
## Summary

Third (and final) slice of #36 Phase 2 (time-aware verbs). `gate farewell` stamps an "until next session" timestamp — distinct from `gate rest` ("until later today") because farewell **ends** the session.

Pairs with `gate resume` at the next session start. The future `gate resume` integration will compose restoration prose around the most recent farewell so a returning agent starts with "your last farewell at {ts}, here's what was open at the time" rather than guessing from the tail of the activity log.

## Why two boundary verbs (rest / farewell) rather than one with a flag

Ergonomics. The verb name carries the semantic — agents reach for `rest` mid-session and `farewell` at session-end naturally. A `--scope=session|day` flag on `rest` would push the decision into the call site every time. Two short verbs cost nothing on the dispatch table and stay frictionless.

## suggested_next is null (terminal in session sense)

Pre-suggesting `resume` from farewell would be a weird shape — the JSON consumer that just farewelled by definition won't run resume (it's the **next** session's first call). The advisory pointer at resume lives in the text-mode message footer instead, where a human reader sees it as a parting note.

## Surface

```
$ gate farewell --by alice --note 'shipping the wake/farewell PR'
✓ farewell: 2026-05-08-001 by alice
  note: shipping the wake/farewell PR
  next session: `gate resume` will pick up around this farewell.

$ gate farewell --by alice --format json
{
  "ok": true,
  "id": "2026-05-08-002",
  "kind": "farewell",
  "by": "alice",
  "at": "...",
  "message": "✓ farewell: 2026-05-08-002 by alice",
  "suggested_next": null
}
```

## Mechanics

Mirrors rest/wake exactly (PR #261, #262): same `SessionEventUseCases.record({kind, by, note?})`, same storage (`<content_root>/sessions/<id>.yaml`, `kind: farewell`), same per-day sequence (rest + wake + farewell share the `sessions/` namespace, contiguous chronological ordering), same `--note` tight-scope rules.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1373/1373 pass on linux (8 new tests)
  - writes session event YAML with `kind: farewell`
  - text mode prints next-session `gate resume` hint
  - JSON envelope: `suggested_next` is null
  - `--note` stamps note + still prints resume hint in text mode
  - rest + wake + farewell share per-day sequence
  - missing `--by` + missing `GUILD_ACTOR` fails closed
  - `--note` > 240 chars rejected
  - whitespace-only `--note` collapses to no-note
- [x] Visual sanity check: live rest → wake → farewell flow

## Files

**New**:
- `src/interface/gate/handlers/farewell.ts` — handler
- `tests/interface/farewell.test.ts` — 8 new tests

**Modified**:
- `src/interface/gate/handlers/schema.ts` — schema entry
- `src/interface/gate/index.ts` — dispatch case + KNOWN_COMMANDS
- `src/interface/gate/verbs.ts` — `WRITE_VERBS.add('farewell')`
- `tests/interface/verbs-consistency.test.ts` — `GATE_ALL` adds `'farewell'`

## Phase 2 status after this PR

- [x] `gate rest` (PR #261)
- [x] `gate wake` (PR #262)
- [x] `gate farewell` (this PR)
- [ ] `gate resume` integration with rest / wake / farewell records — deferred follow-up. Composes "you were away N hours" into restoration prose using the boundary timestamps. Lower urgency than the verbs themselves: the records already write correctly; reading them is additive.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_