### PR TITLE
feat(gate resume): surface session boundary in restoration prose (#36 Phase 2 follow-up)

### DIFF
--- a/src/application/session/SessionEventUseCases.ts
+++ b/src/application/session/SessionEventUseCases.ts
@@ -48,4 +48,16 @@ export class SessionEventUseCases {
     await this.deps.events.save(event);
     return event;
   }
+
+  /**
+   * Read every session-boundary record under content_root. Used by
+   * `gate resume` to surface the most recent boundary in the
+   * restoration prose ("you said farewell N hours ago — welcome
+   * back"). Pure read, no side effects. Empty when the
+   * `<content_root>/sessions/` directory is missing or empty —
+   * matches the conservative pattern other repository ports use.
+   */
+  async listAll(): Promise<readonly SessionEvent[]> {
+    return this.deps.events.listAll();
+  }
 }

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -11,6 +11,24 @@ import { Request, StatusLogEntry } from '../../../domain/request/Request.js';
 import { collectUtterances, Utterance, RequestJSON } from '../voices.js';
 import { deriveSuggestedNext, SuggestedNext } from './writeFormat.js';
 import { UnrespondedConcernsEntry } from '../../../application/concern/UnrespondedConcernsQuery.js';
+import type { SessionEvent, SessionKind } from '../../../domain/session/SessionEvent.js';
+
+/**
+ * Most recent session boundary stamped by the resuming actor
+ * (#36 Phase 2 integration). Surfaced so a returning session sees
+ * "you said farewell N hours ago — welcome back" instead of
+ * inferring the gap from the last activity timestamp.
+ *
+ * Null when the actor has no boundary records (pre-Phase-2
+ * content_roots, or actors who never reach for `gate rest` /
+ * `gate wake` / `gate farewell`).
+ */
+interface SessionBoundaryHint {
+  readonly kind: SessionKind;
+  readonly at: string;
+  readonly age_hint: string;
+  readonly note?: string;
+}
 
 /**
  * gate resume [--format json|text]
@@ -85,6 +103,16 @@ interface TransitionJSON {
 interface ResumePayload {
   actor: string;
   session_hint: string | null;
+  /**
+   * Most recent session boundary stamped by THIS actor (#36
+   * Phase 2). Distinct from `session_hint` (which is the actor's
+   * last activity timestamp): a boundary record is an explicit
+   * "I am putting this down" / "I am picking it back up" /
+   * "until next session" stamp. Null when the actor has no
+   * boundary records — either pre-Phase-2 content_roots or
+   * actors who never reach for the boundary verbs.
+   */
+  last_boundary: SessionBoundaryHint | null;
   last_context: {
     summary: string;
     last_utterance: Utterance | null;
@@ -181,6 +209,16 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   // in the record. Null when the actor hasn't spoken yet.
   const sessionHint = lastUtterance?.at ?? lastTransition?.at ?? null;
 
+  // Most recent session boundary for this actor (#36 Phase 2
+  // integration). Loaded as a separate concern from the request
+  // listAll above — boundaries live under sessions/, requests under
+  // requests/, the two paths don't overlap. listAll throws an empty
+  // array on a missing sessions/ dir (the conservative read pattern
+  // the safe-fs helpers already use), so pre-Phase-2 content_roots
+  // simply land on null without needing a special branch here.
+  const allEvents = await c.sessionEventUC.listAll();
+  const lastBoundary = findLastBoundary(allEvents, actorLower);
+
   // Locale resolution: --locale takes precedence, then GUILD_LOCALE,
   // then default 'en'. Kept narrow (en / ja) because the templates
   // live in this file; adding a locale means writing the prose here.
@@ -199,12 +237,14 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     openLoops,
     unrespondedConcerns,
     suggested,
+    lastBoundary,
     locale,
   });
 
   const payload: ResumePayload = {
     actor,
     session_hint: sessionHint,
+    last_boundary: lastBoundary,
     last_context: {
       summary,
       last_utterance: lastUtterance,
@@ -237,6 +277,32 @@ function transitionToJSON(
   if (entry.note !== undefined) out.note = entry.note;
   if (entry.invokedBy !== undefined) out.invoked_by = entry.invokedBy;
   return out;
+}
+
+/**
+ * Most recent session-boundary record for the given actor, or null
+ * when the actor has no boundaries on file. Single-pass scan keyed
+ * on `event.by.value === actorLower`. The `at` field is an ISO-8601
+ * UTC timestamp so lexicographic comparison is exact (every boundary
+ * write goes through `Clock.now().toISOString()`).
+ */
+function findLastBoundary(
+  events: readonly SessionEvent[],
+  actorLower: string,
+): SessionBoundaryHint | null {
+  let latest: SessionEvent | null = null;
+  for (const e of events) {
+    if (e.by.value !== actorLower) continue;
+    if (latest === null || e.at > latest.at) latest = e;
+  }
+  if (latest === null) return null;
+  const hint: SessionBoundaryHint = {
+    kind: latest.kind,
+    at: latest.at,
+    age_hint: ageHint(latest.at, new Date().toISOString()),
+    ...(latest.note !== undefined ? { note: latest.note } : {}),
+  };
+  return hint;
 }
 
 function findLastTransition(
@@ -364,6 +430,7 @@ function composeRestorationProse(ctx: {
   openLoops: readonly OpenLoop[];
   unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
+  lastBoundary: SessionBoundaryHint | null;
   locale: 'en' | 'ja';
 }): string {
   if (ctx.locale === 'ja') return composeRestorationProseJa(ctx);
@@ -377,11 +444,37 @@ function composeRestorationProseEn(ctx: {
   openLoops: readonly OpenLoop[];
   unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
+  lastBoundary: SessionBoundaryHint | null;
 }): string {
-  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested } = ctx;
+  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested, lastBoundary } = ctx;
   const lines: string[] = [];
   lines.push(`# resuming as ${actor}`);
   lines.push('');
+
+  // Session boundary line (#36 Phase 2). Sits at the top of the
+  // prose because it's the single most useful piece of context for
+  // a returning agent: "you said farewell N hours ago" frames
+  // everything that follows. The line shapes per kind so the
+  // reader sees the right semantic at a glance.
+  if (lastBoundary !== null) {
+    const noteSuffix =
+      lastBoundary.note !== undefined ? ` — "${truncate(lastBoundary.note, 120)}"` : '';
+    if (lastBoundary.kind === 'farewell') {
+      lines.push(
+        `You said farewell at ${lastBoundary.at} (${lastBoundary.age_hint})${noteSuffix} — welcome back.`,
+      );
+    } else if (lastBoundary.kind === 'rest') {
+      lines.push(
+        `You rested at ${lastBoundary.at} (${lastBoundary.age_hint})${noteSuffix}.`,
+      );
+    } else {
+      // wake
+      lines.push(
+        `You woke at ${lastBoundary.at} (${lastBoundary.age_hint})${noteSuffix}.`,
+      );
+    }
+    lines.push('');
+  }
 
   // "Utterance" = a voice (authored / reviewed) — something you said
   // that now lives in the record as text others can read.
@@ -524,11 +617,33 @@ function composeRestorationProseJa(ctx: {
   openLoops: readonly OpenLoop[];
   unrespondedConcerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested: SuggestedNext | null;
+  lastBoundary: SessionBoundaryHint | null;
 }): string {
-  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested } = ctx;
+  const { actor, lastUtterance, lastTransition, openLoops, unrespondedConcerns, suggested, lastBoundary } = ctx;
   const lines: string[] = [];
   lines.push(`# ${actor} として再開`);
   lines.push('');
+
+  // Session boundary line (ja). Same purpose as the en branch:
+  // top of the prose, frames everything that follows.
+  if (lastBoundary !== null) {
+    const noteSuffix =
+      lastBoundary.note !== undefined ? ` — 「${truncate(lastBoundary.note, 120)}」` : '';
+    if (lastBoundary.kind === 'farewell') {
+      lines.push(
+        `${lastBoundary.at} (${lastBoundary.age_hint}) に farewell していました${noteSuffix}。お帰りなさい。`,
+      );
+    } else if (lastBoundary.kind === 'rest') {
+      lines.push(
+        `${lastBoundary.at} (${lastBoundary.age_hint}) に rest しました${noteSuffix}。`,
+      );
+    } else {
+      lines.push(
+        `${lastBoundary.at} (${lastBoundary.age_hint}) に wake しました${noteSuffix}。`,
+      );
+    }
+    lines.push('');
+  }
 
   if (lastUtterance) {
     const age = ageHint(lastUtterance.at, new Date().toISOString());

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -574,6 +574,21 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         actor: str,
         session_hint: str,
+        last_boundary: {
+          type: 'object',
+          description:
+            'Most recent session-boundary record stamped by this actor (#36 Phase 2). ' +
+            "Null when the actor has no `gate rest` / `gate wake` / `gate farewell` " +
+            'records on file. Distinct from `session_hint` (which is the actor\'s last ' +
+            'activity timestamp); a boundary record is an explicit "I am putting this ' +
+            'down" / "picking it back up" / "until next session" stamp.',
+          properties: {
+            kind: { type: 'string', enum: ['rest', 'wake', 'farewell'] },
+            at: str,
+            age_hint: str,
+            note: strOpt(),
+          },
+        },
         last_context: {
           type: 'object',
           properties: {

--- a/tests/interface/resume.test.ts
+++ b/tests/interface/resume.test.ts
@@ -333,3 +333,130 @@ test('resume: empty-path prose points at gate boot (ja)', () => {
     cleanup();
   }
 });
+
+// --- #36 Phase 2 integration: rest / wake / farewell records ---
+
+test('gate resume: last_boundary is null when actor has no boundary records', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    const { stdout, status } = runGate(root, ['resume', '--format', 'json'], {
+      GUILD_ACTOR: 'alice',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.last_boundary, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume: surfaces the most recent farewell with welcome-back framing', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    const farewell = runGate(
+      root,
+      ['farewell', '--by', 'alice', '--note', 'shipping the wake/farewell PR', '--format', 'json'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(farewell.status, 0);
+    const farewellAt = JSON.parse(farewell.stdout).at;
+
+    const r = runGate(root, ['resume', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.last_boundary.kind, 'farewell');
+    assert.equal(payload.last_boundary.at, farewellAt);
+    assert.equal(payload.last_boundary.note, 'shipping the wake/farewell PR');
+    assert.match(payload.last_boundary.age_hint, /ago|just now/);
+    // Welcome-back framing in restoration prose.
+    assert.match(payload.restoration_prose, /welcome back/);
+    assert.match(payload.restoration_prose, /farewell at/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume: rest boundary emits "you rested at" framing', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGate(root, ['rest', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+
+    const r = runGate(root, ['resume', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.last_boundary.kind, 'rest');
+    assert.match(payload.restoration_prose, /You rested at/);
+    assert.doesNotMatch(payload.restoration_prose, /welcome back/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume: wake boundary emits "you woke at" framing', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGate(root, ['wake', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+
+    const r = runGate(root, ['resume', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.last_boundary.kind, 'wake');
+    assert.match(payload.restoration_prose, /You woke at/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume: most recent boundary wins when multiple are stamped', () => {
+  // rest then wake then farewell — last_boundary names farewell.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGate(root, ['rest', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+    runGate(root, ['wake', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+    runGate(root, ['farewell', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+
+    const r = runGate(root, ['resume', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.last_boundary.kind, 'farewell');
+  } finally {
+    cleanup();
+  }
+});
+
+test("gate resume: ignores other actors' boundaries", () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGuild(root, ['new', '--name', 'bob', '--category', 'professional']);
+    // bob farewelled, alice has no boundaries — alice's resume sees null.
+    runGate(root, ['farewell', '--by', 'bob'], { GUILD_ACTOR: 'bob' });
+
+    const r = runGate(root, ['resume', '--format', 'json'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.last_boundary, null, "alice should not see bob's boundary");
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --locale ja: surfaces the boundary in Japanese prose', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'alice', '--category', 'professional']);
+    runGate(root, ['farewell', '--by', 'alice'], { GUILD_ACTOR: 'alice' });
+
+    const r = runGate(
+      root,
+      ['resume', '--format', 'text', '--locale', 'ja'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /farewell していました/);
+    assert.match(r.stdout, /お帰りなさい/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from the rest / wake / farewell triple (PRs #261, #262, #263). `gate resume` now reads the boundary records and frames the restoration prose around them: a returning agent sees "you said farewell N hours ago — welcome back" instead of guessing the gap from the last activity timestamp.

## What changes

### Payload

`ResumePayload` gains a `last_boundary` field:

```ts
last_boundary: {
  kind: 'rest' | 'wake' | 'farewell';
  at: string;
  age_hint: string;
  note?: string;
} | null
```

Null when the actor has no boundary records (pre-Phase-2 content_roots, or actors who never reach for the boundary verbs). Distinct from `session_hint` (which is the actor's last activity timestamp); `last_boundary` is an explicit "I am putting this down" / "picking it back up" / "until next session" stamp.

### Restoration prose

Surfaces the boundary at the top, before `last_utterance` / `open_loops` / `suggested_next`:

```
# resuming as alice

You said farewell at 2026-05-08T23:12:21Z (0s ago) — "shipping Phase 2 integration" — welcome back.

No prior utterance on this content_root — you are arriving fresh.
...
```

Per-kind framing keeps the semantic at-a-glance:

| kind | en framing | ja framing |
|------|------------|------------|
| `farewell` | "you said farewell at ... — welcome back" | "... に farewell していました ... お帰りなさい。" |
| `rest`     | "you rested at ..." | "... に rest しました ..." |
| `wake`     | "you woke at ..." | "... に wake しました ..." |

## Implementation

- `SessionEventUseCases.listAll()` — the repo already had this; the use case was the missing seam
- `resume.ts` loads `c.sessionEventUC.listAll()` alongside requests, runs `findLastBoundary()` over the actor's events (case-insensitive `by` match, lex-compare on `at`)
- Both prose composers (en + ja) get a `lastBoundary` parameter and inject the boundary line before the existing content
- Schema entry for `gate resume` documents the new field with description tying it to `session_hint`

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1380/1380 pass on linux (7 new tests)
  - `last_boundary` is null for actors without boundary records
  - farewell record → "welcome back" framing in prose
  - rest record → "you rested at" framing
  - wake record → "you woke at" framing
  - most recent boundary wins when multiple are stamped
  - other actors' boundaries are ignored
  - ja locale surfaces "お帰りなさい" / "farewell していました"
- [x] Visual sanity check on a live `gate farewell` → `gate resume` flow

## Files

- `src/application/session/SessionEventUseCases.ts` — public `listAll()`
- `src/interface/gate/handlers/resume.ts` — load events, find last boundary, surface in payload + prose
- `src/interface/gate/handlers/schema.ts` — schema entry for the new `last_boundary` field
- `tests/interface/resume.test.ts` — 7 new tests

## Phase 2 status after this PR

- [x] `gate rest` (PR #261)
- [x] `gate wake` (PR #262)
- [x] `gate farewell` (PR #263)
- [x] `gate resume` integration (this PR)

Phase 2 (time-aware verbs) is fully shipped. Phase 3 (multi-guild federation, #36) and Phase 4 (event fabric, #36) remain in the roadmap.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_