### PR TITLE
feat(gate show): surface session_id in text rendering (#249 slice 3)

### DIFF
--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -700,6 +700,15 @@ function formatRequestText(r: Request): string {
   if (j['source_agora_play']) {
     lines.push(`  source_agora_play: ${j['source_agora_play']}`);
   }
+  // opened_by_session (#249 slice 3) — the request author's boot
+  // session at create time. Sits with the other tool-stamped
+  // backlinks (promoted_from / source_agora_play) for the same
+  // "where did this come from" mental cluster. Absence is the
+  // common case (pre-#249 records, unstamped post-#249 writes); the
+  // line drops out entirely so byte-stable text rendering survives.
+  if (typeof j['opened_by_session'] === 'string' && j['opened_by_session'].length > 0) {
+    lines.push(`  opened_by_session: ${j['opened_by_session']}`);
+  }
   lines.push(`  created:  ${j['created_at']}`);
   lines.push('');
   pushMultilineField(lines, '  action:   ', String(j['action']));
@@ -764,7 +773,18 @@ function formatRequestText(r: Request): string {
         typeof j['claim_note'] === 'string' && j['claim_note'].length > 0
           ? ` — ${j['claim_note']}`
           : '';
-      lines.push(`    claimed by: ${j['claimed_by']} at ${j['claimed_at']}${claimNote}`);
+      // claimed_by_session (#249 slice 3): inline `[session=<id>]`
+      // tag between actor and timestamp. Bracket form (rather than
+      // parens) keeps it visually distinct from claim_note's em-dash
+      // suffix so a reader scanning the line sees three independent
+      // axes: who, when, attribution.
+      const claimSession =
+        typeof j['claimed_by_session'] === 'string' && j['claimed_by_session'].length > 0
+          ? ` [session=${j['claimed_by_session']}]`
+          : '';
+      lines.push(
+        `    claimed by: ${j['claimed_by']}${claimSession} at ${j['claimed_at']}${claimNote}`,
+      );
     }
     if (hasWitnesses) {
       // Per-witness notes (issue #246) emitted inline as
@@ -774,12 +794,25 @@ function formatRequestText(r: Request): string {
         j['witness_notes'] && typeof j['witness_notes'] === 'object' && !Array.isArray(j['witness_notes'])
           ? (j['witness_notes'] as Record<string, string>)
           : {};
+      // Per-witness session_id (#249 slice 3) surfaces as a
+      // bracket-tagged `[session=<id>]` suffix on the actor name.
+      // Mirrors the claim line's tagging shape so a reader sees one
+      // consistent annotation grammar across both stake variants.
+      const witnessSessions =
+        j['witness_sessions'] && typeof j['witness_sessions'] === 'object' && !Array.isArray(j['witness_sessions'])
+          ? (j['witness_sessions'] as Record<string, string>)
+          : {};
       const names = (j['witnesses'] as unknown[]).map((w) => {
         const name = String(w);
         const note = witnessNotes[name];
-        return typeof note === 'string' && note.length > 0
-          ? `${name} (${note})`
-          : name;
+        const session = witnessSessions[name];
+        const noteSuffix =
+          typeof note === 'string' && note.length > 0 ? ` (${note})` : '';
+        const sessionSuffix =
+          typeof session === 'string' && session.length > 0
+            ? ` [session=${session}]`
+            : '';
+        return `${name}${noteSuffix}${sessionSuffix}`;
       }).join(', ');
       lines.push(`    witnesses: ${names}`);
     }

--- a/tests/interface/sessionIdRendering.test.ts
+++ b/tests/interface/sessionIdRendering.test.ts
@@ -1,0 +1,271 @@
+// `gate show --format text` — session_id surfaces (#249 slice 3).
+//
+// Coverage:
+//   - opened_by_session line appears when stamped (header position)
+//   - opened_by_session line absent when unset (byte-stable)
+//   - claimed by: gets `[session=<id>]` tag when claimed_by_session set
+//   - witnesses: each entry gets `[session=<id>]` suffix per actor
+//   - notes + sessions coexist: `name (note) [session=<id>]`
+//   - mixed: some witnesses with session, others without (only those
+//     with attribution get the bracket tag)
+//
+// Records-outlive-writers: every absence path is asserted to NOT
+// emit the new line/tag — pre-#249 records show identically to today.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-sessrender-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const merged: NodeJS.ProcessEnv = { ...process.env };
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k];
+    else merged[k] = v;
+  }
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: merged,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function registerAll(root: string, names: string[]): void {
+  for (const n of names) {
+    const r = run(root, ['register', '--name', n]);
+    assert.equal(r.status, 0, `register ${n} failed: ${r.stderr}`);
+  }
+}
+
+function newRequest(
+  root: string,
+  from: string,
+  env: Record<string, string | undefined> = {},
+): string {
+  const r = run(
+    root,
+    ['request', '--from', from, '--action', 'do thing', '--reason', 'because', '--format', 'json'],
+    env,
+  );
+  assert.equal(r.status, 0, `request failed: ${r.stderr}`);
+  return (JSON.parse(r.stdout) as { id: string }).id;
+}
+
+test('show text: opened_by_session line appears when set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const id = newRequest(root, 'alice', { GUILD_SESSION_ID: 'eris-local-evening' });
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /^ {2}opened_by_session: eris-local-evening$/m,
+    'opened_by_session line should be in header column',
+  );
+  // Position: between source_agora_play (or promoted_from) and
+  // created. Check it lands above `created:` since `source_agora_play`
+  // is absent in this fixture.
+  const idxOpened = r.stdout.indexOf('opened_by_session:');
+  const idxCreated = r.stdout.indexOf('created:');
+  assert.ok(
+    idxOpened > 0 && idxCreated > idxOpened,
+    'opened_by_session must come before created:',
+  );
+});
+
+test('show text: opened_by_session absent when env unset (byte-stable)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice']);
+  const id = newRequest(root, 'alice', { GUILD_SESSION_ID: undefined });
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.ok(
+    !r.stdout.includes('opened_by_session'),
+    'no session stamped → no opened_by_session line',
+  );
+});
+
+test('show text: claim line gets [session=<id>] tag', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  const c = run(
+    root,
+    ['claim', id, '--by', 'leysia'],
+    { GUILD_SESSION_ID: 'leysia-tmux-3' },
+  );
+  assert.equal(c.status, 0, `claim: ${c.stderr}`);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(
+    r.stdout,
+    /claimed by: leysia \[session=leysia-tmux-3\] at \d{4}-\d{2}-\d{2}T/,
+    'claim line should include the session bracket tag',
+  );
+});
+
+test('show text: claim line without session keeps original shape', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['claim', id, '--by', 'leysia']).status, 0);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /claimed by: leysia at \d{4}-\d{2}-\d{2}T/);
+  assert.ok(
+    !/claimed by:.*\[session=/.test(r.stdout),
+    'unstamped claim must not carry a session tag',
+  );
+});
+
+test('show text: claim line with note + session keeps both', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  const c = run(
+    root,
+    ['claim', id, '--by', 'leysia', '--note', 'starting now'],
+    { GUILD_SESSION_ID: 'leysia-tmux-3' },
+  );
+  assert.equal(c.status, 0, `claim: ${c.stderr}`);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  // Order: actor, then [session=...], then `at TS`, then ` — note`.
+  assert.match(
+    r.stdout,
+    /claimed by: leysia \[session=leysia-tmux-3\] at \d{4}-\d{2}-\d{2}T[^\n]+ — starting now/,
+  );
+});
+
+test('show text: witness line gets [session=<id>] per actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki']);
+  const id = newRequest(root, 'alice');
+  assert.equal(
+    run(
+      root,
+      ['witness', id, '--by', 'leysia'],
+      { GUILD_SESSION_ID: 'leysia-tmux-3' },
+    ).status,
+    0,
+  );
+  assert.equal(
+    run(
+      root,
+      ['witness', id, '--by', 'miki'],
+      { GUILD_SESSION_ID: 'miki-laptop' },
+    ).status,
+    0,
+  );
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  // Both witnesses tagged with their respective sessions.
+  assert.match(
+    r.stdout,
+    /witnesses: leysia \[session=leysia-tmux-3\], miki \[session=miki-laptop\]/,
+  );
+});
+
+test('show text: witness mixed sessions/notes — only-session, only-note, both, neither', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia', 'miki', 'noir']);
+  const id = newRequest(root, 'alice');
+  // leysia: session only
+  assert.equal(
+    run(root, ['witness', id, '--by', 'leysia'], { GUILD_SESSION_ID: 'leysia-1' }).status,
+    0,
+  );
+  // miki: note only (no session env)
+  assert.equal(
+    run(
+      root,
+      ['witness', id, '--by', 'miki', '--note', 'perf'],
+      { GUILD_SESSION_ID: undefined },
+    ).status,
+    0,
+  );
+  // noir: both
+  assert.equal(
+    run(
+      root,
+      ['witness', id, '--by', 'noir', '--note', 'dedup'],
+      { GUILD_SESSION_ID: 'noir-2' },
+    ).status,
+    0,
+  );
+  // alice: bare witness (also acts as the request author).
+  assert.equal(
+    run(root, ['witness', id, '--by', 'alice'], { GUILD_SESSION_ID: undefined }).status,
+    0,
+  );
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  // Each actor should render with the right combination. Order is
+  // registration order (leysia, miki, noir, alice).
+  assert.match(
+    r.stdout,
+    /witnesses: leysia \[session=leysia-1\], miki \(perf\), noir \(dedup\) \[session=noir-2\], alice/,
+  );
+});
+
+test('show text: witness without any session keeps pre-#249 shape', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'leysia']);
+  const id = newRequest(root, 'alice');
+  assert.equal(run(root, ['witness', id, '--by', 'leysia']).status, 0);
+
+  const r = run(root, ['show', id, '--format', 'text']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /witnesses: leysia$/m);
+  assert.ok(
+    !/witnesses:.*\[session=/.test(r.stdout),
+    'unstamped witness must not carry a session tag',
+  );
+});


### PR DESCRIPTION
## Summary

Slice 3 of #249 — surfaces the session attribution shipped in slice 2
(#266) in `gate show --format text` so humans can read it, not just
JSON consumers.

- Header: `opened_by_session: <id>` line lands alongside the other
  tool-stamped backlinks (`promoted_from` / `source_agora_play`).
- Stake block claim line: `claimed by: <actor> [session=<id>] at <ts>
  — note` — bracket tag sits between actor and timestamp, coexisting
  with the em-dash `claim_note` suffix.
- Stake block witness line: each entry gets a `[session=<id>]` suffix
  when attribution is present. Mixed waves render each actor with the
  right combination, e.g. `leysia [session=A], miki (perf), noir
  (dedup) [session=C], alice`.

JSON / YAML output is unchanged — every field has been on
`toJSON()` since slice 1. This slice is text-rendering only.

Records-outlive-writers: every absence path drops the new line/tag,
so pre-#249 records and unstamped post-#249 writes render byte-stably.

## Test plan

- [x] `npm run build` clean
- [x] Full suite — 1410/1410 pass
- [x] New tests: `tests/interface/sessionIdRendering.test.ts` (8 cases)
  - opened_by_session line appears when set
  - opened_by_session absent when env unset (byte-stable)
  - claim line gets `[session=<id>]` tag
  - claim without session keeps original shape
  - claim with note + session keeps both (correct ordering)
  - witness line gets per-actor `[session=<id>]`
  - witness mixed sessions/notes (4-way matrix: only-session,
    only-note, both, neither)
  - witness without any session keeps pre-#249 shape

## What's NOT in this slice

- Slice 4: `gate boot` overlap warning extension (#234) flagging
  same-member parallel sessions
- Slice 5: `broadcast --to all-sessions` (deferred per Q3)

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_