### PR TITLE
feat(gate boot): flag same-actor parallel sessions in overlap surface (#249 slice 4)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -134,7 +134,43 @@ export interface BootActiveOverlap {
      * the wave at a glance.
      */
     claimed_by?: string;
+    /**
+     * The session_id under which this request was authored (#249
+     * slice 4). Carried verbatim from the record's
+     * `opened_by_session` field. Surfaced inside the overlap
+     * payload so the reader can spot the self-race shape: one
+     * member with multiple overlapping records authored from
+     * different sessions. Omitted when the record has no session
+     * stamp — pre-#249 records and unstamped post-#249 writes both
+     * present absence as the signal-free case.
+     */
+    opened_by_session?: string;
   }>;
+  /**
+   * Members in this overlap group who authored ≥2 requests from
+   * ≥2 distinct sessions (#249 slice 4). Map keys are member names
+   * (lowercase, canonical); values are the distinct session_ids
+   * the member authored from inside this group, in first-mention
+   * order. Empty / omitted when no member's authorship splits
+   * across sessions.
+   *
+   * The "self-race" surface: an actor running two shells (or two
+   * AI agents on the same machine) may legitimately not realize
+   * they have overlapping work in flight under their own name.
+   * This map names exactly that case so the boot text rendering
+   * can prompt: "you have parallel sessions on the same target —
+   * was the second one intended?".
+   *
+   * Detection requires that ≥2 of the actor's records in the
+   * group carry an `opened_by_session` AND those values diverge.
+   * A pre-#249 record with no session stamp does NOT count toward
+   * the divergence (we cannot know what session it came from); a
+   * post-#249 unstamped record (caller didn't `export
+   * GUILD_SESSION_ID`) similarly does not. Detection is best-
+   * effort: it surfaces the case the substrate can prove, not
+   * every possible parallel-shell scenario.
+   */
+  parallel_session_authors?: Record<string, readonly string[]>;
 }
 
 /**
@@ -1056,6 +1092,34 @@ export function computeActiveOverlappingTargets(
     const sorted = [...reqs].sort((a, b) =>
       a.id.value < b.id.value ? -1 : a.id.value > b.id.value ? 1 : 0,
     );
+    // Same-actor parallel-session detection (#249 slice 4). For each
+    // author in the group, collect distinct session_ids in first-
+    // mention order. A record without `opened_by_session` does NOT
+    // count toward divergence — its provenance is unknown, and
+    // counting absence as a separate "session" would falsely flag
+    // every mixed pre-#249 / post-#249 group. The map only includes
+    // authors with ≥2 distinct sessions; empty when no author races
+    // themselves.
+    const sessionsByAuthor = new Map<string, string[]>();
+    for (const r of sorted) {
+      const author = r.from.value;
+      const sess = r.openedBySession;
+      if (sess === undefined || sess.length === 0) continue;
+      const list = sessionsByAuthor.get(author);
+      if (list === undefined) {
+        sessionsByAuthor.set(author, [sess]);
+      } else if (!list.includes(sess)) {
+        list.push(sess);
+      }
+    }
+    const parallelSessionAuthors: Record<string, readonly string[]> = {};
+    let hasParallel = false;
+    for (const [author, sessions] of sessionsByAuthor) {
+      if (sessions.length >= 2) {
+        parallelSessionAuthors[author] = sessions;
+        hasParallel = true;
+      }
+    }
     overlaps.push({
       target,
       requests: sorted.map((r) => ({
@@ -1063,7 +1127,11 @@ export function computeActiveOverlappingTargets(
         state: r.state as 'pending' | 'approved' | 'executing',
         executors: r.executors.map((e) => e.value),
         ...(r.claimedBy !== undefined ? { claimed_by: r.claimedBy.value } : {}),
+        ...(r.openedBySession !== undefined
+          ? { opened_by_session: r.openedBySession }
+          : {}),
       })),
+      ...(hasParallel ? { parallel_session_authors: parallelSessionAuthors } : {}),
     });
   }
   overlaps.sort((a, b) =>
@@ -1373,14 +1441,41 @@ function renderBootText(p: BootPayload): string {
         const exec =
           r.executors.length > 0 ? r.executors.join(',') : '(no executor)';
         const claim = r.claimed_by !== undefined ? ', claim_held' : '';
+        // Session tag (#249 slice 4) — bracket-shaped, mirroring
+        // the `gate show` stake-block convention so the two
+        // surfaces share one annotation grammar.
+        const session =
+          r.opened_by_session !== undefined
+            ? ` [session=${r.opened_by_session}]`
+            : '';
         lines.push(
-          `  - ${r.id} (${exec}, ${r.state}${claim}) — target: ${o.target}`,
+          `  - ${r.id} (${exec}, ${r.state}${claim})${session} — target: ${o.target}`,
         );
       }
     }
     lines.push(
       '  ⚠ overlap detected. coordinate via `gate witness <id>` or `gate claim <id>`.',
     );
+    // Same-actor parallel-session warning (#249 slice 4). One line
+    // per actor whose authorship splits across sessions in any
+    // overlap group. The hint deliberately frames it as a question
+    // ("was the second session intended?") rather than an
+    // accusation — there are legitimate parallel-session shapes
+    // (e.g. the same human deliberately running two waves), and
+    // the substrate's job is to surface the case, not adjudicate it.
+    const parallelLines: string[] = [];
+    for (const o of p.active_overlapping_targets) {
+      const map = o.parallel_session_authors;
+      if (map === undefined) continue;
+      for (const [author, sessions] of Object.entries(map)) {
+        parallelLines.push(
+          `  ⚠ same-actor parallel sessions: ${author} on target "${o.target}" ` +
+            `(sessions: ${sessions.join(', ')}). check whether the second ` +
+            `session was intended.`,
+        );
+      }
+    }
+    for (const line of parallelLines) lines.push(line);
   }
 
   if (p.tail.length > 0) {

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -345,8 +345,34 @@ const VERBS: readonly VerbSchema[] = [
                     },
                     executors: { type: 'array', items: { type: 'string' } },
                     claimed_by: { type: 'string' },
+                    opened_by_session: {
+                      type: 'string',
+                      description:
+                        'session_id this request was authored under ' +
+                        '(#249 slice 4). Carried verbatim from the ' +
+                        "record's opened_by_session field. Omitted when " +
+                        'the record has no session stamp (pre-#249 or ' +
+                        'unstamped post-#249 writes).',
+                    },
                   },
                 },
+              },
+              parallel_session_authors: {
+                type: 'object',
+                description:
+                  'Members in this overlap group who authored ≥2 ' +
+                  'requests from ≥2 distinct sessions (#249 slice 4). ' +
+                  'Map keys are member names (lowercase, canonical); ' +
+                  'values are the distinct session_ids the member ' +
+                  'authored from inside this group, in first-mention ' +
+                  'order. Omitted when no member self-races. The boot ' +
+                  'text rendering surfaces a per-actor warning ' +
+                  '(`⚠ same-actor parallel sessions: ...`) for each ' +
+                  'entry; JSON consumers branch on the field directly. ' +
+                  'Detection requires ≥2 of the actor\'s records in ' +
+                  "the group to carry an opened_by_session AND those " +
+                  'values to diverge — pre-#249 / unstamped records do ' +
+                  'NOT count toward divergence (provenance unknown).',
               },
             },
           },

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -1055,3 +1055,163 @@ test('gate boot: active_overlapping_targets text section is omitted when no over
     cleanup();
   }
 });
+
+// ---- Slice 4 (#249): same-actor parallel-session detection ---------
+
+function makeRequestSessioned(
+  root: string,
+  from: string,
+  action: string,
+  target: string,
+  sessionId: string,
+): string {
+  const r = spawnSync(
+    process.execPath,
+    [
+      GATE,
+      'request',
+      '--from', from,
+      '--action', action,
+      '--reason', 'overlap test',
+      '--target', target,
+      '--format', 'json',
+    ],
+    {
+      cwd: root,
+      env: { ...process.env, GUILD_SESSION_ID: sessionId },
+      encoding: 'utf8',
+    },
+  );
+  if (r.status !== 0) {
+    throw new Error(`gate request failed: ${r.stderr}`);
+  }
+  return JSON.parse(r.stdout).id as string;
+}
+
+test('gate boot: overlap requests carry opened_by_session when stamped (#249 slice 4)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestSessioned(root, 'alice', 'work B', 'src/foo', 'alice-tmux-1');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    assert.equal(entry.requests.length, 2);
+    for (const r of entry.requests) {
+      assert.equal(r.opened_by_session, 'alice-tmux-1');
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: parallel_session_authors flags actor with two sessions on same target (#249 slice 4)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Same author (alice), same target, two distinct sessions — the
+    // self-race shape the slice exists to surface.
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestSessioned(root, 'alice', 'work B', 'src/foo', 'alice-tmux-2');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    assert.deepEqual(entry.parallel_session_authors, {
+      alice: ['alice-tmux-1', 'alice-tmux-2'],
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: parallel_session_authors omitted when sessions match (#249 slice 4)', () => {
+  // Same author, same target, IDENTICAL session — that's not a
+  // self-race (the actor knows about both records). The map must
+  // stay absent so the "warn-on-divergence" contract holds.
+  const { root, cleanup } = bootstrap();
+  try {
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestSessioned(root, 'alice', 'work B', 'src/foo', 'alice-tmux-1');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    assert.equal(
+      'parallel_session_authors' in entry,
+      false,
+      'identical sessions are not a self-race',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: parallel_session_authors omitted when only one record stamped (#249 slice 4)', () => {
+  // One stamped, one unstamped — provenance unknown for the second
+  // record. Detection requires ≥2 of the actor's records to BOTH
+  // carry sessions AND those values to diverge. Mixed pre/post-#249
+  // groups should not falsely flag.
+  const { root, cleanup } = bootstrap();
+  try {
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestWithTarget(root, 'alice', 'work B', 'src/foo'); // no GUILD_SESSION_ID
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    assert.equal(
+      'parallel_session_authors' in entry,
+      false,
+      'one stamped + one unstamped is not enough to prove divergence',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot: different actors with different sessions do NOT flag (#249 slice 4)', () => {
+  // alice from session A, leysia from session B → genuine cross-
+  // session overlap (the original #234 surface), but NOT a
+  // SAME-actor parallel-session race. Only flag when a single
+  // actor's authorship splits.
+  const { root, cleanup } = bootstrap();
+  try {
+    registerMember(root, 'leysia');
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestSessioned(root, 'leysia', 'work B', 'src/foo', 'leysia-tmux-1');
+
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const entry = payload.active_overlapping_targets[0];
+    assert.equal(
+      'parallel_session_authors' in entry,
+      false,
+      'different actors authoring is not a self-race',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: parallel-session warning lands under overlap section (#249 slice 4)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
+    makeRequestSessioned(root, 'alice', 'work B', 'src/foo', 'alice-tmux-2');
+
+    const t = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(t.status, 0);
+    assert.match(t.stdout, /active waves with overlapping target:/);
+    // The per-request line carries the bracket-tagged session.
+    assert.match(t.stdout, /\[session=alice-tmux-1\]/);
+    assert.match(t.stdout, /\[session=alice-tmux-2\]/);
+    // The dedicated warning line names the actor and both sessions.
+    assert.match(
+      t.stdout,
+      /⚠ same-actor parallel sessions: alice on target "src\/foo" \(sessions: alice-tmux-1, alice-tmux-2\)/,
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Slice 4 of #249 — extends the cross-session overlap surface (#234)
with session-aware self-race detection. When one member authored ≥2
overlapping requests from ≥2 distinct sessions, `gate boot` surfaces
it as a dedicated warning so the agent can ask "was the second
session intended?" before pre-empting their own work.

### JSON shape

`active_overlapping_targets[].requests[]` gains optional
`opened_by_session` (carried verbatim from the record).

`active_overlapping_targets[]` gains optional
`parallel_session_authors`: map of actor → list of distinct
session_ids the actor authored from inside this group, in
first-mention order. Only present when an actor's authorship splits
across ≥2 sessions.

### Text rendering

```
active waves with overlapping target:
  - 2026-05-09-001 (alice, pending) [session=alice-tmux-1] — target: src/foo
  - 2026-05-09-002 (alice, pending) [session=alice-tmux-2] — target: src/foo
  ⚠ overlap detected. coordinate via `gate witness <id>` or `gate claim <id>`.
  ⚠ same-actor parallel sessions: alice on target "src/foo" (sessions: alice-tmux-1, alice-tmux-2). check whether the second session was intended.
```

The bracket-tagged `[session=<id>]` mirrors slice 3's `gate show`
stake-block convention so the two surfaces share one annotation
grammar.

### Detection rules

Best-effort, conservative:

- Requires ≥2 of the actor's records in the group to BOTH carry
  `opened_by_session` AND those values to diverge.
- Mixed pre-#249 / post-#249 (one stamped, one not) does NOT flag —
  provenance unknown for the unstamped record.
- Same actor with identical sessions does NOT flag (the actor
  knows about both records — same shell).
- Different actors with different sessions does NOT flag — the
  original #234 surface already covers cross-actor overlap; the
  slice's contribution is the SAME-actor case.

## Test plan

- [x] `npm run build` clean
- [x] Full suite — 1416/1416 pass
- [x] New tests in `tests/interface/boot.test.ts` (6 cases)
  - overlap requests carry `opened_by_session` when stamped
  - `parallel_session_authors` flags actor with two sessions on same target
  - `parallel_session_authors` omitted when sessions match
  - `parallel_session_authors` omitted when only one record stamped
  - different actors with different sessions do NOT flag
  - text rendering: per-request session tag + warning line

## What's NOT in this slice

- Slice 5: `broadcast --to all-sessions` (deferred per Q3)
- Cross-target same-actor parallel-session detection (e.g. alice has
  two unrelated active sessions). The current detection is per-
  overlap-group; the cross-target case is broader and would need a
  different surface.

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_