### PR TITLE
docs: catch AGENT.md + verbs.md up to recent shipped features

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -28,11 +28,17 @@ gate register --name <you>              # category defaults to "professional"
 
 # Every session after:
 gate boot                # identity + status + tail + your_recent + inbox_unread (1 JSON)
+gate boot --session-id <id>             # opt-in: stamps a session label on subsequent writes
 gate resume              # picking up where the last session ended (needs GUILD_ACTOR)
 # (old 3-command recipe — use boot above if you can consume JSON)
 gate status              # pending/approved/executing/issues/inbox
 gate whoami              # your identity + recent utterances (needs GUILD_ACTOR)
 gate tail 10             # last 10 events across all actors
+
+# Mid-session boundaries (#36 Phase 2 — append-only timestamp records):
+gate rest                # "putting this down for now" — boundary record only
+gate wake                # "picking it back up"        — pairs with rest, decoupled
+gate farewell            # "until next session"        — pairs with `gate resume` next session
 ```
 
 ## Agent-first knobs
@@ -51,13 +57,18 @@ pending ─ approve ─▶ approved ─ execute ─▶ executing ─ complete �
 ```
 
 ```bash
-gate request --from <m> --action "..." --reason "..." [--executor <m>] [--auto-review <m>] [--with <m>[,<m>...]]
+gate request --from <m> --action "..." --reason "..." \
+             [--executor <m> | --executors a,b,c] \
+             [--auto-review <m>] [--with <m>[,<m>...]] \
+             [--target <s>] [--depth shallow|standard|deep] \
+             [--from-agora <play_id>] [--template <name>]
 gate approve <id> --by <m> [--note "..."]
 gate deny <id> --by <m> --reason "..."
-gate execute <id> --by <m>
+gate execute <id> --by <m> [--cwd <path>]                  # cwd stamped on the status_log entry
 gate complete <id> --by <m> [--note "..."]
 gate fail <id> --by <m> --reason "..."
-gate fast-track --from <m> --action "..." --reason "..."   # one-shot create→complete
+gate fast-track --from <m> --action "..." --reason "..." \
+                [--executor <m> | --executors a,b,c] [--with ...]
 gate thank <to> --for <id> [--by <m>] [--reason <s>]       # gratitude (no verdict, no calibration)
 ```
 
@@ -67,6 +78,26 @@ the substrate captures both, and `gate execute` emits a `notice:` so
 the mismatch is visible at the surface that did it. See
 [issue #168](https://github.com/eris-ths/guild-cli/issues/168) for the
 design rationale.
+
+`--executors a,b,c` records **multiple executors** for parallel waves
+(#230). Mutually exclusive with `--executor`. Under `profile: swarm`,
+parallel waves additionally require worktree isolation (`gate execute`
+refuses same-cwd collisions, #231).
+
+`--depth shallow|standard|deep` is an **advisory** that the substrate
+carries to reviewer agents (#221). Default = `standard` (current
+behaviour); `shallow` invites point-checks; `deep` invites
+arch / threat-model scrutiny. Per principle 02 the reviewer can
+disagree.
+
+`--from-agora <play_id>` lifts the play's most recent
+cliff/invitation into `--reason` / `--action` (#232). The link is
+recorded as `source_agora_play: <play_id>` in YAML so a later reader
+can walk back to the discussion.
+
+`--template <name>` expands a wave-brief skeleton from the
+template registry (#235); discover available names with
+`gate templates list` (see below).
 
 ## Review (Two-Persona Devil)
 
@@ -96,7 +127,48 @@ gate tail [N]                           # recent activity stream (default 20)
 gate chain <id>                         # cross-reference walk (one hop)
 gate transcript <id>                    # narrative prose arc of a request
 gate suggest [--format json|text]       # suggested_next only (hot-loop sibling of boot)
+gate why <id>                           # decision walk: why is this request in this state?
+gate summarize <id> [--limit <N>]       # narrative summary
+gate unresponded [--for <m>]            # concerns recorded but not yet responded to
 ```
+
+## Coordination & stake (#226 / #244 / #246)
+
+Cross-session race mediation for waves where multiple actors might
+silently overlap. `claim` is exclusive ("I'm working on this"),
+`witness` is non-exclusive ("I'm watching this"); both cooperate with
+`gate boot`'s overlap surface (#234).
+
+```bash
+gate claim <id> --by <m> [--note "..."]        # exclusive stake; refuses on conflict
+gate witness <id> --by <m> [--note "..."]      # non-exclusive observer; never refuses
+gate unwitness <id> --by <m>                   # remove your own witness
+```
+
+- `claim` allowed on `pending` / `approved`; refuses if a different
+  actor already holds the claim. Same-actor re-claim is a no-op.
+- `witness` allowed on `pending` / `approved` / `executing`;
+  multiple actors can witness the same wave simultaneously.
+- Both auto-release on terminal transitions (completed / failed / denied).
+- `--note` is short metadata for the stake event (≤ 80 chars), not
+  commentary. Wider discussion belongs in agora plays.
+
+## Templates (#235)
+
+Wave-brief skeletons under `data/guild/templates/wave-brief/`. The
+registry surfaces them through `gate` so agents discover what
+templates are available without scanning the filesystem.
+
+```bash
+gate templates list                            # available template names
+gate templates show <name>                     # full template body
+gate request --template <name> [--action ...]  # expand skeleton on create
+```
+
+Under `profile: swarm`, parallel-shaped waves
+(`--executors a,b`) emit a notice when filed without a `--template`
+so the brief is on record (Phase 1 — warning only; enforcement is
+follow-up).
 
 ## Issues
 
@@ -120,10 +192,39 @@ the actor; falls back to `GUILD_ACTOR` when unset.
 
 ```bash
 gate message --from <m> --to <m> --text "..." [--type <s>]
-gate broadcast --from <m> --text "..." [--type <s>]
+gate broadcast --from <m> --text "..." [--type <s>] [--expects-response]
 gate inbox --for <m> [--unread]
 gate inbox mark-read [N] --for <m>
 ```
+
+`--expects-response` (#220) on a broadcast opts the sender into the
+`broadcast-pending-response` surface. `gate boot` then leads with
+that suggestion when no higher-priority lifecycle work is open;
+the surface clears when the recipient marks the entry read.
+
+## Sessions (#249)
+
+Optional **session_id** dimension on top of the member axis so
+multi-body coordination (one member running multiple shells, or a
+member coexisting with their AI agent counterpart) keeps an
+attributable trail.
+
+```bash
+gate boot --session-id eris-local-2026-05-08-evening   # validates + echoes payload
+export GUILD_SESSION_ID=eris-local-2026-05-08-evening  # whole-shell carrier
+gate request ...           # stamps `opened_by_session: <id>`
+gate claim <id> --by <m>   # stamps `claimed_by_session: <id>`
+gate witness <id> --by <m> # stamps `witness_sessions[<actor>]: <id>`
+```
+
+- Format: free-form ASCII, regex `^[a-z0-9][a-z0-9_:.-]{0,63}$`.
+- Opt-in: nothing is required; pre-#249 records and unstamped
+  post-#249 writes round-trip byte-identical YAML.
+- Discovery: `gate boot` surfaces `hints.session_id_unset: true`
+  when an actor resolved but no session is configured.
+- Self-race detection: `gate boot.active_overlapping_targets[].parallel_session_authors`
+  flags an actor authoring ≥2 overlapping requests from ≥2 distinct
+  sessions; text mode prints `⚠ same-actor parallel sessions: <m>`.
 
 ## Members
 
@@ -370,14 +471,40 @@ gate repair [--from-doctor <path>] [--apply] [--format json|text]
 content_root: .
 host_names: [alice, bob]
 lenses: [devil, layer, cognitive, user]   # optional, these are defaults
+
+profile: standard                          # 'standard' (default) | 'swarm'
+features:
+  self_approve: warn                       # 'allowed' | 'warn' (default) | 'forbidden'
+  worktree_required_for_parallel: false    # swarm-default true; refuses same-cwd parallel waves
+
 doctor:
   plugins: [./plugins/doc-check.mjs]      # optional, ES module paths
+
+# #36 Phase 1 — verb plugins + lifecycle hooks (require explicit trust opt-in)
+plugins:
+  trusted: false                           # MUST be true to load verbs/hooks
+  verbs:    [./plugins/verbs/my-verb.mjs]
+  hooks:    [./plugins/hooks/my-policy.mjs]
+
 paths:
   members: members
   requests: requests
   issues: issues
   inbox: inbox
 ```
+
+`profile: swarm` (#227) is the niche multi-SubAgent orchestration
+profile. It tightens defaults (`self_approve: forbidden`,
+`worktree_required_for_parallel: true`) and surfaces extra warnings
+in `gate boot` for cross-session race risks. `profile: standard`
+default behaviour is unchanged.
+
+`plugins.trusted: true` is required to load any verb / hook plugin
+(#36 Phase 1). Without it, the loader logs the path but skips
+execution. Trust model is explicit because plugins run as
+in-process Node modules with full filesystem access — see
+[`SECURITY.md`](./SECURITY.md) and [`examples/plugins/`](./examples/plugins/)
+for the end-to-end shape.
 
 ## File layout
 
@@ -415,6 +542,17 @@ walked, the same shape as `guild.config.yaml`.
 
 `GUILD_LOCALE=<en|ja>` — prose language for `gate resume`
 `restoration_prose`. Defaults to `en`. Also settable via `--locale`.
+
+`GUILD_SESSION_ID=<id>` — session_id stamp for write verbs (#249).
+Validated against `^[a-z0-9][a-z0-9_:.-]{0,63}$`. When set,
+`gate request` / `gate fast-track` stamp `opened_by_session`;
+`gate claim` stamps `claimed_by_session`; `gate witness` stamps
+`witness_sessions[<actor>]`. Invalid values emit a one-time
+notice and the resolver treats them as unset (no silent stamping
+of malformed ids). Unlike `GUILD_ACTOR`, there is no
+`.guild-session-id` file fallback by design — the session is a
+per-shell concept, and committing one would re-export a single
+name across collaborators.
 
 ## Output format
 
@@ -485,7 +623,12 @@ cue carries cross-verb without re-reading.
 ## Deep dives
 
 - [`docs/verbs.md`](./docs/verbs.md) — per-verb examples and design notes
+- [`docs/playbook.md`](./docs/playbook.md) — combo recipes (gate × agora × devil flows)
+- [`docs/storage-format.md`](./docs/storage-format.md) — full per-record YAML schema
+- [`docs/POLICY.md`](./docs/POLICY.md) — versioning + plugin-stability contract
+- [`SECURITY.md`](./SECURITY.md) — plugin trust model + threat surface
 - [`examples/dogfood-session/`](./examples/dogfood-session/) — real multi-actor session
+- [`examples/plugins/`](./examples/plugins/) — verb + hook plugin walkthrough (#36 Phase 1)
 - [`README.md`](./README.md) — full documentation with design rationale
 
 ---

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -954,17 +954,170 @@ narrative a cold reader needs to understand what happened without
 parsing YAML. If agents render this better themselves, the verb
 can be dropped — the data path isn't disturbed (read-only).
 
-**Plugins.** `gate doctor` supports plugins via `guild.config.yaml`:
+**Plugins.** Three plugin surfaces today, all loaded via
+`guild.config.yaml`:
 
 ```yaml
+# Doctor plugins — append additional findings to gate doctor output.
 doctor:
   plugins:
     - ./plugins/doc-check.mjs
+
+# Verb + hook plugins (#36 Phase 1) — require explicit trust opt-in.
+plugins:
+  trusted: false                 # MUST be true to load verbs/hooks
+  verbs:    [./plugins/verbs/my-verb.mjs]
+  hooks:    [./plugins/hooks/my-policy.mjs]
 ```
 
-A plugin is an ES module exporting a function that returns additional
-findings. Plugin errors become findings (never crash doctor). See
-`DoctorPluginFn` in `DiagnosticUseCases.ts` for the interface.
+- **Doctor plugins**: ES module exporting a function that returns
+  additional findings. Errors become findings (never crash doctor).
+  See `DoctorPluginFn` in `DiagnosticUseCases.ts`.
+- **Verb plugins**: register new `gate <verb>` names into the dispatch
+  table. The verb appears in `gate schema` with `source: 'plugin'`.
+- **Lifecycle hooks**: `before:` / `after:` listeners on `request` /
+  `claim` / `witness` mutations. `before:` may veto by returning
+  `{ allow: false, reason }` (turns into exit non-zero).
+
+`plugins.trusted: true` is required because verb / hook plugins run
+as in-process Node modules with full filesystem access. The full
+walkthrough — including the `examples/plugins/policy-veto-on-self-approve`
+sample — lives in [`examples/plugins/README.md`](../examples/plugins/README.md)
+and the trust model is documented in [`SECURITY.md`](../SECURITY.md).
+
+### Time-aware verbs (#36 Phase 2)
+
+A session-boundary primitive: append-only timestamp records that
+mark "putting things down" / "picking back up" / "until next
+session". Decoupled from the request lifecycle — they record the
+passage of time itself as substrate.
+
+```bash
+gate rest                # boundary record: "putting this down for now"
+gate wake                # pairing verb: "picking it back up"
+gate farewell            # ceremonial close: "until next session"
+gate resume              # restoration prose; surfaces the latest boundary
+```
+
+- `gate rest` is **not** a lifecycle toggle. It just stamps "I am
+  putting this down now"; the length of the break is itself
+  information, the way a commit timestamp is information. There is
+  no mandatory wake note (that would turn it into reflect).
+- `gate wake` is decoupled from `rest` — they don't have to be
+  used together. wake records "picking it back up" cleanly even if
+  no preceding `rest` exists.
+- `gate farewell` is the **session-end** record meant to be paired
+  with `gate resume` at the next session start. Different from
+  `rest` because it's "until next session," not "until later today."
+- `gate resume` reads the latest boundary record (rest / wake /
+  farewell) and surfaces it in the restoration prose so a fresh
+  session sees how the prior one ended.
+
+Records live under `<content_root>/sessions/<actor>/<id>.yaml`.
+Per-actor, per-day sequence ids; never deleted.
+
+### Coordination & stake (#226 / #244 / #246)
+
+Cross-session race mediation. `gate claim` is the **exclusive**
+stake ("I'm working on this"); `gate witness` is the **non-exclusive**
+observer ("I'm watching this"). Both compose with `gate boot`'s
+overlap surface (#234) so a fresh agent sees who already has hands
+on a wave.
+
+```bash
+gate claim <id> --by <m> [--note "..."]        # exclusive; refuses on conflict
+gate witness <id> --by <m> [--note "..."]      # non-exclusive
+gate unwitness <id> --by <m>                   # remove your own witness
+```
+
+State guards:
+
+- `claim` allowed on `pending` / `approved` (the cross-session
+  race window). A different actor's claim → refuse with the
+  current claimant's name. Same-actor re-claim → no-op (idempotent).
+- `witness` allowed on `pending` / `approved` / `executing`. Multiple
+  actors witness simultaneously; the witness list doubles as a set
+  ordered by first registration.
+- Both auto-release on terminal transitions (`completed` / `failed`
+  / `denied`); the witness list resets, the claim clears.
+
+Notes are tight-scope: ≤ 80 chars, single line, metadata for the
+stake event itself. **Not** discussion — that belongs in agora plays.
+Notes overwrite-on-divergence (re-claim with a different note
+updates it; re-claim with no note leaves it).
+
+`gate show <id>` text mode lifts both into a dedicated `stake:`
+section under `status_log` so they don't read as transition entries:
+
+```
+  stake:
+    claimed by: leysia at 2026-05-08T14:23:04Z — held while debugging
+    witnesses: alice (watching dedup), bob, carol (perf)
+```
+
+### Templates (#235)
+
+`gate templates list` / `show` discover wave-brief skeletons
+shipped under `data/guild/templates/wave-brief/`. The registry
+surfaces them so agents pick a brief shape without scanning the
+filesystem; `gate request --template <name>` expands the chosen
+skeleton into action / reason while preserving caller overrides.
+
+```bash
+gate templates list                     # available template names
+gate templates show parallel-impl       # full template body
+gate request --template parallel-impl --executors a,b
+# action defaults to "wave-brief: parallel-impl"; reason defaults to
+# the template's `intended_use`. Both can be overridden with explicit
+# --action / --reason.
+```
+
+Records carry `template`, `template_version`, and
+`gate_required_acknowledged` so audits can tell template-shaped waves
+apart. Under `profile: swarm`, parallel-shaped waves
+(`--executors a,b`) emit a notice when filed without `--template`
+(Phase 1 — warning only; enforcement is follow-up).
+
+### Sessions (#249)
+
+Optional **session_id** dimension for multi-body coordination — one
+member running multiple shells, or a member coexisting with their
+AI agent counterpart. Without it, claim/witness records say "alice
+claimed wave 230" but can't disambiguate *which* alice.
+
+```bash
+gate boot --session-id eris-local-2026-05-08-evening
+# JSON payload echoes:
+#   "session_id": "eris-local-2026-05-08-evening"
+#   "session_id_source": "flag"
+
+export GUILD_SESSION_ID=eris-local-2026-05-08-evening
+gate request ...                # stamps `opened_by_session: <id>`
+gate claim 230 --by eris        # stamps `claimed_by_session: <id>`
+gate witness 230 --by erismind  # stamps `witness_sessions[erismind]: <id>`
+```
+
+- Format: free-form ASCII, regex `^[a-z0-9][a-z0-9_:.-]{0,63}$`.
+  Convention emerges per team (e.g. `eris-local-2026-05-08-evening`,
+  `terminal-A`, `claude-opus-4-7-run42`, `ci-build-12345`).
+- **Opt-in everywhere** — pre-#249 records and unstamped post-#249
+  writes round-trip byte-identical YAML (records-outlive-writers,
+  principle 04).
+- Discovery: `gate boot.hints.session_id_unset: true` when an actor
+  is resolved but no session is configured. Text mode prints a
+  one-shot notice with the env / flag fix.
+- Self-race detection: `gate boot.active_overlapping_targets[].parallel_session_authors`
+  flags an actor authoring ≥2 overlapping requests from ≥2 distinct
+  sessions on the same target. Text mode warns:
+  `⚠ same-actor parallel sessions: alice on target "src/foo" (sessions: A, B)`.
+- `gate show <id>` text mode threads session attribution through
+  `opened_by_session:` (header line, alongside other tool-stamped
+  backlinks) and `[session=<id>]` bracket tags in the `stake:` block.
+
+Session_id is **immutable in the trail**. There is no timeout, no
+heartbeat, no explicit lifecycle — `gate farewell` records the end
+as a write event; the session_id itself lives forever in whatever it
+claimed / witnessed / authored. A new session is just a new id.
 
 ---
 


### PR DESCRIPTION
## Summary

The agent-facing references had drifted ~5 months behind the
substrate. Sweeping in the major surfaces that landed since the
last refresh.

### `AGENT.md` (quick-reference)

- Session start: time-aware verbs (`rest` / `wake` / `farewell`,
  #36 Phase 2) + `gate boot --session-id` opt-in
- Request lifecycle: `--executors` / `--target` / `--depth` /
  `--from-agora` / `--template` flags (#221 / #230 / #232 / #235)
  + worktree isolation notice (#231)
- New **Coordination & stake** section: `claim` / `witness` /
  `unwitness` (#226 / #244 / #246)
- New **Templates** section: `gate templates list` / `show` +
  `--template` expansion (#235)
- New **Sessions** section: `GUILD_SESSION_ID` +
  `opened_by_session` / `claimed_by_session` / `witness_sessions[]`
  + parallel-session warning (#249)
- Messages: `--expects-response` opt-in (#220)
- Reading: `gate why` / `summarize` / `unresponded` / `transcript`
- Configuration: `profile` / `features.self_approve` /
  `features.worktree_required_for_parallel` + `plugins.trusted` +
  `plugins.verbs` / `plugins.hooks` (#36 Phase 1)
- Environment: `GUILD_SESSION_ID` format + opt-in semantics
- Deep dives: link to `docs/playbook.md`, `storage-format.md`,
  `POLICY.md`, `SECURITY.md`, `examples/plugins/`

### `docs/verbs.md` (cookbook)

- Plugins paragraph extended to cover all three surfaces (doctor /
  verbs / hooks) with the trust opt-in callout
- New **Time-aware verbs** section walking the rest / wake /
  farewell / resume quartet
- New **Coordination & stake** section with state-guard rules and
  the text-mode `stake:` rendering example
- New **Templates** section with the registry shape
- New **Sessions** section covering format, opt-in, discovery,
  self-race detection, and immutability semantics

## Test plan

- [x] `npm run build` clean
- [x] Full suite — 1416/1416 pass on linux
- [x] Pure docs change — no code, no schema, no test surface modified
- [x] Cross-references resolve: every linked file (`POLICY.md`,
  `SECURITY.md`, `examples/plugins/README.md`, etc.) exists in the
  repo today

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_