### PR TITLE
feat(devil): add 'system' to TargetType for bird's-eye reviews (#134 J1)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -318,13 +318,13 @@ reviewers can be working simultaneously; the cliff/invitation just
 records re-entry context.
 
 ```bash
-devil open <target-ref> --type <pr|file|function|commit> [--by <m>]
+devil open <target-ref> --type <pr|file|function|commit|system> [--by <m>]
 devil entry <rev-id> --persona <p> --lense <l> --kind <k> --text "<prose>"
                      [--severity <c|h|m|l|info>]
                      [--severity-rationale "<prose>"]   # required when kind=finding
                      [--addresses <e-NNN>]
                      [--by <m>]
-devil list [--state <open|concluded>] [--target-type <pr|file|function|commit>]
+devil list [--state <open|concluded>] [--target-type <pr|file|function|commit|system>]
 devil show <rev-id>
 devil conclude <rev-id> --synthesis "<prose>" [--unresolved e-001,e-002,...] [--by <m>]
 devil dismiss <rev-id> <entry-id> --reason <r> [--note "..."] [--by <m>]

--- a/src/passages/devil/README.md
+++ b/src/passages/devil/README.md
@@ -97,7 +97,10 @@ devil-specific records live under `<content_root>/devil/`:
 ## Verbs (v1, complete — 11 verbs)
 
 - `devil open <ref>` — start a review session against a target
-  (`--type pr|file|function|commit`)
+  (`--type pr|file|function|commit|system`). `system` is the
+  bird's-eye scope: free-form `<ref>` like `"guild-cli@v0.4.0"` or
+  `"the devil-review passage"`, pairing naturally with the
+  `coherence` lense. See #134 J1 for the design rationale.
 - `devil entry <rev-id>` — append a hand-rolled entry. `kind=finding`
   requires `--severity` AND `--severity-rationale` (the friction
   forces exploitability-context reasoning). Persona must be

--- a/src/passages/devil/domain/DevilReview.ts
+++ b/src/passages/devil/domain/DevilReview.ts
@@ -59,13 +59,14 @@ export function parseReviewId(raw: unknown): string {
   return raw;
 }
 
-export type TargetType = 'pr' | 'file' | 'function' | 'commit';
+export type TargetType = 'pr' | 'file' | 'function' | 'commit' | 'system';
 
 const VALID_TARGET_TYPES: ReadonlySet<TargetType> = new Set([
   'pr',
   'file',
   'function',
   'commit',
+  'system',
 ]);
 
 export function parseTargetType(raw: unknown): TargetType {
@@ -80,7 +81,10 @@ export function parseTargetType(raw: unknown): TargetType {
 
 export interface Target {
   readonly type: TargetType;
-  readonly ref: string; // github-pr-url, file path, function symbol, or commit sha
+  // pr → github-pr-url; file → path; function → symbol; commit → sha;
+  // system → free-form scope label for bird's-eye reviews (e.g.
+  // "guild-cli@v0.4.0", "the devil-review passage"). Issue #134 J1.
+  readonly ref: string;
 }
 
 function parseTarget(raw: unknown): Target {

--- a/src/passages/devil/interface/handlers/list.ts
+++ b/src/passages/devil/interface/handlers/list.ts
@@ -18,7 +18,7 @@ const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  *
  * Usage:
  *   devil list [--state open|concluded|all]
- *              [--target-type pr|file|function|commit]
+ *              [--target-type pr|file|function|commit|system]
  *              [--format json|text]
  *
  * Reads only — no mutation. Returns a summary view of each review

--- a/src/passages/devil/interface/handlers/open.ts
+++ b/src/passages/devil/interface/handlers/open.ts
@@ -18,7 +18,7 @@ const OPEN_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  * devil open — start a new review session against a target.
  *
  * Usage:
- *   devil open <target-ref> --type <pr|file|function|commit>
+ *   devil open <target-ref> --type <pr|file|function|commit|system>
  *                           [--by <m>] [--format json|text]
  *
  * Produces: <content_root>/devil/reviews/<rev-id>.yaml where
@@ -32,6 +32,11 @@ const OPEN_KNOWN_FLAGS: ReadonlySet<string> = new Set([
  *   file      — a path under the repo
  *   function  — a symbol identifier (informal; for narrow reviews)
  *   commit    — a commit sha
+ *   system    — bird's-eye review scope: free-form ref naming the
+ *               module / release / passage being audited as a whole
+ *               (e.g. "guild-cli@v0.4.0", "the devil-review passage").
+ *               Pairs naturally with the `coherence` lense; see #134
+ *               item J for the design rationale.
  *
  * AI-first per principle 11: --by attribution is required (or
  * GUILD_ACTOR), the same shape gate / agora use.
@@ -48,12 +53,12 @@ export async function openReview(deps: OpenDeps, args: ParsedArgs): Promise<numb
   if (!ref) {
     process.stderr.write(
       'error: positional <target-ref> required.\n' +
-        '  Usage: devil open <target-ref> --type <pr|file|function|commit> [--by <m>]\n',
+        '  Usage: devil open <target-ref> --type <pr|file|function|commit|system> [--by <m>]\n',
     );
     return 1;
   }
 
-  const typeRaw = requireOption(args, 'type', '<pr|file|function|commit>');
+  const typeRaw = requireOption(args, 'type', '<pr|file|function|commit|system>');
   // parseTargetType throws DomainError on invalid input — let it
   // bubble to the dispatcher's catch (turns into stderr error: ...).
   const type = parseTargetType(typeRaw);

--- a/src/passages/devil/interface/handlers/schema.ts
+++ b/src/passages/devil/interface/handlers/schema.ts
@@ -86,11 +86,13 @@ const VERBS: readonly VerbSchema[] = [
         target_ref: {
           type: 'string',
           description:
-            'positional; the target reference (PR URL, file path, function symbol, or commit sha)',
+            'positional; the target reference (PR URL, file path, function symbol, commit sha, or — for type=system — a free-form scope label)',
         },
         type: {
           type: 'string',
-          enum: ['pr', 'file', 'function', 'commit'],
+          enum: ['pr', 'file', 'function', 'commit', 'system'],
+          description:
+            "system = bird's-eye review scope (e.g. \"guild-cli@v0.4.0\", \"the devil-review passage\"). Pairs with the coherence lense. Per #134 J1.",
         },
         by: strOpt('actor (defaults to GUILD_ACTOR)'),
         format: formatField,
@@ -102,7 +104,7 @@ const VERBS: readonly VerbSchema[] = [
       target: {
         type: 'object',
         properties: {
-          type: { type: 'string', enum: ['pr', 'file', 'function', 'commit'] },
+          type: { type: 'string', enum: ['pr', 'file', 'function', 'commit', 'system'] },
           ref: str,
         },
         required: ['type', 'ref'],
@@ -174,7 +176,7 @@ const VERBS: readonly VerbSchema[] = [
     summary:
       'enumerate review sessions in the content_root. Filters: --state narrows by ' +
       'open|concluded, or `all` for every state (no filter); --target-type ' +
-      'narrows by pr|file|function|commit. Read-only.',
+      'narrows by pr|file|function|commit|system. Read-only.',
     input: {
       type: 'object',
       properties: {
@@ -184,7 +186,7 @@ const VERBS: readonly VerbSchema[] = [
         },
         'target-type': {
           type: 'string',
-          enum: ['pr', 'file', 'function', 'commit'],
+          enum: ['pr', 'file', 'function', 'commit', 'system'],
         },
         format: formatField,
       },
@@ -202,7 +204,7 @@ const VERBS: readonly VerbSchema[] = [
               target: {
                 type: 'object',
                 properties: {
-                  type: { type: 'string', enum: ['pr', 'file', 'function', 'commit'] },
+                  type: { type: 'string', enum: ['pr', 'file', 'function', 'commit', 'system'] },
                   ref: str,
                 },
                 required: ['type', 'ref'],

--- a/src/passages/devil/interface/index.ts
+++ b/src/passages/devil/interface/index.ts
@@ -41,12 +41,15 @@ import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 const HELP = `devil-review — security-backstop review passage (alpha, 11 verbs)
 
 Usage:
-  devil open <target-ref> --type <pr|file|function|commit>
+  devil open <target-ref> --type <pr|file|function|commit|system>
                           [--by <m>] [--format json|text]
                               Open a review session against a target.
                               Lands at <content_root>/devil/reviews/<rev-id>.yaml.
                               Initial state: open. Allocates a fresh
                               rev-YYYY-MM-DD-NNN id per the runtime clock.
+                              type=system marks a bird's-eye scope
+                              (free-form ref, e.g. "guild-cli@v0.4.0");
+                              pairs naturally with the coherence lense.
 
   devil entry <rev-id> --persona <p> --lense <l> --kind <k>
                        --text "<prose>"
@@ -62,7 +65,7 @@ Usage:
                               author-defender / mirror); ingest-only
                               personas are rejected here.
 
-  devil list [--state open|concluded|all] [--target-type pr|file|function|commit]
+  devil list [--state open|concluded|all] [--target-type pr|file|function|commit|system]
              [--format json|text]
                               Enumerate review sessions. Read-only,
                               one-line-per-review summary; --state and

--- a/tests/passages/devil/DevilReview.test.ts
+++ b/tests/passages/devil/DevilReview.test.ts
@@ -41,7 +41,27 @@ test('parseTargetType rejects unknown types', () => {
   assert.equal(parseTargetType('file'), 'file');
   assert.equal(parseTargetType('function'), 'function');
   assert.equal(parseTargetType('commit'), 'commit');
+  assert.equal(parseTargetType('system'), 'system');
   assert.throws(() => parseTargetType('feature'), /must be one of/);
+});
+
+test('DevilReview.open accepts target.type=system with free-form ref', () => {
+  // #134 J1: bird's-eye review scope. The ref carries a free-form
+  // module / release / passage label; only the non-empty rule applies.
+  const review = DevilReview.open({
+    id: 'rev-2026-05-09-001',
+    target: { type: 'system', ref: 'guild-cli@v0.4.0' },
+    opened_by: 'alice',
+  });
+  assert.equal(review.target.type, 'system');
+  assert.equal(review.target.ref, 'guild-cli@v0.4.0');
+  // Round-trip: the YAML payload preserves the new type as-is.
+  const json = review.toJSON();
+  assert.equal((json as Record<string, unknown>).target instanceof Object, true);
+  assert.deepEqual(
+    (json as { target: { type: string; ref: string } }).target,
+    { type: 'system', ref: 'guild-cli@v0.4.0' },
+  );
 });
 
 test('parseReviewState rejects unknown states (no suspended in v0)', () => {


### PR DESCRIPTION
## Summary

Smallest of the three v2 candidates from #134 — add a new
`target.type` value to model bird's-eye review scope without
disturbing the existing 4 types or the schema shape.

## What changes

- `TargetType`: add `'system'` to the union + `VALID_TARGET_TYPES` set
- `Target.ref` doc clarifies semantics — `pr` / `file` / `function` /
  `commit` retain their existing shapes; `system` carries a
  free-form scope label
- Interface usage strings (`devil open` / `devil list` / `devil`
  index help / `devil schema`) surface the new option
- Devil README + AGENT.md catch up

## What stays the same

- `target.ref` validation: still "non-empty trimmed string" (the
  existing rule already accepts free-form labels — no new validator)
- No new YAML keys, no new interfaces, no new lifecycle. The new
  enum value is the minimum addition.
- Backward compat: pre-this-fix records (4-type targets) hydrate
  unchanged

## Use case (from #134)

Reviews like "audit the devil-review passage as a whole" or
"bird's-eye on `guild-cli@v0.4.0`" pair naturally with the
`coherence` lense (PR #129) which was added precisely for
system-level observation. Before this, such reviews had to lie with
`target.type=pr/file`. Now: `target.type=system` + free-form ref.

```bash
$ devil open "guild-cli@v0.4.0" --type system --by alice --format json
{
  "ok": true,
  "review_id": "rev-2026-05-09-001",
  "target": { "type": "system", "ref": "guild-cli@v0.4.0" },
  "state": "open",
  ...
}
$ devil list --target-type system
```

## Out of scope (deferred per #134 tradeoff discussion)

- **J2** (feature / module / release granular types) — defer until
  concrete pain emerges; J1 covers the bird's-eye case alone
- **J3** (composite multi-target schema) — defer; schema complexity
  is load-bearing in v1, raise it only when J1 + J2 prove
  insufficient
- **Item G** (per-content_root lense override loader) and **Item H**
  (gate/devil lense semantics convergence) tracked separately on #134

## Test plan

- [x] `npm run build` clean
- [x] Full suite — 1417/1417 pass on linux (+1 new test for the
  `system` enum value + a round-trip through `DevilReview.toJSON()`)
- [x] Smoke-tested `devil open --type system` + `devil list
  --target-type system` end-to-end on a fresh content_root
- [x] Schema introspection (`devil schema --verb open`) emits the
  new enum value with description naming `#134 J1`

https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XV8fyeQn3FT21QN42GM5X6)_