### PR TITLE
chore: deprecation notice for --executor singular + repo CLAUDE.md (#239)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 # THS hook artifacts (accidental cwd)
 data/sync/
 examples/dogfood-session/data/
+
+# Local gate dogfood records (actor names + session content — do not publish)
+requests/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ data/sync/
 examples/dogfood-session/data/
 
 # Local gate dogfood records (actor names + session content — do not publish)
-requests/
+# Root-anchored so examples/*/requests/ fixtures stay tracked.
+/requests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`--executor` (singular) on `gate request` / `gate fast-track`**
+  ([#239](https://github.com/eris-ths/guild-cli/issues/239)).
+  Explicit `--executor <name>` now emits a stderr notice pointing at
+  `--executors <name>` and announcing v0.7.0 removal. The implicit
+  `--executor` fallback in `gate fast-track` (defaulting to `--from`
+  when neither flag is given) stays silent — only user-supplied
+  values trigger the notice. Behavior is otherwise unchanged through
+  the v0.6 cycle; the deprecated surface is removed at v0.7.0 cut
+  along with the `executor` JSON alias on rendering.
+
 ### Fixed
 
 - **friction bundle — flag aliases / lense help / self-approve discoverability /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   values trigger the notice. Behavior is otherwise unchanged through
   the v0.6 cycle; the deprecated surface is removed at v0.7.0 cut
   along with the `executor` JSON alias on rendering.
+  Notice introduced for v0.6.0; removal scheduled for v0.7.0.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ Domain → Application → Infrastructure → Interface の Clean Architecture (
 
 ```bash
 # 起票 (eris は default host、members/ に登録済み actor を --executor に指定)
-gate request --action "ship #N <feature>" --reason "<why>" --executor <actor> --from eris --target "<files>"
+gate request --action "ship #N <feature>" --reason "<why>" --executors <actor> --from eris --target "<files>"
+# (Note: --executor (singular) is deprecated as of v0.6 — use --executors. See #239.)
 # → 2026-MM-DD-NNNN (state=pending)
 
 gate approve <id> --by eris        # self-approve は notice 出るが通る (現行)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md — guild-cli
+
+このファイルは Claude Code (および互換 AI agent) が guild-cli リポジトリで作業するときの guide。
+
+## What this repo is
+
+TypeScript 製 CLI `guild-cli` を提供する public repo。4 つの passage を持つ：
+
+- **gate** — request/approve/execute/complete の wave coordination + claim/witness の cross-session stake
+- **agora** — improvise / suspend / conclude の議論プリミティブ
+- **devil** — devil's advocate review (lenses: devil/layer/cognitive/user + custom)
+- **ctx** — session 跨ぎの文脈 primitive
+
+Domain → Application → Infrastructure → Interface の Clean Architecture (`src/` 配下に layer 分割)。`bin/*.mjs` が CLI dispatcher、各 passage の handler は `src/interface/<passage>/handlers/` に。
+
+## Dogfooding rule
+
+**guild-cli の開発は guild-cli substrate の上で回す**。これは設計原則ではなく実用要請：
+
+- 自分で作った primitive を自分の wave 進行に乗せれば friction が surface する
+- surface した friction が次の improvement issue になる (例: #228 friction bundle、#233 self_approve)
+- records-outlive-writers の原則は開発自身にも効く — 「誰が・なぜ・いつ・何を変えたか」が gate record に残る
+
+### 標準ワークフロー (single-executor wave)
+
+```bash
+# 起票 (eris は default host、members/ に登録済み actor を --executor に指定)
+gate request --action "ship #N <feature>" --reason "<why>" --executor <actor> --from eris --target "<files>"
+# → 2026-MM-DD-NNNN (state=pending)
+
+gate approve <id> --by eris        # self-approve は notice 出るが通る (現行)
+gate execute <id> --by <actor>     # → state=executing
+
+# (worktree 切って実装 / レビュー / テスト)
+
+gate complete <id> --by <actor>    # → terminal、claim/witnesses は auto-reset
+```
+
+### 並列 wave (parallel-impl 等)
+
+`gate request --executors a,b,c` で複数 executor を同時記録 (#230)。
+**worktree isolation 必須** — `profile: swarm` で強制される (#231)。
+attribution race の物理化防止は filesystem 層 + record 層 + agent-loop 層の三層分担。
+
+## Cross-session coordination
+
+別セッション (別 SubAgent / 別 main session) が同 issue を独立着手するケースに備える：
+
+- `gate claim <id> --by <actor>` — 「私が動かす」exclusive stake (PR #243 / phase 1 ship 済)
+- `gate witness <id> --by <actor>` — 「観察するだけ」non-exclusive (#244 / phase 2)
+- `gate boot` で overlap 検知 (#234 / 設計中)
+
+セッション開始時は **open issue 確認 → 関連 wave に claim 取得 → 作業開始** の routine 推奨。
+
+## Repository layout
+
+| dir | 内容 | shared? |
+|-----|------|--------|
+| `src/` `tests/` | 実装と test (TS) | ✅ git |
+| `bin/*.mjs` | CLI entrypoint dispatcher | ✅ git |
+| `examples/` | sample guild instances (各種 config パターン) | ✅ git |
+| `docs/` | 設計・運用ドキュメント | ✅ git |
+| `members/` | gate member 登録 (alice/bob 等) | ❌ local-only via `.git/info/exclude` |
+| `substrate/` | agora plays/games の作業領域 | ❌ local-only |
+| `experiments/` | substrate-experiment 跡地 | ❌ local-only |
+| `.claude/` | worktree shadow / settings | ❌ local-only |
+| `requests/` | gate request YAML records (dogfood 履歴、actor 名含む) | ❌ local-only via `.gitignore` |
+
+## Development workflow
+
+1. **branch + worktree**: 大きい変更は `git worktree add ../guild-cli-<topic> -b feat/<topic>` で隔離
+2. **build + test**: `npm run build && npm test` (Jest、~1250 tests)
+3. **commit**: 必須 (Task tool / SubAgent の auto-cleanup 防止)
+4. **PR**: `gh pr create`、main rebase してから push、squash merge で fast ship
+5. **docs**: behavior change は `CHANGELOG.md` の `[Unreleased]` に entry 追加
+
+詳細は `docs/` 配下と `.gate-sessions/` (もしあれば) の wave 履歴を参照。
+
+## Style
+
+- TS strict mode、no `any`
+- domain は外部依存ゼロ (Clean Arch の依存方向厳守)
+- text mode と json mode の両 surface を維持 (LLM 消費前提)
+- byte-stable YAML (空 field omit、hydrate tolerance) は永続層の不変条件
+- error message に "next:" を添えて recovery path を提示 (touch-feel UX)
+
+## References
+
+- 進行中 wave の resume: `.gate-sessions/` 配下 / 開発者の ctx (例: `data/ctx/guild_cli_dev_resume.md`)
+- Roadmap: #36
+- Profile design: #227 (swarm profile epic)
+- Friction bundle: #228
+- Cross-session: #226 (claim/witness)

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -338,7 +338,16 @@ export async function reqCreate(c: C, args: ParsedArgs): Promise<number> {
     }
     if (parsed.list.length > 0) input.executors = parsed.list;
   }
-  if (executor !== undefined) input.executor = executor;
+  if (executor !== undefined) {
+    // Deprecation: `--executor` (singular) was kept for back-compat
+    // through the v0.6 cycle (#230). Removal scheduled for v0.7.0
+    // (#239). Surface a notice so explicit callers migrate to
+    // `--executors` ahead of the cut.
+    process.stderr.write(
+      `notice: --executor (singular) is deprecated and will be removed in v0.7.0; use --executors <name> instead. (issue #239)\n`,
+    );
+    input.executor = executor;
+  }
   if (target !== undefined) input.target = target;
   // Worktree-isolation gating (#231). Two effects, both keyed on
   // "is this a parallel wave?" (executors.length > 1):
@@ -1336,6 +1345,13 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
   }
   // Single-executor surface: explicit --executor wins, else default
   // to the author for the self-execute happy path.
+  if (executorOpt !== undefined) {
+    // Deprecation notice — same policy as reqCreate (#239). Only warn
+    // on explicit user input, not the implicit `from` fallback.
+    process.stderr.write(
+      `notice: --executor (singular) is deprecated and will be removed in v0.7.0; use --executors <name> instead. (issue #239)\n`,
+    );
+  }
   const executor = executorsList === undefined
     ? (executorOpt ?? from)
     : undefined;

--- a/tests/interface/executorSingularDeprecation239.test.ts
+++ b/tests/interface/executorSingularDeprecation239.test.ts
@@ -1,0 +1,125 @@
+// #239 — `--executor` (singular) deprecation notice.
+//
+// Pins the contract introduced in PR #272:
+//   1. Explicit `--executor <name>` on `gate request` emits a stderr
+//      notice pointing at `--executors` and announcing v0.7.0 removal.
+//   2. Explicit `--executor <name>` on `gate fast-track` emits the
+//      same notice.
+//   3. The implicit fast-track fallback (defaulting executor to
+//      `--from` when neither `--executor` nor `--executors` is given)
+//      stays silent — only user-supplied values trigger the notice.
+//   4. The notice rides stderr, never stdout, so `--format json`
+//      consumers stay clean.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-deprecation-239-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(cwd: string, args: string[]): {
+  stdout: string;
+  stderr: string;
+  status: number;
+} {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+const NOTICE_RE = /--executor \(singular\) is deprecated.*v0\.7\.0/;
+
+test('#239: gate request --executor (singular) emits stderr deprecation notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(root, ['register', '--name', 'alice']);
+
+  const r = run(root, [
+    'request',
+    '--from', 'eris',
+    '--action', 'do',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  assert.equal(r.status, 0, `request should still succeed: ${r.stderr}`);
+  assert.match(r.stderr, NOTICE_RE);
+  // JSON purity — stdout must NOT contain the notice.
+  assert.equal(NOTICE_RE.test(r.stdout), false,
+    `notice must not leak into stdout; got: ${r.stdout}`);
+});
+
+test('#239: gate request --executors (plural) does NOT emit the notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(root, ['register', '--name', 'alice']);
+
+  const r = run(root, [
+    'request',
+    '--from', 'eris',
+    '--action', 'do',
+    '--reason', 'r',
+    '--executors', 'alice',
+  ]);
+  assert.equal(r.status, 0, `request should succeed: ${r.stderr}`);
+  assert.equal(NOTICE_RE.test(r.stderr), false,
+    `--executors must not trigger the notice; got: ${r.stderr}`);
+});
+
+test('#239: gate fast-track --executor (singular) emits the notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(root, ['register', '--name', 'alice']);
+
+  const r = run(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'do',
+    '--reason', 'r',
+    '--executor', 'alice',
+  ]);
+  assert.equal(r.status, 0, `fast-track should succeed: ${r.stderr}`);
+  assert.match(r.stderr, NOTICE_RE);
+  assert.equal(NOTICE_RE.test(r.stdout), false,
+    `notice must not leak into stdout; got: ${r.stdout}`);
+});
+
+test('#239: gate fast-track without --executor stays silent (implicit fallback)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(root, ['register', '--name', 'alice']);
+
+  // Self-execute happy path: neither --executor nor --executors. The
+  // handler defaults executor to `from`. This implicit fallback MUST
+  // NOT trigger the deprecation notice — we only warn on user input.
+  const r = run(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'do',
+    '--reason', 'r',
+  ]);
+  assert.equal(r.status, 0, `fast-track should succeed: ${r.stderr}`);
+  assert.equal(NOTICE_RE.test(r.stderr), false,
+    `implicit from-fallback must stay silent; got: ${r.stderr}`);
+});


### PR DESCRIPTION
## Summary

- **Deprecation notice for `--executor` (singular)** on `gate request` / `gate fast-track` (#239). Explicit user-supplied `--executor <name>` now emits a stderr notice pointing at `--executors` and announcing v0.7.0 removal. The implicit fast-track fallback (defaulting executor to `--from` when neither flag is given) stays silent — only explicit calls warn, so the self-execute happy path keeps a clean stderr.
- **`CLAUDE.md`** added at repo root: dogfood rule, standard gate workflow, parallel-wave / cross-session coordination, repo layout (with `requests/` flagged as local-only), dev workflow, style.
- **`.gitignore`**: `requests/` added. Local `gate request` YAML records carry actor names + dogfood reasons and should not publish.

Behavior unchanged otherwise. v0.7.0 cut removes the deprecated CLI flag and the JSON `executor` alias on rendering — tracked in #239.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1425 tests pass, no regressions
- [ ] Reviewer: confirm stderr notice text reads cleanly, JSON consumers stay clean (notice is stderr-only)
- [ ] Reviewer: confirm `gate fast-track` without `--executor` does NOT emit the notice (implicit `from` fallback stays silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)