### PR TITLE
feat(devil): per-content_root lense extension loader (#134 G)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Added
+
+- **per-content_root lense extension loader for devil-review (#134 G)**
+  ([#134](https://github.com/eris-ths/guild-cli/issues/134)).
+  `<content_root>/devil/lenses/<name>.yaml` now extends the bundled
+  lense catalog. Each YAML file follows the same shape as `Lense.create`
+  input (`name` / `title` / `description` / `ingest_sources?` /
+  `delegate?` / `examples?`) and is loaded by `ComposedLenseCatalog`
+  on top of `BundledLenseCatalog`.
+  - **extend-only, hard-error on collision.** A name collision between
+    a content_root extension and a bundled lense raises `LenseCollision`
+    at startup. Silent override would make older review records
+    ambiguous to re-read (records-outlive-writers). The fix is to pick
+    a distinct extension name (e.g. `security-strict`).
+  - **provenance pinned at write time.** Every `Lense` carries
+    `source: 'bundled' | 'extension'`; entry records persist
+    `lense_source: extension` when the lense was loaded from
+    content_root (omitted for the bundled-default common case to keep
+    YAML terse). A future bundled v2 that adds the same name cannot
+    retroactively reinterpret a recorded entry — the record disambiguates
+    itself.
+  - **doctor-friendly failure modes.** Malformed YAML and schema
+    validation failures route through `onMalformed` rather than
+    crashing startup, so `gate doctor` can surface them.
+  - `devil schema --format json` now exposes `source` per lense so
+    consumers can distinguish bundled vs extension entries.
+  - H2 (gate-side `gate.strict_lenses` opt-in mode) is the next slice
+    and lands as a separate PR; this ship is loader + record
+    annotation only.
+
 ### Deprecated
 
 - **`--executor` (singular) on `gate request` / `gate fast-track`**

--- a/src/passages/devil/domain/Entry.ts
+++ b/src/passages/devil/domain/Entry.ts
@@ -23,7 +23,7 @@
 //   - toJSON omits absent optionals so re-readers don't see noise
 
 import { DomainError } from '../../../domain/shared/DomainError.js';
-import { parseLenseName } from './Lense.js';
+import { parseLenseName, LenseSource } from './Lense.js';
 import { parsePersonaName } from './Persona.js';
 
 export type EntryKind =
@@ -177,6 +177,14 @@ export interface EntryProps {
   readonly by: string;
   readonly persona: string;
   readonly lense: string;
+  /**
+   * Provenance of `lense` at entry-write time (#134 G). Only persisted
+   * when the lense was an extension; bundled is the default and is
+   * omitted to keep records terse for the common case. records-outlive-
+   * writers: pinning the source here means a future bundled v2 that
+   * adds the same name cannot retroactively change what this record meant.
+   */
+  readonly lense_source?: LenseSource;
   readonly kind: EntryKind;
   readonly text: string;
   readonly addresses?: string; // optional cross-reference to earlier entry id
@@ -201,6 +209,7 @@ export class Entry {
   readonly by: string;
   readonly persona: string;
   readonly lense: string;
+  readonly lense_source?: LenseSource;
   readonly kind: EntryKind;
   readonly text: string;
   readonly addresses?: string;
@@ -220,6 +229,7 @@ export class Entry {
     this.lense = props.lense;
     this.kind = props.kind;
     this.text = props.text;
+    if (props.lense_source !== undefined) this.lense_source = props.lense_source;
     if (props.addresses !== undefined) this.addresses = props.addresses;
     if (props.severity !== undefined) this.severity = props.severity;
     if (props.severity_rationale !== undefined)
@@ -257,6 +267,16 @@ export class Entry {
     const persona = parsePersonaName(input.persona);
     const lense = parseLenseName(input.lense);
     const kind = parseEntryKind(input.kind);
+    if (
+      input.lense_source !== undefined &&
+      input.lense_source !== 'bundled' &&
+      input.lense_source !== 'extension'
+    ) {
+      throw new DomainError(
+        `lense_source must be 'bundled' or 'extension', got: ${String(input.lense_source)}`,
+        'lense_source',
+      );
+    }
     if (typeof input.text !== 'string' || input.text.trim().length === 0) {
       throw new DomainError('text required (non-empty string)', 'text');
     }
@@ -387,6 +407,7 @@ export class Entry {
         kind,
         text: input.text.trim(),
         stages,
+        ...(input.lense_source !== undefined ? { lense_source: input.lense_source } : {}),
         ...(input.severity_rationale !== undefined
           ? { severity_rationale: input.severity_rationale.trim() }
           : {}),
@@ -435,6 +456,9 @@ export class Entry {
       kind: r['kind'] as EntryKind,
       text: r['text'] as string,
       ...(r['addresses'] !== undefined ? { addresses: r['addresses'] as string } : {}),
+      ...(r['lense_source'] !== undefined
+        ? { lense_source: r['lense_source'] as LenseSource }
+        : {}),
       ...(r['severity'] !== undefined ? { severity: r['severity'] as Severity } : {}),
       ...(r['severity_rationale'] !== undefined
         ? { severity_rationale: r['severity_rationale'] as string }
@@ -465,6 +489,7 @@ export class Entry {
       kind: this.kind,
       text: this.text,
     };
+    if (this.lense_source !== undefined) out['lense_source'] = this.lense_source;
     if (this.addresses !== undefined) out['addresses'] = this.addresses;
     if (this.severity !== undefined) out['severity'] = this.severity;
     if (this.severity_rationale !== undefined)

--- a/src/passages/devil/domain/Lense.ts
+++ b/src/passages/devil/domain/Lense.ts
@@ -37,6 +37,18 @@ export function parseLenseName(raw: unknown): string {
   return raw;
 }
 
+/**
+ * Provenance marker (#134 G): is this lense from the bundled catalog
+ * or from a content_root extension under `devil/lenses/*.yaml`?
+ *
+ * Pinning provenance lets entry records (and `devil schema`) name the
+ * source of every lense they touch. Without it, a future bundled v2
+ * that adds `security` would silently re-bind older entries that named
+ * a then-extension lense `security` — records-outlive-writers requires
+ * the record itself to disambiguate.
+ */
+export type LenseSource = 'bundled' | 'extension';
+
 export interface LenseProps {
   readonly name: string;
   readonly title: string;
@@ -60,6 +72,8 @@ export interface LenseProps {
    * scope without re-deriving from the title alone.
    */
   readonly examples?: readonly string[];
+  /** See LenseSource. Defaults to 'bundled' when omitted in create(). */
+  readonly source?: LenseSource;
 }
 
 export class Lense {
@@ -69,6 +83,7 @@ export class Lense {
   readonly ingest_sources: readonly string[];
   readonly delegate?: string;
   readonly examples?: readonly string[];
+  readonly source: LenseSource;
 
   private constructor(props: LenseProps) {
     this.name = props.name;
@@ -77,6 +92,7 @@ export class Lense {
     this.ingest_sources = props.ingest_sources;
     if (props.delegate !== undefined) this.delegate = props.delegate;
     if (props.examples !== undefined) this.examples = props.examples;
+    this.source = props.source ?? 'bundled';
   }
 
   /**
@@ -91,6 +107,7 @@ export class Lense {
     ingest_sources?: readonly string[];
     delegate?: string;
     examples?: readonly string[];
+    source?: LenseSource;
   }): Lense {
     const name = parseLenseName(input.name);
     if (typeof input.title !== 'string' || input.title.trim().length === 0) {
@@ -117,6 +134,12 @@ export class Lense {
         }
       }
     }
+    if (input.source !== undefined && input.source !== 'bundled' && input.source !== 'extension') {
+      throw new DomainError(
+        `source must be 'bundled' or 'extension', got: ${String(input.source)}`,
+        'source',
+      );
+    }
     const props: LenseProps = {
       name,
       title: input.title.trim(),
@@ -124,6 +147,7 @@ export class Lense {
       ingest_sources,
       ...(input.delegate !== undefined ? { delegate: input.delegate } : {}),
       ...(input.examples !== undefined ? { examples: input.examples } : {}),
+      ...(input.source !== undefined ? { source: input.source } : {}),
     };
     return new Lense(props);
   }
@@ -137,7 +161,33 @@ export class Lense {
     };
     if (this.delegate !== undefined) out['delegate'] = this.delegate;
     if (this.examples !== undefined) out['examples'] = this.examples;
+    // source is always present (default 'bundled') so the schema output
+    // is unambiguous; consumers don't have to infer the default.
+    out['source'] = this.source;
     return out;
+  }
+}
+
+export class LenseCollision extends Error {
+  /**
+   * Hard-error at catalog load time when a content_root extension
+   * names the same lense as a bundled default. records-outlive-writers:
+   * silently shadowing bundled meaning across content_roots makes a
+   * 2-year-old review record ambiguous to re-read. The fix is to pick
+   * a distinct extension name.
+   */
+  readonly bundledName: string;
+  readonly extensionPath: string;
+  constructor(bundledName: string, extensionPath: string) {
+    super(
+      `Lense "${bundledName}" defined by extension at ${extensionPath} ` +
+        `collides with a bundled lense of the same name. ` +
+        `next: rename the extension lense to a distinct name (e.g. "${bundledName}-strict") — ` +
+        `silent override would make older review records ambiguous to re-read.`,
+    );
+    this.name = 'LenseCollision';
+    this.bundledName = bundledName;
+    this.extensionPath = extensionPath;
   }
 }
 

--- a/src/passages/devil/infrastructure/ComposedLenseCatalog.ts
+++ b/src/passages/devil/infrastructure/ComposedLenseCatalog.ts
@@ -1,0 +1,138 @@
+// devil-review — composed lense catalog (#134 G).
+//
+// Layout: bundled defaults from BundledLenseCatalog merged with
+// per-content_root extensions read from `<content_root>/devil/lenses/
+// <name>.yaml` (one file per lense). Each extension YAML follows the
+// same shape as Lense.create's input (name/title/description/
+// ingest_sources?/delegate?/examples?). Source provenance is pinned on
+// every Lense so review records and `devil schema` can disambiguate.
+//
+// Policy (records-outlive-writers):
+//   - extend-only. A name collision between bundled and extension is
+//     a hard error at load time (LenseCollision). The fix is to pick
+//     a distinct extension name (e.g. "security-strict") rather than
+//     silently shadow the bundled meaning, since older review records
+//     would otherwise become ambiguous to re-read.
+//   - file-system errors (missing dir → no extensions; malformed YAML
+//     or schema validation failure) route through onMalformed so
+//     `gate doctor` can surface them. Loader does NOT crash the CLI;
+//     a bad extension drops out of the catalog with a notice.
+
+import { join } from 'node:path';
+import { Lense, LenseCollision } from '../domain/Lense.js';
+import { LenseCatalog } from '../application/LenseCatalog.js';
+import { BundledLenseCatalog } from './BundledLenseCatalog.js';
+import {
+  existsSafe,
+  listDirSafe,
+  readTextSafe,
+} from '../../../infrastructure/persistence/safeFs.js';
+import { parseYamlSafe } from '../../../infrastructure/persistence/parseYamlSafe.js';
+import { OnMalformed } from '../../../application/ports/OnMalformed.js';
+
+const EXTENSIONS_SUBDIR = 'devil/lenses';
+
+export class ComposedLenseCatalog implements LenseCatalog {
+  private readonly map: ReadonlyMap<string, Lense>;
+  private readonly order: readonly string[];
+
+  /**
+   * @param bundled the bundled defaults (canonical-order anchor)
+   * @param extensions content_root-loaded extras (after bundled in name list)
+   */
+  private constructor(
+    bundled: BundledLenseCatalog,
+    extensions: readonly Lense[],
+  ) {
+    const m = new Map<string, Lense>();
+    for (const l of bundled.list()) m.set(l.name, l);
+    for (const ext of extensions) {
+      // collisions among extensions surface here too (later wins is
+      // not the policy — but the loader already enforces no-dup at
+      // read time, so this is defense-in-depth).
+      m.set(ext.name, ext);
+    }
+    this.map = m;
+    this.order = [
+      ...bundled.names(),
+      ...extensions.map((e) => e.name),
+    ];
+  }
+
+  /**
+   * Load extensions from <contentRoot>/devil/lenses/*.yaml. Missing
+   * directory → no extensions (same shape as gate handlers when
+   * members/ is empty). Malformed files route via onMalformed.
+   */
+  static load(
+    bundled: BundledLenseCatalog,
+    contentRoot: string,
+    onMalformed: OnMalformed,
+  ): ComposedLenseCatalog {
+    const dir = join(contentRoot, EXTENSIONS_SUBDIR);
+    if (!existsSafe(contentRoot, dir)) {
+      return new ComposedLenseCatalog(bundled, []);
+    }
+    const files = listDirSafe(contentRoot, dir)
+      .filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'))
+      .sort(); // stable order, file-name lex
+    const bundledNames = new Set(bundled.names());
+    const extByName = new Map<string, Lense>();
+    for (const f of files) {
+      const path = join(dir, f);
+      const text = readTextSafe(contentRoot, path);
+      const parsed = parseYamlSafe(text, path, onMalformed);
+      if (parsed === undefined) continue; // YAML parse error already reported
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        onMalformed(path, 'lense extension must be a YAML mapping (one lense per file)');
+        continue;
+      }
+      const r = parsed as Record<string, unknown>;
+      let lense: Lense;
+      try {
+        lense = Lense.create({
+          name: r['name'] as string,
+          title: r['title'] as string,
+          description: r['description'] as string,
+          ingest_sources: (r['ingest_sources'] as readonly string[] | undefined) ?? [],
+          ...(r['delegate'] !== undefined ? { delegate: r['delegate'] as string } : {}),
+          ...(r['examples'] !== undefined
+            ? { examples: r['examples'] as readonly string[] }
+            : {}),
+          source: 'extension',
+        });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        onMalformed(path, `lense schema failed: ${msg}`);
+        continue;
+      }
+      if (bundledNames.has(lense.name)) {
+        // Hard error — extend-only policy. The CLI surfaces this as a
+        // startup failure rather than a doctor finding because silently
+        // dropping an extension that the team explicitly authored would
+        // mask the problem; the actor who edited the file expects the
+        // failure to be loud.
+        throw new LenseCollision(lense.name, path);
+      }
+      if (extByName.has(lense.name)) {
+        // duplicate within extensions → also LenseCollision, with the
+        // second-seen path so the message points at the offending file.
+        throw new LenseCollision(lense.name, path);
+      }
+      extByName.set(lense.name, lense);
+    }
+    return new ComposedLenseCatalog(bundled, [...extByName.values()]);
+  }
+
+  list(): readonly Lense[] {
+    return this.order.map((n) => this.map.get(n) as Lense);
+  }
+
+  find(name: string): Lense | null {
+    return this.map.get(name) ?? null;
+  }
+
+  names(): readonly string[] {
+    return this.order;
+  }
+}

--- a/src/passages/devil/interface/container.ts
+++ b/src/passages/devil/interface/container.ts
@@ -10,12 +10,14 @@
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { YamlDevilReviewRepository } from '../infrastructure/YamlDevilReviewRepository.js';
 import { BundledLenseCatalog } from '../infrastructure/BundledLenseCatalog.js';
+import { ComposedLenseCatalog } from '../infrastructure/ComposedLenseCatalog.js';
 import { BundledPersonaCatalog } from '../infrastructure/BundledPersonaCatalog.js';
+import { LenseCatalog } from '../application/LenseCatalog.js';
 
 export interface DevilContainer {
   config: GuildConfig;
   reviews: YamlDevilReviewRepository;
-  lenses: BundledLenseCatalog;
+  lenses: LenseCatalog;
   personas: BundledPersonaCatalog;
 }
 
@@ -28,7 +30,14 @@ export function buildDevilContainer(
 ): DevilContainer {
   const config = GuildConfig.load(opts.cwd);
   const reviews = new YamlDevilReviewRepository(config);
-  const lenses = new BundledLenseCatalog();
+  // #134 G: bundled defaults + content_root extensions under
+  // <contentRoot>/devil/lenses/*.yaml. Hard-errors at startup when an
+  // extension collides with a bundled name (records-outlive-writers).
+  const lenses = ComposedLenseCatalog.load(
+    new BundledLenseCatalog(),
+    config.contentRoot,
+    config.onMalformed,
+  );
   const personas = new BundledPersonaCatalog();
   return { config, reviews, lenses, personas };
 }

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -214,6 +214,9 @@ export async function entryOnReview(
     by,
     persona: persona.name,
     lense: lense.name,
+    // #134 G: pin extension provenance on the record. Bundled is the
+    // default and is omitted to keep the common-case YAML terse.
+    ...(lense.source === 'extension' ? { lense_source: 'extension' as const } : {}),
     kind,
     text,
     ...(severity !== undefined ? { severity } : {}),

--- a/tests/passages/devil/composedLenseCatalog.test.ts
+++ b/tests/passages/devil/composedLenseCatalog.test.ts
@@ -1,0 +1,133 @@
+// #134 G — ComposedLenseCatalog tests.
+//
+// Pin the loader contract: bundled defaults preserved, content_root
+// extensions appended with `source: 'extension'`, hard-error on name
+// collision, malformed extensions routed via onMalformed (no crash).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BundledLenseCatalog } from '../../../src/passages/devil/infrastructure/BundledLenseCatalog.js';
+import { ComposedLenseCatalog } from '../../../src/passages/devil/infrastructure/ComposedLenseCatalog.js';
+import { LenseCollision } from '../../../src/passages/devil/domain/Lense.js';
+
+function bootstrap(): { root: string; cleanup: () => void; reports: Array<{ src: string; msg: string }> } {
+  const root = mkdtempSync(join(tmpdir(), 'composed-lenses-'));
+  const reports: Array<{ src: string; msg: string }> = [];
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+    reports,
+  };
+}
+
+function writeExt(root: string, name: string, body: string): void {
+  const dir = join(root, 'devil', 'lenses');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.yaml`), body);
+}
+
+test('ComposedLenseCatalog.load with no extensions = bundled passthrough', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  const bundled = new BundledLenseCatalog();
+  const c = ComposedLenseCatalog.load(bundled, root, (s, m) => reports.push({ src: s, msg: m }));
+  assert.deepEqual(c.names(), bundled.names());
+  assert.equal(reports.length, 0);
+  // bundled lenses retain source = 'bundled'.
+  for (const l of c.list()) assert.equal(l.source, 'bundled');
+});
+
+test('ComposedLenseCatalog.load picks up *.yaml extensions and tags source=extension', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  writeExt(
+    root,
+    'team-perf',
+    [
+      'name: team-perf',
+      'title: Team Performance',
+      'description: hot path budgets and N+1 detection.',
+      'examples:',
+      '  - "request handler exceeds 200ms p95"',
+      '',
+    ].join('\n'),
+  );
+  const bundled = new BundledLenseCatalog();
+  const c = ComposedLenseCatalog.load(bundled, root, (s, m) => reports.push({ src: s, msg: m }));
+  const found = c.find('team-perf');
+  assert.ok(found, 'extension should be loaded');
+  assert.equal(found.source, 'extension');
+  assert.equal(found.title, 'Team Performance');
+  // bundled order preserved; extension appended.
+  assert.deepEqual(c.names().slice(0, bundled.names().length), bundled.names());
+  assert.equal(c.names()[c.names().length - 1], 'team-perf');
+  assert.equal(reports.length, 0);
+});
+
+test('ComposedLenseCatalog.load throws LenseCollision when extension shadows a bundled name', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  writeExt(
+    root,
+    'injection',
+    [
+      'name: injection',
+      'title: Custom Injection',
+      'description: should be rejected — bundled already owns this name.',
+      '',
+    ].join('\n'),
+  );
+  const bundled = new BundledLenseCatalog();
+  assert.throws(
+    () =>
+      ComposedLenseCatalog.load(bundled, root, (s, m) =>
+        reports.push({ src: s, msg: m }),
+      ),
+    (err: unknown) => {
+      assert.ok(err instanceof LenseCollision);
+      assert.equal((err as LenseCollision).bundledName, 'injection');
+      return true;
+    },
+  );
+});
+
+test('ComposedLenseCatalog.load: malformed YAML routes via onMalformed and skips the file', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  writeExt(root, 'broken', '::: not yaml :::\n  - [unbalanced');
+  const bundled = new BundledLenseCatalog();
+  const c = ComposedLenseCatalog.load(bundled, root, (s, m) =>
+    reports.push({ src: s, msg: m }),
+  );
+  assert.deepEqual(c.names(), bundled.names(), 'broken file must not pollute the catalog');
+  assert.equal(reports.length, 1);
+  assert.match(reports[0]!.msg, /yaml parse failed/);
+});
+
+test('ComposedLenseCatalog.load: schema-invalid extension routes via onMalformed', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  // Missing required `description` field — Lense.create rejects.
+  writeExt(root, 'noop', 'name: noop\ntitle: NoOp\n');
+  const bundled = new BundledLenseCatalog();
+  const c = ComposedLenseCatalog.load(bundled, root, (s, m) =>
+    reports.push({ src: s, msg: m }),
+  );
+  assert.equal(c.find('noop'), null, 'invalid extension must drop out');
+  assert.equal(reports.length, 1);
+  assert.match(reports[0]!.msg, /lense schema failed/);
+});
+
+test('ComposedLenseCatalog.load: missing devil/lenses directory is silent (no extensions)', (t) => {
+  const { root, cleanup, reports } = bootstrap();
+  t.after(cleanup);
+  const bundled = new BundledLenseCatalog();
+  const c = ComposedLenseCatalog.load(bundled, root, (s, m) =>
+    reports.push({ src: s, msg: m }),
+  );
+  assert.deepEqual(c.names(), bundled.names());
+  assert.equal(reports.length, 0);
+});


### PR DESCRIPTION
## Summary

- `<content_root>/devil/lenses/<name>.yaml` now extends the bundled lense catalog via `ComposedLenseCatalog` (bundled defaults + content_root extensions, canonical-order preserved with extensions appended).
- Extend-only policy: name collision with a bundled lense raises `LenseCollision` at startup. Records-outlive-writers — silent override would make older review entries ambiguous when read later.
- Provenance pinned: `Lense.source: 'bundled'|'extension'`; entries persist `lense_source: extension` only when relevant (bundled is the default and is omitted to keep YAML terse). A future bundled v2 that adds the same name cannot retroactively reinterpret an existing record.
- Failure modes route through `onMalformed` (no startup crash); `gate doctor` can surface bad extension files.
- `devil schema --format json` now exposes `source` per lense.

Implements Item G of #134 per [the design refinement](https://github.com/eris-ths/guild-cli/issues/134#issuecomment-4414205651). Item H2 (`gate.strict_lenses` opt-in mode) lands as a follow-up PR — together they close #134.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1435/1435 pass (was 1429; +6 from new `composedLenseCatalog.test.ts`)
- [x] New tests cover: bundled passthrough, extension load + source tag, hard-error on collision, malformed YAML routed via onMalformed, schema-invalid extension routed via onMalformed, missing extensions dir is silent
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)