### PR TITLE
feat(gate): opt-in strict lense vocabulary — gate.strict_lenses (#134 H2 / closes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **opt-in strict lense vocabulary for `gate review` (#134 H2 — closes #134)**
+  ([#274](https://github.com/eris-ths/guild-cli/issues/274)).
+  New top-level `gate.strict_lenses: bool` config (default `false`,
+  **permanently** opt-in). When `false`, gate review's allowed-lense
+  set comes from `lenses:` in `guild.config.yaml` — byte-identical to
+  pre-H2. When `true`, the allowed set is the unified devil
+  `ComposedLenseCatalog` (bundled defaults + content_root extensions
+  from G under `<content_root>/devil/lenses/*.yaml`). Composes with G:
+  teams that registered `team-perf.yaml` / `team-a11y.yaml` etc. get
+  gate-side vocabulary enforcement on the full custom catalog without
+  touching devil's coverage discipline. `gate review --help` reflects
+  whichever source is load-bearing for the run. Coverage gating
+  (devil's "conclude requires every catalog lense touched") is NOT
+  propagated — strict mode is vocabulary enforcement only. Default is
+  permanently opt-in: we do not flip to `true` at v1.0 or any future
+  cut.
+
 - **per-content_root lense extension loader for devil-review (#134 G)**
   ([#134](https://github.com/eris-ths/guild-cli/issues/134)).
   `<content_root>/devil/lenses/<name>.yaml` now extends the bundled

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -53,6 +53,35 @@ export type GuildProfile = 'standard' | 'swarm';
  */
 export type SelfApprovePolicy = 'allowed' | 'warn' | 'forbidden';
 
+/**
+ * Gate-scoped configuration (#134 H2). New top-level namespace for
+ * gate-specific knobs that don't fit cleanly under the cross-passage
+ * `features:` block.
+ */
+export interface GateConfig {
+  /**
+   * H2 strict lense vocabulary (#134 H2 / closes #134 with G):
+   *   false (default, **permanent**) — gate review's allowed-lense set
+   *     comes from `lenses:` in guild.config.yaml (current behavior,
+   *     byte-identical to pre-H2).
+   *   true — gate review's allowed-lense set is the devil
+   *     ComposedLenseCatalog (bundled defaults + content_root
+   *     extensions under `<content_root>/devil/lenses/*.yaml`). Unknown
+   *     lenses are rejected at the domain boundary with the same
+   *     error shape as today.
+   *
+   * Default is permanently opt-in: we do not flip to true at v1.0 or
+   * any future cut. The whole point of H2 is letting each team pick
+   * its own enforcement timing — auto-flipping defeats that.
+   *
+   * Coverage gating (devil's "conclude requires every catalog lense
+   * touched") is NOT propagated. Strict mode is vocabulary enforcement
+   * only; coverage discipline stays devil-side where the substrate-as-
+   * floor guarantee lives.
+   */
+  strictLenses: boolean;
+}
+
 export interface GuildFeatures {
   /**
    * When true, parallel waves (multi-executor requests) carry a
@@ -110,6 +139,7 @@ export interface GuildConfigProps {
   hookPluginPaths: readonly string[];
   profile: GuildProfile;
   features: GuildFeatures;
+  gate: GateConfig;
   onMalformed: OnMalformed;
 }
 
@@ -133,6 +163,7 @@ export class GuildConfig implements GuildConfigProps {
     readonly hookPluginPaths: readonly string[],
     readonly profile: GuildProfile,
     readonly features: GuildFeatures,
+    readonly gate: GateConfig,
     readonly onMalformed: OnMalformed,
     /**
      * Absolute path to the `guild.config.yaml` that produced this
@@ -282,7 +313,26 @@ export class GuildConfig implements GuildConfigProps {
         explicitWorktreeRequired ?? (profile === 'swarm'),
       selfApprove,
     };
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, profile, features, onMalformed, configPath);
+    // gate.* (#134 H2). Top-level namespace, not nested under features:
+    // these knobs are gate-passage-scoped (no cross-passage interaction
+    // with profile/features). Default is permanently opt-in — we do
+    // not auto-flip at any future cut. Malformed values fall back to
+    // false with an onMalformed notice (same conservative read pattern).
+    const gateRaw = raw.gate ?? {};
+    let strictLenses = false;
+    if (gateRaw.strict_lenses !== undefined) {
+      if (typeof gateRaw.strict_lenses === 'boolean') {
+        strictLenses = gateRaw.strict_lenses;
+      } else {
+        onMalformed(
+          configPath,
+          `unknown gate.strict_lenses ${JSON.stringify(gateRaw.strict_lenses)} — ` +
+            `falling back to 'false'. Valid: true | false.`,
+        );
+      }
+    }
+    const gate: GateConfig = { strictLenses };
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, profile, features, gate, onMalformed, configPath);
   }
 
   static default(
@@ -307,6 +357,7 @@ export class GuildConfig implements GuildConfigProps {
       [],
       'standard',
       { worktreeRequiredForParallel: false, selfApprove: 'warn' },
+      { strictLenses: false },
       onMalformed,
       null,
     );

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -44,13 +44,26 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   // `gate review --help` sees the accepted enum without first having
   // to fail with a bogus value. The error path already lists the same
   // info; this brings the discoverability up one level.
+  // #134 H2: when gate.strict_lenses is on, the allowed-lense set
+  // mirrors the devil ComposedLenseCatalog (bundled + content_root
+  // extensions). Otherwise the configured `lenses:` list governs.
+  // Help shows whichever source is actually load-bearing for this run
+  // so the reviewer doesn't have to discover the difference from a
+  // failing call.
   const lenseList = c.config.lenses.length > 0
     ? c.config.lenses.join(', ')
     : 'devil, layer, cognitive, user';
-  const helpExtras: readonly string[] = [
-    `accepted lenses (resolved from guild.config.yaml): ${lenseList}`,
-    `note: --comment is a deprecated alias of --note (kept for back-compat)`,
-  ];
+  const helpExtras: readonly string[] = c.config.gate.strictLenses
+    ? [
+        `accepted lenses (gate.strict_lenses=true → unified devil catalog, ` +
+          `bundled + <content_root>/devil/lenses/*.yaml extensions). ` +
+          `See \`devil schema --format json\` for the full list with provenance.`,
+        `note: --comment is a deprecated alias of --note (kept for back-compat)`,
+      ]
+    : [
+        `accepted lenses (resolved from guild.config.yaml): ${lenseList}`,
+        `note: --comment is a deprecated alias of --note (kept for back-compat)`,
+      ];
   rejectUnknownFlags(args, REVIEW_KNOWN_FLAGS, 'review', helpExtras);
   const id = args.positional[0];
   if (!id) {

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -16,6 +16,8 @@ import { RepairUseCases } from '../../application/repair/RepairUseCases.js';
 import { UnrespondedConcernsQuery } from '../../application/concern/UnrespondedConcernsQuery.js';
 import { SafeFsQuarantineStore } from '../../infrastructure/persistence/SafeFsQuarantineStore.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
+import { BundledLenseCatalog } from '../../passages/devil/infrastructure/BundledLenseCatalog.js';
+import { ComposedLenseCatalog } from '../../passages/devil/infrastructure/ComposedLenseCatalog.js';
 import { YamlPlayRepository } from '../../passages/agora/infrastructure/YamlPlayRepository.js';
 import { PlayRepository } from '../../passages/agora/application/PlayRepository.js';
 import { FsTemplateRepository } from '../../infrastructure/template/TemplateRepository.js';
@@ -162,7 +164,23 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
   return {
     config,
     memberUC: new MemberUseCases(members),
-    requestUC: new RequestUseCases({ requests, members, notifier, clock, allowedLenses: config.lenses }),
+    requestUC: new RequestUseCases({
+      requests,
+      members,
+      notifier,
+      clock,
+      // #134 H2: when gate.strict_lenses is on, the allowed-lense set
+      // is the unified devil catalog (bundled + content_root extensions
+      // from G). Otherwise the historical config.lenses list keeps
+      // driving validation. Default is permanently opt-in.
+      allowedLenses: config.gate.strictLenses
+        ? ComposedLenseCatalog.load(
+            new BundledLenseCatalog(),
+            config.contentRoot,
+            config.onMalformed,
+          ).names()
+        : config.lenses,
+    }),
     issueUC: new IssueUseCases(issues, members, clock),
     messageUC: new MessageUseCases({ members, notifier, clock }),
     diagnosticUC: new DiagnosticUseCases(

--- a/tests/interface/gateStrictLenses134H2.test.ts
+++ b/tests/interface/gateStrictLenses134H2.test.ts
@@ -1,0 +1,215 @@
+// #134 H2 — gate.strict_lenses opt-in mode tests.
+//
+// Pin the H2 contract:
+//   - default (unset / false) — gate review's allowed-lense set comes
+//     from `lenses:` in guild.config.yaml (current behavior, byte-
+//     identical to pre-H2).
+//   - true — gate review's allowed-lense set is the unified devil
+//     catalog (bundled defaults + <content_root>/devil/lenses/*.yaml
+//     extensions). Unknown lenses rejected.
+//   - regression: `--lense devil` always works under default config
+//     (DEFAULT_LENSES include 'devil') AND under strict mode (bundled
+//     catalog includes 'devil-substrate' lenses but NOT a 'devil' lens
+//     — wait — the substrate-side bundled lenses are different from
+//     gate's DEFAULT_LENSES. Strict-mode flip is a real migration step
+//     for teams that used 'devil' as a gate framing label).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function bootstrap(extraConfig = ''): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'gate-strict-lenses-h2-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n' + extraConfig,
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(cwd: string, args: string[]): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, encoding: 'utf8' });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+function makeReviewable(root: string, by = 'alice'): string {
+  run(root, ['register', '--name', by]);
+  run(root, ['register', '--name', 'bob']);
+  const created = run(root, [
+    'request',
+    '--from', by,
+    '--action', 'do',
+    '--reason', 'r',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  run(root, ['approve', id, '--by', 'eris']);
+  run(root, ['execute', id, '--by', by]);
+  run(root, ['complete', id, '--by', by]);
+  return id;
+}
+
+// -------------------- default (unset / false) — current behavior --------------------
+
+test('#134 H2: gate.strict_lenses unset → default DEFAULT_LENSES still accept devil', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'ok',
+    '--note', 'fine',
+  ]);
+  assert.equal(r.status, 0, `default should accept 'devil': ${r.stderr}`);
+  assert.match(r.stdout, /✓ review recorded/);
+});
+
+test('#134 H2: gate.strict_lenses=false explicit → byte-identical to unset', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: false\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil',
+    '--verdict', 'ok',
+    '--note', 'fine',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+});
+
+test('#134 H2: gate.strict_lenses unset → unknown lense rejected per existing config.lenses', (t) => {
+  // Existing behavior: unknown lense fails domain validation against
+  // DEFAULT_LENSES (devil/layer/cognitive/user). H2 must NOT regress this.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'injection', // bundled devil catalog name, not in DEFAULT_LENSES
+    '--verdict', 'ok',
+    '--note', 'x',
+  ]);
+  assert.notEqual(r.status, 0, 'default mode must still reject lenses outside config.lenses');
+  assert.match(r.stderr, /Invalid lense/);
+});
+
+// -------------------- strict mode — devil catalog --------------------
+
+test('#134 H2: strict mode accepts a bundled devil catalog lense', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'injection', // bundled devil catalog
+    '--verdict', 'ok',
+    '--note', 'sql injection check',
+  ]);
+  assert.equal(r.status, 0, `strict mode must accept bundled catalog lense: ${r.stderr}`);
+  assert.match(r.stdout, /✓ review recorded/);
+});
+
+test('#134 H2: strict mode rejects an unknown lense (not in bundled or extension)', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'totally-made-up',
+    '--verdict', 'ok',
+    '--note', 'x',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Invalid lense/);
+});
+
+test('#134 H2: strict mode picks up a content_root extension (G+H2 compose)', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  // Register an extension via G's loader.
+  const extDir = join(root, 'devil', 'lenses');
+  mkdirSync(extDir, { recursive: true });
+  writeFileSync(
+    join(extDir, 'team-a11y.yaml'),
+    [
+      'name: team-a11y',
+      'title: Accessibility',
+      'description: keyboard nav, contrast, ARIA correctness.',
+      '',
+    ].join('\n'),
+  );
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'team-a11y',
+    '--verdict', 'ok',
+    '--note', 'a11y pass',
+  ]);
+  assert.equal(r.status, 0, `extension must be accepted under strict mode: ${r.stderr}`);
+  assert.match(r.stdout, /✓ review recorded/);
+});
+
+// -------------------- help text reflects mode --------------------
+
+test('#134 H2: gate review --help text reflects strict-mode source', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  const r = run(root, ['review', '--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /gate\.strict_lenses=true/);
+  assert.match(r.stdout, /unified devil catalog/);
+});
+
+test('#134 H2: gate review --help (default) keeps the resolved-from-config wording', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = run(root, ['review', '--help']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /resolved from guild\.config\.yaml/);
+});
+
+// -------------------- malformed config falls back to false --------------------
+
+test('#134 H2: malformed gate.strict_lenses falls back to false (no crash)', (t) => {
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: "yes-please"\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const r = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'devil', // would be rejected if strict accidentally on (not bundled)
+    '--verdict', 'ok',
+    '--note', 'x',
+  ]);
+  assert.equal(r.status, 0, `malformed config must fall back to non-strict: ${r.stderr}`);
+});


### PR DESCRIPTION
## Summary

- New \`gate.strict_lenses: bool\` config (default \`false\`, **permanently** opt-in). When \`true\`, \`gate review\`'s allowed-lense set is the unified devil \`ComposedLenseCatalog\` (bundled + content_root extensions from G); when \`false\`, the historical \`config.lenses\` list governs (byte-identical to pre-H2).
- Composes cleanly with G (#273): teams that registered \`team-perf.yaml\` / \`team-a11y.yaml\` etc. as extensions get gate-side vocabulary enforcement on the full custom catalog without touching devil's coverage discipline.
- \`gate review --help\` text reflects whichever source is load-bearing for the run.
- Coverage gating (devil's "conclude requires every catalog lense touched") is **NOT** propagated — strict mode is vocabulary enforcement only. Substrate-as-floor stays devil-side.
- Default is permanently opt-in: never auto-flipped at v1.0 or any future cut. Each team picks its own enforcement timing.

Implements Item H2 of #134 per [the design refinement](https://github.com/eris-ths/guild-cli/issues/134#issuecomment-4414205651). Together with G (#273), this **closes #134**.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1444/1444 pass (was 1435; +9 from new \`gateStrictLenses134H2.test.ts\`)
- [x] Tests cover: default unset / explicit-false byte-identical to pre-H2; strict mode accepts bundled catalog lense; strict mode rejects unknown; strict mode picks up content_root extension (G+H2 compose); help text reflects mode; malformed config falls back to false (no crash)
- [ ] CI green

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)