### PR TITLE
fix(domain): permissive lense parsing on hydrate (#134 H2 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Fixed
+
+- **strict-mode review hydrate (#134 H2 hotfix)** — review records
+  written under `gate.strict_lenses: true` (using a bundled devil
+  catalog lense like `injection`) failed re-read by `gate show` /
+  `gate list` because the hydrate path only knew the (narrower)
+  `config.lenses` allowed-set. `Review.restore` now uses a permissive
+  lense parser (`parseLenseLoose`): the allowed-set check fires only
+  on fresh writes, not on re-reads. Records-outlive-writers — a
+  historical record's lense was already validated at write time, and
+  re-validating against a possibly-changed policy would erase the
+  audit trail. This also closes a pre-existing latent bug where
+  removing a lense from `config.lenses` would silently drop older
+  reviews from list output.
+
 ### Added
 
 - **opt-in strict lense vocabulary for `gate review` (#134 H2 — closes #134)**

--- a/src/domain/request/Review.ts
+++ b/src/domain/request/Review.ts
@@ -1,4 +1,4 @@
-import { Lense, parseLense } from '../shared/Lense.js';
+import { Lense, parseLense, parseLenseLoose } from '../shared/Lense.js';
 import { Verdict, parseVerdict } from '../shared/Verdict.js';
 import { MemberName } from '../member/MemberName.js';
 import { DomainError } from '../shared/DomainError.js';
@@ -79,7 +79,16 @@ export class Review {
     strictComment: boolean,
   ): Review {
     const by = MemberName.of(input.by);
-    const lense = parseLense(input.lense, input.allowedLenses);
+    // Hydrate path uses the loose parser (records-outlive-writers): a
+    // historical record's lense was already validated at write time;
+    // re-checking it against a possibly-changed allowed-set (config
+    // edited, or #134 H2 strict mode toggled since the write) would
+    // erase the record from list/show output and break the audit
+    // trail. Strict path keeps the allowed-set check so a fresh write
+    // with a typo'd lense still fails closed.
+    const lense = strictComment
+      ? parseLense(input.lense, input.allowedLenses)
+      : parseLenseLoose(input.lense);
     const verdict = parseVerdict(input.verdict);
     const comment = sanitizeComment(input.comment, strictComment);
     // sanitize keeps inner/leading whitespace (`trim: false` so code

--- a/src/domain/shared/Lense.ts
+++ b/src/domain/shared/Lense.ts
@@ -37,5 +37,35 @@ export function parseLense(
   );
 }
 
+/**
+ * Permissive lense parser for the hydrate path (records-outlive-writers).
+ *
+ * The strict `parseLense` checks `value` against an allowed-set so a
+ * fresh CLI write fails closed when the user typo'd the lense name.
+ * That contract is correct at write time — the user is right there
+ * and can fix it.
+ *
+ * At RE-read time, the lense was already validated when it was first
+ * written. Re-validating against a possibly-different allowed-set
+ * (config.lenses changed since the write, or #134 H2 strict mode is
+ * now on/off) would erase historical records — the audit trail dies
+ * because the policy moved. The principle is the opposite: records
+ * outlive writers, so the read path tolerates lense values that the
+ * current allowed-set rejects.
+ *
+ * Still validates `value` is a non-empty string so a corrupted record
+ * (`lense: null`, `lense: 42`) surfaces as a hydrate failure rather
+ * than smuggling a non-string into the domain.
+ */
+export function parseLenseLoose(value: unknown): Lense {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new DomainError(
+      `lense must be a non-empty string, got: ${typeof value === 'string' ? '""' : typeof value}`,
+      'lense',
+    );
+  }
+  return value;
+}
+
 // Backward compat — old code may reference LENSES
 export const LENSES = DEFAULT_LENSES;

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -176,10 +176,14 @@ test('gate boot: content_root_health reports clean when everything hydrates', ()
 });
 
 test('gate boot: content_root_health surfaces malformed records with a fix hint', () => {
-  // Seed a request with an invalid lense so hydration fails;
+  // Seed a request with an invalid verdict so hydration fails;
   // the ID pattern must match YamlRequestRepository's listAll filter
   // (YYYY-MM-DD-NNN[N]), otherwise the file is filtered out before
   // hydration even attempts it — a subtlety worth asserting against.
+  // (Lense was the original malformation vector, but #134 H2's
+  // hotfix made the lense restore path permissive — records-outlive-
+  // writers — so verdict is now the better corruption signal: it has
+  // a closed enum and no policy-drift use case.)
   const { root, cleanup } = bootstrap();
   try {
     mkdirSync(join(root, 'requests', 'completed'), { recursive: true });
@@ -204,8 +208,8 @@ test('gate boot: content_root_health surfaces malformed records with a fix hint'
         'reviews:',
         '  - by: alice',
         '    at: 2099-04-17T10:00:01.000Z',
-        '    lense: not_a_real_lense',
-        '    verdict: ok',
+        '    lense: devil',
+        '    verdict: not_a_real_verdict',
         '    comment: test',
         '',
       ].join('\n'),

--- a/tests/interface/gateStrictLenses134H2.test.ts
+++ b/tests/interface/gateStrictLenses134H2.test.ts
@@ -198,6 +198,64 @@ test('#134 H2: gate review --help (default) keeps the resolved-from-config wordi
   assert.match(r.stdout, /resolved from guild\.config\.yaml/);
 });
 
+// -------------------- read-after-write under strict mode --------------------
+
+test('#134 H2: write-then-read under strict mode survives hydrate (records-outlive-writers)', (t) => {
+  // Regression for the dogfood-found bug: strict mode wrote a review
+  // with a bundled-catalog lense (`injection`), then `gate show` /
+  // `gate list` failed hydrate because the read path only knew
+  // config.lenses (= DEFAULT_LENSES) — the strict-mode allowed set
+  // wasn't propagated to the hydrate path. Fix: Review.restore uses
+  // parseLenseLoose so the allowed-set check only fires on fresh
+  // writes, not on re-reads of historical records.
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  const w = run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'injection',
+    '--verdict', 'ok',
+    '--note', 'no injection vectors',
+  ]);
+  assert.equal(w.status, 0, `strict-mode write must succeed: ${w.stderr}`);
+
+  // The bug surfaces on read, not write. show/list must round-trip.
+  const s = run(root, ['show', id, '--format', 'json']);
+  assert.equal(s.status, 0, `show must hydrate the strict-mode review: ${s.stderr}`);
+  const payload = JSON.parse(s.stdout);
+  assert.equal(payload.reviews.length, 1);
+  assert.equal(payload.reviews[0].lense, 'injection');
+});
+
+test('#134 H2: read tolerates a lense not in the CURRENT allowed-set (config drift)', (t) => {
+  // Config-drift variant: write under strict mode, then turn strict
+  // OFF and re-read. The historical record must survive even though
+  // `injection` is no longer in config.lenses. Same principle: the
+  // record was valid at write time; the read path doesn't re-litigate
+  // policy changes.
+  const { root, cleanup } = bootstrap('gate:\n  strict_lenses: true\n');
+  t.after(cleanup);
+  const id = makeReviewable(root);
+  run(root, [
+    'review', id,
+    '--by', 'bob',
+    '--lense', 'injection',
+    '--verdict', 'ok',
+    '--note', 'no inj',
+  ]);
+  // Flip strict OFF — now the allowed set is DEFAULT_LENSES which
+  // doesn't include `injection`. Read must still work.
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\ngate:\n  strict_lenses: false\n',
+  );
+  const s = run(root, ['show', id, '--format', 'json']);
+  assert.equal(s.status, 0, `historical record must survive policy flip: ${s.stderr}`);
+  const payload = JSON.parse(s.stdout);
+  assert.equal(payload.reviews[0].lense, 'injection');
+});
+
 // -------------------- malformed config falls back to false --------------------
 
 test('#134 H2: malformed gate.strict_lenses falls back to false (no crash)', (t) => {


### PR DESCRIPTION
## Summary

Dogfood-found regression in #134 H2: review records written under \`gate.strict_lenses: true\` with a bundled devil catalog lense (e.g. \`injection\`) failed re-read by \`gate show\` / \`gate list\` because the hydrate path only knew the (narrower) \`config.lenses\` allowed-set. Strict-mode **write** succeeded; **read** crashed.

## Fix

\`Review.restore\` now uses a permissive lense parser (\`parseLenseLoose\`) — records-outlive-writers. The allowed-set check fires only on fresh writes; re-reads tolerate any non-empty string. A record's lense was already validated at write time; re-litigating against a policy that may have moved (config edited, or H2 strict mode toggled since the write) erases the audit trail.

**Side benefit**: closes a pre-existing latent bug where removing a lense from \`config.lenses\` would silently drop older reviews from list output.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1446/1446 pass (was 1444; +2 regression pins for write-then-read under strict mode and config-drift tolerance)
- [x] Manual smoke (cd into fresh dir, gate.strict_lenses=true, write review with \`injection\`, gate show round-trips ✅)
- [x] boot test updated: switched malformed-record probe from \`lense: not_a_real_lense\` to \`verdict: not_a_real_verdict\` since verdict has a closed enum with no policy-drift use case
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)