### PR TITLE
fix(gate): fast-track fires lifecycle hooks at each sub-step (closes #279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **`gate fast-track` now fires lifecycle hooks (#279)**
+  ([#279](https://github.com/eris-ths/guild-cli/issues/279)).
+  Pre-fix, `reqFastTrack` called the use cases directly (create →
+  approve → execute → complete) and skipped every handler-level hook
+  fire. Audit-log plugins (`after:approve`, `after:execute`,
+  `after:complete`) observed zero events for self-flow waves; policy
+  plugins (`before:approve`, ...) were silently bypassed — the exact
+  path those policies were designed to govern. Post-fix: each of the
+  three sub-transitions runs its before/after hooks identically to
+  the multi-step path. A before-hook veto aborts the chain and leaves
+  the substrate in the pre-veto state (no synthetic "fast-track
+  aborted" state — same contract as the multi-step path). Three new
+  regression tests pin the fires + veto semantics. Discovered via
+  dogfood walking `examples/plugins/`.
+
 - **strict-mode review hydrate (#134 H2 hotfix)** — review records
   written under `gate.strict_lenses: true` (using a bundled devil
   catalog lense like `injection`) failed re-read by `gate show` /

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -1394,9 +1394,35 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
     envActor && envActor.length > 0 && envActor !== execActor
       ? envActor
       : undefined;
-  await c.requestUC.approve(id, from, 'fast-track: self-approved', invokedByFrom);
-  await c.requestUC.execute(id, execActor, 'fast-track: self-executed', invokedByExec);
+  // Lifecycle hook fires (#279). Fast-track is a single user-facing
+  // verb that compresses three transitions; each transition is a
+  // first-class lifecycle event the substrate records, so each must
+  // run through the hook bus identically to the multi-step path.
+  // Without these fires, `after:approve` audit-log plugins miss every
+  // self-flow wave and `before:approve` policy plugins are silently
+  // bypassed — exactly the path those policies were designed to govern.
+  //
+  // veto on any before-hook aborts the chain and exits non-zero. The
+  // request stays in whatever state the chain reached before the veto
+  // (pending if before:approve vetoed, approved if before:execute, ...)
+  // — matching the multi-step path's contract that a vetoed transition
+  // leaves the substrate in the pre-transition state, not a synthetic
+  // "fast-track aborted" state. Re-running the user-side multi-step
+  // path is the recovery from a partial fast-track.
+  const beforeApproveVeto = await fireBeforeHook(c.hookSubscriptions, 'approve', created, from);
+  if (beforeApproveVeto) return emitHookVeto('approve', id, beforeApproveVeto);
+  const approved = await c.requestUC.approve(id, from, 'fast-track: self-approved', invokedByFrom);
+  await fireAfterHook(c.hookSubscriptions, 'approve', approved, from);
+
+  const beforeExecuteVeto = await fireBeforeHook(c.hookSubscriptions, 'execute', approved, execActor);
+  if (beforeExecuteVeto) return emitHookVeto('execute', id, beforeExecuteVeto);
+  const executing = await c.requestUC.execute(id, execActor, 'fast-track: self-executed', invokedByExec);
+  await fireAfterHook(c.hookSubscriptions, 'execute', executing, execActor);
+
+  const beforeCompleteVeto = await fireBeforeHook(c.hookSubscriptions, 'complete', executing, execActor);
+  if (beforeCompleteVeto) return emitHookVeto('complete', id, beforeCompleteVeto);
   const completed = await c.requestUC.complete(id, execActor, note, invokedByExec);
+  await fireAfterHook(c.hookSubscriptions, 'complete', completed, execActor);
 
   const extraLines: string[] = [];
   if (completed.autoReview) {

--- a/tests/interface/hookPluginLoader.test.ts
+++ b/tests/interface/hookPluginLoader.test.ts
@@ -299,6 +299,107 @@ test('hook plugin: plugins.trusted absent → hooks skipped + onMalformed notice
   assert.match(status.stderr, /plugins\.hooks present but plugins\.trusted is not true/);
 });
 
+// -------------------- #279: fast-track lifecycle hooks --------------------
+
+test('#279: fast-track fires after:approve / after:execute / after:complete', (t) => {
+  // Pre-#279: fast-track called the use cases directly and skipped the
+  // handler-level hook fires entirely. An audit-log plugin subscribing
+  // to all three after-hooks would observe ZERO events for self-flow
+  // waves — the silent gap this test pins against.
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit-multi.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'audit-multi.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: ['after:approve', 'after:execute', 'after:complete'],
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)}, ctx.event + ':' + ctx.request.state + '\\n');
+       },
+     };`,
+  );
+
+  const r = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'self-flow',
+    '--reason', 'because',
+    '--note', 'done',
+  ]);
+  assert.equal(r.status, 0, `fast-track should succeed: ${r.stderr}`);
+
+  // All three after-hooks must fire, in order, with the correct
+  // post-transition state on each event.
+  assert.equal(
+    readFileSync(trace, 'utf8'),
+    'after:approve:approved\nafter:execute:executing\nafter:complete:completed\n',
+  );
+});
+
+test('#279: fast-track honors before:approve veto (chain aborts at approve)', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/policy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'policy.mjs'),
+    `export default {
+       on: 'before:approve',
+       run: async () => ({ allow: false, reason: 'org policy: fast-track approve blocked' }),
+     };`,
+  );
+
+  const r = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'self-flow',
+    '--reason', 'because',
+  ]);
+  // Veto on the first transition aborts the chain.
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed approve on .+org policy: fast-track approve blocked/);
+
+  // Substrate state: the request was created (pending) but the chain
+  // never advanced. Same contract as the multi-step path's vetoed
+  // approve — no synthetic "fast-track aborted" state.
+  const list = runGate(root, ['list', '--state', 'pending', '--format', 'json']);
+  const payload = JSON.parse(list.stdout);
+  assert.equal(payload.requests.length, 1, 'request should remain pending after veto');
+});
+
+test('#279: fast-track honors before:execute veto (chain aborts mid-flow, state=approved)', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/policy.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'policy.mjs'),
+    `export default {
+       on: 'before:execute',
+       run: async () => ({ allow: false, reason: 'org policy: execute requires worktree isolation' }),
+     };`,
+  );
+
+  const r = runGate(root, [
+    'fast-track',
+    '--from', 'alice',
+    '--action', 'self-flow',
+    '--reason', 'because',
+  ]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed execute on .+execute requires worktree/);
+
+  // Substrate is in the in-between approved state — exactly what the
+  // multi-step path leaves behind when before:execute vetoes there.
+  // The user's recovery is `gate execute` (multi-step) once the policy
+  // condition is satisfied. We do not auto-rollback the approve.
+  const list = runGate(root, ['list', '--state', 'approved', '--format', 'json']);
+  assert.equal(JSON.parse(list.stdout).requests.length, 1);
+});
+
 test('hook plugin: before:review veto blocks review append', (t) => {
   const { root, pluginDir, cleanup } = bootstrap(
     'plugins:\n  trusted: true\n  hooks:\n    - plugins/review-policy.mjs\n',


### PR DESCRIPTION
## Summary

\`gate fast-track\` now fires \`before:\` and \`after:\` hooks at each sub-transition (approve / execute / complete), closing the silent-gap that hid every self-flow wave from audit-log plugins and silently bypassed every policy plugin designed to govern self-flow.

## Behavior

- **after-hooks**: \`after:approve\`, \`after:execute\`, \`after:complete\` all fire, in order, with the correct post-transition state on each event — identical to the multi-step path.
- **before-hooks**: \`before:approve\`, \`before:execute\`, \`before:complete\` all fire. A veto on any one aborts the chain and leaves the substrate in the pre-veto state (pending / approved / executing). No synthetic "fast-track aborted" state — same contract as the multi-step path's vetoed transitions.
- **Recovery**: a partially-applied fast-track (vetoed mid-flow) is recovered via the multi-step verbs (\`gate execute\` / \`gate complete\`) once the policy condition is satisfied. We do NOT auto-rollback the prior transitions.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1449/1449 pass (was 1446; +3 regression pins for the three behaviors above)
- [x] Discovered via dogfood walking \`examples/plugins/\`; the audit-log + policy plugin demos now observe fast-track waves identically to multi-step waves
- [ ] CI green

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)