### PR TITLE
feat: issues.ts hardening (#289) + hook bus SessionEvent extension (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **hook bus extended for session-boundary events (#290 — closes #290)**
+  ([#290](https://github.com/eris-ths/guild-cli/issues/290)).
+  The Phase 1 hook bus (#259) was request-shaped only — `HookContext.request`
+  was a non-optional `Request` and the event union covered only the six
+  request-lifecycle verbs plus review. Phase 2 verbs (`gate rest` /
+  `gate wake` / `gate farewell`, #261-#263) now fire `before:` / `after:`
+  hooks via a new `ctx.sessionEvent: SessionEvent | undefined` field
+  alongside the existing `ctx.request: Request | undefined`. Exactly one
+  of the two is populated per invocation — picked by which verb fired
+  the hook. The event union grew six entries (`before:`/`after:rest`,
+  `wake`, `farewell`). A `before:` veto on a session-boundary event
+  blocks the YAML write, so a vetoed `gate rest` leaves no record on
+  disk (substrate untouched). The `after:` fires post-save with the
+  final id allocated. Existing plugins that read `ctx.request.X`
+  directly continue to work for their subscribed events; multi-axis
+  plugins discriminate on which subject is populated. Migration
+  guidance in `docs/POLICY.md` § "Hook subject migration"; updated
+  `examples/plugins/hooks/audit-log.mjs` shows the branching pattern;
+  `policy-no-self-approve.mjs` got a defensive null-check for
+  forward-compat. Plugin schema doc updated with a `SessionEvent`
+  reference section.
+
 - **plugin schema doc drift detection (#283 — closes #283)**
   ([#283](https://github.com/eris-ths/guild-cli/issues/283)).
   New CI test `tests/docs/pluginSchemaDocSync.test.ts` enforces sync

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -185,6 +185,24 @@ the `toJSON()` escape hatch — is documented in
 [`docs/plugin-schema.md`](plugin-schema.md). Read it before writing
 your first hook; the alternative is reading `src/domain/`.
 
+### Hook subject migration (#290 — Phase 2 extension)
+
+Phase 1 hooks (#259) saw `ctx.request: Request` as a non-optional
+field. Phase 2 (#290) added session-boundary verbs (`gate rest` /
+`gate wake` / `gate farewell`) whose subject is a `SessionEvent`
+instead. Rather than break the existing field, the bus now exposes
+two orthogonal optionals: `ctx.request?: Request` and
+`ctx.sessionEvent?: SessionEvent`. Exactly one is populated per
+invocation, picked by which verb fired the hook. Existing plugins
+that read `ctx.request.X` directly continue to work for their
+subscribed events (request-lifecycle invocations always set
+`ctx.request`); the only migration cost is a one-line null-check
+when a plugin spans both subject axes — and even that's optional if
+the plugin only subscribes to events on one axis. See
+[`docs/plugin-schema.md`](plugin-schema.md) § "HookContext shape" for
+the full table and `examples/plugins/hooks/audit-log.mjs` for the
+multi-axis branching pattern.
+
 ## Security fixes
 
 Security patches may ship in any release type (patch, minor, major).

--- a/docs/plugin-schema.md
+++ b/docs/plugin-schema.md
@@ -40,12 +40,21 @@ export default {
 
 ### `HookContext` shape (passed to `run`)
 
-| field          | runtime type                  | notes |
-|----------------|-------------------------------|-------|
-| `ctx.event`    | `string`                      | Discriminator like `'before:approve'`. Useful when one plugin subscribes to many events. |
-| `ctx.request`  | `Request` instance            | Pre-mutation snapshot for `before:`; post-mutation for `after:`. **Has value-object fields** — see § Request reference below. |
-| `ctx.actor`    | `string`                      | The canonicalised `--by` / `--from` invoker. Already trimmed and lowercased. |
-| `ctx.extra`    | `{ review?: ... }` \| undefined | Event-specific. Only `before:review` / `after:review` set `extra.review` (the appended review record). |
+| field             | runtime type                            | notes |
+|-------------------|-----------------------------------------|-------|
+| `ctx.event`       | `string`                                | Discriminator like `'before:approve'`. Useful when one plugin subscribes to many events. |
+| `ctx.request`     | `Request` instance \| `undefined`       | Populated for **request-lifecycle** events (approve/deny/execute/complete/fail/review). Pre-mutation snapshot for `before:`; post-mutation for `after:`. Undefined for session-boundary events (#290). **Has value-object fields** — see § Request reference below. |
+| `ctx.sessionEvent`| `SessionEvent` instance \| `undefined`  | Populated for **session-boundary** events (`before:`/`after:rest`, `wake`, `farewell` — #290). Pre-save aggregate for `before:`; post-save for `after:`. Undefined for request-lifecycle events. See § SessionEvent reference below. |
+| `ctx.actor`       | `string`                                | The canonicalised `--by` / `--from` invoker. Already trimmed and lowercased. |
+| `ctx.extra`       | `{ review?: ... }` \| undefined         | Event-specific. Only `before:review` / `after:review` set `extra.review` (the appended review record). |
+
+**EXACTLY ONE** of `ctx.request` / `ctx.sessionEvent` is set on any
+single hook invocation — picked by the event's verb axis. A plugin
+that subscribes to events from both axes (e.g. an audit log spanning
+`after:approve` and `after:rest`) must branch on which field is
+populated. A plugin that only handles one axis can null-check the
+field it reads and return early when absent — this keeps the plugin
+forward-compatible if a future major rolls in a third subject kind.
 
 ### Veto shape (`before:` hooks)
 
@@ -67,7 +76,10 @@ return undefined;                                    // pass
 
 ### Lifecycle events
 
-Phase 1 covers six request-lifecycle verbs plus review:
+Phase 1 (#259) covers six request-lifecycle verbs plus review.
+Phase 2 (#290) extends the bus with the three session-boundary verbs.
+
+Request-lifecycle (`ctx.request` populated):
 
 | event | fires when | `ctx.request.state` (post for `after:`) |
 |-------|------------|------------------------------------------|
@@ -78,15 +90,29 @@ Phase 1 covers six request-lifecycle verbs plus review:
 | `before:fail`    / `after:fail`    | `gate fail`                        | `failed` (terminal) |
 | `before:review`  / `after:review`  | `gate review`                      | unchanged (review is non-mutating on state) |
 
+Session-boundary (`ctx.sessionEvent` populated, #290):
+
+| event | fires when | `ctx.sessionEvent.kind` |
+|-------|------------|--------------------------|
+| `before:rest`     / `after:rest`     | `gate rest`     | `rest` |
+| `before:wake`     / `after:wake`     | `gate wake`     | `wake` |
+| `before:farewell` / `after:farewell` | `gate farewell` | `farewell` |
+
+For session-boundary events, the `before:` veto fires *after* the
+SessionEvent aggregate is built and validated, *before* the YAML
+write. A vetoed `gate rest` / `gate wake` / `gate farewell` therefore
+leaves no record on disk — the substrate is untouched. The `after:`
+fires post-save so the id (allocated by the per-day sequence) is
+final and the YAML is readable.
+
 `fast-track` runs three sub-transitions (approve → execute → complete)
 and fires the corresponding before/after hooks at each step (#279). A
 veto at any step aborts the chain and leaves the substrate in the
 pre-veto state.
 
-Verbs **not** covered by phase 1: `request` (creation has no
-`before:create` / `after:create` event yet), `claim` / `witness` /
-`unwitness` (stake-axis verbs, not lifecycle), `thank` (annotation,
-not transition).
+Verbs **not** covered: `request` (creation has no `before:create` /
+`after:create` event yet), `claim` / `witness` / `unwitness` (stake-
+axis verbs, not lifecycle), `thank` (annotation, not transition).
 
 ---
 
@@ -142,6 +168,50 @@ primitives. The table below tells you which.
 | `request.thanks`    | `readonly Thank[]`  | `t.by.value` / `t.to.value`; `t.note` / `t.at` are strings |
 | `request.witnessNotes`    | `ReadonlyMap<string, string>` | iterate with `for (const [actor, note] of map)` |
 | `request.witnessSessions` | `ReadonlyMap<string, string>` | same shape |
+
+---
+
+## SessionEvent reference (#290 — session-boundary events)
+
+`ctx.sessionEvent` is a `SessionEvent` **class instance**, populated
+on session-boundary events (`before:`/`after:rest`, `wake`,
+`farewell`). Smaller surface than `Request` — five readable getters
+plus `toJSON()`.
+
+### Value-object field — needs `.value`
+
+| getter | runtime type | unwrap |
+|--------|--------------|--------|
+| `sessionEvent.by` | `MemberName` | `sessionEvent.by.value` → e.g. `'alice'` |
+
+### Plain primitives — no unwrap needed
+
+| getter | runtime type | example value |
+|--------|--------------|---------------|
+| `sessionEvent.id`   | `string` | `'2026-05-11-001'` (per-day sequence, distinct from request id format) |
+| `sessionEvent.kind` | `'rest' \| 'wake' \| 'farewell'` | `'rest'` |
+| `sessionEvent.at`   | `string` | ISO 8601 timestamp |
+| `sessionEvent.note` | `string \| undefined` | optional free-form, capped at 240 chars |
+
+Like `Request`, `SessionEvent` exposes a `toJSON()` escape hatch —
+returns the snake_case wire shape (`{ id, kind, by, at, note? }`)
+matching the on-disk YAML.
+
+```js
+export default {
+  on: 'after:rest',
+  run: async (ctx) => {
+    if (!ctx.sessionEvent) return;
+    const e = ctx.sessionEvent;
+    appendFileSync('rests.log', `${e.at} ${e.by.value} rested${e.note ? ': ' + e.note : ''}\n`);
+  },
+};
+```
+
+A `before:rest` / `before:wake` / `before:farewell` veto blocks the
+record before it is persisted — the standard `hook vetoed <verb>`
+stderr surface and exit code 1, with `(unsaved)` in the id slot since
+no id is allocated to a vetoed record.
 
 ---
 
@@ -278,6 +348,11 @@ work is naturally idempotent on `(id, state)` pairs.
    it. (Only `ctx.request.*` member fields are value objects.)
 3. **`ctx.extra` may be undefined.** Always optional-chain:
    `ctx.extra?.review`.
+3a. **`ctx.request` may be undefined (#290).** A hook subscribed to
+   a session-boundary event (`before:rest`, `after:wake`, etc.) gets
+   `ctx.sessionEvent` populated and `ctx.request` undefined. Plugins
+   that span both axes should branch; plugins that only handle one
+   should null-check the field they read and return early when absent.
 4. **`before:` hook errors fail-closed.** A typo that throws will
    block the transition. Test your hook — or use `try/catch` inside
    to convert unexpected errors to explicit vetoes with a useful

--- a/examples/plugins/hooks/audit-log.mjs
+++ b/examples/plugins/hooks/audit-log.mjs
@@ -1,11 +1,14 @@
-// Example hook plugin (issue #36 Phase 1 step 5).
+// Example hook plugin (issue #36 Phase 1 step 5; #290 — Phase 2 extension).
 //
 // Subscribes to every `after:` event and appends an audit-log line
 // to a file under content_root. Demonstrates:
 //   - multi-event subscription via the array form of `on`
 //   - the `after:` shape — observation only, no veto
 //   - reading the request through `ctx.request` (post-mutation
-//     snapshot for after-events)
+//     snapshot for request-lifecycle events)
+//   - reading the session event through `ctx.sessionEvent` (#290 —
+//     post-save snapshot for `after:rest` / `after:wake` /
+//     `after:farewell`)
 //
 // To enable:
 //
@@ -15,10 +18,15 @@
 //     hooks:
 //       - examples/plugins/hooks/audit-log.mjs
 //
-// Each transition appends one JSON line to `audit.log` next to
-// guild.config.yaml:
+// Each request transition appends one JSON line to `audit.log` next
+// to guild.config.yaml:
 //
 //   {"at":"2026-...","event":"after:approve","id":"2026-...","by":"alice","state":"approved"}
+//
+// Each session boundary (#290) emits a parallel-shaped line keyed on
+// the session event id and kind:
+//
+//   {"at":"2026-...","event":"after:rest","id":"2026-05-11-001","by":"alice","kind":"rest"}
 
 import { appendFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -38,15 +46,42 @@ export default {
     'after:complete',
     'after:fail',
     'after:review',
+    // #290 — session-boundary events. The subject is `ctx.sessionEvent`
+    // (a SessionEvent aggregate) rather than `ctx.request`.
+    'after:rest',
+    'after:wake',
+    'after:farewell',
   ],
   run: async (ctx) => {
-    const line = JSON.stringify({
-      at: new Date().toISOString(),
-      event: ctx.event,
-      id: ctx.request.id.value,
-      by: ctx.actor,
-      state: ctx.request.state,
-    });
+    // #290: discriminate by which subject field is populated. A
+    // request-lifecycle event leaves `ctx.sessionEvent` undefined and
+    // vice versa — exactly one is set. Plugins that subscribe to BOTH
+    // axes (this one) must branch; plugins that only care about one
+    // axis can null-check the field they read and return early when
+    // absent.
+    let line;
+    if (ctx.request) {
+      line = JSON.stringify({
+        at: new Date().toISOString(),
+        event: ctx.event,
+        id: ctx.request.id.value,
+        by: ctx.actor,
+        state: ctx.request.state,
+      });
+    } else if (ctx.sessionEvent) {
+      line = JSON.stringify({
+        at: new Date().toISOString(),
+        event: ctx.event,
+        id: ctx.sessionEvent.id,
+        by: ctx.actor,
+        kind: ctx.sessionEvent.kind,
+      });
+    } else {
+      // Defensive: a future event kind we don't recognise. Skip
+      // rather than crash — the audit log is best-effort and
+      // forward-compatible (records-outlive-writers).
+      return;
+    }
     try {
       appendFileSync(AUDIT_LOG, line + '\n', 'utf8');
     } catch {

--- a/examples/plugins/hooks/policy-no-self-approve.mjs
+++ b/examples/plugins/hooks/policy-no-self-approve.mjs
@@ -32,6 +32,14 @@
 export default {
   on: 'before:approve',
   run: async (ctx) => {
+    // #290: defensive null check. `before:approve` always populates
+    // `ctx.request`, but a typo upstream that subscribed this plugin
+    // to a session-boundary event (`before:rest`/`before:wake`/
+    // `before:farewell`) would land here with `ctx.request` undefined.
+    // Returning silently rather than throwing keeps the policy hook
+    // forward-compatible with future event kinds — bad config should
+    // not fail the transition closed.
+    if (!ctx.request) return;
     const author = ctx.request.from.value;
     if (ctx.actor === author) {
       return {

--- a/src/application/issue/IssueUseCases.ts
+++ b/src/application/issue/IssueUseCases.ts
@@ -88,12 +88,13 @@ export class IssueUseCases {
     state: string,
     by: string,
     invokedBy?: string,
+    note?: string,
   ): Promise<Issue> {
     await assertActor(by, '--by', this.members);
     const issueId = IssueId.of(id);
     const issue = await this.issues.findById(issueId);
     if (!issue) throw new DomainError(`Issue not found: ${id}`, 'id');
-    issue.setState(parseIssueState(state) as IssueState, by, invokedBy);
+    issue.setState(parseIssueState(state) as IssueState, by, invokedBy, note);
     await this.issues.save(issue);
     return issue;
   }

--- a/src/application/plugin/HookBus.ts
+++ b/src/application/plugin/HookBus.ts
@@ -22,12 +22,14 @@ import {
   HookVeto,
 } from './HookPlugin.js';
 import type { Request } from '../../domain/request/Request.js';
+import type { SessionEvent } from '../../domain/session/SessionEvent.js';
 
 export type HookSubscriptions = ReadonlyMap<HookEvent, readonly HookFn[]>;
 
 /**
- * The verb half of a hook event. Used by handlers to compose
- * `before:<verb>` / `after:<verb>` without typo risk on the prefix.
+ * The verb half of a request-lifecycle hook event. Used by handlers
+ * to compose `before:<verb>` / `after:<verb>` without typo risk on
+ * the prefix.
  */
 export type LifecycleVerb =
   | 'approve'
@@ -37,7 +39,18 @@ export type LifecycleVerb =
   | 'fail'
   | 'review';
 
-function toEvent(prefix: 'before' | 'after', verb: LifecycleVerb): HookEvent {
+/**
+ * The verb half of a session-boundary hook event (#290 — Phase 2
+ * extension to the hook bus). Same shape as `LifecycleVerb` but
+ * for the rest/wake/farewell axis, where the subject is a
+ * `SessionEvent` rather than a `Request`.
+ */
+export type SessionVerb = 'rest' | 'wake' | 'farewell';
+
+function toEvent(
+  prefix: 'before' | 'after',
+  verb: LifecycleVerb | SessionVerb,
+): HookEvent {
   return `${prefix}:${verb}` as HookEvent;
 }
 
@@ -109,10 +122,93 @@ export async function fireAfterHook(
  * exit code 1. Centralised so every lifecycle handler emits the same
  * shape — an operator's grep for "hook vetoed" finds the entry
  * regardless of which verb tripped.
+ *
+ * Accepts both `LifecycleVerb` (request-axis) and `SessionVerb`
+ * (rest/wake/farewell-axis, #290) so the session handlers reuse the
+ * same render path.
  */
-export function emitHookVeto(verb: LifecycleVerb, id: string, veto: HookVeto): number {
+export function emitHookVeto(
+  verb: LifecycleVerb | SessionVerb,
+  id: string,
+  veto: HookVeto,
+): number {
   process.stderr.write(
     `error: hook vetoed ${verb} on ${id}: ${veto.reason}\n`,
   );
   return 1;
+}
+
+// -------------------- Session-boundary fire helpers (#290) -----------------
+//
+// Same dispatch contract as the request-shaped fires above:
+//   - first veto wins; before-hook errors fail-closed
+//   - after-hook errors written to stderr but never propagate
+// The only difference is the subject populated on `HookContext`:
+// `sessionEvent` instead of `request`. Hook authors discriminate by
+// either `ctx.event` (string) or null-checking which field is set.
+
+/**
+ * Fire every `before:<sessionVerb>` subscriber in order. Returns the
+ * first veto seen, or null if all hooks passed (or none subscribed).
+ * Hook errors are converted to vetoes — see file header for rationale.
+ *
+ * The `event` argument is the **pre-save** SessionEvent — the verb
+ * handler builds the aggregate, fires before-hooks, then persists
+ * only if no veto. A vetoed `gate rest` therefore writes nothing to
+ * the session log; the substrate stays untouched.
+ */
+export async function fireBeforeSessionHook(
+  subs: HookSubscriptions,
+  verb: SessionVerb,
+  event: SessionEvent,
+  actor: string,
+): Promise<HookVeto | null> {
+  const hookEvent = toEvent('before', verb);
+  const fns = subs.get(hookEvent);
+  if (!fns || fns.length === 0) return null;
+  const ctx: HookContext = { event: hookEvent, sessionEvent: event, actor };
+  for (const fn of fns) {
+    let result: void | HookVeto;
+    try {
+      result = await fn(ctx);
+    } catch (e) {
+      return {
+        allow: false,
+        reason: `hook threw on ${hookEvent}: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+    if (result && typeof result === 'object' && (result as HookVeto).allow === false) {
+      return result as HookVeto;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fire every `after:<sessionVerb>` subscriber in order. Hook errors
+ * are written to stderr as warnings; they never break the handler.
+ *
+ * The `event` argument is the **post-save** SessionEvent — the
+ * record has already landed on disk, so an after-hook can rely on
+ * the id being final and the YAML being readable.
+ */
+export async function fireAfterSessionHook(
+  subs: HookSubscriptions,
+  verb: SessionVerb,
+  event: SessionEvent,
+  actor: string,
+): Promise<void> {
+  const hookEvent = toEvent('after', verb);
+  const fns = subs.get(hookEvent);
+  if (!fns || fns.length === 0) return;
+  const ctx: HookContext = { event: hookEvent, sessionEvent: event, actor };
+  for (const fn of fns) {
+    try {
+      await fn(ctx);
+    } catch (e) {
+      process.stderr.write(
+        `warning: hook threw on ${hookEvent}: ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+    }
+  }
 }

--- a/src/application/plugin/HookPlugin.ts
+++ b/src/application/plugin/HookPlugin.ts
@@ -31,15 +31,22 @@
 
 import type { Request } from '../../domain/request/Request.js';
 import type { DevilReview } from '../../passages/devil/domain/DevilReview.js';
+import type { SessionEvent } from '../../domain/session/SessionEvent.js';
 
 /**
- * The lifecycle events a hook can subscribe to. Phase 1 covers the
- * five request transitions plus review. fast-track / claim / witness
- * / unwitness / thank are intentionally out of scope for v1 — they
- * either compose multiple events (fast-track) or sit on a different
- * axis from state transitions (the stake/observe verbs). Adding
- * those is additive within the 0.x line per `docs/POLICY.md`
- * § "Plugin stability".
+ * The lifecycle events a hook can subscribe to.
+ *
+ * Phase 1 (#259): the six request transitions plus review.
+ * Phase 2 (#290): the three session-boundary verbs (rest / wake /
+ *   farewell, #261-#263). These do not transition request state —
+ *   they stamp a `SessionEvent` record. Hooks see the event on
+ *   `ctx.sessionEvent` (instead of `ctx.request`).
+ *
+ * fast-track / claim / witness / unwitness / thank are intentionally
+ * out of scope — they either compose multiple events (fast-track) or
+ * sit on a different axis from state transitions (the stake/observe
+ * verbs). Adding those is additive within the 0.x line per
+ * `docs/POLICY.md` § "Plugin stability".
  */
 export type HookEvent =
   | 'before:approve' | 'after:approve'
@@ -47,7 +54,10 @@ export type HookEvent =
   | 'before:execute' | 'after:execute'
   | 'before:complete' | 'after:complete'
   | 'before:fail'    | 'after:fail'
-  | 'before:review'  | 'after:review';
+  | 'before:review'  | 'after:review'
+  | 'before:rest'    | 'after:rest'
+  | 'before:wake'    | 'after:wake'
+  | 'before:farewell' | 'after:farewell';
 
 export const ALL_HOOK_EVENTS: readonly HookEvent[] = [
   'before:approve', 'after:approve',
@@ -56,23 +66,54 @@ export const ALL_HOOK_EVENTS: readonly HookEvent[] = [
   'before:complete', 'after:complete',
   'before:fail',    'after:fail',
   'before:review',  'after:review',
+  'before:rest',    'after:rest',
+  'before:wake',    'after:wake',
+  'before:farewell', 'after:farewell',
 ];
 
 /**
- * Per-event context the hook receives. The `request` is the
- * pre-mutation snapshot for `before:` events (so a veto sees the
- * original state) and the post-mutation snapshot for `after:`
- * events (so an audit hook sees the new state). `actor` is the
- * canonicalised `--by` / `--from` invoker.
+ * Per-event context the hook receives.
+ *
+ * EXACTLY ONE of `request` / `sessionEvent` is populated, picked by
+ * which verb fired the hook:
+ *
+ *   - request-lifecycle events (`approve`, `deny`, `execute`,
+ *     `complete`, `fail`, `review`) populate `request` — pre-mutation
+ *     snapshot for `before:` events (so a veto sees the original
+ *     state), post-mutation for `after:` events (so an audit hook
+ *     sees the new state).
+ *
+ *   - session-boundary events (`rest`, `wake`, `farewell`, #290)
+ *     populate `sessionEvent` — the `SessionEvent` aggregate that
+ *     either WILL be saved (before) or HAS been saved (after).
+ *     `request` is undefined; a plugin that only handles
+ *     request-lifecycle events should null-check `ctx.request` and
+ *     return early when absent.
+ *
+ * `actor` is the canonicalised `--by` / `--from` invoker, populated
+ * for both subject kinds.
  *
  * `extra` carries event-specific payload — currently only `review`
- * uses it (carries the DevilReview-like record). Kept as an
- * optional discriminated field so phase-2 events can extend without
- * a breaking change to the base shape.
+ * uses it (carries the DevilReview-like record). Kept as an optional
+ * discriminated field so future events can extend without a breaking
+ * change to the base shape.
+ *
+ * Why orthogonal optionals (Option B) rather than a discriminated
+ * `subject: { kind, ... }` (Option A): existing plugins read
+ * `ctx.request.X` directly. Option B keeps that exact path working
+ * — the only migration is one defensive null-check at the top of a
+ * hook that subscribes to a session-boundary event. Option A would
+ * have forced every existing access site through a discriminator
+ * branch. See commit message + #290 for the trade analysis.
  */
 export interface HookContext {
   readonly event: HookEvent;
-  readonly request: Request;
+  /** Populated for request-lifecycle events (approve/deny/execute/
+   *  complete/fail/review). Undefined for session-boundary events. */
+  readonly request?: Request;
+  /** Populated for session-boundary events (rest/wake/farewell, #290).
+   *  Undefined for request-lifecycle events. */
+  readonly sessionEvent?: SessionEvent;
   readonly actor: string;
   readonly extra?: { readonly review?: DevilReview | unknown };
 }

--- a/src/application/session/SessionEventUseCases.ts
+++ b/src/application/session/SessionEventUseCases.ts
@@ -10,6 +10,56 @@ export interface RecordSessionEventInput {
   readonly note?: string;
 }
 
+/**
+ * Outcome of an interceptor run. Mirrors the shape of `HookVeto`
+ * without importing it (Clean Arch — the use case layer should not
+ * reach into plugin/hook abstractions). The interface caller wraps
+ * the hook bus into this contract.
+ */
+export interface RecordSessionInterceptResult {
+  readonly veto: { readonly reason: string } | null;
+}
+
+/**
+ * Optional interceptors the caller can wire so a hook bus (or other
+ * cross-cut) can observe / veto a `record()` call.
+ *
+ *   - `beforeSave(event)` runs after the SessionEvent aggregate is
+ *     built and validated, before persistence. Returning a veto
+ *     aborts the record path; the use case throws a
+ *     `SessionEventVetoed` error and the handler renders the same
+ *     stderr shape as the request-side veto.
+ *   - `afterSave(event)` runs after persistence succeeded. Errors
+ *     from `afterSave` are the caller's responsibility — the use case
+ *     does not catch them.
+ *
+ * Why callbacks rather than passing the hook bus directly: keeps the
+ * application layer free of plugin/hook imports (Clean Arch), and
+ * makes the unit-test path trivial — pass a stub interceptor instead
+ * of building a hook subscription map.
+ */
+export interface RecordSessionInterceptors {
+  readonly beforeSave?: (event: SessionEvent) => Promise<RecordSessionInterceptResult> | RecordSessionInterceptResult;
+  readonly afterSave?: (event: SessionEvent) => Promise<void> | void;
+}
+
+/**
+ * Thrown by `record()` when a `beforeSave` interceptor vetoes the
+ * boundary record. Carries the structured reason so the handler can
+ * render it via the shared `emitHookVeto` path. Distinct from a
+ * generic `Error` so the handler's catch can route the rendering
+ * decisively (rather than string-matching messages).
+ */
+export class SessionEventVetoed extends Error {
+  constructor(
+    public readonly verb: SessionKind,
+    public readonly reason: string,
+  ) {
+    super(`hook vetoed ${verb}: ${reason}`);
+    this.name = 'SessionEventVetoed';
+  }
+}
+
 export interface SessionEventUseCasesDeps {
   readonly events: SessionEventRepository;
   readonly members: MemberRepository;
@@ -31,8 +81,16 @@ export class SessionEventUseCases {
    * Record one boundary event. Allocates a per-day sequence id,
    * stamps the system clock, and persists. Returns the saved
    * record so the handler can emit it back to the caller.
+   *
+   * Optional `interceptors` plug a hook bus (#290) into the
+   * before-save / after-save fire points. A `beforeSave` veto
+   * throws `SessionEventVetoed` — the handler maps that to the
+   * standard `hook vetoed <verb>` stderr surface and exit code 1.
    */
-  async record(input: RecordSessionEventInput): Promise<SessionEvent> {
+  async record(
+    input: RecordSessionEventInput,
+    interceptors?: RecordSessionInterceptors,
+  ): Promise<SessionEvent> {
     const actor = await assertActor(input.by, '--by', this.deps.members);
     const at = this.deps.clock.now().toISOString();
     const dateKey = at.slice(0, 10); // YYYY-MM-DD
@@ -45,7 +103,16 @@ export class SessionEventUseCases {
       at,
       ...(input.note !== undefined ? { note: input.note } : {}),
     });
+    if (interceptors?.beforeSave) {
+      const result = await interceptors.beforeSave(event);
+      if (result.veto) {
+        throw new SessionEventVetoed(input.kind, result.veto.reason);
+      }
+    }
     await this.deps.events.save(event);
+    if (interceptors?.afterSave) {
+      await interceptors.afterSave(event);
+    }
     return event;
   }
 

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -191,6 +191,14 @@ export interface IssueStateLogEntry {
   by: string;
   at: string;
   invokedBy?: string;
+  /**
+   * Optional free-form transition rationale (#289 hunk 1). Threaded
+   * from `gate issues defer/resolve/start/reopen --note <s>` so the
+   * audit trail records *why* the state moved, not just who/when.
+   * Omitted on the wire when absent so pre-#289 records and same-body
+   * unstamped writes both round-trip byte-identical YAML.
+   */
+  note?: string;
 }
 
 export interface IssueProps {
@@ -296,7 +304,12 @@ export class Issue {
     return this.props.text;
   }
 
-  setState(next: IssueState, by: string, invokedBy?: string): void {
+  setState(
+    next: IssueState,
+    by: string,
+    invokedBy?: string,
+    note?: string,
+  ): void {
     assertIssueTransition(this.props.state, next);
     const byName = MemberName.of(by).value;
     this.props.state = next;
@@ -314,6 +327,13 @@ export class Issue {
     };
     if (invokedBy !== undefined && invokedBy !== byName) {
       entry.invokedBy = invokedBy;
+    }
+    if (note !== undefined) {
+      const cleaned = sharedSanitizeText(note, 'note', {
+        maxLen: MAX_TEXT,
+        requireNonEmpty: false,
+      });
+      if (cleaned.length > 0) entry.note = cleaned;
     }
     this.props.stateLog.push(entry);
   }
@@ -407,6 +427,7 @@ function stateLogEntryToJSON(e: IssueStateLogEntry): Record<string, unknown> {
     at: e.at,
   };
   if (e.invokedBy !== undefined) out['invoked_by'] = e.invokedBy;
+  if (e.note !== undefined) out['note'] = e.note;
   return out;
 }
 

--- a/src/infrastructure/persistence/YamlIssueRepository.ts
+++ b/src/infrastructure/persistence/YamlIssueRepository.ts
@@ -285,6 +285,9 @@ function hydrateStateLog(
     }
     const logEntry: IssueStateLogEntry = { state, by, at };
     if (typeof r['invoked_by'] === 'string') logEntry.invokedBy = r['invoked_by'];
+    if (typeof r['note'] === 'string' && r['note'].length > 0) {
+      logEntry.note = r['note'];
+    }
     out.push(logEntry);
   }
   return out;

--- a/src/interface/gate/handlers/farewell.ts
+++ b/src/interface/gate/handlers/farewell.ts
@@ -6,6 +6,12 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { parseFormat } from './writeFormat.js';
+import {
+  fireBeforeSessionHook,
+  fireAfterSessionHook,
+  emitHookVeto,
+} from '../../../application/plugin/HookBus.js';
+import { SessionEventVetoed } from '../../../application/session/SessionEventUseCases.js';
 
 /**
  * gate farewell [--by <m>] [--note <s>] [--format json|text]
@@ -47,11 +53,37 @@ export async function farewellCmd(c: C, args: ParsedArgs): Promise<number> {
   const note = optionalOption(args, 'note');
   const format = parseFormat(args);
 
-  const event = await c.sessionEventUC.record({
-    kind: 'farewell',
-    by,
-    ...(note !== undefined ? { note } : {}),
-  });
+  // #290: same before:/after: hook fire shape as `gate rest`. See
+  // rest.ts for the rationale; the only difference here is the verb.
+  let event;
+  try {
+    event = await c.sessionEventUC.record(
+      {
+        kind: 'farewell',
+        by,
+        ...(note !== undefined ? { note } : {}),
+      },
+      {
+        beforeSave: async (e) => {
+          const veto = await fireBeforeSessionHook(
+            c.hookSubscriptions, 'farewell', e, by,
+          );
+          return { veto: veto ? { reason: veto.reason } : null };
+        },
+        afterSave: async (e) => {
+          await fireAfterSessionHook(c.hookSubscriptions, 'farewell', e, by);
+        },
+      },
+    );
+  } catch (e) {
+    if (e instanceof SessionEventVetoed) {
+      return emitHookVeto('farewell', '(unsaved)', {
+        allow: false,
+        reason: e.reason,
+      });
+    }
+    throw e;
+  }
 
   const message = `✓ farewell: ${event.id} by ${event.by.value}`;
   if (format === 'json') {

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -42,7 +42,13 @@ const ISSUES_NOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['by', 'text']);
 // `gate issues resolve/defer/start/reopen` take `--by <m>` (or fall
 // back to GUILD_ACTOR) so the state_log audit entry can record who
 // ran the transition. See Sec H3 (state_log per transition).
-const ISSUES_TRANSITION_KNOWN_FLAGS: ReadonlySet<string> = new Set(['by']);
+// `--note <s>` is optional free-form rationale (#289 hunk 1) persisted
+// onto the state_log entry; omitted from the YAML when absent so
+// pre-#289 records round-trip byte-identical.
+const ISSUES_TRANSITION_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'by',
+  'note',
+]);
 
 export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
@@ -207,10 +213,13 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   if (nextState !== undefined) {
     rejectUnknownFlags(args, ISSUES_TRANSITION_KNOWN_FLAGS, `issues ${sub}`);
     const id = args.positional[1];
-    if (!id) throw new Error(`Usage: gate issues ${sub} <id> --by <m>`);
+    if (!id) {
+      throw new Error(`Usage: gate issues ${sub} <id> --by <m> [--note <s>]`);
+    }
     const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
     const invokedBy = resolveInvokedBy(by, `issues ${sub}`, id);
-    const issue = await c.issueUC.setState(id, nextState, by, invokedBy);
+    const note = optionalOption(args, 'note');
+    const issue = await c.issueUC.setState(id, nextState, by, invokedBy, note);
     process.stdout.write(`✓ issue ${issue.id.value}: → ${nextState} by ${by}\n`);
     return 0;
   }

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -5,6 +5,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { resolveGuildSessionId } from '../../shared/resolveGuildSessionId.js';
 import { parseExecutorsList } from './request.js';
 import {
   C,
@@ -299,6 +300,12 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
   // promotion is visible in the new request's initial status_log.
   const invokedByPromote = deriveInvokedBy(from);
   if (invokedByPromote !== undefined) input.invokedBy = invokedByPromote;
+  // Boot-context session_id (#249 / #289 hunk 2). promote → request
+  // is the same write-side primitive as `gate request`, so the same
+  // GUILD_SESSION_ID stamping contract applies. Absence stays absent
+  // on disk so pre-#249 records stay byte-identical.
+  const sessionId = resolveGuildSessionId();
+  if (sessionId !== undefined) input.openedBySession = sessionId;
 
   // Non-atomic by design: create request first, then resolve issue.
   // If the second step fails we emit the request id so the operator

--- a/src/interface/gate/handlers/rest.ts
+++ b/src/interface/gate/handlers/rest.ts
@@ -6,6 +6,12 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { parseFormat } from './writeFormat.js';
+import {
+  fireBeforeSessionHook,
+  fireAfterSessionHook,
+  emitHookVeto,
+} from '../../../application/plugin/HookBus.js';
+import { SessionEventVetoed } from '../../../application/session/SessionEventUseCases.js';
 
 /**
  * gate rest [--by <m>] [--note <s>] [--format json|text]
@@ -40,11 +46,42 @@ export async function restCmd(c: C, args: ParsedArgs): Promise<number> {
   const note = optionalOption(args, 'note');
   const format = parseFormat(args);
 
-  const event = await c.sessionEventUC.record({
-    kind: 'rest',
-    by,
-    ...(note !== undefined ? { note } : {}),
-  });
+  // #290: fire before:rest / after:rest hooks around the record path.
+  // The `before` veto sees the unsaved SessionEvent (so a policy can
+  // inspect note / actor before persistence); a veto blocks the save.
+  // The `after` fires post-save so an audit hook sees the final id.
+  let event;
+  try {
+    event = await c.sessionEventUC.record(
+      {
+        kind: 'rest',
+        by,
+        ...(note !== undefined ? { note } : {}),
+      },
+      {
+        beforeSave: async (e) => {
+          const veto = await fireBeforeSessionHook(
+            c.hookSubscriptions, 'rest', e, by,
+          );
+          return { veto: veto ? { reason: veto.reason } : null };
+        },
+        afterSave: async (e) => {
+          await fireAfterSessionHook(c.hookSubscriptions, 'rest', e, by);
+        },
+      },
+    );
+  } catch (e) {
+    if (e instanceof SessionEventVetoed) {
+      // No id is allocated to a vetoed record — render `(unsaved)` so
+      // the operator's grep for "hook vetoed rest" still matches the
+      // standard surface from `emitHookVeto`.
+      return emitHookVeto('rest', '(unsaved)', {
+        allow: false,
+        reason: e.reason,
+      });
+    }
+    throw e;
+  }
 
   const message = `✓ rested: ${event.id} by ${event.by.value}`;
   if (format === 'json') {

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1330,6 +1330,13 @@ const VERBS: readonly VerbSchema[] = [
             "`list` only. text (default) flattens notes for human reading; " +
             'json keeps notes nested per issue.',
         },
+        note: strOpt(
+          'optional rationale for `resolve`/`defer`/`start`/`reopen` ' +
+            'transitions (#289 hunk 1). Persisted onto the matching ' +
+            'state_log entry as `note: <s>`; omitted when absent so ' +
+            'pre-#289 records and same-body unstamped writes round-trip ' +
+            'byte-identical YAML.',
+        ),
       },
     },
     output: { type: 'object' },

--- a/src/interface/gate/handlers/wake.ts
+++ b/src/interface/gate/handlers/wake.ts
@@ -6,6 +6,12 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { parseFormat } from './writeFormat.js';
+import {
+  fireBeforeSessionHook,
+  fireAfterSessionHook,
+  emitHookVeto,
+} from '../../../application/plugin/HookBus.js';
+import { SessionEventVetoed } from '../../../application/session/SessionEventUseCases.js';
 
 /**
  * gate wake [--by <m>] [--note <s>] [--format json|text]
@@ -47,11 +53,37 @@ export async function wakeCmd(c: C, args: ParsedArgs): Promise<number> {
   const note = optionalOption(args, 'note');
   const format = parseFormat(args);
 
-  const event = await c.sessionEventUC.record({
-    kind: 'wake',
-    by,
-    ...(note !== undefined ? { note } : {}),
-  });
+  // #290: same before:/after: hook fire shape as `gate rest`. See
+  // rest.ts for the rationale; the only difference here is the verb.
+  let event;
+  try {
+    event = await c.sessionEventUC.record(
+      {
+        kind: 'wake',
+        by,
+        ...(note !== undefined ? { note } : {}),
+      },
+      {
+        beforeSave: async (e) => {
+          const veto = await fireBeforeSessionHook(
+            c.hookSubscriptions, 'wake', e, by,
+          );
+          return { veto: veto ? { reason: veto.reason } : null };
+        },
+        afterSave: async (e) => {
+          await fireAfterSessionHook(c.hookSubscriptions, 'wake', e, by);
+        },
+      },
+    );
+  } catch (e) {
+    if (e instanceof SessionEventVetoed) {
+      return emitHookVeto('wake', '(unsaved)', {
+        allow: false,
+        reason: e.reason,
+      });
+    }
+    throw e;
+  }
 
   const message = `✓ woke: ${event.id} by ${event.by.value}`;
   if (format === 'json') {

--- a/tests/interface/hookPluginSessionEvents.test.ts
+++ b/tests/interface/hookPluginSessionEvents.test.ts
@@ -1,0 +1,299 @@
+// Hook bus extension for session-boundary events (#290).
+//
+// Pins:
+//   - after:rest fires on a successful `gate rest` and the hook sees
+//     `ctx.sessionEvent` (id, kind, by, at) with `ctx.request` undefined
+//   - same for after:wake and after:farewell
+//   - before:rest veto blocks the YAML write entirely (substrate clean)
+//   - a multi-axis plugin (subscribed to after:approve AND after:rest)
+//     can branch on which subject is populated
+//   - the existing request-lifecycle plugins keep working unchanged
+//     (backward compat — `ctx.request` still populated for those events)
+//   - throwing before:rest hook fails closed (treated as veto)
+//   - throwing after:rest hook is logged but doesn't break the verb
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface RunResult { stdout: string; stderr: string; status: number; }
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+interface Bootstrap {
+  root: string;
+  pluginDir: string;
+  cleanup: () => void;
+}
+
+function bootstrap(extraConfig = ''): Bootstrap {
+  const root = makeTempRoot('gate-hp-sess-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n' + extraConfig,
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins'));
+  return {
+    root,
+    pluginDir: join(root, 'plugins'),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test('hook plugin: after:rest fires once on a successful gate rest', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit-rest.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  // The hook reads ctx.sessionEvent (the new #290 field) and writes
+  // the kind+id+by triple to assert that the subject is populated.
+  // ctx.request must be undefined for session-boundary events; the
+  // assertion `request_set:no` pins that contract.
+  writeFileSync(
+    join(pluginDir, 'audit-rest.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'after:rest',
+       run: async (ctx) => {
+         const requestSet = ctx.request !== undefined ? 'yes' : 'no';
+         appendFileSync(${JSON.stringify(trace)},
+           ctx.event + ':' + ctx.sessionEvent.kind + ':' + ctx.sessionEvent.by.value +
+           ':request_set=' + requestSet + ':id=' + ctx.sessionEvent.id + '\\n');
+       },
+     };`,
+  );
+
+  const r = runGate(root, ['rest', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(existsSync(trace), 'after:rest hook should have written to trace');
+  const line = readFileSync(trace, 'utf8');
+  assert.match(line, /^after:rest:rest:alice:request_set=no:id=\d{4}-\d{2}-\d{2}-\d{3,4}\n$/);
+});
+
+test('hook plugin: after:wake fires once on a successful gate wake', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit-wake.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'audit-wake.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'after:wake',
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)},
+           ctx.event + ':' + ctx.sessionEvent.kind + ':' + ctx.sessionEvent.by.value + '\\n');
+       },
+     };`,
+  );
+
+  const r = runGate(root, ['wake', '--by', 'alice']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(readFileSync(trace, 'utf8'), 'after:wake:wake:alice\n');
+});
+
+test('hook plugin: after:farewell fires once on a successful gate farewell', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/audit-farewell.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'audit-farewell.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'after:farewell',
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)},
+           ctx.event + ':' + ctx.sessionEvent.kind + ':' + (ctx.sessionEvent.note ?? '_') + '\\n');
+       },
+     };`,
+  );
+
+  const r = runGate(root, ['farewell', '--by', 'alice', '--note', 'see you']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(readFileSync(trace, 'utf8'), 'after:farewell:farewell:see you\n');
+});
+
+test('hook plugin: before:rest veto blocks the YAML write (no record on disk)', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/policy-rest.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'policy-rest.mjs'),
+    `export default {
+       on: 'before:rest',
+       run: async () => ({ allow: false, reason: 'no rest during incident response' }),
+     };`,
+  );
+
+  const r = runGate(root, ['rest', '--by', 'alice']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed rest on .+no rest during incident/);
+  // Substrate is clean — no sessions/ dir was created since the
+  // veto fires before the YAML write.
+  assert.ok(
+    !existsSync(join(root, 'sessions')) ||
+      readdirSync(join(root, 'sessions')).length === 0,
+    'vetoed gate rest must not write any session record',
+  );
+});
+
+test('hook plugin: throwing before:rest is a veto (fail-closed) and blocks the write', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/buggy-rest.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'buggy-rest.mjs'),
+    `export default {
+       on: 'before:rest',
+       run: async () => { throw new Error('plugin bug'); },
+     };`,
+  );
+
+  const r = runGate(root, ['rest', '--by', 'alice']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /hook vetoed rest on .+plugin bug/);
+  assert.ok(
+    !existsSync(join(root, 'sessions')) ||
+      readdirSync(join(root, 'sessions')).length === 0,
+    'fail-closed: thrown before-hook must not let the write through',
+  );
+});
+
+test('hook plugin: throwing after:rest is logged but does not break the verb', (t) => {
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/throwy-rest.mjs\n',
+  );
+  t.after(cleanup);
+  writeFileSync(
+    join(pluginDir, 'throwy-rest.mjs'),
+    `export default {
+       on: 'after:rest',
+       run: async () => { throw new Error('boom'); },
+     };`,
+  );
+
+  const r = runGate(root, ['rest', '--by', 'alice']);
+  assert.equal(r.status, 0, 'after-hook error must NOT break the handler');
+  assert.match(r.stderr, /warning: hook threw on after:rest.*boom/);
+  // Record landed on disk.
+  const files = readdirSync(join(root, 'sessions'));
+  assert.equal(files.length, 1, 'after-hook error must not block the write');
+});
+
+test('hook plugin: multi-axis plugin discriminates by which subject is populated', (t) => {
+  // One plugin subscribes to BOTH a request-lifecycle event
+  // (after:approve) and a session-boundary event (after:rest).
+  // It must read `ctx.request` for the former and `ctx.sessionEvent`
+  // for the latter — pinning that the bus populates the right subject
+  // for each event.
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/multi-axis.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'multi-axis.mjs'),
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: ['after:approve', 'after:rest'],
+       run: async (ctx) => {
+         if (ctx.request) {
+           appendFileSync(${JSON.stringify(trace)},
+             'req:' + ctx.event + ':' + ctx.request.state + '\\n');
+         } else if (ctx.sessionEvent) {
+           appendFileSync(${JSON.stringify(trace)},
+             'sess:' + ctx.event + ':' + ctx.sessionEvent.kind + '\\n');
+         }
+       },
+     };`,
+  );
+
+  // Fire one of each.
+  const reqResult = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--action', 'do thing',
+    '--reason', 'because',
+    '--format', 'json',
+  ]);
+  assert.equal(reqResult.status, 0, reqResult.stderr);
+  const id = JSON.parse(reqResult.stdout).id;
+  assert.equal(runGate(root, ['approve', id, '--by', 'bob']).status, 0);
+  assert.equal(runGate(root, ['rest', '--by', 'alice']).status, 0);
+
+  assert.equal(
+    readFileSync(trace, 'utf8'),
+    'req:after:approve:approved\nsess:after:rest:rest\n',
+  );
+});
+
+test('hook plugin: existing request-lifecycle plugin keeps working unchanged (backward compat)', (t) => {
+  // Pre-#290, ctx.request was a non-optional field. After #290 it's
+  // optional but still populated for request-lifecycle events.
+  // Existing plugins that read ctx.request.X directly without a
+  // null-check must keep working — this pins that contract.
+  const { root, pluginDir, cleanup } = bootstrap(
+    'plugins:\n  trusted: true\n  hooks:\n    - plugins/legacy-shape.mjs\n',
+  );
+  t.after(cleanup);
+  const trace = join(root, 'trace.log');
+  writeFileSync(
+    join(pluginDir, 'legacy-shape.mjs'),
+    // No null-check on ctx.request — exact pre-#290 idiom.
+    `import { appendFileSync } from 'node:fs';
+     export default {
+       on: 'after:approve',
+       run: async (ctx) => {
+         appendFileSync(${JSON.stringify(trace)},
+           ctx.request.id.value + ':' + ctx.request.state + '\\n');
+       },
+     };`,
+  );
+
+  const reqResult = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--action', 'thing',
+    '--reason', 'r',
+    '--format', 'json',
+  ]);
+  const id = JSON.parse(reqResult.stdout).id;
+  const approve = runGate(root, ['approve', id, '--by', 'bob']);
+  assert.equal(approve.status, 0, approve.stderr);
+  assert.equal(readFileSync(trace, 'utf8'), `${id}:approved\n`);
+});

--- a/tests/interface/issuePromoteSessionStamp.test.ts
+++ b/tests/interface/issuePromoteSessionStamp.test.ts
@@ -1,0 +1,146 @@
+// gate issues promote stamps opened_by_session (#289 hunk 2)
+//
+// promote → request is the same write-side primitive as `gate request`,
+// so the GUILD_SESSION_ID → opened_by_session contract from #249 must
+// apply equally. Pre-#289 the promote handler did NOT thread
+// resolveGuildSessionId, so the resulting request never carried the
+// session stamp even when the env was set.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-issue-promote-sess-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string | undefined> = {},
+): { stdout: string; stderr: string; status: number } {
+  const merged: NodeJS.ProcessEnv = { ...process.env };
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k];
+    else merged[k] = v;
+  }
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: merged,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function newIssue(root: string, env: Record<string, string | undefined> = {}): string {
+  const add = run(
+    root,
+    [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'something to promote',
+    ],
+    { GUILD_ACTOR: 'alice', ...env },
+  );
+  assert.equal(add.status, 0, `add failed: ${add.stderr}`);
+  const m = add.stdout.match(/i-\d{4}-\d{2}-\d{2}-\d+/);
+  assert.ok(m, 'issue id should be emitted');
+  return m[0];
+}
+
+const SESSION = 'alice-local-2026-05-11-promote';
+
+test('issues promote stamps opened_by_session from GUILD_SESSION_ID', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const issueId = newIssue(root);
+
+  const promote = run(
+    root,
+    [
+      'issues',
+      'promote',
+      issueId,
+      '--from',
+      'alice',
+      '--executors',
+      'alice',
+    ],
+    { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: SESSION },
+  );
+  assert.equal(promote.status, 0, `promote failed: ${promote.stderr}`);
+  const m = promote.stdout.match(/(\d{4}-\d{2}-\d{2}-\d+)/);
+  assert.ok(m, 'request id should appear in promote stdout');
+  const reqId = m[1]!;
+
+  const show = run(root, ['show', reqId, '--format', 'json']);
+  assert.equal(show.status, 0, `show failed: ${show.stderr}`);
+  const j = JSON.parse(show.stdout) as Record<string, unknown>;
+  assert.equal(j['opened_by_session'], SESSION);
+});
+
+test('issues promote: GUILD_SESSION_ID unset → no opened_by_session field', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const issueId = newIssue(root);
+
+  const promote = run(
+    root,
+    [
+      'issues',
+      'promote',
+      issueId,
+      '--from',
+      'alice',
+      '--executors',
+      'alice',
+    ],
+    { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: undefined },
+  );
+  assert.equal(promote.status, 0, `promote failed: ${promote.stderr}`);
+  const m = promote.stdout.match(/(\d{4}-\d{2}-\d{2}-\d+)/);
+  assert.ok(m, 'request id should appear in promote stdout');
+  const reqId = m[1]!;
+
+  const show = run(root, ['show', reqId, '--format', 'json']);
+  assert.equal(show.status, 0);
+  const j = JSON.parse(show.stdout) as Record<string, unknown>;
+  // Byte-stable: pre-#289 promote-without-session never wrote this
+  // field, so the same write today must not introduce it.
+  assert.equal(j['opened_by_session'], undefined);
+});

--- a/tests/interface/issueTransitionNote.test.ts
+++ b/tests/interface/issueTransitionNote.test.ts
@@ -1,0 +1,214 @@
+// gate issues defer/resolve/start/reopen --note (#289 hunk 1)
+//
+// state_log audit trail records who/when transitioned an issue but
+// pre-#289 had no slot for *why*. Optional --note <s> persists into
+// the matching state_log entry as `note: <s>` and is omitted when
+// absent (byte-stable YAML invariant — pre-#289 records round-trip
+// identically).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import YAML from 'yaml';
+import {
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-issue-note-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function newIssue(root: string): string {
+  const add = runGate(
+    root,
+    [
+      'issues',
+      'add',
+      '--from',
+      'alice',
+      '--severity',
+      'low',
+      '--area',
+      'ux',
+      '--text',
+      'test issue',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(add.status, 0, `add failed: ${add.stderr}`);
+  const m = add.stdout.match(/i-\d{4}-\d{2}-\d{2}-\d+/);
+  assert.ok(m, 'issue id should be emitted');
+  return m[0];
+}
+
+test('issues resolve --note persists onto state_log entry', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = newIssue(root);
+
+  const r = runGate(
+    root,
+    [
+      'issues',
+      'resolve',
+      id,
+      '--by',
+      'alice',
+      '--note',
+      'cannot reproduce on macOS 14.5',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, `resolve failed: ${r.stderr}`);
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const parsed = YAML.parse(readFileSync(yml, 'utf8'));
+  assert.equal(parsed.state_log.length, 1);
+  assert.equal(parsed.state_log[0].state, 'resolved');
+  assert.equal(parsed.state_log[0].by, 'alice');
+  assert.equal(
+    parsed.state_log[0].note,
+    'cannot reproduce on macOS 14.5',
+  );
+});
+
+test('issues defer --note persists onto state_log entry', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = newIssue(root);
+
+  const r = runGate(
+    root,
+    [
+      'issues',
+      'defer',
+      id,
+      '--by',
+      'alice',
+      '--note',
+      'waiting on upstream patch',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, `defer failed: ${r.stderr}`);
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const parsed = YAML.parse(readFileSync(yml, 'utf8'));
+  assert.equal(parsed.state_log[0].state, 'deferred');
+  assert.equal(parsed.state_log[0].note, 'waiting on upstream patch');
+});
+
+test('issues resolve without --note omits the field (byte-stable)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = newIssue(root);
+
+  const r = runGate(
+    root,
+    ['issues', 'resolve', id, '--by', 'alice'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, `resolve failed: ${r.stderr}`);
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const raw = readFileSync(yml, 'utf8');
+  // Byte-stable: pre-#289 YAML never carried `note:` on state_log
+  // entries, so the same write without --note must not introduce it.
+  assert.doesNotMatch(raw, /^\s*note:/m);
+  const parsed = YAML.parse(raw);
+  assert.equal(parsed.state_log[0].note, undefined);
+});
+
+test('issues note round-trips through hydrate (resolve + reopen with notes)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = newIssue(root);
+
+  // Two transitions, each with its own note.
+  const r1 = runGate(
+    root,
+    [
+      'issues',
+      'resolve',
+      id,
+      '--by',
+      'alice',
+      '--note',
+      'shipped in v0.6',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r1.status, 0, r1.stderr);
+
+  const r2 = runGate(
+    root,
+    [
+      'issues',
+      'reopen',
+      id,
+      '--by',
+      'alice',
+      '--note',
+      'regression spotted in 0.6.1',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r2.status, 0, r2.stderr);
+
+  const yml = join(root, 'issues', `${id}.yaml`);
+  const parsed = YAML.parse(readFileSync(yml, 'utf8'));
+  assert.equal(parsed.state_log.length, 2);
+  assert.equal(parsed.state_log[0].note, 'shipped in v0.6');
+  assert.equal(parsed.state_log[1].note, 'regression spotted in 0.6.1');
+
+  // Hydrate by reading via gate show to confirm the repo round-trips
+  // the note back out (json mode preserves the structure).
+  const list = runGate(root, ['issues', 'list', '--state', 'open', '--format', 'json']);
+  assert.equal(list.status, 0, list.stderr);
+  const items = JSON.parse(list.stdout) as Array<Record<string, unknown>>;
+  const issue = items.find((i) => i['id'] === id);
+  assert.ok(issue, `issue ${id} should be in open list after reopen`);
+  const log = issue['state_log'] as Array<Record<string, unknown>>;
+  assert.equal(log.length, 2);
+  assert.equal(log[0]!['note'], 'shipped in v0.6');
+  assert.equal(log[1]!['note'], 'regression spotted in 0.6.1');
+});


### PR DESCRIPTION
## Summary

Two independent slices shipped via a `profile: swarm` parallel-impl wave (`/tmp/swarm-real` substrate, request `2026-05-11-0001`):

- **#289 — issues.ts hardening** (2 commits, cleanly cherry-pickable)
  1. `feat(gate): --note on issues defer/resolve/start/reopen` — adds optional `--note` to all four state transitions, persisted into `state_log` (omitted when absent per byte-stable YAML). Closes principle-04 trail-loss on issue lifecycle.
  2. `fix(gate): stamp opened_by_session on issues promote` — threads `resolveGuildSessionId` through promote so the resulting request follows the same #249 stamping contract as `gate request` / `gate fast-track`.

- **#290 — hook bus SessionEvent extension** (1 commit)
  - Phase 1 hooks (#259) were request-shaped only; Phase 2 session verbs (`rest` / `wake` / `farewell`, #261-#263) now fire `before:` / `after:` hooks. Picked **Option B** (orthogonal optional fields: `ctx.request?` + `ctx.sessionEvent?`) over Option A (discriminated subject) — existing plugins migrate with zero edits when subscribing only to request events; one defensive null-check covers the multi-axis case. Existing hook plugin examples (`audit-log.mjs`, `policy-no-self-approve.mjs`) updated. CHANGELOG entry added.

## Provenance

This PR replaces a 4-issue batch (#285-#288) that was rolled back because:
- #285 (boot text rendering) was filed on a false premise — the text formatter already renders cross_passage when non-empty (boot.ts:1417-1429); the original report didn't observe a non-empty substrate
- the implementation went through Claude worktree isolation only, **not** via gate's swarm coordination layer

This re-run engaged gate properly:
- `profile: swarm` enabled
- multi-executor request with `--executors agent-issues,agent-hookbus`
- `requires_worktree_isolation: true` stamped at file time
- `self_approve: forbidden` enforced (eris's self-approve refused; critic approved on eris's behalf)
- both executors witnessed with per-slice notes; both `witness_sessions[<actor>]` stamped with distinct session_ids
- gate transcript captures the full arc (3 actors, 21min) at `/tmp/swarm-real/requests/completed/2026-05-11-0001.yaml`

A third dependent slice (rest-suspends-agora example plugin, original #287) is intentionally deferred — it now properly waits for #290 to land.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1459/1459 pass
- [x] cherry-picked commits stay individually buildable (each was tested in its worktree before cherry-pick)
- [x] `state_log` `note` omits-when-absent (byte-stable YAML invariant)
- [x] `opened_by_session` omits when env unset
- [x] existing hook plugins unchanged behavior on request-lifecycle paths
- [x] new `after:rest` / `after:wake` / `after:farewell` fire and pass `ctx.sessionEvent` correctly

Closes #289
Closes #290

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_