### PR TITLE
fix(boot): surface enrichment failures via warnings[] (combo C3 / silent-fallback-loses-signal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Fixed
+
+- **`gate boot` now surfaces enrichment failures via `warnings: string[]`
+  (combo C3 / silent-fallback-loses-signal)**.
+  Pre-fix, four enrichment paths (issues count, inbox unread,
+  unresponded concerns, content_root_health probe) caught their own
+  errors silently — `// may not be configured — non-fatal` — so a
+  broken issue repository or a partly-quarantined inbox passed
+  through invisibly: `status.open_issues = 0` looked identical
+  whether there were genuinely zero issues or the repo was unreadable.
+  Devil's concern2 on PR #105 (agent-first-session 2026-04-16-0001)
+  flagged this; 2026-05-10 dogfood (`substrate/agora/plays/eris-
+  dogfood-0510/`) re-surfaced it. New `warnings: string[]` field on
+  `BootPayload` (sorted into the keys snapshot per 0.x stability);
+  each silent catch now pushes a descriptive single-line entry
+  including `e.message`. Empty array = clean case (no extra noise).
+  Text format adds a `⚠ N warning(s) raised...` block when non-empty
+  with a one-line disclaimer naming which downstream values may be
+  inaccurate. Three regression tests pin: clean-empty / broken-repo-
+  surfaces / message-includes-error-detail.
+
 ### Added
 
 - **hook bus extended for session-boundary events (#290 — closes #290)**

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -238,6 +238,25 @@ interface BootPayload {
   }>;
   last_activity: string | null;
   /**
+   * Non-fatal warnings raised while assembling the payload (combo C3
+   * — silent-fallback-loses-signal).
+   *
+   * Pre-this-field, four enrichment paths (issues count, inbox unread,
+   * unresponded concerns, content_root_health probe) caught their own
+   * errors silently — `// may not be configured — non-fatal` — so a
+   * broken issue repository or a partly-quarantined inbox passed
+   * through invisibly. Devil's concern2 on PR #105 (agent-first-session
+   * 2026-04-16) flagged this as the gap that lets agents trust an
+   * orientation snapshot more than they should.
+   *
+   * Each warning is a human-readable single-line string. Empty array
+   * is the common case (no enrichment failed). Plugin authors and
+   * orchestrators can surface these directly to the operator without
+   * re-parsing — same shape as `gate doctor` findings, but local to
+   * the orientation snapshot.
+   */
+  warnings: string[];
+  /**
    * Diagnostic hints to help agents detect misconfiguration early.
    *
    * `misconfigured_cwd`: true iff NO `guild.config.yaml` was found up
@@ -442,14 +461,19 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   const status = collectStatus(allRequests, actor);
 
   // Enrich status with issues + inbox (mirrors statusCmd) so the
-  // single payload is self-contained.
+  // single payload is self-contained. Errors surface in `warnings[]`
+  // (combo C3 / devil concern2 PR #105) — silent try/catch was the
+  // pre-this-PR shape and let broken repos pass through invisibly.
+  const warnings: string[] = [];
   try {
     const issues = await c.issueUC.listAll();
     status.open_issues = issues.filter(
       (i) => i.state === 'open' || i.state === 'in_progress',
     ).length;
-  } catch {
-    // issues dir may not exist — non-fatal
+  } catch (e) {
+    warnings.push(
+      `issues enrichment failed (open_issues count may be inaccurate): ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 
   const inboxUnread: BootPayload['inbox_unread'] = [];
@@ -467,8 +491,10 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
           ...(m.expectsResponse === true ? { expects_response: true } : {}),
         });
       }
-    } catch {
-      // inbox may not exist for this actor — non-fatal
+    } catch (e) {
+      warnings.push(
+        `inbox enrichment failed for actor=${actor} (inbox_unread may be inaccurate): ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 
@@ -483,8 +509,10 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
         now: new Date(),
       });
       status.unresponded = entries.length;
-    } catch {
-      // requests/issues dirs may be missing — non-fatal.
+    } catch (e) {
+      warnings.push(
+        `unresponded-concerns scan failed for actor=${actor} (unresponded count may be inaccurate): ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
 
@@ -555,8 +583,10 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
         'Quarantine is reversible: files move under ' +
         '`<content_root>/quarantine/<timestamp>/<area>/`.';
     }
-  } catch {
-    // Diagnostic errored — skip health, keep boot usable.
+  } catch (e) {
+    warnings.push(
+      `content_root health probe failed (malformed_count may be inaccurate): ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 
   const baseSuggestedNext = deriveBootSuggestedNext(
@@ -617,6 +647,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     your_recent: yourRecent,
     inbox_unread: inboxUnread,
     last_activity: status.last_activity,
+    warnings,
     hints: {
       session_id_unset: sessionIdUnset,
       misconfigured_cwd: misconfiguredCwd,
@@ -1410,6 +1441,15 @@ function renderBootText(p: BootPayload): string {
     }
   }
   if (p.last_activity) lines.push(`last activity: ${p.last_activity}`);
+  if (p.warnings.length > 0) {
+    lines.push('');
+    lines.push(`⚠ ${p.warnings.length} warning(s) raised while assembling this snapshot:`);
+    for (const w of p.warnings) {
+      lines.push(`   ${w}`);
+    }
+    lines.push(`   (counts in 'queues:' / 'inbox unread:' may be inaccurate;`);
+    lines.push(`    run 'gate doctor' to inspect the underlying repos)`);
+  }
 
   // Cross-passage summary: render only the passages with records.
   // Empty cross_passage stays silent (voice budget — fresh roots

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -66,6 +66,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'suggested_next',
         'tail',
         'verbs_available_now',
+        'warnings',
         'your_recent',
       ],
       'boot payload top-level keys changed — agents depend on this contract',
@@ -1214,6 +1215,86 @@ test('gate boot text: parallel-session warning lands under overlap section (#249
     assert.match(
       t.stdout,
       /⚠ same-actor parallel sessions: alice on target "src\/foo" \(sessions: alice-tmux-1, alice-tmux-2\)/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// -------------------- C3 / silent-fallback-loses-signal --------------------
+//
+// Combo C3 from the 2026-05-10 dogfood arc (substrate/agora/plays/
+// eris-dogfood-0510/2026-05-10-001.yaml). Pre-this-PR, four
+// enrichment paths in boot caught their own errors silently and the
+// payload's status counts went on lying. Devil's concern2 on PR #105
+// (agent-first-session 2026-04-16) flagged this as the gap that lets
+// agents trust the snapshot more than they should.
+
+test('#C3: clean boot has empty warnings array (no false positives)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    assert.ok(Array.isArray(payload.warnings),
+      'warnings must always be an array (empty in clean case)');
+    assert.equal(payload.warnings.length, 0,
+      `clean bootstrap should produce zero warnings, got: ${JSON.stringify(payload.warnings)}`);
+
+    // text format must NOT print the warning block when empty
+    const { stdout: textOut } = runGate(root, ['boot', '--format', 'text']);
+    assert.doesNotMatch(textOut, /warning\(s\) raised/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('#C3: broken issues path surfaces a warning instead of silent swallow', () => {
+  // Sabotage the issues directory: replace it with a regular file so
+  // listAll() throws when it tries to readdir(). This reproduces the
+  // exact silent-swallow path the original `// issues dir may not
+  // exist — non-fatal` catch was hiding.
+  const { root, cleanup } = bootstrap();
+  try {
+    // The issues path defaults to <content_root>/issues. Create a
+    // regular file at that path so the directory walk fails.
+    writeFileSync(join(root, 'issues'), 'NOT A DIRECTORY');
+    const { stdout, status } = runGate(root, ['boot']);
+    assert.equal(status, 0, 'boot must remain non-fatal even when enrichment fails');
+    const payload = JSON.parse(stdout);
+    assert.ok(Array.isArray(payload.warnings));
+    assert.ok(
+      payload.warnings.some((w: string) => /issues enrichment failed/.test(w)),
+      `expected an issues-enrichment warning; got: ${JSON.stringify(payload.warnings)}`,
+    );
+
+    // text format surfaces the warning block + the inaccuracy disclaimer
+    const { stdout: textOut } = runGate(root, ['boot', '--format', 'text']);
+    assert.match(textOut, /warning\(s\) raised/);
+    assert.match(textOut, /issues enrichment failed/);
+    assert.match(textOut, /counts in 'queues:'.*may be inaccurate/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('#C3: warning text in JSON includes the underlying error message', () => {
+  // Silent try/catch dropped the error info entirely. The new shape
+  // must propagate enough of `e.message` for an agent reading the
+  // payload to know what actually broke.
+  const { root, cleanup } = bootstrap();
+  try {
+    writeFileSync(join(root, 'issues'), 'NOT A DIRECTORY');
+    const { stdout } = runGate(root, ['boot']);
+    const payload = JSON.parse(stdout);
+    const w = payload.warnings.find((s: string) =>
+      /issues enrichment failed/.test(s));
+    assert.ok(w, 'expected to find an issues-enrichment warning');
+    // The exact ENOTDIR / EEXIST shape varies by node version; just
+    // confirm SOMETHING about the error was preserved (not just the
+    // generic "issues enrichment failed").
+    assert.ok(
+      w.length > 'issues enrichment failed (open_issues count may be inaccurate): '.length + 5,
+      `warning should include the underlying error detail, got: ${w}`,
     );
   } finally {
     cleanup();


### PR DESCRIPTION
## Summary

\`gate boot\` now surfaces the four silent \`try/catch\` paths via a new \`warnings: string[]\` field on \`BootPayload\`. Pre-this-PR, a broken issue repository / partly-quarantined inbox / failed diagnostic probe passed through invisibly: \`status.open_issues = 0\` looked identical whether there were genuinely zero issues or the repo was unreadable.

## Provenance — two independent observations, 24 days apart

- **Devil concern2 on PR #105** (agent-first-session 2026-04-16-0001 review) flagged the silent try/catch as the gap that lets agents trust the snapshot more than they should.
- **2026-05-10 dogfood** (\`substrate/agora/plays/eris-dogfood-0510/2026-05-10-001.yaml\` move 011) re-surfaced it as the canonical instance of a broader pattern (combo C3 — silent-fallback-loses-signal).

Trigger met. Devil agent memory now carries \`trap_silent_fallback_loses_signal.md\` routing future fallback-path PR review to require the \`warnings[]\` shape (any \`// non-fatal\` swallow must be replaced).

## Behavior

- **JSON**: new \`warnings: string[]\` field. Empty array = clean case. Each entry is a descriptive single-line string including the underlying \`e.message\`.
- **Text**: when non-empty, renders a \`⚠ N warning(s) raised while assembling this snapshot:\` block listing each, followed by a one-line disclaimer naming which downstream values may be inaccurate (\`counts in 'queues:' / 'inbox unread:' may be inaccurate; run 'gate doctor'\`).
- **Boot keys snapshot test** updated: \`warnings\` added to the sorted top-level keys list (forward-compatible additive per 0.x stability).

## What's NOT in this PR

The cwd-fallback notice variant of combo C3 (Instance 1 — \`agora new\` silently writes \`./agora/\` without suggesting next steps) is **not fixed**. Single-session evidence only; deferred per the [\`trap_dogfood_deferred_open_rot.md\`](https://github.com/eris-ths/guild-cli/) operational rule that closed #278/#280. Memory pin captures the design so a 2nd observation routes back to the right place.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1473/1473 pass (was 1470 on main; +3 regression)
- [x] Manual smoke: sabotaged issues/ path with a file → warning surfaced in JSON + text format with correct disclaimer
- [x] Existing boot tests unchanged (clean bootstrap still warnings = [])
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)