### PR TITLE
feat(swarm-dogfood): SessionEvent drift extension + cwd-fallback next: hint

### DIFF
--- a/src/interface/gate/handlers/internal.ts
+++ b/src/interface/gate/handlers/internal.ts
@@ -242,11 +242,18 @@ export function warnIfMisconfiguredCwd(c: C, isEmpty: boolean): void {
  *
  * The shape:
  *   `content root: <abs> (config: <abs>/guild.config.yaml)`
- *   `content root: <abs> (config: none — cwd used as fallback root)`
+ *   `content root: <abs> (config: none — cwd used as fallback root)\n  next: create guild.config.yaml here, OR cd into an existing content_root`
  *
  * Phrasing matches `gate register`'s success notice (PR #108)
  * `(config: ...)` segment so the operator recognises the
  * orientation cue across verbs without re-reading.
+ *
+ * When `configFile === null` (the silent-fallback case), the line
+ * is followed by a `\n  next:` sub-bullet pointing at the two
+ * corrective paths — addresses combo C3 ("silent-fallback-loses-
+ * signal") surfaced in the 2026-05-10 eris-dogfood agora play:
+ * the notice identifies the fallback but historically didn't
+ * suggest how to opt out.
  *
  * Pure formatter — caller decides where the line goes (stderr,
  * stdout text body, etc.) and whether to additionally guard on
@@ -264,7 +271,11 @@ export function formatContentRootDisclosure(
     config.configFile === null
       ? 'config: none — cwd used as fallback root'
       : `config: ${config.configFile}`;
-  return `content root: ${config.contentRoot} (${configSegment})`;
+  const base = `content root: ${config.contentRoot} (${configSegment})`;
+  if (config.configFile === null) {
+    return `${base}\n  next: create guild.config.yaml here, OR cd into an existing content_root`;
+  }
+  return base;
 }
 
 // --- Editor fallback for long-form review comments ---------------------

--- a/tests/docs/pluginSchemaDocSync.test.ts
+++ b/tests/docs/pluginSchemaDocSync.test.ts
@@ -44,6 +44,7 @@ const REPO = resolve(here, '../../..');
 
 const REQUEST_DTS = resolve(REPO, 'dist/src/domain/request/Request.d.ts');
 const REVIEW_DTS = resolve(REPO, 'dist/src/domain/request/Review.d.ts');
+const SESSION_EVENT_DTS = resolve(REPO, 'dist/src/domain/session/SessionEvent.d.ts');
 const SCHEMA_DOC = resolve(REPO, 'docs/plugin-schema.md');
 
 /**
@@ -118,6 +119,23 @@ function extractDocReviewFields(docText: string): Set<string> {
   // Same negative-lookahead rule as Request: skip method calls.
   // See extractDocRequestFields for the backtracking-defeat rationale.
   const re = /`r\.([a-zA-Z_]\w*)(?![\w(])/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(docText)) !== null) {
+    out.add(m[1]!);
+  }
+  return out;
+}
+
+/**
+ * Extract SessionEvent field names referenced as `sessionEvent.NAME` in
+ * the doc. Same shape as extractDocReviewFields but for the inline
+ * `sessionEvent.X` pattern used in the § SessionEvent reference section.
+ */
+function extractDocSessionEventFields(docText: string): Set<string> {
+  const out = new Set<string>();
+  // Same negative-lookahead rule as Request/Review: skip method calls.
+  // See extractDocRequestFields for the backtracking-defeat rationale.
+  const re = /`sessionEvent\.([a-zA-Z_]\w*)(?![\w(])/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(docText)) !== null) {
     out.add(m[1]!);
@@ -221,6 +239,31 @@ test('#283: every `r.X` reference in docs/plugin-schema.md exists as a Review ge
       `next: a Review getter was likely renamed or removed; update or\n` +
       `delete the corresponding inline reference in the\n` +
       `§ ctx.extra.review section of docs/plugin-schema.md.\n`,
+  );
+});
+
+// -------------------- SessionEvent stale-reference check --------------------
+
+test('#283: every `sessionEvent.X` reference in docs/plugin-schema.md exists as a SessionEvent getter', () => {
+  // Note: this is a one-way check — the doc does NOT claim to enumerate
+  // every SessionEvent getter. Same posture as Review: the doc surface
+  // is opt-in for non-Request classes. We only fail when the doc makes
+  // a claim that no longer matches code.
+  const codeGetters = extractGetters(SESSION_EVENT_DTS, 'SessionEvent');
+  const docText = readFileSync(SCHEMA_DOC, 'utf8');
+  const documented = extractDocSessionEventFields(docText);
+
+  const stale = [...documented].filter((d) => !codeGetters.has(d));
+  assert.equal(
+    stale.length,
+    0,
+    `\n\n` +
+      `docs/plugin-schema.md references \`sessionEvent.X\` field(s) on\n` +
+      `SessionEvent that do NOT exist as public getters:\n` +
+      `  ${fmt(stale)}\n\n` +
+      `next: a SessionEvent getter was likely renamed or removed; update\n` +
+      `or delete the corresponding inline reference in the\n` +
+      `§ SessionEvent reference section of docs/plugin-schema.md.\n`,
   );
 });
 

--- a/tests/interface/formatContentRootDisclosure.test.ts
+++ b/tests/interface/formatContentRootDisclosure.test.ts
@@ -1,0 +1,82 @@
+// Pins the shape of `formatContentRootDisclosure()` — the helper
+// that emits the one-line orientation disclosure shared by gate,
+// agora, devil and ctx when cwd isn't the canonical content root,
+// or when no `guild.config.yaml` was found (silent-fallback case).
+//
+// Combo C3 from the 2026-05-10 eris-dogfood agora play
+// ("silent-fallback-loses-signal") surfaced that the fallback
+// notice identifies the situation but doesn't suggest a corrective
+// next step. Slice B of wave 2026-05-11-0001 appends a `next:`
+// sub-bullet to the disclosure ONLY in the fallback case
+// (configFile === null). When a real config is loaded, the
+// historical shape is preserved.
+//
+// Scope is deliberately narrow: pure formatter contract. Caller
+// integration (boot, register, agora new/play, devil open) is
+// exercised by their respective handler tests.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatContentRootDisclosure } from '../../src/interface/gate/handlers/internal.js';
+
+const NEXT_LINE =
+  '\n  next: create guild.config.yaml here, OR cd into an existing content_root';
+
+test('formatContentRootDisclosure: null when cwd == contentRoot AND real config is loaded', () => {
+  const result = formatContentRootDisclosure(
+    { configFile: '/abs/repo/guild.config.yaml', contentRoot: '/abs/repo' },
+    '/abs/repo',
+  );
+  assert.equal(result, null);
+});
+
+test('formatContentRootDisclosure: config present + cwd subdir → disclosure WITHOUT next: hint', () => {
+  const result = formatContentRootDisclosure(
+    { configFile: '/abs/repo/guild.config.yaml', contentRoot: '/abs/repo' },
+    '/abs/repo/subdir',
+  );
+  assert.equal(
+    result,
+    'content root: /abs/repo (config: /abs/repo/guild.config.yaml)',
+  );
+  assert.ok(!result?.includes('next:'), 'next: hint must not leak into config-present case');
+});
+
+test('formatContentRootDisclosure: configFile null (fallback) → disclosure WITH next: hint', () => {
+  const result = formatContentRootDisclosure(
+    { configFile: null, contentRoot: '/tmp/some-cwd' },
+    '/tmp/some-cwd',
+  );
+  assert.equal(
+    result,
+    `content root: /tmp/some-cwd (config: none — cwd used as fallback root)${NEXT_LINE}`,
+  );
+});
+
+test('formatContentRootDisclosure: next: hint uses newline + 2-space indent (sub-bullet)', () => {
+  const result = formatContentRootDisclosure(
+    { configFile: null, contentRoot: '/x' },
+    '/x',
+  );
+  const lines = (result as string).split('\n');
+  assert.equal(lines.length, 2);
+  assert.match(
+    lines[0]!,
+    /^content root: \/x \(config: none — cwd used as fallback root\)$/,
+  );
+  assert.equal(
+    lines[1],
+    '  next: create guild.config.yaml here, OR cd into an existing content_root',
+  );
+});
+
+test('formatContentRootDisclosure: fallback case keyed on configFile, not cwd alignment', () => {
+  // When configFile is null AND cwd is outside, the fallback branch
+  // still owns the recovery hint — it's keyed on configFile, not on
+  // cwd alignment.
+  const result = formatContentRootDisclosure(
+    { configFile: null, contentRoot: '/root' },
+    '/elsewhere',
+  );
+  assert.ok(result?.includes('next: create guild.config.yaml here'));
+});


### PR DESCRIPTION
## Summary

Two small follow-up slices shipped via a real \`profile: swarm\` parallel-impl wave to dogfood substrate engagement before proposing \`lore/principles/14-*.md\` "substrate-engagement = context-cost-reduction." This PR is the shipped output; the substrate trail lives at \`substrate/swarm-experiments/2026-05-11-eris-swarm-test/requests/executing/2026-05-11-0001.yaml\` (persistent, not /tmp).

### Slice A — \`tests/docs/pluginSchemaDocSync.test.ts\` (+43 lines)
SessionEvent stale-ref check added (mirrors the Review one-way posture). Every \`sessionEvent.X\` reference in \`docs/plugin-schema.md\` must correspond to a public getter on \`SessionEvent\`. 5/5 #283 tests pass.

Executor: \`agent-driftext\` (session \`agent-driftext-2026-05-11\`).

### Slice B — \`src/interface/gate/handlers/internal.ts\` + new test file (+95/-2 lines)
\`formatContentRootDisclosure()\` now appends \`\\n  next: create guild.config.yaml here, OR cd into an existing content_root\` when \`configFile === null\`. Closes combo C3 instance 1 (silent-fallback-loses-signal, 1st observation). 5 focused tests pin the helper output shape under both branches.

Executor: \`agent-fallbackhint\` (session \`agent-fallbackhint-2026-05-11\`).

## Swarm coordination trail (the dogfood payoff)

- \`profile: swarm\` + \`self_approve: forbidden\` + \`worktree_required_for_parallel: true\`
- Filed by \`eris\` (host) → self-approve refused (proved at try-time) → approved by \`critic\`
- Each executor witnessed onto the wave with their own \`GUILD_SESSION_ID\` BEFORE writing code
- Two Claude SubAgents in \`isolation: "worktree"\` (filesystem axis) AND substrate-stamped executors (substrate axis) — both axes engaged
- Cherry-picked into this branch; full suite \`npm test\` = 1476/1476 pass

## Dogfood findings (will feed principle 14 candidate evaluation)

1. **self_approve forbidden is felt, not read** — proved at try-time on attempt #1
2. **witness_note 80-char cap is real** — useful as slice-status pin; surprised on first try, then natural after one reframe
3. **witness is idempotent on same note text** — repeating a witness note returns "no change" rather than appending. Substrate stays terse but progress history requires note-text changes per update
4. **Orchestrator context cost stayed flat** during 2-slice parallel execution — substrate held the coordination, I didn't have to remember "what is agent-driftext doing now"
5. **Agent self-report ≠ substrate state** — when an agent reports "witness updated," I must read substrate to verify. Agents reports are testimony, not record

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1476/1476 pass (+ Slice A's 1 new test + Slice B's 5 new tests)
- [x] Cherry-pick from 2 worktrees, no conflicts
- [x] Both slices touch disjoint files (verified at request time)
- [ ] CI green

## Related

- Closes the dogfood-trigger Instance 1 of combo C3 (silent-fallback-loses-signal), 1st observation now shipped under the test discipline
- Extends drift detection (#283) to cover SessionEvent — closes the v1 limitation noted at #283 close
- The substrate-engagement experience feeds the principle 14 candidate decision (now: enable lore/principles/14-*.md proposal as a separate concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)