### PR TITLE
feat(gate): wave-status verb — per-executor in-flight slice status (closes #295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Added
+
+- **`gate wave-status <id>` — per-executor in-flight slice status (closes #295)**
+  ([#295](https://github.com/eris-ths/guild-cli/issues/295)).
+  New read verb that composes per-executor view from existing
+  substrate fields (witness notes + claim state + status_log
+  timestamps) — no schema change needed for v1. Sibling of `gate
+  boot`'s cross-request overlap surface (#234): boot is actor-axis
+  cross-wave, wave-status is wave-axis cross-actor.
+  - Works on any state (pending / approved / executing / completed /
+    failed / denied).
+  - Single-executor renders a compact one-line form so the verb is
+    not useless for the common case.
+  - Multi-executor renders a per-executor block with witness note +
+    claim state + last attributable write.
+  - **Age-threshold disambiguation** (per #295 acceptance):
+    `< 5 min` suppresses any "no progress" warning (fresh wave —
+    witnesses may simply be incoming); `5-30 min` neutral note;
+    `≥ 30 min` no attributable activity surfaces `⚠ stale — no
+    in-flight progress note recorded` — the ceremony-swarm failure
+    mode (a wave with executors named who never landed any
+    substrate-side activity).
+  - Forward-compatible with #294: v1 uses witness-inference; when
+    #294 ships structured `executors[].status`, this verb pivots to
+    read that field directly without breaking the JSON shape.
+  - `gate schema` lists the verb under `category: 'read'` with full
+    input/output schema; the keys snapshot test surfaces the
+    addition forward-compatibly.
+
 ### Fixed
 
 - **`gate boot` now surfaces enrichment failures via `warnings: string[]`

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -568,6 +568,55 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'wave-status',
+    category: 'read',
+    summary:
+      "per-executor in-flight slice status for a multi-executor request (#295). Composes witness notes + claim state + status_log timestamps to surface 'is each executor making progress?' inside a single wave. Sibling of `gate boot`'s cross-request overlap surface (#234) — this one is wave-axis, that one is actor-axis.",
+    input: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'positional; request id (YYYY-MM-DD-NNNN)' },
+        format: {
+          type: 'string',
+          enum: ['text', 'json'],
+          description: 'output format (default: text — the per-executor block is human-readable)',
+        },
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        state: str,
+        from: str,
+        executors: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: str,
+              witness_note: { type: 'string', description: 'null when no witness note recorded for this executor' },
+              witness_session: { type: 'string', description: 'null when no session_id was stamped on the witness' },
+              claim_held: { type: 'boolean' },
+              last_attributable_at: { type: 'string', description: 'most recent ISO timestamp in status_log attributable to this executor; null when no transition by them' },
+              activity_band: {
+                type: 'string',
+                enum: ['fresh', 'in-progress', 'stale', 'active'],
+              },
+            },
+          },
+        },
+        age_ms: { type: 'integer', description: 'ms since wave was approved; null when wave has never been approved' },
+        age_band: {
+          type: 'string',
+          enum: ['fresh', 'in-progress', 'stale'],
+        },
+        approved_at: { type: 'string', description: 'ISO timestamp of the first approved entry in status_log; null when wave has never been approved' },
+      },
+    },
+  },
+  {
     name: 'summarize',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/waveStatus.ts
+++ b/src/interface/gate/handlers/waveStatus.ts
@@ -1,0 +1,284 @@
+// gate wave-status — per-executor in-flight slice status for a
+// multi-executor request (#295).
+//
+// Composes from existing substrate fields (no schema change for v1):
+//   - executors[] — the wave's executor list
+//   - witnessNotes / witnessSessions — most recent witness per actor
+//     (note text + session_id; witness has no own timestamp)
+//   - claimedBy / claimedAt — exclusive stake on the wave
+//   - status_log — state transitions, used to infer per-executor
+//     "last attributable activity" age (the witness-note age proxy
+//     since witnesses themselves are untimestamped on this schema)
+//
+// Age-threshold disambiguation per the issue's acceptance criteria:
+//   wave age since approve  → rendering
+//   < 5 min                  no warning (fresh wave, witnesses may be incoming)
+//   5-30 min                 "(in progress — no recent attributable write)"
+//   ≥ 30 min, no witness     "⚠ stale — no in-flight progress note recorded"
+//   ≥ 30 min, witness only   "⚠ stale — last witness has no timestamp; verify"
+//
+// v1 vs future:
+//   v1 uses witness-inference + status_log timestamps. When #294
+//   ships structured `executors[].status`, this verb pivots to read
+//   that directly. The v1 shape is forward-compatible — each
+//   executor entry already carries the fields a structured slice
+//   would populate (`last_attributable_at`, `claim_held`, etc.).
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+
+const WAVE_STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+/**
+ * Age bands for the no-recent-attributable-write rendering. Hard-coded
+ * as best-effort heuristics per the issue (configurable would be
+ * over-engineering for v1).
+ */
+const FRESH_THRESHOLD_MS = 5 * 60 * 1000;
+const STALE_THRESHOLD_MS = 30 * 60 * 1000;
+
+/**
+ * Per-executor slice view derived from substrate. `null` fields signal
+ * absence (no witness note, no attributable activity yet, etc.) rather
+ * than zero values that a consumer might confuse with "value present
+ * but zero-shaped."
+ */
+export interface WaveExecutorView {
+  name: string;
+  witness_note: string | null;
+  witness_session: string | null;
+  claim_held: boolean;
+  /**
+   * Most recent ISO timestamp in `status_log` attributable to this
+   * executor (state transitions they performed). Null when they have
+   * never touched the wave from their own `--by`. Witness notes are
+   * untimestamped on the current schema so cannot contribute to this
+   * field — only state transitions do.
+   */
+  last_attributable_at: string | null;
+  /**
+   * One-line rendering hint for text format. Computed from the wave
+   * age + per-executor activity so the text renderer doesn't have to
+   * re-derive the policy.
+   *
+   * Values:
+   *   - "fresh"        wave < 5 min old; suppress warning
+   *   - "in-progress"  5-30 min old; neutral
+   *   - "stale"        ≥ 30 min old; surface the ⚠ stale line
+   *   - "active"       executor has at least one attributable write
+   */
+  activity_band: 'fresh' | 'in-progress' | 'stale' | 'active';
+}
+
+export interface WaveStatusPayload {
+  id: string;
+  state: string;
+  from: string;
+  executors: readonly WaveExecutorView[];
+  age_ms: number | null;
+  age_band: 'fresh' | 'in-progress' | 'stale';
+  approved_at: string | null;
+}
+
+export async function waveStatusCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, WAVE_STATUS_KNOWN_FLAGS, 'wave-status');
+  const id = args.positional[0];
+  if (!id) {
+    throw new Error('Usage: gate wave-status <id> [--format text|json]');
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(notFoundMessage('request', id));
+    return 1;
+  }
+  const payload = buildWaveStatus(r, new Date());
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(renderText(payload) + '\n');
+  }
+  return 0;
+}
+
+export function buildWaveStatus(r: Request, now: Date): WaveStatusPayload {
+  const j = r.toJSON();
+  const id = String(j['id']);
+  const state = String(j['state']);
+  const from = String(j['from']);
+  const executors = Array.isArray(j['executors'])
+    ? (j['executors'] as string[])
+    : [];
+  const log = Array.isArray(j['status_log'])
+    ? (j['status_log'] as Array<Record<string, unknown>>)
+    : [];
+
+  // Wave-age anchor: first `approved` entry in status_log (or null
+  // when still pending — a pending wave has no age in this sense
+  // because the approve step is what unblocks executor activity).
+  const approvedEntry = log.find((e) => e['state'] === 'approved');
+  const approvedAt =
+    approvedEntry && typeof approvedEntry['at'] === 'string'
+      ? (approvedEntry['at'] as string)
+      : null;
+  const ageMs =
+    approvedAt !== null ? Math.max(0, now.getTime() - new Date(approvedAt).getTime()) : null;
+  const ageBand: WaveStatusPayload['age_band'] = (() => {
+    if (ageMs === null || ageMs < FRESH_THRESHOLD_MS) return 'fresh';
+    if (ageMs < STALE_THRESHOLD_MS) return 'in-progress';
+    return 'stale';
+  })();
+
+  const witnessNotes = r.witnessNotes; // ReadonlyMap<string, string>
+  const witnessSessions = r.witnessSessions;
+  const claimedBy = r.claimedBy?.value;
+
+  const executorViews: WaveExecutorView[] = executors.map((name) => {
+    const note = witnessNotes.get(name) ?? null;
+    const sess = witnessSessions.get(name) ?? null;
+    const claimHeld = claimedBy === name;
+
+    // Last attributable write: max ISO timestamp in status_log where
+    // `by === name`. Fallback to claimedAt only when claim is held by
+    // this executor AND no status_log entry exists (claim is the
+    // earliest verifiable activity in that case).
+    let lastAt: string | null = null;
+    for (const e of log) {
+      if (e['by'] === name && typeof e['at'] === 'string') {
+        const at = e['at'] as string;
+        if (lastAt === null || at > lastAt) lastAt = at;
+      }
+    }
+    if (lastAt === null && claimHeld && r.claimedAt) {
+      lastAt = r.claimedAt;
+    }
+
+    const band: WaveExecutorView['activity_band'] = (() => {
+      if (lastAt !== null) return 'active';
+      // No attributable write yet — fall back to wave age.
+      if (ageBand === 'fresh') return 'fresh';
+      if (ageBand === 'in-progress') return 'in-progress';
+      return 'stale';
+    })();
+
+    return {
+      name,
+      witness_note: note,
+      witness_session: sess,
+      claim_held: claimHeld,
+      last_attributable_at: lastAt,
+      activity_band: band,
+    };
+  });
+
+  return {
+    id,
+    state,
+    from,
+    executors: executorViews,
+    age_ms: ageMs,
+    age_band: ageBand,
+    approved_at: approvedAt,
+  };
+}
+
+function renderText(p: WaveStatusPayload): string {
+  const lines: string[] = [];
+  const execNames = p.executors.map((e) => e.name).join(', ') || '(none)';
+  lines.push(`wave ${p.id}  [${p.state}]  from=${p.from}  →  ${execNames}`);
+  lines.push('');
+
+  if (p.executors.length === 0) {
+    lines.push('  (no executors assigned)');
+    return lines.join('\n');
+  }
+
+  // Single-executor compact form: one summary line per executor, no
+  // section heading. Keeps the verb useful for the common case rather
+  // than emitting a 6-line block for a 1-actor wave.
+  if (p.executors.length === 1) {
+    const e = p.executors[0]!;
+    lines.push(`executor: ${e.name}` + (e.claim_held ? ' (claim_held)' : ''));
+    if (e.witness_note) {
+      lines.push(`  witness: ${e.witness_note}` + (e.witness_session ? `  [session=${e.witness_session}]` : ''));
+    }
+    if (e.last_attributable_at) {
+      lines.push(`  last write: ${e.last_attributable_at}`);
+    }
+    lines.push('');
+    lines.push(...renderAgeFooter(p));
+    return lines.join('\n');
+  }
+
+  // Multi-executor: full per-executor block.
+  lines.push('executors:');
+  for (const e of p.executors) {
+    const claim = e.claim_held ? '  [claim_held]' : '';
+    const sess = e.witness_session ? `  session=${e.witness_session}` : '';
+    lines.push(`  ${e.name}${claim}${sess}`);
+    if (e.witness_note) {
+      lines.push(`    witness: ${e.witness_note}`);
+    }
+    if (e.last_attributable_at) {
+      lines.push(`    last write: ${e.last_attributable_at}`);
+    } else {
+      // Per-executor band-driven rendering. The age-threshold contract
+      // from the issue lives here — different text for fresh / in-
+      // progress / stale so a just-approved wave isn't unfairly flagged.
+      switch (e.activity_band) {
+        case 'fresh':
+          // Suppress noise on a fresh wave; the executor may simply
+          // not have witnessed yet.
+          break;
+        case 'in-progress':
+          lines.push(`    (in progress — no recent attributable write)`);
+          break;
+        case 'stale':
+          if (e.witness_note) {
+            lines.push(`    ⚠ stale — witness recorded but no transition by this actor`);
+          } else {
+            lines.push(`    ⚠ stale — no in-flight progress note recorded`);
+          }
+          break;
+        case 'active':
+          // Should not reach here (active implies last_attributable_at
+          // is set), but cover it explicitly.
+          break;
+      }
+    }
+  }
+  lines.push('');
+  lines.push(...renderAgeFooter(p));
+  return lines.join('\n');
+}
+
+function renderAgeFooter(p: WaveStatusPayload): string[] {
+  if (p.age_ms === null) {
+    return [`wave state: ${p.state}   (not yet approved — age undefined)`];
+  }
+  const ageHuman = formatDuration(p.age_ms);
+  const bandTag =
+    p.age_band === 'fresh'
+      ? 'fresh'
+      : p.age_band === 'in-progress'
+        ? 'in-progress'
+        : 'stale';
+  return [`wave state: ${p.state}   age: ${ageHuman} (${bandTag})`];
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60 * 1000) return `${Math.floor(ms / 1000)}s`;
+  if (ms < 60 * 60 * 1000) return `${Math.floor(ms / 60000)}m`;
+  const hours = Math.floor(ms / (60 * 60 * 1000));
+  const remMin = Math.floor((ms % (60 * 60 * 1000)) / 60000);
+  return remMin > 0 ? `${hours}h${remMin}m` : `${hours}h`;
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -48,6 +48,7 @@ import {
 import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
+import { waveStatusCmd } from './handlers/waveStatus.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
@@ -284,6 +285,7 @@ const KNOWN_COMMANDS = [
   'rest',
   'wake',
   'farewell',
+  'wave-status',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -457,6 +459,8 @@ async function dispatch(
       return await suggestCmd(c, args);
     case 'transcript':
       return await transcriptCmd(c, args);
+    case 'wave-status':
+      return await waveStatusCmd(c, args);
     case 'summarize':
       return await summarizeCmd(c, args);
     case 'why':

--- a/tests/interface/waveStatus295.test.ts
+++ b/tests/interface/waveStatus295.test.ts
@@ -1,0 +1,218 @@
+// #295 — gate wave-status regression suite.
+//
+// Acceptance per the issue:
+//   - works on any state (pending / approved / executing / completed / failed / denied)
+//   - single-executor renders compact form (one summary line)
+//   - multi-executor with witnesses renders the per-executor block
+//   - multi-executor with no witnesses + age threshold:
+//       fresh (<5min)        → no warning
+//       in-progress (5-30m)  → "(in progress — no recent attributable write)"
+//       stale (≥30m, never)  → "⚠ stale — no in-flight progress note recorded"
+//   - non-existent id → exit 1 with notFoundHint
+//
+// Time-sensitive bands are exercised by injecting a stale approve
+// timestamp via direct YAML edit — the alternative (waiting real
+// 30 minutes) would be hostile to CI.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(cwd: string, args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, encoding: 'utf8' });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(extraConfig = ''): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-wave-status-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n' + extraConfig,
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob', 'critic']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+// -------------------- non-existent id --------------------
+
+test('#295: wave-status on non-existent id exits 1 with notFoundHint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['wave-status', '9999-99-99-9999']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found: 9999-99-99-9999/);
+});
+
+// -------------------- single-executor compact form --------------------
+
+test('#295: single-executor wave renders compact form (one line)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'single-actor work',
+    '--reason', 'solo slice',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+
+  const text = runGate(root, ['wave-status', id, '--format', 'text']);
+  assert.equal(text.status, 0, text.stderr);
+  assert.match(text.stdout, /wave [\d-]+\s+\[approved\]\s+from=alice/);
+  assert.match(text.stdout, /executor: alice/);
+  // The "executors:" header is the multi-executor surface; single-
+  // actor compact form must NOT use it.
+  assert.doesNotMatch(text.stdout, /\nexecutors:\n/);
+});
+
+// -------------------- multi-executor with witnesses --------------------
+
+test('#295: multi-executor with witnesses renders the per-executor block', (t) => {
+  const { root, cleanup } = bootstrap('profile: swarm\n');
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'eris',
+    '--executors', 'alice,bob',
+    '--action', 'parallel work',
+    '--reason', 'two slices',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+  runGate(root, ['witness', id, '--by', 'alice', '--note', 'claim slice 1']);
+  runGate(root, ['witness', id, '--by', 'bob', '--note', 'claim slice 2']);
+
+  const r = runGate(root, ['wave-status', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.state, 'approved');
+  assert.equal(payload.executors.length, 2);
+
+  const alice = payload.executors.find((e: { name: string }) => e.name === 'alice');
+  const bob = payload.executors.find((e: { name: string }) => e.name === 'bob');
+  assert.equal(alice.witness_note, 'claim slice 1');
+  assert.equal(bob.witness_note, 'claim slice 2');
+
+  const text = runGate(root, ['wave-status', id, '--format', 'text']);
+  assert.match(text.stdout, /executors:/);
+  assert.match(text.stdout, /alice/);
+  assert.match(text.stdout, /witness: claim slice 1/);
+  assert.match(text.stdout, /bob/);
+  assert.match(text.stdout, /witness: claim slice 2/);
+});
+
+// -------------------- fresh wave: no warning --------------------
+
+test('#295: fresh wave (<5min) suppresses stale warning even with no witness', (t) => {
+  const { root, cleanup } = bootstrap('profile: swarm\n');
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'eris',
+    '--executors', 'alice,bob',
+    '--action', 'fresh wave',
+    '--reason', 'no witnesses yet',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+
+  const r = runGate(root, ['wave-status', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.age_band, 'fresh');
+  // No witnesses, no claims — but age is fresh so no stale warning.
+  const text = runGate(root, ['wave-status', id, '--format', 'text']);
+  assert.doesNotMatch(text.stdout, /⚠ stale/);
+  assert.doesNotMatch(text.stdout, /in progress — no recent/);
+});
+
+// -------------------- stale wave: ⚠ surfaces --------------------
+
+test('#295: stale wave (≥30min approved, no witnesses) surfaces ⚠ stale rendering', (t) => {
+  const { root, cleanup } = bootstrap('profile: swarm\n');
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'eris',
+    '--executors', 'alice,bob',
+    '--action', 'stale ceremony',
+    '--reason', 'witnesses never came',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+
+  // Sabotage the approved_at timestamp to push wave age past 30 min.
+  // Direct YAML edit — same approach the boot malformed-records test
+  // uses. The file lives under requests/approved/<id>.yaml after the
+  // approve transition.
+  const approvedDir = join(root, 'requests', 'approved');
+  const fname = `${id}.yaml`;
+  const path = join(approvedDir, fname);
+  const yaml = readFileSync(path, 'utf8');
+  // Push the approved entry back by 45 minutes.
+  const oldTime = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+  const patched = yaml.replace(
+    /(state: approved\n\s+by: critic\n\s+at: )[^\n]+/,
+    `$1${oldTime}`,
+  );
+  writeFileSync(path, patched);
+
+  const r = runGate(root, ['wave-status', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.age_band, 'stale', `expected stale band, got: ${payload.age_band} (age_ms=${payload.age_ms})`);
+  for (const e of payload.executors) {
+    assert.equal(e.activity_band, 'stale');
+  }
+
+  const text = runGate(root, ['wave-status', id, '--format', 'text']);
+  assert.match(text.stdout, /⚠ stale — no in-flight progress note recorded/);
+});
+
+// -------------------- terminal-state still works --------------------
+
+test('#295: terminal-state wave (completed) still renders without crashing', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'completed wave',
+    '--reason', 'lifecycle through',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+  runGate(root, ['execute', id, '--by', 'alice']);
+  runGate(root, ['complete', id, '--by', 'alice', '--note', 'done']);
+
+  const r = runGate(root, ['wave-status', id, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.state, 'completed');
+  // The executor `alice` has attributable status_log entries
+  // (execute + complete) — `last_attributable_at` should be set even
+  // though witnesses were auto-released on terminal transition.
+  assert.equal(payload.executors.length, 1);
+  assert.ok(payload.executors[0].last_attributable_at !== null,
+    `expected alice's last_attributable_at to be populated from status_log; got: ${JSON.stringify(payload.executors[0])}`);
+  assert.equal(payload.executors[0].activity_band, 'active');
+});


### PR DESCRIPTION
## Summary

New read verb \`gate wave-status <id>\` composing per-executor view from existing substrate fields. Sibling of \`gate boot\`'s cross-request overlap (#234): boot = actor-axis, wave-status = wave-axis.

## Behavior

\`\`\`
$ gate wave-status 2026-05-11-0001 --format text
wave 2026-05-11-0001  [completed]  from=eris  →  agent-driftext, agent-fallbackhint

executors:
  agent-driftext
    last write: 2026-05-11T02:41:28.536Z
  agent-fallbackhint
    ⚠ stale — no in-flight progress note recorded

wave state: completed   age: 46m (stale)
\`\`\`

This is the real swarm wave from PR #296 viewed through the new verb. The output **makes the #294 awkwardness visible**: agent-fallbackhint witnessed the wave but never landed a state transition (since complete fired only once, by agent-driftext), so wave-status shows the asymmetry that the substrate previously carried only implicitly.

## Acceptance (per #295)

- ✅ Works on any state — pending / approved / executing / completed / failed / denied
- ✅ Single-executor renders compact one-line form
- ✅ Multi-executor renders per-executor block (witness + claim + last write)
- ✅ Age-threshold disambiguation per my #295 design comment:
  - \`< 5 min\` → no warning (fresh, witnesses may be incoming)
  - \`5-30 min\` → \`(in progress — no recent attributable write)\`
  - \`≥ 30 min\` → \`⚠ stale — no in-flight progress note recorded\`
- ✅ Non-existent id → exit 1 with notFoundHint
- ✅ \`gate schema\` lists the verb under \`category: 'read'\` with full input/output schema
- ✅ Forward-compatible with #294 — v1 uses witness-inference, pivots to structured \`executors[].status\` when that ships

## Implementation choice — \`last_attributable_at\`

Witness notes are **untimestamped** on the current Request schema; only status_log entries carry per-actor timestamps. v1 derives "last attributable activity" by scanning status_log for entries where \`by === executor\`. This is honest about the schema limitation — the ceremony-swarm failure mode (executors named who never landed a state transition) surfaces as \`last_attributable_at === null\` + \`activity_band === 'stale'\`.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 1482/1482 pass (+6 regression tests)
- [x] Time-injection test (stale band) backdates the approved entry rather than waiting 30 real minutes
- [x] Manual smoke against \`substrate/swarm-experiments/2026-05-11-eris-swarm-test/2026-05-11-0001\` (real swarm wave from PR #296) — verb correctly surfaces the asymmetry
- [ ] CI green

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)