### PR TITLE
fix(294 followup): hydrate sanitize + auto-review on slice-only + vocab/style unify (closes #312 #313 #314)

### DIFF
--- a/docs/plugin-schema.md
+++ b/docs/plugin-schema.md
@@ -383,11 +383,13 @@ forces one or the other on every new `Request` getter.
 - `mutationSeq` — internal sequence number for in-memory mutation
   ordering. Not stable across processes.
 - `executorRecords` — structured per-executor slice records (issue #294
-  internal shape: `{ name, status, completedAt?, note? }`). Plugins
-  should read `executors` (the `MemberName[]` name list) and, when a
-  slice-status check is needed, call `executorStatus(name)` — both are
-  stable wrappers; the record shape is part of the internal migration
-  surface and may grow new fields without notice.
+  internal shape: `{ name, status, completedAt?, note? }`). The record
+  object shape is part of the internal migration surface and may grow
+  new fields without notice — plugins should NOT destructure it. Use
+  the stable wrappers instead: `executors` (the `MemberName[]` name
+  list) for membership / iteration, and `executorStatus(name)` (method)
+  for a slice-status check by name. Those two surfaces are version-
+  stable.
 
 If you reach for one of these inside a plugin, you almost certainly
 want a different field — open an issue describing the use case.

--- a/src/infrastructure/persistence/YamlRequestRepository.ts
+++ b/src/infrastructure/persistence/YamlRequestRepository.ts
@@ -17,6 +17,7 @@ import { Review } from '../../domain/request/Review.js';
 import { isRequestDepth } from '../../domain/request/RequestDepth.js';
 import { Thank } from '../../domain/request/Thank.js';
 import { MemberName } from '../../domain/member/MemberName.js';
+import { sanitizeText as sharedSanitizeText } from '../../domain/shared/sanitizeText.js';
 import {
   RequestRepository,
   RequestIdCollision,
@@ -555,7 +556,26 @@ function hydrate(
             (rec as { completedAt?: string }).completedAt = ro['completed_at'] as string;
           }
           if (typeof ro['note'] === 'string' && (ro['note'] as string).length > 0) {
-            (rec as { note?: string }).note = ro['note'] as string;
+            // Defense in depth (#7 elevated by #294 devil round-2): a
+            // hand-edited or corrupted YAML can carry control bytes in
+            // the note. The domain save path always runs sanitizeText
+            // before persisting, but a record planted out-of-band
+            // would bypass that — and the render-time newline strip
+            // in wave-status text mode (#294 §Security 1) covers only
+            // newlines, not C0 escape sequences. Sanitize at hydrate so
+            // every read-then-render path sees a normalized note.
+            try {
+              const cleaned = sharedSanitizeText(ro['note'], `executors[${i}].note`, {
+                maxLen: 4096,
+                requireNonEmpty: false,
+              });
+              if (cleaned.length > 0) {
+                (rec as { note?: string }).note = cleaned;
+              }
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              onMalformed(source, `executors[${i}].note dropped at hydrate: ${msg}`);
+            }
           }
           list.push(rec);
         }

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -1210,10 +1210,20 @@ function emitSliceClose(
   if (remaining.length > 0) {
     lines.push('open slices remaining:');
     for (const rec of remaining) {
-      lines.push(`  - ${rec.name.value} (status: ${rec.status})`);
+      // Tag aligned with `gate wave-status` rendering (#294 vocab
+      // unify): `[?]` for legacy `unknown`, plain status name for
+      // recognized values. Keeping the two surfaces' vocabulary in
+      // lockstep so an operator who reads `wave-status` first and
+      // `complete` second sees the same shape for the same record.
+      const tag = rec.status === 'unknown' ? '[?]' : `[${rec.status}]`;
+      lines.push(`  - ${rec.name.value}  ${tag}`);
     }
+    // Style aligned with stdout success-mode `→ next:` convention
+    // (matches boot.ts:1564, 1569). Previously bare `next:` was a
+    // third style alongside stderr-error `  next:` and stdout-success
+    // `→ next:`; consolidating to one style per channel.
     lines.push(
-      `next: each remaining executor must run \`gate ${verb} ${r.id.value} --by <name>\` to terminate the wave.`,
+      `→ next: each remaining executor must run \`gate ${verb} ${r.id.value} --by <name>\` to terminate the wave.`,
     );
   }
   for (const e of extraLines) lines.push(e);
@@ -1263,15 +1273,6 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   const priorState = priorComplete?.state;
   const r = await c.requestUC.complete(id, by, note, invokedBy);
   await fireAfterHook(c.hookSubscriptions, 'complete', r, by);
-  const extraLines: string[] = [];
-  if (r.autoReview) {
-    const reviewer = r.autoReview.value;
-    const tpl =
-      `gate review ${id} --by ${reviewer} --lense devil ` +
-      `--verdict <ok|concern|reject> "<comment>"`;
-    extraLines.push(`→ auto-review pending for: ${reviewer}`);
-    extraLines.push(`  ${tpl}`);
-  }
   // Issue #294: slice-only vs wave-terminal output split.
   //   - Wave terminal: state changed (e.g. executing → completed).
   //     Existing output kept ("✓ completed: <id>").
@@ -1281,6 +1282,21 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   //     slices so the caller knows the wave isn't done.
   const stateUnchanged = priorState !== undefined && priorState === r.state;
   const isSliceOnly = stateUnchanged && r.hasExecutor(by);
+  // auto-review is a WAVE-level callback — it fires once the wave is
+  // terminal. Surfacing the "→ auto-review pending" hint on a slice-
+  // only close would mislead the operator into thinking the reviewer
+  // can act now (they cannot — the wave hasn't transitioned). Suppress
+  // the hint on slice-only path; it will surface on the closing-slice
+  // call when the wave finally moves to its terminal state.
+  const extraLines: string[] = [];
+  if (r.autoReview && !isSliceOnly) {
+    const reviewer = r.autoReview.value;
+    const tpl =
+      `gate review ${id} --by ${reviewer} --lense devil ` +
+      `--verdict <ok|concern|reject> "<comment>"`;
+    extraLines.push(`→ auto-review pending for: ${reviewer}`);
+    extraLines.push(`  ${tpl}`);
+  }
   if (isSliceOnly) {
     emitSliceClose(r, by, 'complete', c.config, parseFormat(args), extraLines);
     return 0;

--- a/tests/interface/sliceClosure294.test.ts
+++ b/tests/interface/sliceClosure294.test.ts
@@ -129,8 +129,8 @@ test('#294: gate complete partial — 1 of 2 slices closed, wave state unchanged
   assert.equal(closed.status, 0, `complete failed: ${closed.stderr}`);
   assert.match(closed.stdout, /✓ slice closed: .* by miki/);
   assert.match(closed.stdout, /open slices remaining:/);
-  assert.match(closed.stdout, /- leysia \(status: pending\)/);
-  assert.match(closed.stdout, /next: each remaining executor must run/);
+  assert.match(closed.stdout, /- leysia\s+\[pending\]/);
+  assert.match(closed.stdout, /→ next: each remaining executor must run/);
 
   // miki should NOT appear in "remaining" (their slice is closed).
   const remainingBlock = closed.stdout.split('open slices remaining:')[1] ?? '';
@@ -185,7 +185,7 @@ test('#294: gate fail partial — 1 of 2 slices failed, wave state unchanged', (
   assert.equal(failed.status, 0, `fail failed: ${failed.stderr}`);
   assert.match(failed.stdout, /✓ slice failed: .* by miki/);
   assert.match(failed.stdout, /open slices remaining:/);
-  assert.match(failed.stdout, /- leysia \(status: pending\)/);
+  assert.match(failed.stdout, /- leysia\s+\[pending\]/);
 
   // Wave stays executing — any-fail-wave-fail composition only fires
   // once every slice is terminal.
@@ -440,4 +440,79 @@ test('#294 / devil round-2 N1: concurrent slice-close races retry instead of err
   for (const e of j.executors) {
     assert.equal(e.status, 'completed');
   }
+});
+
+// -------------------- auto-review hint suppression on slice-only path --------------------
+
+test('#294 followup: auto-review pending hint is suppressed on slice-only complete (Noir review §3)', (t) => {
+  // Auto-review fires once the wave is terminal — surfacing
+  // "→ auto-review pending" on a slice-only close would mislead the
+  // operator into thinking the reviewer can act now. The hint MUST
+  // surface only on the closing-slice call (when the wave moves to
+  // its terminal state).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia', 'bob']);
+
+  // Two-executor wave WITH an auto-reviewer (bob).
+  const created = run(root, [
+    'request',
+    '--from', 'alice',
+    '--action', 'parallel slice work',
+    '--reason', 'two-executor wave with auto-review',
+    '--executors', 'miki,leysia',
+    '--auto-review', 'bob',
+    '--format', 'json',
+  ]);
+  assert.equal(created.status, 0, `request failed: ${created.stderr}`);
+  const id = (JSON.parse(created.stdout) as { id: string }).id;
+  run(root, ['approve', id, '--by', 'eris']);
+  run(root, ['execute', id, '--by', 'miki']);
+
+  // miki closes — slice-only path. Auto-review hint MUST NOT appear.
+  const partial = run(root, ['complete', id, '--by', 'miki', '--note', 'm done']);
+  assert.equal(partial.status, 0);
+  assert.match(partial.stdout, /✓ slice closed/);
+  assert.doesNotMatch(partial.stdout, /auto-review pending/);
+
+  // leysia closes — wave terminal. Auto-review hint MUST appear.
+  const final = run(root, ['complete', id, '--by', 'leysia', '--note', 'l done']);
+  assert.equal(final.status, 0);
+  assert.match(final.stdout, /✓ completed:/);
+  assert.match(final.stdout, /auto-review pending for: bob/);
+});
+
+// -------------------- hydrate sanitize (defense-in-depth) --------------------
+
+test('#294 followup: hand-edited control bytes in executors[].note are stripped at hydrate (#7 elevated)', (t) => {
+  // Domain sanitizeText runs on every save path; a YAML record planted
+  // out-of-band (hand edit, corrupt copy) bypasses that and could carry
+  // C0 escape sequences. wave-status text-mode flattenForRender covers
+  // only newlines. Defense-in-depth: hydrate sanitizes too.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  registerAll(root, ['alice', 'miki', 'leysia']);
+  const id = bootstrapTwoExecWave(root, ['miki', 'leysia']);
+  // Close miki's slice via normal verb, then plant a control byte in
+  // the on-disk note by direct YAML rewrite (simulating a hand edit).
+  run(root, ['complete', id, '--by', 'miki', '--note', 'clean']);
+  const path = join(root, 'requests', 'executing', `${id}.yaml`);
+  const raw = readFileSync(path, 'utf8');
+  // Inject ESC + ANSI color code into miki's note.
+  const tampered = raw.replace(
+    /note: clean/,
+    'note: "clean\\u001b[31mRED\\u001b[0m"',
+  );
+  writeFileSync(path, tampered);
+  // Hydrate via wave-status; the C0 bytes should be stripped before
+  // they reach render.
+  const ws = run(root, ['wave-status', id, '--format', 'json']);
+  assert.equal(ws.status, 0, `wave-status failed: ${ws.stderr}`);
+  const j = JSON.parse(ws.stdout) as {
+    executors: Array<{ name: string; slice_note: string | null }>;
+  };
+  const miki = j.executors.find((e) => e.name === 'miki');
+  assert.ok(miki, 'miki not in wave-status output');
+  // C0 escape () must NOT survive into the rendered note.
+  assert.doesNotMatch(miki!.slice_note ?? '', //);
 });


### PR DESCRIPTION
## Three small followups to PR #311 (#294 PR-A2)

Closes #312 #313 #314. Surfaced during devil round-2 + Noir ship-front review on PR #311 and parked as defer at ship time per `trap_dogfood_deferred_open_rot` — landing them here as a single tight followup PR.

## What ships

### Closes #312 — hydrate sanitize (defense in depth)

`sanitizeText` runs at hydrate on `executors[i].note`. Domain save path already sanitizes; this is defense against out-of-band record planting (hand edit, corrupted copy, attacker with filesystem access). `wave-status` text-mode's `flattenForRender` covered `\r\n` only; this widens to all C0 escape sequences (ANSI color, terminal control, etc.).

### Closes #313 — auto-review hint suppression on slice-only close

`gate complete --by X` on a multi-executor wave can either close one slice (wave stays executing) or close the last slice (wave moves terminal). Auto-review fires only on wave-terminal — surfacing `→ auto-review pending` on a slice-only close was a soft lie. Now suppressed on slice-only path; surfaces on the closing-slice call when the wave actually moves terminal.

### Closes #314 — vocab / style unify

Three small drifts:
1. **Per-executor status tag** — `gate complete`'s "open slices remaining" block used `(status: pending)`; `gate wave-status` uses `[pending]` / `[?]`. Aligned to brackets so both surfaces describe the same record the same way.
2. **`next:` style** — bare `next:` was a third flavor alongside stderr-error `  next:` and stdout-success `→ next:` (boot.ts:1564, 1569). Consolidated to `→ next:`.
3. **`docs/plugin-schema.md`** — `executorRecords` paragraph tightened: explicitly the internal migration surface plugins should NOT destructure; `executors` (getter) and `executorStatus(name)` (method) explicitly the version-stable surfaces.

## Test plan

- [x] `npm run build` clean
- [x] 1511 / 1511 pass (1509 baseline + 2 new tests):
  - `#294 followup: auto-review pending hint is suppressed on slice-only complete`
  - `#294 followup: hand-edited control bytes in executors[].note are stripped at hydrate`
- [x] Existing tests updated for new vocab (`[pending]` instead of `(status: pending)`, `→ next:` instead of bare `next:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
