### PR TITLE
feat(gate): resume --with-doctor (closes #306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,20 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate resume --with-doctor [--auto-repair]` — surface substrate health at session re-entry (closes #306)**
+  ([#306](https://github.com/eris-ths/guild-cli/issues/306)).
+  New flags on the existing `gate resume` verb that fold a `gate
+  doctor` summary into the resume payload (`doctor.findings`,
+  `doctor.summary`, `doctor.is_clean`). With `--auto-repair`,
+  quarantineable findings are processed inline via the repair
+  use case and the outcome is reported under `doctor.auto_repair`.
+  Default behavior is unchanged — without `--with-doctor` the JSON
+  shape and text prose are byte-identical to pre-#306. Closes the
+  2-step friction `eris-gate-flow.md` flagged: a dirty substrate
+  now surfaces at the moment of session boot, before the agent
+  starts writing again. `--auto-repair` without `--with-doctor`
+  is rejected with a pointed error.
+
 - **`gate wave-status <id>` — per-executor in-flight slice status (closes #295)**
   ([#295](https://github.com/eris-ths/guild-cli/issues/295)).
   New read verb that composes per-executor view from existing

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -6,12 +6,47 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 
-const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'locale']);
+const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'format',
+  'locale',
+  'with-doctor',
+  'auto-repair',
+]);
 import { Request, StatusLogEntry } from '../../../domain/request/Request.js';
 import { collectUtterances, Utterance, RequestJSON } from '../voices.js';
 import { deriveSuggestedNext, SuggestedNext } from './writeFormat.js';
 import { UnrespondedConcernsEntry } from '../../../application/concern/UnrespondedConcernsQuery.js';
 import type { SessionEvent, SessionKind } from '../../../domain/session/SessionEvent.js';
+import {
+  DiagnosticReport,
+  DiagnosticFinding,
+} from '../../../domain/diagnostic/DiagnosticReport.js';
+import { RepairResult } from '../../../application/repair/RepairUseCases.js';
+
+/**
+ * #306 — `--with-doctor` augments the resume payload with a
+ * `gate doctor` summary. `--auto-repair` (only meaningful with
+ * `--with-doctor`) additionally invokes the repair use case in
+ * `--apply` mode: quarantine actions run, destructive ones are
+ * skipped. The point is to surface a dirty substrate at the moment
+ * of session re-entry, before the agent starts writing again.
+ *
+ * The shape stays backward compatible — `doctor` is omitted from
+ * the JSON when the flag is absent, and the text mode appends a
+ * trailing section instead of restructuring the prose.
+ */
+interface DoctorSection {
+  readonly findings: ReadonlyArray<DiagnosticFinding>;
+  readonly summary: string;
+  readonly is_clean: boolean;
+  readonly auto_repair?: {
+    readonly attempted: boolean;
+    readonly quarantined: number;
+    readonly skipped: number;
+    readonly errors: number;
+    readonly summary: string;
+  };
+}
 
 /**
  * Most recent session boundary stamped by the resuming actor
@@ -130,6 +165,14 @@ interface ResumePayload {
   unresponded_concerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested_next: SuggestedNext | null;
   restoration_prose: string;
+  /**
+   * #306 — present only when `--with-doctor` was passed. Carries the
+   * doctor summary (+ optional auto-repair outcome) so the agent can
+   * see substrate health at the moment of resume without a second
+   * verb call. Omitted entirely (key absent) when the flag is off,
+   * preserving the pre-#306 JSON shape for existing consumers.
+   */
+  doctor?: DoctorSection;
 }
 
 export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -137,6 +180,15 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  const withDoctor = args.options['with-doctor'] === true;
+  const autoRepair = args.options['auto-repair'] === true;
+  if (autoRepair && !withDoctor) {
+    process.stderr.write(
+      'error: --auto-repair requires --with-doctor\n' +
+        '  next: gate resume --with-doctor --auto-repair\n',
+    );
+    return 1;
   }
   const actor = resolveGuildActor();
   if (!actor || actor.length === 0) {
@@ -241,6 +293,26 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     locale,
   });
 
+  // #306 — doctor section. Only built when --with-doctor was passed
+  // so the default surface stays byte-identical to pre-#306 callers.
+  // Auto-repair runs inline (apply mode) when requested; quarantine
+  // is the only action kind today so "destructive skip" is moot for
+  // now — keeping the flag dichotomy in place anticipates future
+  // RepairAction kinds that may need explicit consent.
+  let doctorSection: DoctorSection | undefined;
+  if (withDoctor) {
+    const report = await c.diagnosticUC.run();
+    doctorSection = buildDoctorSection(report, locale);
+    if (autoRepair && !report.isClean) {
+      const plan = c.repairUC.plan(report.findings);
+      const result = await c.repairUC.apply(plan);
+      doctorSection = {
+        ...doctorSection,
+        auto_repair: buildAutoRepairSummary(result, locale),
+      };
+    }
+  }
+
   const payload: ResumePayload = {
     actor,
     session_hint: sessionHint,
@@ -255,14 +327,112 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     unresponded_concerns: unrespondedConcerns,
     suggested_next: suggested,
     restoration_prose: restorationProse,
+    ...(doctorSection !== undefined ? { doctor: doctorSection } : {}),
   };
 
   if (format === 'json') {
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
   } else {
     process.stdout.write(restorationProse + '\n');
+    if (doctorSection !== undefined) {
+      process.stdout.write('\n' + renderDoctorSectionText(doctorSection, locale) + '\n');
+    }
   }
   return 0;
+}
+
+function buildDoctorSection(
+  report: DiagnosticReport,
+  locale: 'en' | 'ja',
+): DoctorSection {
+  const findings = report.findings;
+  const s = report.summary;
+  const summary =
+    locale === 'ja'
+      ? `members ${s.members.malformed}/${s.members.total} 不正、requests ${s.requests.malformed}/${s.requests.total} 不正、issues ${s.issues.malformed}/${s.issues.total} 不正`
+      : `members ${s.members.malformed}/${s.members.total} malformed, requests ${s.requests.malformed}/${s.requests.total} malformed, issues ${s.issues.malformed}/${s.issues.total} malformed`;
+  return {
+    findings,
+    summary,
+    is_clean: report.isClean,
+  };
+}
+
+function buildAutoRepairSummary(
+  result: RepairResult,
+  locale: 'en' | 'ja',
+): {
+  attempted: boolean;
+  quarantined: number;
+  skipped: number;
+  errors: number;
+  summary: string;
+} {
+  const s = result.summary;
+  const summary =
+    locale === 'ja'
+      ? `auto-repair: ${s.quarantined} quarantine、${s.skipped} skip、${s.error} error`
+      : `auto-repair: ${s.quarantined} quarantined, ${s.skipped} skipped, ${s.error} error(s)`;
+  return {
+    attempted: true,
+    quarantined: s.quarantined,
+    skipped: s.skipped,
+    errors: s.error,
+    summary,
+  };
+}
+
+function renderDoctorSectionText(
+  d: DoctorSection,
+  locale: 'en' | 'ja',
+): string {
+  const lines: string[] = [];
+  if (locale === 'ja') {
+    lines.push('# substrate doctor');
+    if (d.is_clean) {
+      lines.push('✓ clean — malformed record なし');
+    } else {
+      lines.push(`✗ ${d.findings.length} finding(s) — ${d.summary}`);
+      for (const f of d.findings.slice(0, 10)) {
+        lines.push(`  - [${f.area}/${f.kind}] ${f.source}`);
+      }
+      if (d.findings.length > 10) {
+        lines.push(`  ... 他 ${d.findings.length - 10} 件`);
+      }
+    }
+    if (d.auto_repair !== undefined) {
+      lines.push('');
+      lines.push(d.auto_repair.summary);
+    } else if (!d.is_clean) {
+      lines.push('');
+      lines.push(
+        'next: `gate doctor --format json | gate repair --apply` で隔離、または再実行時に `--auto-repair` を付与',
+      );
+    }
+  } else {
+    lines.push('# substrate doctor');
+    if (d.is_clean) {
+      lines.push('✓ clean — no malformed records');
+    } else {
+      lines.push(`✗ ${d.findings.length} finding(s) — ${d.summary}`);
+      for (const f of d.findings.slice(0, 10)) {
+        lines.push(`  - [${f.area}/${f.kind}] ${f.source}`);
+      }
+      if (d.findings.length > 10) {
+        lines.push(`  ... and ${d.findings.length - 10} more`);
+      }
+    }
+    if (d.auto_repair !== undefined) {
+      lines.push('');
+      lines.push(d.auto_repair.summary);
+    } else if (!d.is_clean) {
+      lines.push('');
+      lines.push(
+        'next: pipe `gate doctor --format json | gate repair --apply` or re-run with `--auto-repair`',
+      );
+    }
+  }
+  return lines.join('\n');
 }
 
 function transitionToJSON(

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -677,6 +677,16 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         format: formatField,
         locale: { type: 'string', enum: ['en', 'ja'], description: 'prose language; also via GUILD_LOCALE env' },
+        'with-doctor': {
+          type: 'boolean',
+          description:
+            '#306 — augment payload with a `gate doctor` summary so session re-entry surfaces a dirty substrate before the agent starts writing again.',
+        },
+        'auto-repair': {
+          type: 'boolean',
+          description:
+            '#306 — only meaningful with --with-doctor; runs `gate repair --apply` inline for quarantineable findings. Without --with-doctor this flag is rejected.',
+        },
       },
     },
     output: {
@@ -710,6 +720,26 @@ const VERBS: readonly VerbSchema[] = [
         },
         suggested_next: { type: 'object' },
         restoration_prose: str,
+        doctor: {
+          type: 'object',
+          description:
+            '#306 — present only when --with-doctor was passed. Carries the diagnostic findings and a one-line summary; when --auto-repair was also passed, an `auto_repair` sub-object reports the quarantine outcome.',
+          properties: {
+            findings: { type: 'array', items: { type: 'object' } },
+            summary: str,
+            is_clean: { type: 'boolean' },
+            auto_repair: {
+              type: 'object',
+              properties: {
+                attempted: { type: 'boolean' },
+                quarantined: { type: 'integer' },
+                skipped: { type: 'integer' },
+                errors: { type: 'integer' },
+                summary: str,
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/tests/interface/resumeWithDoctor.test.ts
+++ b/tests/interface/resumeWithDoctor.test.ts
@@ -1,0 +1,203 @@
+// gate resume --with-doctor [--auto-repair] — #306
+//
+// Invariants:
+//   1. --with-doctor on clean substrate → doctor.is_clean=true, no findings,
+//      no auto_repair key (only present when --auto-repair flag set).
+//   2. --with-doctor on dirty substrate → doctor.findings non-empty, summary
+//      mentions the malformed counts. JSON payload retains pre-#306 keys.
+//   3. --with-doctor --auto-repair on dirty substrate → quarantines findings,
+//      auto_repair.quarantined > 0, and a re-run shows is_clean=true.
+//   4. --auto-repair without --with-doctor → exit 1 with a pointed error.
+//   5. text mode with --with-doctor → appends a "substrate doctor" section
+//      to the prose; the pre-existing prose body remains intact.
+//   6. Without --with-doctor → JSON has no `doctor` key (forward compat).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const GUILD = resolve(here, '../../../bin/guild.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-resume-doctor-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+function runGuild(cwd: string, args: string[]): void {
+  spawnSync(process.execPath, [GUILD, ...args], { cwd, stdio: 'ignore' });
+}
+
+test('gate resume --with-doctor: clean substrate → is_clean=true, no findings', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(root, ['resume', '--with-doctor'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.ok(payload.doctor, 'doctor section should exist');
+    assert.equal(payload.doctor.is_clean, true);
+    assert.deepEqual(payload.doctor.findings, []);
+    assert.equal(payload.doctor.auto_repair, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume (no --with-doctor): doctor key absent (forward compat)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(root, ['resume'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(
+      'doctor' in payload,
+      false,
+      'doctor key MUST be absent when --with-doctor is off',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor: dirty substrate surfaces findings', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    // Plant a malformed file under requests/ to produce a finding.
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not valid yaml :::\n');
+    const { stdout, status } = runGate(root, ['resume', '--with-doctor'], {
+      GUILD_ACTOR: 'claude',
+    });
+    // resume's exit code is unaffected by doctor findings — resume is
+    // a read verb; non-clean substrate doesn't fail the session boot.
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.ok(payload.doctor);
+    assert.equal(payload.doctor.is_clean, false);
+    assert.ok(payload.doctor.findings.length > 0);
+    assert.match(payload.doctor.summary, /malformed/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --auto-repair: quarantines and re-run is clean', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not valid yaml :::\n');
+    const first = runGate(
+      root,
+      ['resume', '--with-doctor', '--auto-repair'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(first.status, 0);
+    const p1 = JSON.parse(first.stdout);
+    assert.ok(p1.doctor.auto_repair, 'auto_repair block expected');
+    assert.equal(p1.doctor.auto_repair.attempted, true);
+    assert.ok(
+      p1.doctor.auto_repair.quarantined > 0,
+      'at least one finding should be quarantined',
+    );
+    // Re-run: substrate should now be clean.
+    const second = runGate(
+      root,
+      ['resume', '--with-doctor'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    const p2 = JSON.parse(second.stdout);
+    assert.equal(p2.doctor.is_clean, true);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --auto-repair (no --with-doctor): exit 1 with pointed error', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { status, stderr } = runGate(root, ['resume', '--auto-repair'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 1);
+    assert.match(stderr, /--auto-repair requires --with-doctor/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --format text: appends substrate doctor section', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(
+      root,
+      ['resume', '--with-doctor', '--format', 'text'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(status, 0);
+    // pre-existing prose body
+    assert.match(stdout, /resuming as claude/i);
+    // new section
+    assert.match(stdout, /substrate doctor/i);
+    assert.match(stdout, /clean/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --format text on dirty: lists findings + repair hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not yaml :::\n');
+    const { stdout, status } = runGate(
+      root,
+      ['resume', '--with-doctor', '--format', 'text'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(status, 0);
+    assert.match(stdout, /substrate doctor/i);
+    assert.match(stdout, /finding/i);
+    assert.match(stdout, /auto-repair|gate repair/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- `gate resume --with-doctor` folds a `gate doctor` summary into the resume payload (`doctor.findings`, `doctor.summary`, `doctor.is_clean`). The JSON shape stays forward-compatible: when the flag is off, the `doctor` key is omitted entirely.
- `--auto-repair` (only valid with `--with-doctor`) runs `gate repair --apply` inline for quarantineable findings; outcome is surfaced under `doctor.auto_repair`. Without `--with-doctor`, the flag is rejected with a pointed error.
- text mode appends a `# substrate doctor` section to the prose; the pre-existing prose body remains intact.

The 2-step friction `eris-gate-flow.md` named — `gate resume` → eyeball → maybe `gate doctor | gate repair` — collapses into one verb call, so a dirty substrate surfaces at session re-entry instead of after the agent has started writing.

## Why this shape

- **Forward compat is structural, not promised.** Pre-#306 consumers see the same JSON keys because `doctor` only appears under the explicit flag. The schema is updated in lockstep so MCP wirings advertise the new flags (drift detector enforces this).
- **`--auto-repair` requires `--with-doctor`.** Auto-repair without the diagnostic context would be a write verb hiding inside a read verb — the dependency is enforced at parse time, not silently inferred.
- **Quarantine only.** Today's RepairAction kinds are quarantine + no-op; both are safe for unattended auto-application. The flag dichotomy anticipates future destructive kinds needing explicit consent.

## Test plan

- [x] `node --test dist/tests/interface/resumeWithDoctor.test.js` → 7 pass
- [x] `npm test` → 1510 pass, 0 fail
- [x] Verified clean substrate: `doctor.is_clean=true`, `findings=[]`, no `auto_repair` key
- [x] Verified dirty substrate: malformed YAML under `requests/` surfaces in findings
- [x] Verified `--auto-repair` quarantines, and re-run is clean
- [x] Verified backward compat: `gate resume` (no flag) → JSON has no `doctor` key
- [x] Verified text mode appends `# substrate doctor` block on both clean + dirty paths
- [x] Verified `--auto-repair` without `--with-doctor` → exit 1 with `next:` hint

## Files touched

- `src/interface/gate/handlers/resume.ts` — flag parse, doctor invocation, text rendering
- `src/interface/gate/handlers/schema.ts` — schema entries for new input flags + doctor output
- `tests/interface/resumeWithDoctor.test.ts` — 7 cases
- `CHANGELOG.md` — `[Unreleased] / Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)