### PR TITLE
feat(gate): flow-suggest advisory verb (closes #307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate flow-suggest` — advisory verb for picking a flow shape (closes #307)**
+  ([#307](https://github.com/eris-ths/guild-cli/issues/307)).
+  New read verb: `gate flow-suggest --severity <low|med|high> --area <s>
+  [--scope <s>] [--format json|text]`. Maps the (severity, area, scope)
+  tuple to a recommended flow — `fast-track`, `direct-pr`, or
+  `full-request` — and returns the reason plus alternative options.
+  Pure advisory: no substrate writes, no state. The rule engine lives
+  in `application/request/flowSuggest.ts` so a future v2 layer
+  (`guild.config.yaml` override) can wrap it without touching the CLI
+  surface; v1 ships with the hard-coded default rules from the issue.
+  Motivation: ErisMind dogfood surfaced friction where trivial typo
+  fixes were getting routed through the full issue → agora → devil
+  ceremony — `flow-suggest` lets the operator (human or agent) get a
+  one-line "this is a direct PR" answer without re-deriving the
+  trade-off each time.
+
 - **`gate wave-status <id>` — per-executor in-flight slice status (closes #295)**
   ([#295](https://github.com/eris-ths/guild-cli/issues/295)).
   New read verb that composes per-executor view from existing

--- a/src/application/request/flowSuggest.ts
+++ b/src/application/request/flowSuggest.ts
@@ -1,0 +1,135 @@
+// flowSuggest — pure advisory rule engine for `gate flow-suggest`.
+//
+// Purpose: given severity + area (+ optional scope), recommend ONE of
+// three flows so the operator doesn't have to re-derive the trade-off
+// each time. Substrate-free — no I/O, no state. The verb that wraps
+// this is read-only and the engine is a single lookup function.
+//
+// Why a dedicated module (not inlined in the handler): the rule table
+// is the thing future PRs will extend (issue #307 implementation note
+// flagged guild.config.yaml override as a v2 follow-up). Keeping the
+// rule logic in `application/` lets it be imported and exercised by
+// tests without touching the CLI surface, and lets a future override
+// layer (config-driven rule merge) wrap this same pure function.
+//
+// Design choice — explicit if/else over data-driven match table:
+// the rule table from #307 is small (three default rows) and reads
+// as a flat list of guards. A switch/table would compress the code
+// but obscure the precedence: "high severity in a security-adjacent
+// area beats everything else." Branching keeps that precedence as
+// the literal order of `if` statements, which is what reviewers will
+// audit.
+
+/** All three recommended flows the engine can return. */
+export type FlowRecommendation = 'fast-track' | 'direct-pr' | 'full-request';
+
+/** Severity classification (mirrors `gate issues add --severity` enum). */
+export type FlowSeverity = 'low' | 'med' | 'high';
+
+/** Area tag — open string, not an enum: callers pass arbitrary domain
+ * tags (copy/doc/style/bug/auth/data/security/...). The engine
+ * categorises by membership in known buckets and falls back to
+ * `full-request` for anything it doesn't recognise (conservative). */
+export type FlowArea = string;
+
+/** Scope hint — optional, advisory. Not load-bearing in v1 (the rule
+ * table doesn't branch on it), but plumbed through so the JSON
+ * output can echo it back and a v2 rule layer can use it without a
+ * second signature change. */
+export type FlowScope = 'single-file' | 'multi-file' | 'multi-pr' | string;
+
+export interface FlowSuggestInput {
+  severity: FlowSeverity;
+  area: FlowArea;
+  scope?: FlowScope;
+}
+
+export interface FlowSuggestResult {
+  recommended: FlowRecommendation;
+  reason: string;
+  alternatives: FlowRecommendation[];
+}
+
+// Area buckets. Lower-cased on the way in; callers may pass mixed
+// case freely (`Auth`, `COPY`) without surprising the engine.
+const COSMETIC_AREAS: ReadonlySet<string> = new Set([
+  'copy',
+  'doc',
+  'docs',
+  'style',
+]);
+
+const BUG_AREAS: ReadonlySet<string> = new Set(['bug', 'fix']);
+
+const HIGH_RISK_AREAS: ReadonlySet<string> = new Set([
+  'security',
+  'auth',
+  'data',
+]);
+
+/**
+ * Decide which flow to recommend for a (severity, area, scope) tuple.
+ *
+ * Precedence — the order of these branches is the rule:
+ *   1. high severity in a high-risk area (security/auth/data) →
+ *      full-request. The blast radius justifies the ceremony.
+ *   2. low severity in a cosmetic area (copy/doc/style) →
+ *      direct-pr. The most common dogfood friction (#307 motivation).
+ *   3. low/med severity bug → fast-track. Bug fixes that aren't a
+ *      compliance issue benefit from a single-pass record without a
+ *      full agora play.
+ *   4. anything else → full-request. The conservative default: when
+ *      the engine doesn't recognise the shape, pay the ceremony cost
+ *      rather than skip a step the situation might need.
+ */
+export function suggestFlow(input: FlowSuggestInput): FlowSuggestResult {
+  const severity = input.severity;
+  const area = input.area.toLowerCase();
+  const scope = input.scope?.toLowerCase();
+
+  // 1. high-risk area at any meaningful severity → full ceremony.
+  if (HIGH_RISK_AREAS.has(area) && severity === 'high') {
+    return {
+      recommended: 'full-request',
+      reason:
+        `severity=${severity} + area=${area} → high-risk area at high ` +
+        `severity, run the full request → review → ship flow.`,
+      alternatives: ['fast-track'],
+    };
+  }
+
+  // 2. low + cosmetic → direct PR, skip the gate ceremony entirely.
+  if (severity === 'low' && COSMETIC_AREAS.has(area)) {
+    const scopePart = scope ? ` + scope=${scope}` : '';
+    return {
+      recommended: 'direct-pr',
+      reason:
+        `severity=${severity} + area=${area}${scopePart} → cosmetic ` +
+        `low-severity change, a direct PR is enough.`,
+      alternatives: ['fast-track', 'full-request'],
+    };
+  }
+
+  // 3. low/med bug → fast-track (single-pass record, no agora).
+  if ((severity === 'low' || severity === 'med') && BUG_AREAS.has(area)) {
+    return {
+      recommended: 'fast-track',
+      reason:
+        `severity=${severity} + area=${area} → routine bug fix, ` +
+        `fast-track records the change without a full request cycle.`,
+      alternatives: ['full-request'],
+    };
+  }
+
+  // 4. fall-through: be conservative. The recommendation here covers
+  //    every shape the rule table doesn't claim — including high
+  //    severity in non-high-risk areas, med severity in cosmetic /
+  //    unknown areas, and any area the engine doesn't know about.
+  return {
+    recommended: 'full-request',
+    reason:
+      `severity=${severity} + area=${area} → no specific rule matched, ` +
+      `defaulting to full request flow (issue → review → ship).`,
+    alternatives: ['fast-track'],
+  };
+}

--- a/src/interface/gate/handlers/flowSuggest.ts
+++ b/src/interface/gate/handlers/flowSuggest.ts
@@ -1,0 +1,99 @@
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import {
+  suggestFlow,
+  FlowSeverity,
+  FlowSuggestResult,
+} from '../../../application/request/flowSuggest.js';
+
+const FLOW_SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'severity',
+  'area',
+  'scope',
+  'format',
+]);
+
+const SEVERITIES: ReadonlySet<string> = new Set(['low', 'med', 'high']);
+
+/**
+ * gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]
+ *                    [--format json|text]
+ *
+ * Advisory verb: maps (severity, area, scope) → a recommended flow
+ * (fast-track / direct-pr / full-request) plus a reason and the
+ * alternatives the operator can fall back to. Pure read — no
+ * substrate writes. The rule engine lives in
+ * `application/request/flowSuggest.ts` so a future v2 layer (config
+ * override) can wrap it without touching the CLI surface.
+ *
+ * The reason output uses the same `key=value` shape as the
+ * suggested_next.args echo in `gate suggest` so a downstream agent
+ * doesn't have to learn a second envelope.
+ */
+export async function flowSuggestCmd(
+  _c: C,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, FLOW_SUGGEST_KNOWN_FLAGS, 'flow-suggest');
+
+  const severityRaw = requireOption(args, 'severity', '<low|med|high>');
+  const area = requireOption(args, 'area', '<copy|doc|style|bug|auth|...>');
+  const scope = optionalOption(args, 'scope');
+  const format = optionalOption(args, 'format') ?? 'json';
+
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  if (!SEVERITIES.has(severityRaw)) {
+    // The check fires AFTER format validation so a `--format xml` typo
+    // still surfaces the format error first (more likely the operator
+    // mis-typed the format than the severity). Order matters because
+    // both errors are equally cheap to compute; we surface the most
+    // actionable first.
+    throw new Error(
+      `--severity must be one of low|med|high, got: ${severityRaw}`,
+    );
+  }
+
+  const result: FlowSuggestResult = suggestFlow(
+    scope === undefined
+      ? { severity: severityRaw as FlowSeverity, area }
+      : { severity: severityRaw as FlowSeverity, area, scope },
+  );
+
+  if (format === 'json') {
+    // Echo back the inputs alongside the recommendation so the call is
+    // self-describing — a downstream agent doesn't have to keep the
+    // original argv around to interpret the answer. `scope` is omitted
+    // when not provided (byte-stable: empty fields stay empty), matching
+    // the same omit-rule the YAML persistence layer uses.
+    const payload: Record<string, unknown> = {
+      recommended: result.recommended,
+      reason: result.reason,
+      alternatives: result.alternatives,
+      inputs: scope
+        ? { severity: severityRaw, area, scope }
+        : { severity: severityRaw, area },
+    };
+    process.stdout.write(JSON.stringify(payload) + '\n');
+  } else {
+    // Text rendering: three short lines (recommended / reason /
+    // alternatives) and a one-line stderr advisory footer mirroring
+    // `gate suggest`. The footer reminds the reader this is a
+    // heuristic, not a directive, at the point they read the answer.
+    process.stdout.write(`recommended: ${result.recommended}\n`);
+    process.stdout.write(`reason: ${result.reason}\n`);
+    const alts =
+      result.alternatives.length === 0
+        ? '(none)'
+        : result.alternatives.join(', ');
+    process.stdout.write(`alternatives: ${alts}\n`);
+    process.stderr.write('# advisory — override freely\n');
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -532,6 +532,75 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'flow-suggest',
+    category: 'read',
+    summary:
+      'advisory: maps (severity, area, [scope]) → a recommended flow (fast-track / direct-pr / full-request) with reason and alternatives. Pure read; no substrate writes. Heuristic — `reason` is the load-bearing output.',
+    input: {
+      type: 'object',
+      properties: {
+        severity: {
+          type: 'string',
+          enum: ['low', 'med', 'high'],
+          description: 'severity tier matching `gate issues add --severity`',
+        },
+        area: {
+          type: 'string',
+          description:
+            'free-form domain tag (e.g. copy, doc, style, bug, auth, data). ' +
+            'The engine matches case-insensitively against known buckets; ' +
+            'unknown areas fall through to the conservative default.',
+        },
+        scope: {
+          type: 'string',
+          description:
+            'optional scope hint (single-file, multi-file, multi-pr, ...). ' +
+            'Echoed back in the response; not load-bearing in v1.',
+        },
+        format: formatField,
+      },
+      required: ['severity', 'area'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        recommended: {
+          type: 'string',
+          enum: ['fast-track', 'direct-pr', 'full-request'],
+        },
+        reason: {
+          type: 'string',
+          description:
+            'The load-bearing field: a one-line explanation of why this ' +
+            'flow was chosen, in the same `key=value` shape the rest of ' +
+            'the gate envelopes use.',
+        },
+        alternatives: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['fast-track', 'direct-pr', 'full-request'],
+          },
+          description:
+            'Other flows the operator can fall back to if the primary ' +
+            'recommendation does not fit the situation.',
+        },
+        inputs: {
+          type: 'object',
+          description:
+            'Echo of the inputs the engine consumed, so the response is ' +
+            'self-describing without the caller having to retain argv.',
+          properties: {
+            severity: { type: 'string' },
+            area: { type: 'string' },
+            scope: { type: 'string' },
+          },
+        },
+      },
+      required: ['recommended', 'reason', 'alternatives', 'inputs'],
+    },
+  },
+  {
     name: 'transcript',
     category: 'read',
     summary:

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -47,6 +47,7 @@ import {
 } from './handlers/messages.js';
 import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
+import { flowSuggestCmd } from './handlers/flowSuggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
 import { summarizeCmd } from './handlers/summarize.js';
@@ -219,6 +220,14 @@ Status:
                        Defaults: --tail 5 --utterances 5 (lean for
                        hot-path session start; pass higher N for deeper
                        history).
+  gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]
+                    [--format json|text]
+                       Advisory: maps (severity, area, [scope]) → a
+                       recommended flow (fast-track / direct-pr /
+                       full-request) plus reason and alternatives. Pure
+                       read — no substrate writes. Heuristic, not a
+                       directive; the reason field is the load-bearing
+                       output (override when judgement differs).
   gate suggest [--format json|text]
                        Tight-loop sibling of boot: returns ONLY the
                        suggested_next triple (verb/args/reason) or
@@ -279,7 +288,7 @@ const KNOWN_COMMANDS = [
   'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
   'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
-  'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
+  'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
   'unresponded',
   'templates',
   'rest',
@@ -457,6 +466,8 @@ async function dispatch(
       return await bootCmd(c, args);
     case 'suggest':
       return await suggestCmd(c, args);
+    case 'flow-suggest':
+      return await flowSuggestCmd(c, args);
     case 'transcript':
       return await transcriptCmd(c, args);
     case 'wave-status':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -30,6 +30,7 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'status',
   'boot',
   'suggest',
+  'flow-suggest',
   'transcript',
   'summarize',
   'why',

--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -47,6 +47,7 @@ export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
     boot: 'boot',
     status: 'status',
     suggest: 'suggest',
+    'flow-suggest': 'flow-suggest --severity low --area copy',
     resume: 'resume',
     summarize: 'summarize <id>',
     why: 'why <id>',

--- a/tests/interface/flowSuggest.test.ts
+++ b/tests/interface/flowSuggest.test.ts
@@ -1,0 +1,250 @@
+// gate flow-suggest — advisory verb that maps (severity, area, scope)
+// to a recommended flow (#307).
+//
+// Pins:
+//   - rule table covers the three default rows from the issue plus
+//     the conservative fall-through
+//   - JSON envelope shape (recommended / reason / alternatives / inputs)
+//   - text mode renders three labelled lines + stderr advisory footer
+//   - severity / area validation fails closed with actionable errors
+//   - scope is optional, echoed when provided, omitted when not
+//   - unknown areas fall through to full-request (conservative default)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  suggestFlow,
+  FlowSuggestResult,
+} from '../../src/application/request/flowSuggest.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+function runGate(args: string[]): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+// ---------- pure rule engine tests ----------
+
+test('flow-suggest rule: low + copy → direct-pr', () => {
+  const r: FlowSuggestResult = suggestFlow({ severity: 'low', area: 'copy' });
+  assert.equal(r.recommended, 'direct-pr');
+  assert.match(r.reason, /low.*copy/);
+  assert.ok(r.alternatives.includes('full-request'));
+});
+
+test('flow-suggest rule: low + doc → direct-pr', () => {
+  const r = suggestFlow({ severity: 'low', area: 'doc' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: low + style → direct-pr', () => {
+  const r = suggestFlow({ severity: 'low', area: 'style' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: low + bug → fast-track', () => {
+  const r = suggestFlow({ severity: 'low', area: 'bug' });
+  assert.equal(r.recommended, 'fast-track');
+  assert.ok(r.alternatives.includes('full-request'));
+});
+
+test('flow-suggest rule: med + bug → fast-track', () => {
+  const r = suggestFlow({ severity: 'med', area: 'bug' });
+  assert.equal(r.recommended, 'fast-track');
+});
+
+test('flow-suggest rule: high + auth → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'auth' });
+  assert.equal(r.recommended, 'full-request');
+  assert.match(r.reason, /high.*auth/);
+});
+
+test('flow-suggest rule: high + security → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'security' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: high + data → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'data' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: med + bug stays fast-track even with scope', () => {
+  const r = suggestFlow({
+    severity: 'med',
+    area: 'bug',
+    scope: 'multi-file',
+  });
+  assert.equal(r.recommended, 'fast-track');
+});
+
+test('flow-suggest rule: case-insensitive on area', () => {
+  const r = suggestFlow({ severity: 'low', area: 'COPY' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: unknown area → full-request (conservative default)', () => {
+  const r = suggestFlow({ severity: 'low', area: 'something-weird' });
+  assert.equal(r.recommended, 'full-request');
+  assert.ok(r.alternatives.includes('fast-track'));
+});
+
+test('flow-suggest rule: high + non-high-risk area → full-request', () => {
+  // high severity in an unrecognised area should still fall to the
+  // conservative default rather than slip into fast-track.
+  const r = suggestFlow({ severity: 'high', area: 'bug' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: med + copy → full-request (no rule matches)', () => {
+  // med+cosmetic is intentionally NOT in the direct-pr bucket (the
+  // direct-pr rule requires severity=low). This pins the precedence.
+  const r = suggestFlow({ severity: 'med', area: 'copy' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: low + cosmetic with scope echoes scope in reason', () => {
+  const r = suggestFlow({
+    severity: 'low',
+    area: 'doc',
+    scope: 'single-file',
+  });
+  assert.equal(r.recommended, 'direct-pr');
+  assert.match(r.reason, /single-file/);
+});
+
+// ---------- CLI surface tests ----------
+
+test('flow-suggest CLI: JSON envelope shape (low + copy)', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'direct-pr');
+  assert.equal(typeof payload.reason, 'string');
+  assert.ok(Array.isArray(payload.alternatives));
+  assert.deepEqual(payload.inputs, { severity: 'low', area: 'copy' });
+});
+
+test('flow-suggest CLI: scope echoed in inputs when provided', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'high',
+    '--area',
+    'auth',
+    '--scope',
+    'multi-pr',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'full-request');
+  assert.deepEqual(payload.inputs, {
+    severity: 'high',
+    area: 'auth',
+    scope: 'multi-pr',
+  });
+});
+
+test('flow-suggest CLI: defaults to json format', () => {
+  const r = runGate(['flow-suggest', '--severity', 'low', '--area', 'bug']);
+  assert.equal(r.status, 0, r.stderr);
+  // Output must be parseable JSON when format flag is omitted.
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'fast-track');
+});
+
+test('flow-suggest CLI: text format renders three labelled lines', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'med',
+    '--area',
+    'bug',
+    '--format',
+    'text',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /^recommended: fast-track$/m);
+  assert.match(r.stdout, /^reason: /m);
+  assert.match(r.stdout, /^alternatives: /m);
+  // advisory footer goes to stderr so stdout stays clean for shell pipes.
+  assert.match(r.stderr, /advisory/);
+});
+
+test('flow-suggest CLI: invalid severity fails closed', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'critical',
+    '--area',
+    'auth',
+  ]);
+  assert.notEqual(r.status, 0);
+  // The error envelope is the standard one; just check the message
+  // mentions the validated value so the operator knows what to fix.
+  assert.match(r.stderr + r.stdout, /severity/);
+});
+
+test('flow-suggest CLI: invalid format fails closed', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--format',
+    'xml',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /format/);
+});
+
+test('flow-suggest CLI: missing --severity fails with shape hint', () => {
+  const r = runGate(['flow-suggest', '--area', 'copy']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /severity/);
+});
+
+test('flow-suggest CLI: missing --area fails with shape hint', () => {
+  const r = runGate(['flow-suggest', '--severity', 'low']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /area/);
+});
+
+test('flow-suggest CLI: unknown flag rejected', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--bogus',
+    'x',
+  ]);
+  assert.notEqual(r.status, 0);
+});

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -169,7 +169,7 @@ test('VERB_EXAMPLES: every documented verb is mapped to a runnable example', () 
       'inbox mark-read', 'issues add', 'issues list', 'issues note',
       'issues promote', 'issues resolve', 'issues defer', 'issues start',
       'issues reopen', 'show', 'list', 'board', 'tail', 'chain', 'transcript',
-      'voices', 'whoami', 'boot', 'status', 'suggest', 'resume', 'summarize',
+      'voices', 'whoami', 'boot', 'status', 'suggest', 'flow-suggest', 'resume', 'summarize',
       'why', 'unresponded', 'schema', 'doctor', 'repair',
     ],
     agora: [

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -41,7 +41,7 @@ const GATE_ALL = [
   'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
-  'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
+  'boot', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
 ] as const;
 

--- a/tests/interface/voiceBudget.test.ts
+++ b/tests/interface/voiceBudget.test.ts
@@ -101,13 +101,18 @@ const VOICE_BUDGET: readonly BudgetEntry[] = [
   },
   {
     phrase: 'advisory — override freely',
-    budget: 1,
-    allowed_files: ['src/interface/gate/handlers/suggest.ts'],
+    budget: 2,
+    allowed_files: [
+      'src/interface/gate/handlers/suggest.ts',
+      'src/interface/gate/handlers/flowSuggest.ts',
+    ],
     rationale:
-      'stderr footer of `gate suggest --format text` — principle 02 ' +
-      'at the point of use. budget 1 because this is an at-the-edge ' +
-      'phrase tied to one surface (the suggest verb), not pedagogical ' +
-      'across surfaces.',
+      'stderr footer of advisory read verbs (gate suggest, gate ' +
+      'flow-suggest) — principle 02 at the point of use. budget 2 ' +
+      'covers both advisory surfaces; the phrase is intentionally ' +
+      'shared so the reader recognises "this is a heuristic" across ' +
+      'verbs. New advisory verbs should reuse this footer rather than ' +
+      'inventing a paraphrase.',
   },
   {
     phrase: 'DETECTOR, not an enforcer',


### PR DESCRIPTION
## Summary

- New read-only `gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>] [--format json|text]` verb. Maps the (severity, area, scope) tuple to a recommended flow (`fast-track` / `direct-pr` / `full-request`) plus reason and alternatives.
- Pure advisory: substrate-free, no writes. Rule engine lives in `src/application/request/flowSuggest.ts` so a future v2 layer (`guild.config.yaml` override) can wrap it without touching the CLI surface.
- v1 ships the default rule table from #307: low+cosmetic→direct-pr, low/med+bug→fast-track, high+auth/data/security→full-request, else→full-request (conservative default).

## Motivation

ErisMind dogfood (2026-05-11) surfaced friction where trivial typo fixes were getting routed through the full issue → agora → devil ceremony. `flow-suggest` lets the operator (human or agent) get a one-line "this is a direct PR" answer without re-deriving the trade-off each time. See #307 for the full context.

## Surface

```bash
$ gate flow-suggest --severity low --area copy
{"recommended":"direct-pr","reason":"severity=low + area=copy → cosmetic low-severity change, a direct PR is enough.","alternatives":["fast-track","full-request"],"inputs":{"severity":"low","area":"copy"}}

$ gate flow-suggest --severity high --area auth --scope multi-pr --format text
recommended: full-request
reason: severity=high + area=auth → high-risk area at high severity, run the full request → review → ship flow.
alternatives: fast-track
# advisory — override freely    (← stderr)
```

## Test plan

- [x] `npm run build` clean (no TS errors)
- [x] 23 new tests in `tests/interface/flowSuggest.test.ts` covering every rule-table branch + CLI surface (JSON envelope, text rendering, validation failures, unknown flag rejection)
- [x] `verbs-consistency` updated and passes (flow-suggest in READ + GATE_ALL)
- [x] `verbHelp` updated and passes (flow-suggest in the expected gate list)
- [x] `voiceBudget` budget extended from 1→2 for `'advisory — override freely'` — the phrase is intentionally shared across advisory verbs so the reader recognises "this is a heuristic" across surfaces
- [x] Schema entry added; `schemaInputDriftDetector` / `schemaFlagCoverage` pass

## Notes

- `guild.config.yaml` rule-override is flagged as a v2 follow-up in the issue and module-level comment; v1 ships hard-coded defaults so the engine is one pure function ready to be wrapped.
- Wave: 2026-05-11-0003 (executor: miki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)