### PR TITLE
feat(gate): review-context verb — depth-aware reviewer bundle (closes #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ## [Unreleased]
 
+### Added
+
+- **`gate review-context <id>` verb — depth-aware reviewer bundle (closes #310)**
+  ([#310](https://github.com/eris-ths/guild-cli/issues/310),
+  builds on [#221](https://github.com/eris-ths/guild-cli/issues/221)).
+  Single read verb that returns the bundle a reviewer needs to drive
+  behaviour from substrate state: `action`, `reason`, `target`,
+  `executors`, `depth`, `recommended_lenses`, `recommended_extras`,
+  `prior_reviews`. Lens recommendation derives from the wave's
+  `depth` advisory:
+  - `shallow` → `[Logic]`
+  - `standard` → 6-lens default (`Logic, Pattern, Flow, Error, Test, Input`)
+  - `deep` → all 10 lenses + extras (`memory_mcp_trap_lookup`,
+    `state_machine_trace`, `prior_review_cross_check`)
+  - depth absent → empty lens set + `warning` advising the reviewer to
+    default to standard and surface the missing advisory in its preamble.
+
+  Closes the substrate-to-reviewer signal loop: `--depth` was
+  previously decorative — set on the wave but read by nobody.
+
+  Also fixes a pre-existing gap: `wave-status` was missing from
+  `verbs.ts` READ_VERBS — now declared alongside `review-context`.
+  The verbs-consistency test pins both.
+
 ### ⚠ BREAKING (JSON shape)
 
 - **`executors` field in JSON / YAML changed shape for any mutated

--- a/src/interface/gate/handlers/reviewContext.ts
+++ b/src/interface/gate/handlers/reviewContext.ts
@@ -1,0 +1,202 @@
+// gate review-context — single read verb that bundles everything a
+// reviewer (devil agent, CI script, human auditor) needs to drive
+// behaviour from substrate state instead of from out-of-band prompt
+// content (#310 Layer A).
+//
+// Today a depth-aware reviewer would shell out to
+//   gate show <id> --format json | jq '.depth, .executors, .target'
+// then jq the prior reviews from the same payload. That works but
+// puts the reviewer in the business of knowing the on-disk shape.
+// Centralising the "what does a reviewer want?" projection here lets
+// the reviewer's prompt stay short and the substrate stay free to
+// evolve its internal shape.
+//
+// Read-only. Composes from existing fields — no schema additions.
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+import { RequestDepth } from '../../../domain/request/RequestDepth.js';
+
+const REVIEW_CONTEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+/**
+ * Lens recommendation by depth. Encoded here (not in domain) because
+ * the choice is policy that may evolve with reviewer practice — keeping
+ * it at the interface layer lets the substrate remain advisory-only.
+ *
+ *   - shallow:  point-check with the highest-severity general lens.
+ *   - standard: 6-lens default mirroring the published /devil contract.
+ *   - deep:     all 10 lenses + memory MCP + state-machine trace.
+ *
+ * The reviewer is free to widen or narrow this set on a given run
+ * (principle 02 — advisory not directive). The set is published so
+ * the reviewer can record what it actually exercised against this
+ * suggestion. A wave whose recorded depth was 'shallow' but whose
+ * reviewer ran the 'deep' set should produce an audit-visible note.
+ */
+const LENSES_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
+  shallow: ['Logic'],
+  standard: ['Logic', 'Pattern', 'Flow', 'Error', 'Test', 'Input'],
+  deep: [
+    'Logic',
+    'Performance',
+    'Flow',
+    'Pattern',
+    'Error',
+    'Test',
+    'Injection',
+    'Auth',
+    'Secrets',
+    'Input',
+  ],
+};
+
+/**
+ * Extras the reviewer is invited to exercise at a given depth, beyond
+ * the lens set itself. Surfaced separately so a deep reviewer sees
+ * "memory MCP lookup + state-machine trace + prior-review cross-check"
+ * as explicit obligations, not just lens names.
+ */
+const EXTRAS_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
+  shallow: [],
+  standard: [],
+  deep: [
+    'memory_mcp_trap_lookup',
+    'state_machine_trace',
+    'prior_review_cross_check',
+  ],
+};
+
+export interface ReviewContextPayload {
+  id: string;
+  state: string;
+  from: string;
+  action: string;
+  reason: string;
+  target: string | null;
+  executors: readonly string[];
+  /** Recorded depth advisory (#221). `null` when the wave was created
+   *  without `--depth` and never re-stamped — reviewer should treat
+   *  as standard and surface a warning. */
+  depth: RequestDepth | null;
+  /** Recommended lens set derived from depth. Empty when `depth` is
+   *  null (reviewer falls back to its own default but can record the
+   *  drift). */
+  recommended_lenses: readonly string[];
+  /** Extras (memory lookup, trace, cross-check) the reviewer is
+   *  invited to exercise at this depth. */
+  recommended_extras: readonly string[];
+  /** Prior reviews on this record. Lets a deep reviewer cross-check
+   *  earlier verdicts without a second `gate show` call. */
+  prior_reviews: readonly {
+    by: string;
+    lense: string;
+    verdict: string;
+    at: string;
+    comment: string | null;
+  }[];
+  /** Advisory the operator/agent should see in the reviewer's preamble
+   *  when no depth is recorded. Empty string when depth is set. */
+  warning: string;
+}
+
+export async function reviewContextCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REVIEW_CONTEXT_KNOWN_FLAGS, 'review-context');
+  const id = args.positional[0];
+  if (!id) {
+    throw new Error('Usage: gate review-context <id> [--format text|json]');
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(notFoundMessage('request', id));
+    return 1;
+  }
+  const payload = buildReviewContext(r);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(renderText(payload) + '\n');
+  }
+  return 0;
+}
+
+export function buildReviewContext(r: Request): ReviewContextPayload {
+  const j = r.toJSON();
+  const depth: RequestDepth | null =
+    typeof j['depth'] === 'string'
+      ? (j['depth'] as RequestDepth)
+      : null;
+  const effective: RequestDepth = depth ?? 'standard';
+  const reviews = r.reviews.map((rv) => ({
+    by: rv.by.value,
+    lense: rv.lense,
+    verdict: rv.verdict,
+    at: rv.at,
+    comment: rv.comment ?? null,
+  }));
+  const execNames = r.executors.map((m) => m.value);
+  return {
+    id: String(j['id']),
+    state: String(j['state']),
+    from: String(j['from']),
+    action: String(j['action'] ?? ''),
+    reason: String(j['reason'] ?? ''),
+    target: typeof j['target'] === 'string' ? (j['target'] as string) : null,
+    executors: execNames,
+    depth,
+    recommended_lenses: depth === null ? [] : LENSES_BY_DEPTH[effective],
+    recommended_extras: depth === null ? [] : EXTRAS_BY_DEPTH[effective],
+    prior_reviews: reviews,
+    warning:
+      depth === null
+        ? 'no depth recorded on this wave — reviewer should default to standard ' +
+          'lens set and surface the missing advisory in its preamble (#310 #221)'
+        : '',
+  };
+}
+
+function renderText(p: ReviewContextPayload): string {
+  const lines: string[] = [];
+  lines.push(`review-context ${p.id}  [${p.state}]  from=${p.from}`);
+  lines.push(`  action: ${p.action}`);
+  if (p.reason) lines.push(`  reason: ${p.reason}`);
+  if (p.target) lines.push(`  target: ${p.target}`);
+  if (p.executors.length > 0) {
+    lines.push(`  executors: ${p.executors.join(', ')}`);
+  }
+  lines.push('');
+  lines.push(`depth: ${p.depth ?? '(not recorded)'}`);
+  if (p.warning) lines.push(`  ⚠ ${p.warning}`);
+  if (p.recommended_lenses.length > 0) {
+    lines.push(`  recommended lenses: ${p.recommended_lenses.join(', ')}`);
+  }
+  if (p.recommended_extras.length > 0) {
+    lines.push(`  recommended extras: ${p.recommended_extras.join(', ')}`);
+  }
+  if (p.prior_reviews.length > 0) {
+    lines.push('');
+    lines.push(`prior reviews (${p.prior_reviews.length}):`);
+    for (const rv of p.prior_reviews) {
+      lines.push(
+        `  ${rv.at}  by=${rv.by}  lense=${rv.lense}  verdict=${rv.verdict}`,
+      );
+      if (rv.comment) {
+        lines.push(`    ${rv.comment.replace(/[\r\n]+/g, ' ')}`);
+      }
+    }
+  } else {
+    lines.push('');
+    lines.push(`prior reviews: (none)`);
+  }
+  return lines.join('\n');
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -617,6 +617,53 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'review-context',
+    category: 'read',
+    summary:
+      'reviewer-facing bundle for a wave: action/reason/target, executors, depth advisory (#221), recommended lens set by depth, and prior reviews. Lets a devil/reviewer agent drive behaviour from substrate state instead of out-of-band prompt content (#310 Layer A). Read-only; depth and lens-set are advisory not directive (principle 02).',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        format: formatField,
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        state: str,
+        from: str,
+        action: str,
+        reason: str,
+        target: { type: 'string', description: 'null when wave has no target field' },
+        executors: { type: 'array', items: str },
+        depth: {
+          type: 'string',
+          enum: ['shallow', 'standard', 'deep'],
+          description: 'null when no depth was recorded on this wave',
+        },
+        recommended_lenses: { type: 'array', items: str },
+        recommended_extras: { type: 'array', items: str },
+        prior_reviews: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              by: str,
+              lense: str,
+              verdict: str,
+              at: str,
+              comment: { type: 'string', description: 'null when review carried no comment' },
+            },
+          },
+        },
+        warning: { type: 'string', description: 'empty string when depth is recorded' },
+      },
+    },
+  },
+  {
     name: 'summarize',
     category: 'read',
     summary:

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -49,6 +49,7 @@ import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
+import { reviewContextCmd } from './handlers/reviewContext.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
@@ -286,6 +287,7 @@ const KNOWN_COMMANDS = [
   'wake',
   'farewell',
   'wave-status',
+  'review-context',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -461,6 +463,8 @@ async function dispatch(
       return await transcriptCmd(c, args);
     case 'wave-status':
       return await waveStatusCmd(c, args);
+    case 'review-context':
+      return await reviewContextCmd(c, args);
     case 'summarize':
       return await summarizeCmd(c, args);
     case 'why':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -37,6 +37,8 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'schema',
   'unresponded',
   'templates',
+  'wave-status',
+  'review-context',
 ]);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set([

--- a/tests/interface/reviewContext310.test.ts
+++ b/tests/interface/reviewContext310.test.ts
@@ -1,0 +1,213 @@
+// #310 — gate review-context regression.
+//
+// Acceptance:
+//   - shallow / standard / deep produce the matching lens recommendation
+//   - missing depth on a wave surfaces a non-empty warning + empty lenses
+//   - prior reviews are bundled into the payload
+//   - non-existent id → exit 1 with notFoundHint
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(cwd: string, args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, encoding: 'utf8' });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-review-context-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob', 'critic']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+test('#310: review-context on non-existent id exits 1 with notFoundHint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['review-context', '9999-99-99-9999']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found: 9999-99-99-9999/);
+});
+
+test('#310: review-context on wave without depth → empty lenses + warning', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'no-depth wave',
+    '--reason', 'reviewer default test',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, null);
+  assert.deepEqual(payload.recommended_lenses, []);
+  assert.deepEqual(payload.recommended_extras, []);
+  assert.match(payload.warning, /no depth recorded/);
+  assert.deepEqual(payload.executors, ['alice']);
+});
+
+test('#310: depth=shallow → point-check lens set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'shallow',
+    '--action', 'shallow wave',
+    '--reason', 'depth=shallow',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'shallow');
+  assert.deepEqual(payload.recommended_lenses, ['Logic']);
+  assert.deepEqual(payload.recommended_extras, []);
+  assert.equal(payload.warning, '');
+});
+
+test('#310: depth=standard → 6-lens default', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'standard',
+    '--action', 'standard wave',
+    '--reason', 'depth=standard',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'standard');
+  assert.equal(payload.recommended_lenses.length, 6);
+  assert.ok(payload.recommended_lenses.includes('Logic'));
+  assert.ok(payload.recommended_lenses.includes('Input'));
+  assert.deepEqual(payload.recommended_extras, []);
+});
+
+test('#310: depth=deep → all 10 lenses + extras (memory MCP + state-machine + cross-check)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'deep wave',
+    '--reason', 'depth=deep',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'deep');
+  assert.equal(payload.recommended_lenses.length, 10);
+  // Spot-check the security cluster that distinguishes deep from standard.
+  assert.ok(payload.recommended_lenses.includes('Injection'));
+  assert.ok(payload.recommended_lenses.includes('Auth'));
+  assert.ok(payload.recommended_lenses.includes('Secrets'));
+  assert.ok(payload.recommended_extras.includes('memory_mcp_trap_lookup'));
+  assert.ok(payload.recommended_extras.includes('state_machine_trace'));
+  assert.ok(payload.recommended_extras.includes('prior_review_cross_check'));
+});
+
+test('#310: review-context bundles prior reviews into the payload', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'reviewed wave',
+    '--reason', 'prior-review bundling',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+  const rev = runGate(root, [
+    'review', id,
+    '--by', 'critic',
+    '--lense', 'layer',
+    '--verdict', 'ok',
+    '--note', 'first pass clean',
+  ]);
+  assert.equal(rev.status, 0, rev.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.prior_reviews.length, 1);
+  assert.equal(payload.prior_reviews[0].by, 'critic');
+  assert.equal(payload.prior_reviews[0].lense, 'layer');
+  assert.equal(payload.prior_reviews[0].verdict, 'ok');
+  assert.equal(payload.prior_reviews[0].comment, 'first pass clean');
+});
+
+test('#310: text format renders depth + lens recommendation + prior reviews', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'text-format wave',
+    '--reason', 'text rendering',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'text']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /review-context [\d-]+/);
+  assert.match(r.stdout, /depth: deep/);
+  assert.match(r.stdout, /recommended lenses:.*Injection/);
+  assert.match(r.stdout, /recommended extras:.*memory_mcp_trap_lookup/);
+});
+
+test('#310: review-context rejects unknown flags', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'standard',
+    '--action', 'flag test',
+    '--reason', 'unknown flag',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--bogus']);
+  assert.notEqual(r.status, 0);
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -43,6 +43,7 @@ const GATE_ALL = [
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
+  'wave-status', 'review-context',
 ] as const;
 
 const AGORA_ALL = [


### PR DESCRIPTION
## Summary

Closes the substrate-to-reviewer signal loop from #221. A reviewer (devil agent, CI script, human auditor) can now call `gate review-context <id>` and get everything needed to drive behaviour from substrate state instead of out-of-band prompt content.

**Lens recommendation by depth:**
- `shallow` → `[Logic]`
- `standard` → 6-lens default (`Logic, Pattern, Flow, Error, Test, Input`)
- `deep` → all 10 lenses + extras (`memory_mcp_trap_lookup`, `state_machine_trace`, `prior_review_cross_check`)
- depth absent → empty set + non-empty `warning` field

**Payload shape:** `action / reason / target / executors / depth / recommended_lenses / recommended_extras / prior_reviews / warning`

## Why

Before this PR, `--depth` was decorative — set on the wave, read by nobody. A reviewer that wanted depth-aware behaviour had to write its own prompt and hope the operator remembered to match flags. The two channels (substrate signal vs invocation prompt) drifted silently.

Now the reviewer calls one verb, gets the bundle, and can record what lenses it actually exercised against the recommendation.

## What this is NOT

- Not a domain change. `Request.depth` was already shipped (#221).
- Not a directive. Lens-set is advisory; reviewer is free to widen/narrow (principle 02).
- Layer B (skill/slash-command normalisation) lives outside this repo.

## Incidental fix

`wave-status` was missing from `verbs.ts` READ_VERBS, silently bypassing the entry-lock fail-safe classification (surfaced during Noir's #305 work). Declared alongside the new verb; verbs-consistency test pins both.

## Test plan

- [x] `npm test` → 1519 / 1519 pass
- [x] 8 new tests in `reviewContext310.test.ts` covering all depth modes + missing-depth warning + prior-review bundling + text format + unknown-flag rejection
- [x] verbs-consistency test now green for both `wave-status` and `review-context`

## Related

- #310 issue (this PR is Layer A of the proposal)
- #221 (depth advisory — the signal source, now finally consumed)
- #305 (lense-usage-stats — independent verb, surfaced the wave-status gap fixed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)