### PR TITLE
feat(gate): bundle 4 new verbs (#305 #306 #307 #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,11 +148,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   quarantineable findings are processed inline via the repair
   use case and the outcome is reported under `doctor.auto_repair`.
   Default behavior is unchanged — without `--with-doctor` the JSON
-  shape and text prose are byte-identical to pre-#306. Closes the
-  2-step friction `eris-gate-flow.md` flagged: a dirty substrate
-  now surfaces at the moment of session boot, before the agent
-  starts writing again. `--auto-repair` without `--with-doctor`
-  is rejected with a pointed error.
+  shape and text prose are byte-identical to pre-#306.
+
+- **`gate flow-suggest` — advisory verb for picking a flow shape (closes #307)**
+  ([#307](https://github.com/eris-ths/guild-cli/issues/307)).
+  New read verb: `gate flow-suggest --severity <low|med|high> --area <s>
+  [--scope <s>] [--format json|text]`. Maps the (severity, area, scope)
+  tuple to a recommended flow — `fast-track`, `direct-pr`, or
+  `full-request` — and returns the reason plus alternative options.
+  Pure advisory: no substrate writes, no state. Rule engine in
+  `application/request/flowSuggest.ts`; future v2 can wrap it with a
+  `guild.config.yaml` override without touching the CLI surface.
 
 - **`gate wave-status <id>` — per-executor in-flight slice status (closes #295)**
   ([#295](https://github.com/eris-ths/guild-cli/issues/295)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,25 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   ([#305](https://github.com/eris-ths/guild-cli/issues/305)).
   Counts review entries per lense over a window (`--since 7d` default),
   highlights the most-frequent and least-frequent lense, and surfaces a
-  `next:` hint when one lense dominates 3× the bottom. Sources: gate
-  `Request.reviews[]` + devil-passage `DevilReview.entries[]`. Read-only,
-  text + json formats, optional `--for <actor>` author filter.
+  `next:` hint when one lense dominates 3× the bottom.
 
 - **Per-executor freshness for `gate wave-status` (closes #309)**
   ([#309](https://github.com/eris-ths/guild-cli/issues/309)).
   Stale judgment is now per-executor, derived from each executor's
-  most recent attributable activity (max of `witnessUpdatedAt[name]`,
-  `status_log[by=name].at`, and `claimedAt` when the claim is held).
-  An executor whose witness note was updated 2 min ago is no longer
-  flagged stale on a 33-min-old wave. Wave-level `(stale)` in the
-  footer now derives from "all executors stale" (`wave_stale_effective`),
-  separating "how long has this been open?" (`age_band`) from
-  "is anyone still working?" (`wave_stale_effective`).
+  most recent attributable activity. Wave-level `(stale)` in the
+  footer now derives from "all executors stale" (`wave_stale_effective`).
+
+- **`gate review-context <id>` verb — depth-aware reviewer bundle (closes #310)**
+  ([#310](https://github.com/eris-ths/guild-cli/issues/310),
+  builds on [#221](https://github.com/eris-ths/guild-cli/issues/221)).
+  Returns the bundle a reviewer needs to drive behaviour from substrate
+  state: `action`, `reason`, `target`, `executors`, `depth`,
+  `recommended_lenses` (`shallow` → `[Logic]`; `standard` → 6-lens
+  default; `deep` → all 10 + memory MCP + state-machine + cross-check),
+  `prior_reviews`. Closes the substrate-to-reviewer signal loop: the
+  `--depth` field was previously decorative — set on the wave but read
+  by nobody. Also declares `wave-status` in `verbs.ts` READ_VERBS,
+  closing a pre-existing gap.
 
 ### ⚠ BREAKING (JSON shape)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,20 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate resume --with-doctor [--auto-repair]` — surface substrate health at session re-entry (closes #306)**
+  ([#306](https://github.com/eris-ths/guild-cli/issues/306)).
+  New flags on the existing `gate resume` verb that fold a `gate
+  doctor` summary into the resume payload (`doctor.findings`,
+  `doctor.summary`, `doctor.is_clean`). With `--auto-repair`,
+  quarantineable findings are processed inline via the repair
+  use case and the outcome is reported under `doctor.auto_repair`.
+  Default behavior is unchanged — without `--with-doctor` the JSON
+  shape and text prose are byte-identical to pre-#306. Closes the
+  2-step friction `eris-gate-flow.md` flagged: a dirty substrate
+  now surfaces at the moment of session boot, before the agent
+  starts writing again. `--auto-repair` without `--with-doctor`
+  is rejected with a pointed error.
+
 - **`gate wave-status <id>` — per-executor in-flight slice status (closes #295)**
   ([#295](https://github.com/eris-ths/guild-cli/issues/295)).
   New read verb that composes per-executor view from existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate lense-stats` verb — lense rotation diagnostic (closes #305)**
+  ([#305](https://github.com/eris-ths/guild-cli/issues/305)).
+  Counts review entries per lense over a window (`--since 7d` default),
+  highlights the most-frequent and least-frequent lense, and surfaces a
+  `next:` hint when one lense dominates 3× the bottom. Sources: gate
+  `Request.reviews[]` + devil-passage `DevilReview.entries[]`. Read-only,
+  text + json formats, optional `--for <actor>` author filter.
+
 - **Per-executor freshness for `gate wave-status` (closes #309)**
   ([#309](https://github.com/eris-ths/guild-cli/issues/309)).
   Stale judgment is now per-executor, derived from each executor's
@@ -19,20 +27,6 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   footer now derives from "all executors stale" (`wave_stale_effective`),
   separating "how long has this been open?" (`age_band`) from
   "is anyone still working?" (`wave_stale_effective`).
-
-  Schema additive: new `witness_updated_at: Map<actor, ISO>` field on
-  `Request`, mirroring `witness_notes` / `witness_sessions`. Stamped
-  on first witness and on any re-witness mutation; cleared on
-  unwitness and terminal auto-reset. Omit-when-empty so pre-#309
-  records round-trip byte-identically. Hydrate-tolerant (ISO-parse
-  failures drop the entry via `onMalformed`).
-
-  Wire-format additions to `gate wave-status --format json` output:
-  - `executors[].witness_updated_at: string | null`
-  - `wave_stale_effective: boolean`
-  - `executors[].activity_band` enum unchanged but `'active'` is now
-    deprecated (never emitted by post-#309 builds; readers that
-    decoded it from legacy snapshots should treat as `'fresh'`).
 
 ### ⚠ BREAKING (JSON shape)
 

--- a/src/application/request/flowSuggest.ts
+++ b/src/application/request/flowSuggest.ts
@@ -1,0 +1,135 @@
+// flowSuggest — pure advisory rule engine for `gate flow-suggest`.
+//
+// Purpose: given severity + area (+ optional scope), recommend ONE of
+// three flows so the operator doesn't have to re-derive the trade-off
+// each time. Substrate-free — no I/O, no state. The verb that wraps
+// this is read-only and the engine is a single lookup function.
+//
+// Why a dedicated module (not inlined in the handler): the rule table
+// is the thing future PRs will extend (issue #307 implementation note
+// flagged guild.config.yaml override as a v2 follow-up). Keeping the
+// rule logic in `application/` lets it be imported and exercised by
+// tests without touching the CLI surface, and lets a future override
+// layer (config-driven rule merge) wrap this same pure function.
+//
+// Design choice — explicit if/else over data-driven match table:
+// the rule table from #307 is small (three default rows) and reads
+// as a flat list of guards. A switch/table would compress the code
+// but obscure the precedence: "high severity in a security-adjacent
+// area beats everything else." Branching keeps that precedence as
+// the literal order of `if` statements, which is what reviewers will
+// audit.
+
+/** All three recommended flows the engine can return. */
+export type FlowRecommendation = 'fast-track' | 'direct-pr' | 'full-request';
+
+/** Severity classification (mirrors `gate issues add --severity` enum). */
+export type FlowSeverity = 'low' | 'med' | 'high';
+
+/** Area tag — open string, not an enum: callers pass arbitrary domain
+ * tags (copy/doc/style/bug/auth/data/security/...). The engine
+ * categorises by membership in known buckets and falls back to
+ * `full-request` for anything it doesn't recognise (conservative). */
+export type FlowArea = string;
+
+/** Scope hint — optional, advisory. Not load-bearing in v1 (the rule
+ * table doesn't branch on it), but plumbed through so the JSON
+ * output can echo it back and a v2 rule layer can use it without a
+ * second signature change. */
+export type FlowScope = 'single-file' | 'multi-file' | 'multi-pr' | string;
+
+export interface FlowSuggestInput {
+  severity: FlowSeverity;
+  area: FlowArea;
+  scope?: FlowScope;
+}
+
+export interface FlowSuggestResult {
+  recommended: FlowRecommendation;
+  reason: string;
+  alternatives: FlowRecommendation[];
+}
+
+// Area buckets. Lower-cased on the way in; callers may pass mixed
+// case freely (`Auth`, `COPY`) without surprising the engine.
+const COSMETIC_AREAS: ReadonlySet<string> = new Set([
+  'copy',
+  'doc',
+  'docs',
+  'style',
+]);
+
+const BUG_AREAS: ReadonlySet<string> = new Set(['bug', 'fix']);
+
+const HIGH_RISK_AREAS: ReadonlySet<string> = new Set([
+  'security',
+  'auth',
+  'data',
+]);
+
+/**
+ * Decide which flow to recommend for a (severity, area, scope) tuple.
+ *
+ * Precedence — the order of these branches is the rule:
+ *   1. high severity in a high-risk area (security/auth/data) →
+ *      full-request. The blast radius justifies the ceremony.
+ *   2. low severity in a cosmetic area (copy/doc/style) →
+ *      direct-pr. The most common dogfood friction (#307 motivation).
+ *   3. low/med severity bug → fast-track. Bug fixes that aren't a
+ *      compliance issue benefit from a single-pass record without a
+ *      full agora play.
+ *   4. anything else → full-request. The conservative default: when
+ *      the engine doesn't recognise the shape, pay the ceremony cost
+ *      rather than skip a step the situation might need.
+ */
+export function suggestFlow(input: FlowSuggestInput): FlowSuggestResult {
+  const severity = input.severity;
+  const area = input.area.toLowerCase();
+  const scope = input.scope?.toLowerCase();
+
+  // 1. high-risk area at any meaningful severity → full ceremony.
+  if (HIGH_RISK_AREAS.has(area) && severity === 'high') {
+    return {
+      recommended: 'full-request',
+      reason:
+        `severity=${severity} + area=${area} → high-risk area at high ` +
+        `severity, run the full request → review → ship flow.`,
+      alternatives: ['fast-track'],
+    };
+  }
+
+  // 2. low + cosmetic → direct PR, skip the gate ceremony entirely.
+  if (severity === 'low' && COSMETIC_AREAS.has(area)) {
+    const scopePart = scope ? ` + scope=${scope}` : '';
+    return {
+      recommended: 'direct-pr',
+      reason:
+        `severity=${severity} + area=${area}${scopePart} → cosmetic ` +
+        `low-severity change, a direct PR is enough.`,
+      alternatives: ['fast-track', 'full-request'],
+    };
+  }
+
+  // 3. low/med bug → fast-track (single-pass record, no agora).
+  if ((severity === 'low' || severity === 'med') && BUG_AREAS.has(area)) {
+    return {
+      recommended: 'fast-track',
+      reason:
+        `severity=${severity} + area=${area} → routine bug fix, ` +
+        `fast-track records the change without a full request cycle.`,
+      alternatives: ['full-request'],
+    };
+  }
+
+  // 4. fall-through: be conservative. The recommendation here covers
+  //    every shape the rule table doesn't claim — including high
+  //    severity in non-high-risk areas, med severity in cosmetic /
+  //    unknown areas, and any area the engine doesn't know about.
+  return {
+    recommended: 'full-request',
+    reason:
+      `severity=${severity} + area=${area} → no specific rule matched, ` +
+      `defaulting to full request flow (issue → review → ship).`,
+    alternatives: ['fast-track'],
+  };
+}

--- a/src/interface/gate/handlers/flowSuggest.ts
+++ b/src/interface/gate/handlers/flowSuggest.ts
@@ -1,0 +1,99 @@
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import {
+  suggestFlow,
+  FlowSeverity,
+  FlowSuggestResult,
+} from '../../../application/request/flowSuggest.js';
+
+const FLOW_SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'severity',
+  'area',
+  'scope',
+  'format',
+]);
+
+const SEVERITIES: ReadonlySet<string> = new Set(['low', 'med', 'high']);
+
+/**
+ * gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]
+ *                    [--format json|text]
+ *
+ * Advisory verb: maps (severity, area, scope) → a recommended flow
+ * (fast-track / direct-pr / full-request) plus a reason and the
+ * alternatives the operator can fall back to. Pure read — no
+ * substrate writes. The rule engine lives in
+ * `application/request/flowSuggest.ts` so a future v2 layer (config
+ * override) can wrap it without touching the CLI surface.
+ *
+ * The reason output uses the same `key=value` shape as the
+ * suggested_next.args echo in `gate suggest` so a downstream agent
+ * doesn't have to learn a second envelope.
+ */
+export async function flowSuggestCmd(
+  _c: C,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, FLOW_SUGGEST_KNOWN_FLAGS, 'flow-suggest');
+
+  const severityRaw = requireOption(args, 'severity', '<low|med|high>');
+  const area = requireOption(args, 'area', '<copy|doc|style|bug|auth|...>');
+  const scope = optionalOption(args, 'scope');
+  const format = optionalOption(args, 'format') ?? 'json';
+
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  if (!SEVERITIES.has(severityRaw)) {
+    // The check fires AFTER format validation so a `--format xml` typo
+    // still surfaces the format error first (more likely the operator
+    // mis-typed the format than the severity). Order matters because
+    // both errors are equally cheap to compute; we surface the most
+    // actionable first.
+    throw new Error(
+      `--severity must be one of low|med|high, got: ${severityRaw}`,
+    );
+  }
+
+  const result: FlowSuggestResult = suggestFlow(
+    scope === undefined
+      ? { severity: severityRaw as FlowSeverity, area }
+      : { severity: severityRaw as FlowSeverity, area, scope },
+  );
+
+  if (format === 'json') {
+    // Echo back the inputs alongside the recommendation so the call is
+    // self-describing — a downstream agent doesn't have to keep the
+    // original argv around to interpret the answer. `scope` is omitted
+    // when not provided (byte-stable: empty fields stay empty), matching
+    // the same omit-rule the YAML persistence layer uses.
+    const payload: Record<string, unknown> = {
+      recommended: result.recommended,
+      reason: result.reason,
+      alternatives: result.alternatives,
+      inputs: scope
+        ? { severity: severityRaw, area, scope }
+        : { severity: severityRaw, area },
+    };
+    process.stdout.write(JSON.stringify(payload) + '\n');
+  } else {
+    // Text rendering: three short lines (recommended / reason /
+    // alternatives) and a one-line stderr advisory footer mirroring
+    // `gate suggest`. The footer reminds the reader this is a
+    // heuristic, not a directive, at the point they read the answer.
+    process.stdout.write(`recommended: ${result.recommended}\n`);
+    process.stdout.write(`reason: ${result.reason}\n`);
+    const alts =
+      result.alternatives.length === 0
+        ? '(none)'
+        : result.alternatives.join(', ');
+    process.stdout.write(`alternatives: ${alts}\n`);
+    process.stderr.write('# advisory — override freely\n');
+  }
+  return 0;
+}

--- a/src/interface/gate/handlers/lenseStats.ts
+++ b/src/interface/gate/handlers/lenseStats.ts
@@ -1,0 +1,288 @@
+// gate lense-stats — lense rotation diagnostic (#305).
+//
+// Counts how many review entries were recorded against each lense in
+// the given window, then highlights the most-frequent ("most") and
+// least-frequent ("least", among lenses with ≥ 1 use) so the operator
+// can spot bias: "I keep hitting auth-access; have I run devil or
+// composition lately?"
+//
+// Two record sources contribute to the same totals:
+//   1. gate `Request.reviews[]` — every `gate review --lense <l>` write
+//      records a review with `at` + `lense`. Filtered by `at` window.
+//   2. devil `DevilReview.entries[]` — every `devil entry --lense <l>`
+//      records a domain Entry with `at` + `lense` + `kind`. All kinds
+//      are counted (finding/assumption/resistance/skip/synthesis/gate)
+//      because every entry committed *to a lense* counts as the
+//      reviewer touching that axis. Filtered by entry `at`.
+//
+// `--for <actor>` filters by author (review.by / entry.by). Default:
+// every actor in the content_root.
+//
+// `--since <duration>` accepts: `7d`, `24h`, `30m`, `45s`. Bare integer
+// + suffix only — the v0 parser keeps the surface minimal. Default
+// window: 7d.
+//
+// Read-only: no on-disk mutation, no state transitions. Safe to call
+// any time; LOCK_EXEMPT-eligible but registered as READ for now (the
+// shared lock middleware allows concurrent reads).
+
+import { join } from 'node:path';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { YamlDevilReviewRepository } from '../../../passages/devil/infrastructure/YamlDevilReviewRepository.js';
+
+const LENSE_STATS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'since',
+  'format',
+]);
+
+/**
+ * Per-lense count plus optional `last_at` (most-recent ISO timestamp
+ * seen in the window). `last_at` is null when the lense has zero hits
+ * — it's a 0-count entry only included when the lense is in the
+ * catalog. Empty lenses still appear in the stats so a reader can see
+ * "composition: 0" rather than guessing whether composition exists.
+ */
+export interface LenseStat {
+  readonly lense: string;
+  readonly count: number;
+  readonly last_at: string | null;
+  readonly sources: {
+    readonly gate_reviews: number;
+    readonly devil_entries: number;
+  };
+}
+
+export interface LenseStatsPayload {
+  readonly window: {
+    readonly since: string; // ISO timestamp; "all-time" rendered as a literal sentinel below
+    readonly duration: string; // the raw `--since` value, e.g. "7d"
+  };
+  readonly filter: {
+    readonly actor: string | null;
+  };
+  readonly totals: {
+    readonly entries_counted: number;
+    readonly lenses_with_use: number;
+  };
+  readonly most: string | null; // most-frequent lense in window; null when totals.entries_counted === 0
+  readonly least: string | null; // least-frequent *with ≥ 1 use*; null when totals === 0
+  readonly stats: readonly LenseStat[]; // sorted by count desc, then lense name asc
+}
+
+export async function lenseStatsCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, LENSE_STATS_KNOWN_FLAGS, 'lense-stats');
+  const forActor = optionalOption(args, 'for') ?? null;
+  const sinceRaw = optionalOption(args, 'since') ?? '7d';
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+
+  const now = new Date();
+  const sinceMs = parseDuration(sinceRaw);
+  const cutoff = new Date(now.getTime() - sinceMs);
+  const cutoffIso = cutoff.toISOString();
+
+  // Source 1: gate reviews. Walk every request and filter its reviews.
+  const requests = await c.requestUC.listAll();
+  // tally[lense] = { gate, devil, lastAt }
+  const tally = new Map<
+    string,
+    { gate: number; devil: number; lastAt: string | null }
+  >();
+  const bump = (
+    lense: string,
+    field: 'gate' | 'devil',
+    at: string,
+  ): void => {
+    const cur = tally.get(lense) ?? { gate: 0, devil: 0, lastAt: null };
+    cur[field] += 1;
+    if (cur.lastAt === null || at > cur.lastAt) cur.lastAt = at;
+    tally.set(lense, cur);
+  };
+
+  for (const r of requests) {
+    const j = r.toJSON() as Record<string, unknown>;
+    const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];
+    for (const rv of reviews) {
+      if (typeof rv !== 'object' || rv === null) continue;
+      const rec = rv as Record<string, unknown>;
+      const at = typeof rec['at'] === 'string' ? (rec['at'] as string) : null;
+      const lense = typeof rec['lense'] === 'string' ? (rec['lense'] as string) : null;
+      const by = typeof rec['by'] === 'string' ? (rec['by'] as string) : null;
+      if (at === null || lense === null) continue;
+      if (at < cutoffIso) continue;
+      if (forActor !== null && by !== forActor) continue;
+      bump(lense, 'gate', at);
+    }
+  }
+
+  // Source 2: devil-passage reviews. Iterate every review file under
+  // <content_root>/devil/reviews/ and tally its entries.
+  // ad-hoc repo construction (the gate container doesn't carry one).
+  // Missing directory is a no-op — a content_root that has never seen
+  // a devil review just contributes zero to the totals.
+  const devilRepo = new YamlDevilReviewRepository(c.config);
+  // Safety: listAll already routes through onMalformed for hydrate
+  // failures, so a tampered review file is dropped not propagated.
+  // Wrapping in try/catch defends against the dir-not-found case;
+  // listDirSafe already returns [] there, so this is belt + braces.
+  let devilReviews: Awaited<ReturnType<typeof devilRepo.listAll>> = [];
+  try {
+    devilReviews = await devilRepo.listAll();
+  } catch {
+    devilReviews = [];
+  }
+  for (const dr of devilReviews) {
+    for (const e of dr.entries) {
+      if (e.at < cutoffIso) continue;
+      if (forActor !== null && e.by !== forActor) continue;
+      bump(e.lense, 'devil', e.at);
+    }
+  }
+
+  // Build stats. Include catalog lenses with zero hits so the operator
+  // sees "composition: 0" rather than guessing what's missing.
+  const catalogLenses = new Set<string>(c.config.lenses);
+  for (const lense of tally.keys()) catalogLenses.add(lense);
+  const stats: LenseStat[] = [];
+  for (const lense of catalogLenses) {
+    const t = tally.get(lense);
+    const gate = t?.gate ?? 0;
+    const devil = t?.devil ?? 0;
+    stats.push({
+      lense,
+      count: gate + devil,
+      last_at: t?.lastAt ?? null,
+      sources: { gate_reviews: gate, devil_entries: devil },
+    });
+  }
+  stats.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.lense.localeCompare(b.lense);
+  });
+
+  const totalEntries = stats.reduce((s, x) => s + x.count, 0);
+  const used = stats.filter((s) => s.count > 0);
+  const most = used.length > 0 ? used[0]!.lense : null;
+  // Least: lowest count among used lenses. Sorted desc, so the last
+  // used-row is the minimum. Ties broken alphabetically by the sort
+  // above, so "least" is deterministic.
+  const least = used.length > 0 ? used[used.length - 1]!.lense : null;
+
+  const payload: LenseStatsPayload = {
+    window: { since: cutoffIso, duration: sinceRaw },
+    filter: { actor: forActor },
+    totals: {
+      entries_counted: totalEntries,
+      lenses_with_use: used.length,
+    },
+    most,
+    least,
+    stats,
+  };
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(renderText(payload) + '\n');
+  return 0;
+}
+
+/**
+ * Parse a duration string like `7d`, `24h`, `30m`, `45s` to ms.
+ * Bare integer + single-char suffix only. Negative / zero / unknown
+ * suffix → throws. The v0 surface is deliberately tiny — agents that
+ * want richer windows can compose by passing a specific ISO cutoff
+ * once an `--at` flag lands.
+ */
+export function parseDuration(raw: string): number {
+  const m = raw.match(/^(\d+)([smhd])$/);
+  if (!m) {
+    throw new Error(
+      `--since must match <int><s|m|h|d>, got: ${raw}` +
+        `\n  next: try --since 7d, --since 24h, --since 30m, or --since 45s`,
+    );
+  }
+  const n = parseInt(m[1] as string, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`--since duration must be a positive integer, got: ${raw}`);
+  }
+  switch (m[2]) {
+    case 's':
+      return n * 1000;
+    case 'm':
+      return n * 60 * 1000;
+    case 'h':
+      return n * 60 * 60 * 1000;
+    case 'd':
+      return n * 24 * 60 * 60 * 1000;
+  }
+  // unreachable — regex constrains suffix to [smhd]
+  throw new Error(`unreachable suffix in --since: ${raw}`);
+}
+
+function renderText(p: LenseStatsPayload): string {
+  const lines: string[] = [];
+  const actorTag = p.filter.actor ? `  actor=${p.filter.actor}` : '';
+  lines.push(
+    `lense-stats  window=${p.window.duration}${actorTag}  ` +
+      `entries=${p.totals.entries_counted}  ` +
+      `lenses_with_use=${p.totals.lenses_with_use}`,
+  );
+  lines.push(`since: ${p.window.since}`);
+  lines.push('');
+  if (p.totals.entries_counted === 0) {
+    lines.push(
+      '(no review entries in window — try a longer --since or check --for)',
+    );
+    return lines.join('\n');
+  }
+  // Width for tidy alignment. Cap at 24 so a long custom lense name
+  // doesn't push the count column off-screen.
+  const widest = Math.min(
+    24,
+    Math.max(8, ...p.stats.map((s) => s.lense.length)),
+  );
+  for (const s of p.stats) {
+    const name = s.lense.padEnd(widest, ' ');
+    const tag =
+      s.lense === p.most && s.lense === p.least
+        ? '  (only)'
+        : s.lense === p.most
+          ? '  ← most'
+          : s.lense === p.least
+            ? '  ← least'
+            : '';
+    const breakdown =
+      s.count > 0
+        ? `  (gate=${s.sources.gate_reviews} devil=${s.sources.devil_entries})`
+        : '';
+    lines.push(`  ${name}  ${String(s.count).padStart(4)}${breakdown}${tag}`);
+  }
+  // Touch-feel "next:" hint — point the operator at the rotation
+  // gap when one lense dominates.
+  if (p.most && p.least && p.most !== p.least) {
+    const top = p.stats.find((s) => s.lense === p.most);
+    const bot = p.stats.find((s) => s.lense === p.least);
+    if (top && bot && top.count >= bot.count * 3 && top.count >= 3) {
+      lines.push('');
+      lines.push(
+        `  next: ${p.most} is dominating (${top.count} vs ${bot.count} on ${p.least}). ` +
+          `consider a ${p.least}-lense review on the next slice.`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+// Re-export the path constant pattern uses (kept for tests that want
+// to assert on the devil reviews dir without re-deriving it).
+export const DEVIL_REVIEWS_REL = join('devil', 'reviews');

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -6,12 +6,47 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 
-const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'locale']);
+const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'format',
+  'locale',
+  'with-doctor',
+  'auto-repair',
+]);
 import { Request, StatusLogEntry } from '../../../domain/request/Request.js';
 import { collectUtterances, Utterance, RequestJSON } from '../voices.js';
 import { deriveSuggestedNext, SuggestedNext } from './writeFormat.js';
 import { UnrespondedConcernsEntry } from '../../../application/concern/UnrespondedConcernsQuery.js';
 import type { SessionEvent, SessionKind } from '../../../domain/session/SessionEvent.js';
+import {
+  DiagnosticReport,
+  DiagnosticFinding,
+} from '../../../domain/diagnostic/DiagnosticReport.js';
+import { RepairResult } from '../../../application/repair/RepairUseCases.js';
+
+/**
+ * #306 — `--with-doctor` augments the resume payload with a
+ * `gate doctor` summary. `--auto-repair` (only meaningful with
+ * `--with-doctor`) additionally invokes the repair use case in
+ * `--apply` mode: quarantine actions run, destructive ones are
+ * skipped. The point is to surface a dirty substrate at the moment
+ * of session re-entry, before the agent starts writing again.
+ *
+ * The shape stays backward compatible — `doctor` is omitted from
+ * the JSON when the flag is absent, and the text mode appends a
+ * trailing section instead of restructuring the prose.
+ */
+interface DoctorSection {
+  readonly findings: ReadonlyArray<DiagnosticFinding>;
+  readonly summary: string;
+  readonly is_clean: boolean;
+  readonly auto_repair?: {
+    readonly attempted: boolean;
+    readonly quarantined: number;
+    readonly skipped: number;
+    readonly errors: number;
+    readonly summary: string;
+  };
+}
 
 /**
  * Most recent session boundary stamped by the resuming actor
@@ -130,6 +165,14 @@ interface ResumePayload {
   unresponded_concerns: ReadonlyArray<UnrespondedConcernsEntry>;
   suggested_next: SuggestedNext | null;
   restoration_prose: string;
+  /**
+   * #306 — present only when `--with-doctor` was passed. Carries the
+   * doctor summary (+ optional auto-repair outcome) so the agent can
+   * see substrate health at the moment of resume without a second
+   * verb call. Omitted entirely (key absent) when the flag is off,
+   * preserving the pre-#306 JSON shape for existing consumers.
+   */
+  doctor?: DoctorSection;
 }
 
 export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -137,6 +180,15 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+  const withDoctor = args.options['with-doctor'] === true;
+  const autoRepair = args.options['auto-repair'] === true;
+  if (autoRepair && !withDoctor) {
+    process.stderr.write(
+      'error: --auto-repair requires --with-doctor\n' +
+        '  next: gate resume --with-doctor --auto-repair\n',
+    );
+    return 1;
   }
   const actor = resolveGuildActor();
   if (!actor || actor.length === 0) {
@@ -241,6 +293,26 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     locale,
   });
 
+  // #306 — doctor section. Only built when --with-doctor was passed
+  // so the default surface stays byte-identical to pre-#306 callers.
+  // Auto-repair runs inline (apply mode) when requested; quarantine
+  // is the only action kind today so "destructive skip" is moot for
+  // now — keeping the flag dichotomy in place anticipates future
+  // RepairAction kinds that may need explicit consent.
+  let doctorSection: DoctorSection | undefined;
+  if (withDoctor) {
+    const report = await c.diagnosticUC.run();
+    doctorSection = buildDoctorSection(report, locale);
+    if (autoRepair && !report.isClean) {
+      const plan = c.repairUC.plan(report.findings);
+      const result = await c.repairUC.apply(plan);
+      doctorSection = {
+        ...doctorSection,
+        auto_repair: buildAutoRepairSummary(result, locale),
+      };
+    }
+  }
+
   const payload: ResumePayload = {
     actor,
     session_hint: sessionHint,
@@ -255,14 +327,112 @@ export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
     unresponded_concerns: unrespondedConcerns,
     suggested_next: suggested,
     restoration_prose: restorationProse,
+    ...(doctorSection !== undefined ? { doctor: doctorSection } : {}),
   };
 
   if (format === 'json') {
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
   } else {
     process.stdout.write(restorationProse + '\n');
+    if (doctorSection !== undefined) {
+      process.stdout.write('\n' + renderDoctorSectionText(doctorSection, locale) + '\n');
+    }
   }
   return 0;
+}
+
+function buildDoctorSection(
+  report: DiagnosticReport,
+  locale: 'en' | 'ja',
+): DoctorSection {
+  const findings = report.findings;
+  const s = report.summary;
+  const summary =
+    locale === 'ja'
+      ? `members ${s.members.malformed}/${s.members.total} 不正、requests ${s.requests.malformed}/${s.requests.total} 不正、issues ${s.issues.malformed}/${s.issues.total} 不正`
+      : `members ${s.members.malformed}/${s.members.total} malformed, requests ${s.requests.malformed}/${s.requests.total} malformed, issues ${s.issues.malformed}/${s.issues.total} malformed`;
+  return {
+    findings,
+    summary,
+    is_clean: report.isClean,
+  };
+}
+
+function buildAutoRepairSummary(
+  result: RepairResult,
+  locale: 'en' | 'ja',
+): {
+  attempted: boolean;
+  quarantined: number;
+  skipped: number;
+  errors: number;
+  summary: string;
+} {
+  const s = result.summary;
+  const summary =
+    locale === 'ja'
+      ? `auto-repair: ${s.quarantined} quarantine、${s.skipped} skip、${s.error} error`
+      : `auto-repair: ${s.quarantined} quarantined, ${s.skipped} skipped, ${s.error} error(s)`;
+  return {
+    attempted: true,
+    quarantined: s.quarantined,
+    skipped: s.skipped,
+    errors: s.error,
+    summary,
+  };
+}
+
+function renderDoctorSectionText(
+  d: DoctorSection,
+  locale: 'en' | 'ja',
+): string {
+  const lines: string[] = [];
+  if (locale === 'ja') {
+    lines.push('# substrate doctor');
+    if (d.is_clean) {
+      lines.push('✓ clean — malformed record なし');
+    } else {
+      lines.push(`✗ ${d.findings.length} finding(s) — ${d.summary}`);
+      for (const f of d.findings.slice(0, 10)) {
+        lines.push(`  - [${f.area}/${f.kind}] ${f.source}`);
+      }
+      if (d.findings.length > 10) {
+        lines.push(`  ... 他 ${d.findings.length - 10} 件`);
+      }
+    }
+    if (d.auto_repair !== undefined) {
+      lines.push('');
+      lines.push(d.auto_repair.summary);
+    } else if (!d.is_clean) {
+      lines.push('');
+      lines.push(
+        'next: `gate doctor --format json | gate repair --apply` で隔離、または再実行時に `--auto-repair` を付与',
+      );
+    }
+  } else {
+    lines.push('# substrate doctor');
+    if (d.is_clean) {
+      lines.push('✓ clean — no malformed records');
+    } else {
+      lines.push(`✗ ${d.findings.length} finding(s) — ${d.summary}`);
+      for (const f of d.findings.slice(0, 10)) {
+        lines.push(`  - [${f.area}/${f.kind}] ${f.source}`);
+      }
+      if (d.findings.length > 10) {
+        lines.push(`  ... and ${d.findings.length - 10} more`);
+      }
+    }
+    if (d.auto_repair !== undefined) {
+      lines.push('');
+      lines.push(d.auto_repair.summary);
+    } else if (!d.is_clean) {
+      lines.push('');
+      lines.push(
+        'next: pipe `gate doctor --format json | gate repair --apply` or re-run with `--auto-repair`',
+      );
+    }
+  }
+  return lines.join('\n');
 }
 
 function transitionToJSON(

--- a/src/interface/gate/handlers/reviewContext.ts
+++ b/src/interface/gate/handlers/reviewContext.ts
@@ -1,0 +1,202 @@
+// gate review-context — single read verb that bundles everything a
+// reviewer (devil agent, CI script, human auditor) needs to drive
+// behaviour from substrate state instead of from out-of-band prompt
+// content (#310 Layer A).
+//
+// Today a depth-aware reviewer would shell out to
+//   gate show <id> --format json | jq '.depth, .executors, .target'
+// then jq the prior reviews from the same payload. That works but
+// puts the reviewer in the business of knowing the on-disk shape.
+// Centralising the "what does a reviewer want?" projection here lets
+// the reviewer's prompt stay short and the substrate stay free to
+// evolve its internal shape.
+//
+// Read-only. Composes from existing fields — no schema additions.
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+import { RequestDepth } from '../../../domain/request/RequestDepth.js';
+
+const REVIEW_CONTEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+/**
+ * Lens recommendation by depth. Encoded here (not in domain) because
+ * the choice is policy that may evolve with reviewer practice — keeping
+ * it at the interface layer lets the substrate remain advisory-only.
+ *
+ *   - shallow:  point-check with the highest-severity general lens.
+ *   - standard: 6-lens default mirroring the published /devil contract.
+ *   - deep:     all 10 lenses + memory MCP + state-machine trace.
+ *
+ * The reviewer is free to widen or narrow this set on a given run
+ * (principle 02 — advisory not directive). The set is published so
+ * the reviewer can record what it actually exercised against this
+ * suggestion. A wave whose recorded depth was 'shallow' but whose
+ * reviewer ran the 'deep' set should produce an audit-visible note.
+ */
+const LENSES_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
+  shallow: ['Logic'],
+  standard: ['Logic', 'Pattern', 'Flow', 'Error', 'Test', 'Input'],
+  deep: [
+    'Logic',
+    'Performance',
+    'Flow',
+    'Pattern',
+    'Error',
+    'Test',
+    'Injection',
+    'Auth',
+    'Secrets',
+    'Input',
+  ],
+};
+
+/**
+ * Extras the reviewer is invited to exercise at a given depth, beyond
+ * the lens set itself. Surfaced separately so a deep reviewer sees
+ * "memory MCP lookup + state-machine trace + prior-review cross-check"
+ * as explicit obligations, not just lens names.
+ */
+const EXTRAS_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
+  shallow: [],
+  standard: [],
+  deep: [
+    'memory_mcp_trap_lookup',
+    'state_machine_trace',
+    'prior_review_cross_check',
+  ],
+};
+
+export interface ReviewContextPayload {
+  id: string;
+  state: string;
+  from: string;
+  action: string;
+  reason: string;
+  target: string | null;
+  executors: readonly string[];
+  /** Recorded depth advisory (#221). `null` when the wave was created
+   *  without `--depth` and never re-stamped — reviewer should treat
+   *  as standard and surface a warning. */
+  depth: RequestDepth | null;
+  /** Recommended lens set derived from depth. Empty when `depth` is
+   *  null (reviewer falls back to its own default but can record the
+   *  drift). */
+  recommended_lenses: readonly string[];
+  /** Extras (memory lookup, trace, cross-check) the reviewer is
+   *  invited to exercise at this depth. */
+  recommended_extras: readonly string[];
+  /** Prior reviews on this record. Lets a deep reviewer cross-check
+   *  earlier verdicts without a second `gate show` call. */
+  prior_reviews: readonly {
+    by: string;
+    lense: string;
+    verdict: string;
+    at: string;
+    comment: string | null;
+  }[];
+  /** Advisory the operator/agent should see in the reviewer's preamble
+   *  when no depth is recorded. Empty string when depth is set. */
+  warning: string;
+}
+
+export async function reviewContextCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, REVIEW_CONTEXT_KNOWN_FLAGS, 'review-context');
+  const id = args.positional[0];
+  if (!id) {
+    throw new Error('Usage: gate review-context <id> [--format text|json]');
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const r = await c.requestUC.show(id);
+  if (!r) {
+    process.stderr.write(notFoundMessage('request', id));
+    return 1;
+  }
+  const payload = buildReviewContext(r);
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(renderText(payload) + '\n');
+  }
+  return 0;
+}
+
+export function buildReviewContext(r: Request): ReviewContextPayload {
+  const j = r.toJSON();
+  const depth: RequestDepth | null =
+    typeof j['depth'] === 'string'
+      ? (j['depth'] as RequestDepth)
+      : null;
+  const effective: RequestDepth = depth ?? 'standard';
+  const reviews = r.reviews.map((rv) => ({
+    by: rv.by.value,
+    lense: rv.lense,
+    verdict: rv.verdict,
+    at: rv.at,
+    comment: rv.comment ?? null,
+  }));
+  const execNames = r.executors.map((m) => m.value);
+  return {
+    id: String(j['id']),
+    state: String(j['state']),
+    from: String(j['from']),
+    action: String(j['action'] ?? ''),
+    reason: String(j['reason'] ?? ''),
+    target: typeof j['target'] === 'string' ? (j['target'] as string) : null,
+    executors: execNames,
+    depth,
+    recommended_lenses: depth === null ? [] : LENSES_BY_DEPTH[effective],
+    recommended_extras: depth === null ? [] : EXTRAS_BY_DEPTH[effective],
+    prior_reviews: reviews,
+    warning:
+      depth === null
+        ? 'no depth recorded on this wave — reviewer should default to standard ' +
+          'lens set and surface the missing advisory in its preamble (#310 #221)'
+        : '',
+  };
+}
+
+function renderText(p: ReviewContextPayload): string {
+  const lines: string[] = [];
+  lines.push(`review-context ${p.id}  [${p.state}]  from=${p.from}`);
+  lines.push(`  action: ${p.action}`);
+  if (p.reason) lines.push(`  reason: ${p.reason}`);
+  if (p.target) lines.push(`  target: ${p.target}`);
+  if (p.executors.length > 0) {
+    lines.push(`  executors: ${p.executors.join(', ')}`);
+  }
+  lines.push('');
+  lines.push(`depth: ${p.depth ?? '(not recorded)'}`);
+  if (p.warning) lines.push(`  ⚠ ${p.warning}`);
+  if (p.recommended_lenses.length > 0) {
+    lines.push(`  recommended lenses: ${p.recommended_lenses.join(', ')}`);
+  }
+  if (p.recommended_extras.length > 0) {
+    lines.push(`  recommended extras: ${p.recommended_extras.join(', ')}`);
+  }
+  if (p.prior_reviews.length > 0) {
+    lines.push('');
+    lines.push(`prior reviews (${p.prior_reviews.length}):`);
+    for (const rv of p.prior_reviews) {
+      lines.push(
+        `  ${rv.at}  by=${rv.by}  lense=${rv.lense}  verdict=${rv.verdict}`,
+      );
+      if (rv.comment) {
+        lines.push(`    ${rv.comment.replace(/[\r\n]+/g, ' ')}`);
+      }
+    }
+  } else {
+    lines.push('');
+    lines.push(`prior reviews: (none)`);
+  }
+  return lines.join('\n');
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -752,6 +752,53 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'review-context',
+    category: 'read',
+    summary:
+      'reviewer-facing bundle for a wave: action/reason/target, executors, depth advisory (#221), recommended lens set by depth, and prior reviews. Lets a devil/reviewer agent drive behaviour from substrate state instead of out-of-band prompt content (#310 Layer A). Read-only; depth and lens-set are advisory not directive (principle 02).',
+    input: {
+      type: 'object',
+      properties: {
+        id: idStr,
+        format: formatField,
+      },
+      required: ['id'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        id: str,
+        state: str,
+        from: str,
+        action: str,
+        reason: str,
+        target: { type: 'string', description: 'null when wave has no target field' },
+        executors: { type: 'array', items: str },
+        depth: {
+          type: 'string',
+          enum: ['shallow', 'standard', 'deep'],
+          description: 'null when no depth was recorded on this wave',
+        },
+        recommended_lenses: { type: 'array', items: str },
+        recommended_extras: { type: 'array', items: str },
+        prior_reviews: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              by: str,
+              lense: str,
+              verdict: str,
+              at: str,
+              comment: { type: 'string', description: 'null when review carried no comment' },
+            },
+          },
+        },
+        warning: { type: 'string', description: 'empty string when depth is recorded' },
+      },
+    },
+  },
+  {
     name: 'summarize',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -617,6 +617,72 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'lense-stats',
+    category: 'read',
+    summary:
+      "lense rotation diagnostic (#305): count review entries per lense over a window, highlight the most-frequent and least-frequent lense so bias surfaces. Sources gate `Request.reviews[]` + devil-passage `DevilReview.entries[]`. Read-only; default window 7d.",
+    input: {
+      type: 'object',
+      properties: {
+        for: { type: 'string', description: 'filter by author of the review/entry (review.by / entry.by)' },
+        since: {
+          type: 'string',
+          description: 'window size as <int><s|m|h|d>; default 7d',
+        },
+        format: {
+          type: 'string',
+          enum: ['text', 'json'],
+          description: 'output format (default: text)',
+        },
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        window: {
+          type: 'object',
+          properties: {
+            since: { type: 'string', description: 'ISO cutoff (now - duration)' },
+            duration: { type: 'string', description: 'echoed --since value, e.g. "7d"' },
+          },
+        },
+        filter: {
+          type: 'object',
+          properties: {
+            actor: { type: 'string', description: 'echoed --for value; null when omitted' },
+          },
+        },
+        totals: {
+          type: 'object',
+          properties: {
+            entries_counted: { type: 'integer' },
+            lenses_with_use: { type: 'integer' },
+          },
+        },
+        most: { type: 'string', description: 'most-frequent lense; null when totals.entries_counted=0' },
+        least: { type: 'string', description: 'least-frequent lense among those with ≥1 use; null when totals=0' },
+        stats: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              lense: str,
+              count: { type: 'integer' },
+              last_at: { type: 'string', description: 'most recent ISO timestamp seen for this lense; null when count=0' },
+              sources: {
+                type: 'object',
+                properties: {
+                  gate_reviews: { type: 'integer' },
+                  devil_entries: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'summarize',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -677,6 +677,16 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         format: formatField,
         locale: { type: 'string', enum: ['en', 'ja'], description: 'prose language; also via GUILD_LOCALE env' },
+        'with-doctor': {
+          type: 'boolean',
+          description:
+            '#306 — augment payload with a `gate doctor` summary so session re-entry surfaces a dirty substrate before the agent starts writing again.',
+        },
+        'auto-repair': {
+          type: 'boolean',
+          description:
+            '#306 — only meaningful with --with-doctor; runs `gate repair --apply` inline for quarantineable findings. Without --with-doctor this flag is rejected.',
+        },
       },
     },
     output: {
@@ -710,6 +720,26 @@ const VERBS: readonly VerbSchema[] = [
         },
         suggested_next: { type: 'object' },
         restoration_prose: str,
+        doctor: {
+          type: 'object',
+          description:
+            '#306 — present only when --with-doctor was passed. Carries the diagnostic findings and a one-line summary; when --auto-repair was also passed, an `auto_repair` sub-object reports the quarantine outcome.',
+          properties: {
+            findings: { type: 'array', items: { type: 'object' } },
+            summary: str,
+            is_clean: { type: 'boolean' },
+            auto_repair: {
+              type: 'object',
+              properties: {
+                attempted: { type: 'boolean' },
+                quarantined: { type: 'integer' },
+                skipped: { type: 'integer' },
+                errors: { type: 'integer' },
+                summary: str,
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -532,6 +532,75 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'flow-suggest',
+    category: 'read',
+    summary:
+      'advisory: maps (severity, area, [scope]) → a recommended flow (fast-track / direct-pr / full-request) with reason and alternatives. Pure read; no substrate writes. Heuristic — `reason` is the load-bearing output.',
+    input: {
+      type: 'object',
+      properties: {
+        severity: {
+          type: 'string',
+          enum: ['low', 'med', 'high'],
+          description: 'severity tier matching `gate issues add --severity`',
+        },
+        area: {
+          type: 'string',
+          description:
+            'free-form domain tag (e.g. copy, doc, style, bug, auth, data). ' +
+            'The engine matches case-insensitively against known buckets; ' +
+            'unknown areas fall through to the conservative default.',
+        },
+        scope: {
+          type: 'string',
+          description:
+            'optional scope hint (single-file, multi-file, multi-pr, ...). ' +
+            'Echoed back in the response; not load-bearing in v1.',
+        },
+        format: formatField,
+      },
+      required: ['severity', 'area'],
+    },
+    output: {
+      type: 'object',
+      properties: {
+        recommended: {
+          type: 'string',
+          enum: ['fast-track', 'direct-pr', 'full-request'],
+        },
+        reason: {
+          type: 'string',
+          description:
+            'The load-bearing field: a one-line explanation of why this ' +
+            'flow was chosen, in the same `key=value` shape the rest of ' +
+            'the gate envelopes use.',
+        },
+        alternatives: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['fast-track', 'direct-pr', 'full-request'],
+          },
+          description:
+            'Other flows the operator can fall back to if the primary ' +
+            'recommendation does not fit the situation.',
+        },
+        inputs: {
+          type: 'object',
+          description:
+            'Echo of the inputs the engine consumed, so the response is ' +
+            'self-describing without the caller having to retain argv.',
+          properties: {
+            severity: { type: 'string' },
+            area: { type: 'string' },
+            scope: { type: 'string' },
+          },
+        },
+      },
+      required: ['recommended', 'reason', 'alternatives', 'inputs'],
+    },
+  },
+  {
     name: 'transcript',
     category: 'read',
     summary:

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -47,6 +47,7 @@ import {
 } from './handlers/messages.js';
 import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
+import { flowSuggestCmd } from './handlers/flowSuggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
 import { lenseStatsCmd } from './handlers/lenseStats.js';
@@ -220,6 +221,14 @@ Status:
                        Defaults: --tail 5 --utterances 5 (lean for
                        hot-path session start; pass higher N for deeper
                        history).
+  gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]
+                    [--format json|text]
+                       Advisory: maps (severity, area, [scope]) → a
+                       recommended flow (fast-track / direct-pr /
+                       full-request) plus reason and alternatives. Pure
+                       read — no substrate writes. Heuristic, not a
+                       directive; the reason field is the load-bearing
+                       output (override when judgement differs).
   gate suggest [--format json|text]
                        Tight-loop sibling of boot: returns ONLY the
                        suggested_next triple (verb/args/reason) or
@@ -290,7 +299,7 @@ const KNOWN_COMMANDS = [
   'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
   'thank', 'fast-track', 'issues', 'message',
   'broadcast', 'inbox', 'doctor', 'repair', 'status', 'boot',
-  'suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
+  'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume', 'schema',
   'unresponded',
   'templates',
   'rest',
@@ -469,6 +478,8 @@ async function dispatch(
       return await bootCmd(c, args);
     case 'suggest':
       return await suggestCmd(c, args);
+    case 'flow-suggest':
+      return await flowSuggestCmd(c, args);
     case 'transcript':
       return await transcriptCmd(c, args);
     case 'wave-status':

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -49,6 +49,7 @@ import { statusCmd } from './handlers/status.js';
 import { suggestCmd } from './handlers/suggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
+import { lenseStatsCmd } from './handlers/lenseStats.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
@@ -262,6 +263,16 @@ Status:
                        concern); 'gate chain <id>' walks the actual
                        references when the reader wants to verify.
 
+Calibration:
+  gate lense-stats [--for <m>] [--since <duration>] [--format json|text]
+                       Count review entries per lense in the window.
+                       Highlights the most-frequent and least-frequent
+                       lense so a reader can spot bias ("I keep hitting
+                       auth-access; have I run devil or composition
+                       lately?"). Sources: gate \`review\` records +
+                       devil-passage entries. Duration: <int><s|m|h|d>
+                       (default 7d). Read-only.
+
 Meta:
   gate schema [--verb <name>] [--format json|text]
                        Introspection: JSON Schema for every verb's
@@ -286,6 +297,7 @@ const KNOWN_COMMANDS = [
   'wake',
   'farewell',
   'wave-status',
+  'lense-stats',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -461,6 +473,8 @@ async function dispatch(
       return await transcriptCmd(c, args);
     case 'wave-status':
       return await waveStatusCmd(c, args);
+    case 'lense-stats':
+      return await lenseStatsCmd(c, args);
     case 'summarize':
       return await summarizeCmd(c, args);
     case 'why':

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -51,6 +51,7 @@ import { flowSuggestCmd } from './handlers/flowSuggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
 import { lenseStatsCmd } from './handlers/lenseStats.js';
+import { reviewContextCmd } from './handlers/reviewContext.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
@@ -307,6 +308,7 @@ const KNOWN_COMMANDS = [
   'farewell',
   'wave-status',
   'lense-stats',
+  'review-context',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -486,6 +488,8 @@ async function dispatch(
       return await waveStatusCmd(c, args);
     case 'lense-stats':
       return await lenseStatsCmd(c, args);
+    case 'review-context':
+      return await reviewContextCmd(c, args);
     case 'summarize':
       return await summarizeCmd(c, args);
     case 'why':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -39,6 +39,8 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'unresponded',
   'templates',
   'lense-stats',
+  'wave-status',
+  'review-context',
 ]);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set([

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -37,6 +37,7 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'schema',
   'unresponded',
   'templates',
+  'lense-stats',
 ]);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set([

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -30,6 +30,7 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'status',
   'boot',
   'suggest',
+  'flow-suggest',
   'transcript',
   'summarize',
   'why',

--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -47,6 +47,7 @@ export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
     boot: 'boot',
     status: 'status',
     suggest: 'suggest',
+    'flow-suggest': 'flow-suggest --severity low --area copy',
     resume: 'resume',
     summarize: 'summarize <id>',
     why: 'why <id>',

--- a/tests/interface/flowSuggest.test.ts
+++ b/tests/interface/flowSuggest.test.ts
@@ -1,0 +1,250 @@
+// gate flow-suggest — advisory verb that maps (severity, area, scope)
+// to a recommended flow (#307).
+//
+// Pins:
+//   - rule table covers the three default rows from the issue plus
+//     the conservative fall-through
+//   - JSON envelope shape (recommended / reason / alternatives / inputs)
+//   - text mode renders three labelled lines + stderr advisory footer
+//   - severity / area validation fails closed with actionable errors
+//   - scope is optional, echoed when provided, omitted when not
+//   - unknown areas fall through to full-request (conservative default)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  suggestFlow,
+  FlowSuggestResult,
+} from '../../src/application/request/flowSuggest.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+function runGate(args: string[]): RunResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+// ---------- pure rule engine tests ----------
+
+test('flow-suggest rule: low + copy → direct-pr', () => {
+  const r: FlowSuggestResult = suggestFlow({ severity: 'low', area: 'copy' });
+  assert.equal(r.recommended, 'direct-pr');
+  assert.match(r.reason, /low.*copy/);
+  assert.ok(r.alternatives.includes('full-request'));
+});
+
+test('flow-suggest rule: low + doc → direct-pr', () => {
+  const r = suggestFlow({ severity: 'low', area: 'doc' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: low + style → direct-pr', () => {
+  const r = suggestFlow({ severity: 'low', area: 'style' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: low + bug → fast-track', () => {
+  const r = suggestFlow({ severity: 'low', area: 'bug' });
+  assert.equal(r.recommended, 'fast-track');
+  assert.ok(r.alternatives.includes('full-request'));
+});
+
+test('flow-suggest rule: med + bug → fast-track', () => {
+  const r = suggestFlow({ severity: 'med', area: 'bug' });
+  assert.equal(r.recommended, 'fast-track');
+});
+
+test('flow-suggest rule: high + auth → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'auth' });
+  assert.equal(r.recommended, 'full-request');
+  assert.match(r.reason, /high.*auth/);
+});
+
+test('flow-suggest rule: high + security → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'security' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: high + data → full-request', () => {
+  const r = suggestFlow({ severity: 'high', area: 'data' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: med + bug stays fast-track even with scope', () => {
+  const r = suggestFlow({
+    severity: 'med',
+    area: 'bug',
+    scope: 'multi-file',
+  });
+  assert.equal(r.recommended, 'fast-track');
+});
+
+test('flow-suggest rule: case-insensitive on area', () => {
+  const r = suggestFlow({ severity: 'low', area: 'COPY' });
+  assert.equal(r.recommended, 'direct-pr');
+});
+
+test('flow-suggest rule: unknown area → full-request (conservative default)', () => {
+  const r = suggestFlow({ severity: 'low', area: 'something-weird' });
+  assert.equal(r.recommended, 'full-request');
+  assert.ok(r.alternatives.includes('fast-track'));
+});
+
+test('flow-suggest rule: high + non-high-risk area → full-request', () => {
+  // high severity in an unrecognised area should still fall to the
+  // conservative default rather than slip into fast-track.
+  const r = suggestFlow({ severity: 'high', area: 'bug' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: med + copy → full-request (no rule matches)', () => {
+  // med+cosmetic is intentionally NOT in the direct-pr bucket (the
+  // direct-pr rule requires severity=low). This pins the precedence.
+  const r = suggestFlow({ severity: 'med', area: 'copy' });
+  assert.equal(r.recommended, 'full-request');
+});
+
+test('flow-suggest rule: low + cosmetic with scope echoes scope in reason', () => {
+  const r = suggestFlow({
+    severity: 'low',
+    area: 'doc',
+    scope: 'single-file',
+  });
+  assert.equal(r.recommended, 'direct-pr');
+  assert.match(r.reason, /single-file/);
+});
+
+// ---------- CLI surface tests ----------
+
+test('flow-suggest CLI: JSON envelope shape (low + copy)', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'direct-pr');
+  assert.equal(typeof payload.reason, 'string');
+  assert.ok(Array.isArray(payload.alternatives));
+  assert.deepEqual(payload.inputs, { severity: 'low', area: 'copy' });
+});
+
+test('flow-suggest CLI: scope echoed in inputs when provided', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'high',
+    '--area',
+    'auth',
+    '--scope',
+    'multi-pr',
+    '--format',
+    'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'full-request');
+  assert.deepEqual(payload.inputs, {
+    severity: 'high',
+    area: 'auth',
+    scope: 'multi-pr',
+  });
+});
+
+test('flow-suggest CLI: defaults to json format', () => {
+  const r = runGate(['flow-suggest', '--severity', 'low', '--area', 'bug']);
+  assert.equal(r.status, 0, r.stderr);
+  // Output must be parseable JSON when format flag is omitted.
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.recommended, 'fast-track');
+});
+
+test('flow-suggest CLI: text format renders three labelled lines', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'med',
+    '--area',
+    'bug',
+    '--format',
+    'text',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /^recommended: fast-track$/m);
+  assert.match(r.stdout, /^reason: /m);
+  assert.match(r.stdout, /^alternatives: /m);
+  // advisory footer goes to stderr so stdout stays clean for shell pipes.
+  assert.match(r.stderr, /advisory/);
+});
+
+test('flow-suggest CLI: invalid severity fails closed', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'critical',
+    '--area',
+    'auth',
+  ]);
+  assert.notEqual(r.status, 0);
+  // The error envelope is the standard one; just check the message
+  // mentions the validated value so the operator knows what to fix.
+  assert.match(r.stderr + r.stdout, /severity/);
+});
+
+test('flow-suggest CLI: invalid format fails closed', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--format',
+    'xml',
+  ]);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /format/);
+});
+
+test('flow-suggest CLI: missing --severity fails with shape hint', () => {
+  const r = runGate(['flow-suggest', '--area', 'copy']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /severity/);
+});
+
+test('flow-suggest CLI: missing --area fails with shape hint', () => {
+  const r = runGate(['flow-suggest', '--severity', 'low']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /area/);
+});
+
+test('flow-suggest CLI: unknown flag rejected', () => {
+  const r = runGate([
+    'flow-suggest',
+    '--severity',
+    'low',
+    '--area',
+    'copy',
+    '--bogus',
+    'x',
+  ]);
+  assert.notEqual(r.status, 0);
+});

--- a/tests/interface/lenseStats305.test.ts
+++ b/tests/interface/lenseStats305.test.ts
@@ -1,0 +1,238 @@
+// #305 — gate lense-stats regression suite.
+//
+// Acceptance:
+//   - empty content_root → totals.entries_counted === 0, exit 0
+//   - gate reviews recorded → counted per lense
+//   - devil-passage entries recorded → counted per lense
+//   - --for <actor> filters by author
+//   - --since rejects junk, accepts 7d/24h/30m/45s
+//   - most / least populated correctly
+//   - --format json shape stable
+//   - rejects unknown flags
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseDuration } from '../../src/interface/gate/handlers/lenseStats.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-lense-stats-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in: ${output}`);
+  return m[0];
+}
+
+// -------------------- parseDuration (unit) --------------------
+
+test('#305 parseDuration: accepts s/m/h/d', () => {
+  assert.equal(parseDuration('45s'), 45 * 1000);
+  assert.equal(parseDuration('30m'), 30 * 60 * 1000);
+  assert.equal(parseDuration('24h'), 24 * 60 * 60 * 1000);
+  assert.equal(parseDuration('7d'), 7 * 24 * 60 * 60 * 1000);
+});
+
+test('#305 parseDuration: rejects malformed', () => {
+  assert.throws(() => parseDuration('7'), /must match/);
+  assert.throws(() => parseDuration('7w'), /must match/);
+  assert.throws(() => parseDuration('0d'), /must match|positive/);
+  assert.throws(() => parseDuration('abc'), /must match/);
+});
+
+// -------------------- empty content_root --------------------
+
+test('#305: empty content_root → entries_counted=0 (text)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lense-stats']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /entries=0/);
+  assert.match(r.stdout, /no review entries in window/);
+});
+
+test('#305: empty content_root → JSON shape', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lense-stats', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const j = JSON.parse(r.stdout);
+  assert.equal(j.totals.entries_counted, 0);
+  assert.equal(j.totals.lenses_with_use, 0);
+  assert.equal(j.most, null);
+  assert.equal(j.least, null);
+  assert.equal(j.filter.actor, null);
+  assert.equal(j.window.duration, '7d');
+  assert.ok(Array.isArray(j.stats));
+  // zero-count catalog lenses still appear so the operator sees "0".
+  const devil = j.stats.find((s: { lense: string }) => s.lense === 'devil');
+  assert.ok(devil, 'expected devil lense to appear with count 0');
+  assert.equal(devil.count, 0);
+});
+
+// -------------------- gate reviews counted --------------------
+
+test('#305: gate reviews counted per lense (and most/least populated)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Create two requests so we can attach multiple reviews under different lenses.
+  const r1 = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'first slice',
+    '--reason', 'r1',
+  ]);
+  const id1 = extractRequestId(r1.stdout + r1.stderr);
+  runGate(root, ['approve', id1, '--by', 'eris']);
+  // 3 devil reviews on r1
+  runGate(root, ['review', id1, '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'looks good']);
+  runGate(root, ['review', id1, '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'second pass']);
+  runGate(root, ['review', id1, '--by', 'alice', '--lense', 'devil', '--verdict', 'ok', '--comment', 'third']);
+  // 1 layer review
+  runGate(root, ['review', id1, '--by', 'bob', '--lense', 'layer', '--verdict', 'concern', '--comment', 'check']);
+
+  const r = runGate(root, ['lense-stats', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const j = JSON.parse(r.stdout);
+  assert.equal(j.totals.entries_counted, 4);
+  assert.equal(j.most, 'devil');
+  assert.equal(j.least, 'layer');
+  const devil = j.stats.find((s: { lense: string }) => s.lense === 'devil');
+  const layer = j.stats.find((s: { lense: string }) => s.lense === 'layer');
+  assert.equal(devil.count, 3);
+  assert.equal(devil.sources.gate_reviews, 3);
+  assert.equal(devil.sources.devil_entries, 0);
+  assert.equal(layer.count, 1);
+  assert.ok(devil.last_at && layer.last_at, 'last_at should be ISO when count>0');
+});
+
+// -------------------- --for filter --------------------
+
+test('#305: --for filters by actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'slice',
+    '--reason', 'r',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+  runGate(root, ['review', id, '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'b1']);
+  runGate(root, ['review', id, '--by', 'bob', '--lense', 'layer', '--verdict', 'ok', '--comment', 'b2']);
+  runGate(root, ['review', id, '--by', 'alice', '--lense', 'devil', '--verdict', 'ok', '--comment', 'a1']);
+
+  const all = JSON.parse(
+    runGate(root, ['lense-stats', '--format', 'json']).stdout,
+  );
+  assert.equal(all.totals.entries_counted, 3);
+
+  const onlyBob = JSON.parse(
+    runGate(root, ['lense-stats', '--for', 'bob', '--format', 'json']).stdout,
+  );
+  assert.equal(onlyBob.filter.actor, 'bob');
+  assert.equal(onlyBob.totals.entries_counted, 2);
+
+  const onlyAlice = JSON.parse(
+    runGate(root, ['lense-stats', '--for', 'alice', '--format', 'json']).stdout,
+  );
+  assert.equal(onlyAlice.totals.entries_counted, 1);
+  assert.equal(onlyAlice.most, 'devil');
+});
+
+// -------------------- --since narrows --------------------
+
+test('#305: --since narrows the window', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'slice',
+    '--reason', 'r',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+  runGate(root, ['review', id, '--by', 'bob', '--lense', 'devil', '--verdict', 'ok', '--comment', 'just-now']);
+
+  // 1-second window — the just-recorded review's `at` is within 1s of now
+  // typically; we relax by using a generous 30m window for stability and
+  // a vanishingly small window (1s would still match within CI clock).
+  // Instead: verify a far-future cutoff (--since 1s) might still include
+  // it; the deterministic check is that 7d (default) includes it.
+  const wide = JSON.parse(
+    runGate(root, ['lense-stats', '--since', '7d', '--format', 'json']).stdout,
+  );
+  assert.equal(wide.totals.entries_counted, 1);
+  assert.equal(wide.window.duration, '7d');
+});
+
+// -------------------- --since rejects junk --------------------
+
+test('#305: --since rejects junk', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lense-stats', '--since', 'forever']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr + r.stdout, /must match|since/);
+});
+
+// -------------------- unknown flag rejected --------------------
+
+test('#305: rejects unknown flags', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lense-stats', '--bogus', 'x']);
+  assert.equal(r.status, 1);
+});
+
+// -------------------- --format invalid --------------------
+
+test('#305: --format must be text or json', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lense-stats', '--format', 'yaml']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr + r.stdout, /format/);
+});

--- a/tests/interface/resumeWithDoctor.test.ts
+++ b/tests/interface/resumeWithDoctor.test.ts
@@ -1,0 +1,203 @@
+// gate resume --with-doctor [--auto-repair] — #306
+//
+// Invariants:
+//   1. --with-doctor on clean substrate → doctor.is_clean=true, no findings,
+//      no auto_repair key (only present when --auto-repair flag set).
+//   2. --with-doctor on dirty substrate → doctor.findings non-empty, summary
+//      mentions the malformed counts. JSON payload retains pre-#306 keys.
+//   3. --with-doctor --auto-repair on dirty substrate → quarantines findings,
+//      auto_repair.quarantined > 0, and a re-run shows is_clean=true.
+//   4. --auto-repair without --with-doctor → exit 1 with a pointed error.
+//   5. text mode with --with-doctor → appends a "substrate doctor" section
+//      to the prose; the pre-existing prose body remains intact.
+//   6. Without --with-doctor → JSON has no `doctor` key (forward compat).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const GUILD = resolve(here, '../../../bin/guild.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-resume-doctor-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+function runGuild(cwd: string, args: string[]): void {
+  spawnSync(process.execPath, [GUILD, ...args], { cwd, stdio: 'ignore' });
+}
+
+test('gate resume --with-doctor: clean substrate → is_clean=true, no findings', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(root, ['resume', '--with-doctor'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.ok(payload.doctor, 'doctor section should exist');
+    assert.equal(payload.doctor.is_clean, true);
+    assert.deepEqual(payload.doctor.findings, []);
+    assert.equal(payload.doctor.auto_repair, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume (no --with-doctor): doctor key absent (forward compat)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(root, ['resume'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(
+      'doctor' in payload,
+      false,
+      'doctor key MUST be absent when --with-doctor is off',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor: dirty substrate surfaces findings', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    // Plant a malformed file under requests/ to produce a finding.
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not valid yaml :::\n');
+    const { stdout, status } = runGate(root, ['resume', '--with-doctor'], {
+      GUILD_ACTOR: 'claude',
+    });
+    // resume's exit code is unaffected by doctor findings — resume is
+    // a read verb; non-clean substrate doesn't fail the session boot.
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.ok(payload.doctor);
+    assert.equal(payload.doctor.is_clean, false);
+    assert.ok(payload.doctor.findings.length > 0);
+    assert.match(payload.doctor.summary, /malformed/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --auto-repair: quarantines and re-run is clean', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not valid yaml :::\n');
+    const first = runGate(
+      root,
+      ['resume', '--with-doctor', '--auto-repair'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(first.status, 0);
+    const p1 = JSON.parse(first.stdout);
+    assert.ok(p1.doctor.auto_repair, 'auto_repair block expected');
+    assert.equal(p1.doctor.auto_repair.attempted, true);
+    assert.ok(
+      p1.doctor.auto_repair.quarantined > 0,
+      'at least one finding should be quarantined',
+    );
+    // Re-run: substrate should now be clean.
+    const second = runGate(
+      root,
+      ['resume', '--with-doctor'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    const p2 = JSON.parse(second.stdout);
+    assert.equal(p2.doctor.is_clean, true);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --auto-repair (no --with-doctor): exit 1 with pointed error', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { status, stderr } = runGate(root, ['resume', '--auto-repair'], {
+      GUILD_ACTOR: 'claude',
+    });
+    assert.equal(status, 1);
+    assert.match(stderr, /--auto-repair requires --with-doctor/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --format text: appends substrate doctor section', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    const { stdout, status } = runGate(
+      root,
+      ['resume', '--with-doctor', '--format', 'text'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(status, 0);
+    // pre-existing prose body
+    assert.match(stdout, /resuming as claude/i);
+    // new section
+    assert.match(stdout, /substrate doctor/i);
+    assert.match(stdout, /clean/i);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate resume --with-doctor --format text on dirty: lists findings + repair hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGuild(root, ['new', '--name', 'claude', '--category', 'professional']);
+    mkdirSync(join(root, 'requests'), { recursive: true });
+    writeFileSync(join(root, 'requests', 'garbage.yaml'), '::: not yaml :::\n');
+    const { stdout, status } = runGate(
+      root,
+      ['resume', '--with-doctor', '--format', 'text'],
+      { GUILD_ACTOR: 'claude' },
+    );
+    assert.equal(status, 0);
+    assert.match(stdout, /substrate doctor/i);
+    assert.match(stdout, /finding/i);
+    assert.match(stdout, /auto-repair|gate repair/);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/interface/reviewContext310.test.ts
+++ b/tests/interface/reviewContext310.test.ts
@@ -1,0 +1,213 @@
+// #310 — gate review-context regression.
+//
+// Acceptance:
+//   - shallow / standard / deep produce the matching lens recommendation
+//   - missing depth on a wave surfaces a non-empty warning + empty lenses
+//   - prior reviews are bundled into the payload
+//   - non-existent id → exit 1 with notFoundHint
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(cwd: string, args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, encoding: 'utf8' });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-review-context-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob', 'critic']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+test('#310: review-context on non-existent id exits 1 with notFoundHint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['review-context', '9999-99-99-9999']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /not found: 9999-99-99-9999/);
+});
+
+test('#310: review-context on wave without depth → empty lenses + warning', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--action', 'no-depth wave',
+    '--reason', 'reviewer default test',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, null);
+  assert.deepEqual(payload.recommended_lenses, []);
+  assert.deepEqual(payload.recommended_extras, []);
+  assert.match(payload.warning, /no depth recorded/);
+  assert.deepEqual(payload.executors, ['alice']);
+});
+
+test('#310: depth=shallow → point-check lens set', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'shallow',
+    '--action', 'shallow wave',
+    '--reason', 'depth=shallow',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'shallow');
+  assert.deepEqual(payload.recommended_lenses, ['Logic']);
+  assert.deepEqual(payload.recommended_extras, []);
+  assert.equal(payload.warning, '');
+});
+
+test('#310: depth=standard → 6-lens default', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'standard',
+    '--action', 'standard wave',
+    '--reason', 'depth=standard',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'standard');
+  assert.equal(payload.recommended_lenses.length, 6);
+  assert.ok(payload.recommended_lenses.includes('Logic'));
+  assert.ok(payload.recommended_lenses.includes('Input'));
+  assert.deepEqual(payload.recommended_extras, []);
+});
+
+test('#310: depth=deep → all 10 lenses + extras (memory MCP + state-machine + cross-check)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'deep wave',
+    '--reason', 'depth=deep',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.depth, 'deep');
+  assert.equal(payload.recommended_lenses.length, 10);
+  // Spot-check the security cluster that distinguishes deep from standard.
+  assert.ok(payload.recommended_lenses.includes('Injection'));
+  assert.ok(payload.recommended_lenses.includes('Auth'));
+  assert.ok(payload.recommended_lenses.includes('Secrets'));
+  assert.ok(payload.recommended_extras.includes('memory_mcp_trap_lookup'));
+  assert.ok(payload.recommended_extras.includes('state_machine_trace'));
+  assert.ok(payload.recommended_extras.includes('prior_review_cross_check'));
+});
+
+test('#310: review-context bundles prior reviews into the payload', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'reviewed wave',
+    '--reason', 'prior-review bundling',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+  const rev = runGate(root, [
+    'review', id,
+    '--by', 'critic',
+    '--lense', 'layer',
+    '--verdict', 'ok',
+    '--note', 'first pass clean',
+  ]);
+  assert.equal(rev.status, 0, rev.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'json']);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.prior_reviews.length, 1);
+  assert.equal(payload.prior_reviews[0].by, 'critic');
+  assert.equal(payload.prior_reviews[0].lense, 'layer');
+  assert.equal(payload.prior_reviews[0].verdict, 'ok');
+  assert.equal(payload.prior_reviews[0].comment, 'first pass clean');
+});
+
+test('#310: text format renders depth + lens recommendation + prior reviews', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'deep',
+    '--action', 'text-format wave',
+    '--reason', 'text rendering',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--format', 'text']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /review-context [\d-]+/);
+  assert.match(r.stdout, /depth: deep/);
+  assert.match(r.stdout, /recommended lenses:.*Injection/);
+  assert.match(r.stdout, /recommended extras:.*memory_mcp_trap_lookup/);
+});
+
+test('#310: review-context rejects unknown flags', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice',
+    '--depth', 'standard',
+    '--action', 'flag test',
+    '--reason', 'unknown flag',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  const r = runGate(root, ['review-context', id, '--bogus']);
+  assert.notEqual(r.status, 0);
+});

--- a/tests/interface/verbHelp.test.ts
+++ b/tests/interface/verbHelp.test.ts
@@ -169,7 +169,7 @@ test('VERB_EXAMPLES: every documented verb is mapped to a runnable example', () 
       'inbox mark-read', 'issues add', 'issues list', 'issues note',
       'issues promote', 'issues resolve', 'issues defer', 'issues start',
       'issues reopen', 'show', 'list', 'board', 'tail', 'chain', 'transcript',
-      'voices', 'whoami', 'boot', 'status', 'suggest', 'resume', 'summarize',
+      'voices', 'whoami', 'boot', 'status', 'suggest', 'flow-suggest', 'resume', 'summarize',
       'why', 'unresponded', 'schema', 'doctor', 'repair',
     ],
     agora: [

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -41,7 +41,7 @@ const GATE_ALL = [
   'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
-  'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
+  'boot', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
   'lense-stats',
 ] as const;

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -43,6 +43,7 @@ const GATE_ALL = [
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
+  'lense-stats',
 ] as const;
 
 const AGORA_ALL = [

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -43,7 +43,7 @@ const GATE_ALL = [
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
-  'lense-stats',
+  'wave-status', 'lense-stats', 'review-context',
 ] as const;
 
 const AGORA_ALL = [

--- a/tests/interface/voiceBudget.test.ts
+++ b/tests/interface/voiceBudget.test.ts
@@ -101,13 +101,18 @@ const VOICE_BUDGET: readonly BudgetEntry[] = [
   },
   {
     phrase: 'advisory — override freely',
-    budget: 1,
-    allowed_files: ['src/interface/gate/handlers/suggest.ts'],
+    budget: 2,
+    allowed_files: [
+      'src/interface/gate/handlers/suggest.ts',
+      'src/interface/gate/handlers/flowSuggest.ts',
+    ],
     rationale:
-      'stderr footer of `gate suggest --format text` — principle 02 ' +
-      'at the point of use. budget 1 because this is an at-the-edge ' +
-      'phrase tied to one surface (the suggest verb), not pedagogical ' +
-      'across surfaces.',
+      'stderr footer of advisory read verbs (gate suggest, gate ' +
+      'flow-suggest) — principle 02 at the point of use. budget 2 ' +
+      'covers both advisory surfaces; the phrase is intentionally ' +
+      'shared so the reader recognises "this is a heuristic" across ' +
+      'verbs. New advisory verbs should reuse this footer rather than ' +
+      'inventing a paraphrase.',
   },
   {
     phrase: 'DETECTOR, not an enforcer',


### PR DESCRIPTION
## Summary

Bundles 4 independent verbs into one mergeable PR. Each commit is preserved with its original Co-Author signature for individual review.

| Issue | Commit | Owner |
|---|---|---|
| #305 lense-stats | `c569232` | Noir |
| #306 resume --with-doctor | `0d81913` | Leysia |
| #307 flow-suggest | `2d00367` | Miki |
| #310 review-context | `b9e7197` | eris |

## Why bundle

The 4 individual PRs (#316/317/318/320) all touch the same configuration sites — `index.ts` dispatcher, `verbs.ts` READ_VERBS, `schema.ts` verb registry, `verbs-consistency.test.ts` GATE_ALL. Each merges cleanly against current main, but the **first** to merge would conflict the others. Bundling them avoids 3 rounds of rebase friction.

## What each verb does

- **`gate lense-stats`** — lense rotation diagnostic. Counts review entries per lense over a window, highlights bias.
- **`gate resume --with-doctor [--auto-repair]`** — folds a doctor summary into resume payload; auto-repair quarantines findings inline.
- **`gate flow-suggest --severity <s> --area <a>`** — advisory verb for picking a flow shape (fast-track / direct-pr / full-request).
- **`gate review-context <id>`** — reviewer-facing bundle: depth advisory + recommended lens set + prior reviews. Closes the substrate-to-reviewer signal loop from #221.

Also fixes a pre-existing gap: `wave-status` was missing from `verbs.ts` READ_VERBS (surfaced by Noir during #305 work) — now declared.

## Test plan

- [x] `npm test` → 1559 / 1559 pass
- [x] 4 individual cherry-picks preserved as separate commits
- [x] All 4 closes-references retained (issues will auto-close on merge)

## Closes

- Closes #305 #306 #307 #310
- Supersedes PRs #316 #317 #318 #320 (will close once this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)