### PR TITLE
feat(boot): profile-aware text projection (axis 1 of solo/swarm coexistence, closes #323)

### DIFF
--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -25,6 +25,7 @@ import {
 import { agoraOrientation } from '../../../passages/agora/interface/orientation.js';
 import { ctxOrientation } from '../../../passages/ctx/interface/orientation.js';
 import { devilOrientation } from '../../../passages/devil/interface/orientation.js';
+import type { GuildProfile } from '../../../infrastructure/config/GuildConfig.js';
 
 /**
  * Next-step hint embedded in boot. Mirrors the SuggestedNext shape
@@ -665,7 +666,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   if (format === 'json') {
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
   } else {
-    process.stdout.write(renderBootText(payload));
+    process.stdout.write(renderBootText(payload, c.config.profile));
   }
   return 0;
 }
@@ -1351,7 +1352,7 @@ function deriveVerbsAvailableNow(
   };
 }
 
-function renderBootText(p: BootPayload): string {
+function renderBootText(p: BootPayload, profile: GuildProfile): string {
   const lines: string[] = [];
   if (p.actor) {
     const sessionTag =
@@ -1360,7 +1361,7 @@ function renderBootText(p: BootPayload): string {
   } else {
     lines.push('── boot (no GUILD_ACTOR; global view) ──');
   }
-  if (p.hints.session_id_unset) {
+  if (p.hints.session_id_unset && profile === 'swarm') {
     lines.push('');
     lines.push(
       'notice: no session_id resolved (GUILD_SESSION_ID unset, no --session-id flag).',
@@ -1473,7 +1474,12 @@ function renderBootText(p: BootPayload): string {
   // silent so the common "no overlap" boot doesn't carry an empty
   // header line. JSON consumers read `active_overlapping_targets`
   // directly — text mode here is the human-readable projection.
-  if (p.active_overlapping_targets.length > 0) {
+  //
+  // Profile gating (#323): swarm-only signal. Solo users on
+  // profile=standard don't see the overlap section or the parallel-
+  // session warning in text mode. JSON envelope is unchanged so
+  // orchestrators keep their contract regardless of profile.
+  if (profile === 'swarm' && p.active_overlapping_targets.length > 0) {
     lines.push('');
     lines.push('active waves with overlapping target:');
     for (const o of p.active_overlapping_targets) {

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -993,6 +993,11 @@ test('gate boot: active_overlapping_targets ignores requests with no target', ()
 test('gate boot: active_overlapping_targets carries claim_held marker for claimed wave', () => {
   const { root, cleanup } = bootstrap();
   try {
+    // Overlap text-mode rendering is profile=swarm only (#323).
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\nprofile: swarm\n',
+    );
     registerMember(root, 'leysia');
     // Use --executor to populate the executors[] slot the surface
     // renders (matching the issue's example output shape, which
@@ -1202,6 +1207,12 @@ test('gate boot: different actors with different sessions do NOT flag (#249 slic
 test('gate boot text: parallel-session warning lands under overlap section (#249 slice 4)', () => {
   const { root, cleanup } = bootstrap();
   try {
+    // Overlap text-mode rendering (and the parallel-session warn it
+    // hangs off) is profile=swarm only (#323).
+    writeFileSync(
+      join(root, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [human]\nprofile: swarm\n',
+    );
     makeRequestSessioned(root, 'alice', 'work A', 'src/foo', 'alice-tmux-1');
     makeRequestSessioned(root, 'alice', 'work B', 'src/foo', 'alice-tmux-2');
 

--- a/tests/interface/bootProfileProjection.test.ts
+++ b/tests/interface/bootProfileProjection.test.ts
@@ -1,0 +1,238 @@
+// gate boot — profile-aware text projection (#323, axis 1 of solo/swarm coexistence).
+//
+// Solo users on profile=standard should not see swarm-only signals in
+// `gate boot --format text`. The JSON envelope is unchanged regardless
+// of profile so orchestrators keep their contract.
+//
+// Signals suppressed under profile=standard text:
+//   - session_id_unset hint
+//   - active_overlapping_targets section
+//   - parallel_session_authors warn
+//
+// JSON stays full-fidelity on every profile (regression guard).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(profile: 'standard' | 'swarm'): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-boot-profile-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    `content_root: .\nhost_names: [human]\nprofile: ${profile}\n`,
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'leysia.yaml'),
+    'name: leysia\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout, status: result.status ?? -1 };
+}
+
+function makeRequestWithTarget(
+  root: string,
+  from: string,
+  action: string,
+  target: string,
+  sessionId?: string,
+): string {
+  const env: Record<string, string> = {};
+  if (sessionId !== undefined) env.GUILD_SESSION_ID = sessionId;
+  const r = spawnSync(
+    process.execPath,
+    [
+      GATE, 'request',
+      '--from', from,
+      '--action', action,
+      '--reason', 'profile projection test',
+      '--target', target,
+      '--format', 'json',
+    ],
+    { cwd: root, env: { ...process.env, ...env }, encoding: 'utf8' },
+  );
+  if (r.status !== 0) throw new Error(`gate request failed: ${r.stderr}`);
+  return JSON.parse(r.stdout).id as string;
+}
+
+// ---- session_id_unset hint (text mode) ----------------------------
+
+test('gate boot text: profile=standard suppresses session_id_unset notice', () => {
+  const { root, cleanup } = bootstrap('standard');
+  try {
+    const { stdout, status } = runGate(
+      root,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: '' },
+    );
+    assert.equal(status, 0);
+    assert.doesNotMatch(stdout, /no session_id resolved/);
+    assert.doesNotMatch(stdout, /GUILD_SESSION_ID unset/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: profile=swarm shows session_id_unset notice', () => {
+  const { root, cleanup } = bootstrap('swarm');
+  try {
+    const { stdout, status } = runGate(
+      root,
+      ['boot', '--format', 'text'],
+      { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: '' },
+    );
+    assert.equal(status, 0);
+    assert.match(stdout, /no session_id resolved/);
+    assert.match(stdout, /GUILD_SESSION_ID unset/);
+  } finally {
+    cleanup();
+  }
+});
+
+// ---- active_overlapping_targets (text mode) -----------------------
+
+test('gate boot text: profile=standard suppresses overlap section even when present', () => {
+  const { root, cleanup } = bootstrap('standard');
+  try {
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared');
+    makeRequestWithTarget(root, 'leysia', 'work B', 'src/shared');
+
+    const { stdout, status } = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(status, 0);
+    assert.doesNotMatch(stdout, /active waves with overlapping target/);
+    assert.doesNotMatch(stdout, /coordinate via .gate witness/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: profile=swarm shows overlap section when present', () => {
+  const { root, cleanup } = bootstrap('swarm');
+  try {
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared');
+    makeRequestWithTarget(root, 'leysia', 'work B', 'src/shared');
+
+    const { stdout, status } = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(status, 0);
+    assert.match(stdout, /active waves with overlapping target:/);
+    assert.match(stdout, /target: src\/shared/);
+  } finally {
+    cleanup();
+  }
+});
+
+// ---- JSON envelope unchanged (regression) -------------------------
+
+test('gate boot JSON: profile=standard preserves all fields (envelope unchanged)', () => {
+  const { root, cleanup } = bootstrap('standard');
+  try {
+    // Trigger overlap so active_overlapping_targets is non-empty.
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared', 'alice-tmux-1');
+    makeRequestWithTarget(root, 'alice', 'work B', 'src/shared', 'alice-tmux-2');
+
+    const { stdout, status } = runGate(
+      root,
+      ['boot'],
+      { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: '' },
+    );
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+
+    // session_id_unset hint still present in JSON
+    assert.equal(payload.hints.session_id_unset, true);
+    // overlap still present in JSON
+    assert.equal(Array.isArray(payload.active_overlapping_targets), true);
+    assert.equal(payload.active_overlapping_targets.length, 1);
+    assert.equal(payload.active_overlapping_targets[0].target, 'src/shared');
+    // parallel_session_authors still present in JSON
+    const entry = payload.active_overlapping_targets[0];
+    assert.ok(entry.parallel_session_authors);
+    assert.deepEqual(
+      entry.parallel_session_authors.alice,
+      ['alice-tmux-1', 'alice-tmux-2'],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot JSON: profile=swarm preserves all fields (envelope unchanged)', () => {
+  const { root, cleanup } = bootstrap('swarm');
+  try {
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared', 'alice-tmux-1');
+    makeRequestWithTarget(root, 'alice', 'work B', 'src/shared', 'alice-tmux-2');
+
+    const { stdout, status } = runGate(
+      root,
+      ['boot'],
+      { GUILD_ACTOR: 'alice', GUILD_SESSION_ID: '' },
+    );
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+
+    assert.equal(payload.hints.session_id_unset, true);
+    assert.equal(payload.active_overlapping_targets.length, 1);
+    assert.equal(payload.active_overlapping_targets[0].target, 'src/shared');
+    const entry = payload.active_overlapping_targets[0];
+    assert.ok(entry.parallel_session_authors);
+    assert.deepEqual(
+      entry.parallel_session_authors.alice,
+      ['alice-tmux-1', 'alice-tmux-2'],
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// ---- parallel_session_authors warn (text mode) --------------------
+
+test('gate boot text: profile=standard suppresses parallel-session warning', () => {
+  const { root, cleanup } = bootstrap('standard');
+  try {
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared', 'alice-tmux-1');
+    makeRequestWithTarget(root, 'alice', 'work B', 'src/shared', 'alice-tmux-2');
+
+    const { stdout, status } = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(status, 0);
+    assert.doesNotMatch(stdout, /same-actor parallel sessions/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate boot text: profile=swarm shows parallel-session warning', () => {
+  const { root, cleanup } = bootstrap('swarm');
+  try {
+    makeRequestWithTarget(root, 'alice', 'work A', 'src/shared', 'alice-tmux-1');
+    makeRequestWithTarget(root, 'alice', 'work B', 'src/shared', 'alice-tmux-2');
+
+    const { stdout, status } = runGate(root, ['boot', '--format', 'text']);
+    assert.equal(status, 0);
+    assert.match(stdout, /same-actor parallel sessions: alice/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Axis 1 of 5 from the solo/swarm coexistence proposal (#323-#327). Smallest axis, ship first as proof-of-flow validating:
- substrate-in-repo (`substrate/swarm-experiments/2026-05-11-solo-swarm-coexistence/`, NOT `/tmp` — principle 14 location rule)
- agora-binding for judgment trace (`agora play 2026-05-11-001` opened pre-wave with 7 design moves, suspended with cliff, bridged via `gate request --from-agora`)
- worktree-ledger blindspot recipe (#322): SubAgent reported progress in final result, parent stamped gate transitions

## Change

`gate boot --format text` no longer surfaces swarm-only signals under `profile: standard`. JSON envelope unchanged (orchestrator contract preserved per principle 11).

| Signal | profile=standard text | profile=swarm text | JSON |
|---|---|---|---|
| `session_id_unset` notice | suppress | show | unchanged |
| `active_overlapping_targets` section | suppress | show | unchanged |
| `parallel_session_authors` warn | suppress | show | unchanged |
| `cross_passage` block | unchanged (already conditional) | unchanged | unchanged |

Implementation: thread `c.config.profile` into `renderBootText`, gate the swarm-only blocks on `profile === 'swarm'`. JSON path untouched.

## Why this matters

A solo user opening guild-cli for the first time runs `gate register` → `gate request` → `gate review` → `gate complete`. They never invoke `claim`, `witness`, or any swarm-specific verb. But `gate boot` (the canonical orient verb, called every session) currently shows them session_id notices, overlap-target warnings, and parallel-session warnings that are noise in their context. Text mode is the human projection (principle 11); pruning belongs here.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1559/1559 pass (+8 new tests, 2 pre-existing tests updated to opt into `profile: swarm` for overlap rendering)
- [x] New: `tests/interface/bootProfileProjection.test.ts` — 8 cases covering 4 text projection pairs + 2 JSON regression cases
- [x] Updated: `boot.test.ts` 2 cases that assert overlap text now write `profile: swarm` into the test config (intentional diff matching the spec)

## Sequencing for remaining axes

The other 4 axes are filed as design issues, **not bundled** into this PR per playbook C6 (#322) lesson "bundle-PR recipe is a symptom":

- #324 axis 2 — tiered `gate --help` (base/swarm/all). Design needed: flag naming, base-set scope.
- #325 axis 3 — docs audience axis + `docs/swarm.md` split. Editorial pass.
- #326 axis 4 — `applies_to:` frontmatter on lore principles. Backward-compat default.
- #327 axis 5 — trap memory `relevant_until` + quarantine sweep. Substrate-affecting; shape A vs B decision needed.

After this PR observes friction (or absence of it) under real solo-user load, axes 2-5 can be sequenced individually.

## Provenance

- agora play (suspended, will resume + conclude post-merge): `solo-swarm-coexistence` 2026-05-11-001 in local substrate
- gate wave: `2026-05-11-0001` in local substrate, single-executor agent-boot, critic approve (self_approve forbidden under swarm), witness + execute, complete on PR merge

Closes #323

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_