### PR TITLE
feat(help): tiered gate --help with profile-aware default (axis 2 of solo/swarm coexistence, closes #324)

### DIFF
--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -1,0 +1,564 @@
+// gate --help — tiered renderer (issue #324, axis 2 of solo/swarm
+// coexistence).
+//
+// `gate --help` previously listed every verb in one flat catalog,
+// mixing the solo-flow primitives (request/approve/execute/complete)
+// with cross-session coordination (claim/witness/wave-status) and
+// alpha utilities (transcript/voices/rest/wake/...). For a solo user
+// on `profile: standard`, the catalog reads as if half the verbs are
+// permanently aspirational. For a swarm user, the coordination verbs
+// are buried in the noise.
+//
+// Tiered model:
+//   BASE          — the 14 verbs every operator needs.
+//   COORDINATION  — cross-session stake + wave-level visibility (5).
+//   EXTRA         — everything else (issues, messages, calibration,
+//                   rest/wake/farewell, transcript, templates, ...).
+//
+// Default surface is profile-driven:
+//   profile=standard  → BASE only
+//   profile=swarm     → BASE + COORDINATION
+//   --all flag        → BASE + COORDINATION + EXTRA (irrespective of
+//                       profile)
+//
+// `gate schema --format json` is unchanged and ALWAYS exhaustive —
+// the orchestrator contract (principle 11: AI-first) takes precedence
+// over the human-readable tiering here.
+
+import type { GuildProfile } from '../../infrastructure/config/GuildConfig.js';
+
+export type HelpTier = 'base' | 'coordination' | 'extra';
+
+interface VerbEntry {
+  readonly tier: HelpTier;
+  readonly text: string;
+}
+
+interface Section {
+  readonly heading: string;
+  readonly entries: readonly VerbEntry[];
+}
+
+// Verb -> tier mapping. The lists below are authoritative for the
+// design lock (issue #324). Adding a new verb without an entry just
+// means it never appears in `gate --help`; the dispatch table in
+// `index.ts` is the single source of truth for runtime behaviour.
+//
+// BASE (14): request, approve, execute, complete, fail, review,
+//            show, list, tail, boot, register, doctor, fast-track,
+//            schema
+// COORDINATION (5): claim, witness, unwitness, wave-status,
+//                   slice-complete (slice-complete is forthcoming
+//                   and intentionally absent from the help body).
+
+const SECTIONS: readonly Section[] = [
+  {
+    heading: 'Getting started:',
+    entries: [
+      {
+        tier: 'base',
+        text:
+          '  gate register --name <n> [--category <c>] [--display-name <s>]\n' +
+          '                 [--dry-run] [--format json|text]\n' +
+          '                       Register yourself (or another member) as an\n' +
+          '                       actor. Category defaults to "professional";\n' +
+          '                       aliases accepted (pro, prof, member). Host is\n' +
+          '                       NOT registerable via CLI — edit\n' +
+          '                       guild.config.yaml directly. --dry-run shows\n' +
+          '                       the YAML that would be written.',
+      },
+    ],
+  },
+  {
+    heading: 'Requests:',
+    entries: [
+      {
+        tier: 'base',
+        text:
+          '  gate request --from <m> --action <a> --reason <r>\n' +
+          '                 [--executor <m>] [--target <s>] [--auto-review <m>]\n' +
+          '                 [--with <n1>[,<n2>...]] [--depth shallow|standard|deep]',
+      },
+      {
+        tier: 'extra',
+        text: '  gate pending [--for <m>]',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate board [--for <m>] [--format json|text]\n' +
+          "                       What's in flight: pending + approved +\n" +
+          '                       executing, grouped by state.',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate list --state <state> [--for <m>] [--from <m>]\n' +
+          '                            [--executor <m>] [--auto-review <m>]',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate show <id> [--format json|text] [--fields k1,k2,...] [--plain]\n' +
+          '                       --fields trims the JSON payload to just the\n' +
+          '                       requested keys (agent-facing; JSON only).\n' +
+          '                       --plain + --fields <single-key> emits just\n' +
+          '                       the value (no JSON quotes) for shell combos:\n' +
+          '                         state=$(gate show $id --fields state --plain)\n' +
+          '                         [ "$state" = "pending" ] && gate approve $id',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]\n' +
+          '                     [--format json|text]          (default: json)',
+      },
+      {
+        tier: 'base',
+        text: '  gate tail [N]                                   (default 20)',
+      },
+      {
+        tier: 'extra',
+        text: '  gate whoami                                     (needs GUILD_ACTOR)',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate chain <id>                                 (request or issue;\n' +
+          '                                                   forward refs + inbound)',
+      },
+      {
+        tier: 'base',
+        text: '  gate approve <id> --by <m> [--note <s>] [--dry-run]',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]',
+      },
+      {
+        tier: 'base',
+        text: '  gate execute <id> --by <m> [--note <s>] [--dry-run]',
+      },
+      {
+        tier: 'base',
+        text: '  gate complete <id> --by <m> [--note <s>] [--dry-run]',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate review <id> --by <m> --lense <l> --verdict <v>\n' +
+          '                   [--comment <s> | --comment - | <comment>] [--dry-run]',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate thank <to> --for <id> [--by <m>] [--reason <s> | --reason -]\n' +
+          '                  [--dry-run]\n' +
+          '                       Record cross-actor appreciation against a\n' +
+          "                       specific request. Sibling of 'review' — no\n" +
+          '                       verdict, no state change, no calibration\n' +
+          '                       impact. Reviews track judgement; thanks\n' +
+          '                       track gratitude.',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate fast-track --from <m> --action <a> --reason <r>\n' +
+          '                  [--executor <m>] [--auto-review <m>] [--note <s>]\n' +
+          '                  [--with <n1>[,<n2>...]]',
+      },
+    ],
+  },
+  {
+    heading: 'Coordination:',
+    entries: [
+      {
+        tier: 'coordination',
+        text:
+          '  gate claim <id> --by <m> [--dry-run]\n' +
+          '                       Stake a cross-session claim on a pending or\n' +
+          '                       approved request (issue #226 phase 1). Same-\n' +
+          '                       actor re-claim is a no-op; a different actor\n' +
+          '                       attempting to claim while one is already held\n' +
+          '                       is refused. The claim auto-releases when the\n' +
+          '                       request reaches a terminal state (completed /\n' +
+          '                       failed / denied).',
+      },
+      {
+        tier: 'coordination',
+        text:
+          '  gate witness <id> --by <m> [--dry-run]\n' +
+          '  gate unwitness <id> --by <m> [--dry-run]\n' +
+          '                       Register / remove a non-exclusive observer on\n' +
+          '                       a pending / approved / executing request\n' +
+          '                       (issue #244). Multiple actors may witness in\n' +
+          '                       parallel and witness coexists with any claim.\n' +
+          '                       Same-actor re-witness is a no-op; unwitness\n' +
+          "                       only removes the caller's own witness (refuses\n" +
+          '                       on a foreign actor). Auto-resets to no\n' +
+          '                       witnesses when the request reaches a terminal\n' +
+          '                       state.\n' +
+          '                       --dry-run on any write verb above emits a\n' +
+          '                       preview JSON envelope (dry_run/verb/would_\n' +
+          '                       transition/preview) without persisting.',
+      },
+      {
+        tier: 'coordination',
+        text:
+          '  gate wave-status <id> [--format text|json]\n' +
+          '                       Roll-up view of a multi-executor wave: per-\n' +
+          '                       executor progress, claim/witness occupancy,\n' +
+          '                       and aggregate state. Companion to claim /\n' +
+          '                       witness for swarm coordination.',
+      },
+    ],
+  },
+  {
+    heading: 'Issues:',
+    entries: [
+      {
+        tier: 'extra',
+        text:
+          '  gate issues add --from <m> --severity <s> --area <a>\n' +
+          '                  [--text <s> | --text - | <text>]',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate issues list [--state <s>] [--format json|text]\n' +
+          '                       Default --state is open (worklist semantic).\n' +
+          '                       Use --state all to see every state, or pass a\n' +
+          '                       specific state. Note: status.open_issues\n' +
+          '                       counts open+in_progress (triage), so list and\n' +
+          '                       status report different scopes on purpose.',
+      },
+      {
+        tier: 'extra',
+        text: '  gate issues resolve|defer|start|reopen <id>',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate issues note <id> --by <m> [--text <s> | --text - | <text>]',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>]\n' +
+          '                                      [--action <a>] [--reason <r>]',
+      },
+    ],
+  },
+  {
+    heading: 'Messages:',
+    entries: [
+      {
+        tier: 'extra',
+        text: '  gate message --from <m> --to <m> [--text <s> | --text -]',
+      },
+      {
+        tier: 'extra',
+        text: '  gate broadcast --from <m> [--text <s> | --text -]',
+      },
+      {
+        tier: 'extra',
+        text: '  gate inbox --for <m> [--unread] [--format json|text]',
+      },
+      {
+        tier: 'extra',
+        text: '  gate inbox mark-read [N] [--for <m>]',
+      },
+    ],
+  },
+  {
+    heading: 'Diagnostic / Repair:',
+    entries: [
+      {
+        tier: 'base',
+        text:
+          '  gate doctor [--summary | --format json]\n' +
+          '                       Read-only health check over the content root.\n' +
+          '                       Exits 1 if any malformed records are detected.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate repair [--apply] [--from-doctor <path>] [--format json]\n' +
+          '                       Intervention layer paired with doctor. Reads\n' +
+          "                       'gate doctor --format json' from stdin (or\n" +
+          '                       --from-doctor <file>) and either prints the\n' +
+          '                       proposed plan (default --dry-run) or executes\n' +
+          '                       it (--apply). Quarantine is the only action;\n' +
+          '                       duplicate_id and unknown findings are no-op.\n' +
+          '                       Usage:\n' +
+          '                         gate doctor --format json | gate repair\n' +
+          '                         gate doctor --format json | gate repair --apply',
+      },
+    ],
+  },
+  {
+    heading: 'Status:',
+    entries: [
+      {
+        tier: 'extra',
+        text:
+          '  gate status [--for <m>] [--format json|text]\n' +
+          '                       Agent orientation: pending/approved/executing\n' +
+          '                       counts, open issues, unread inbox, last activity.\n' +
+          '                       Default output is JSON (agent-first).',
+      },
+      {
+        tier: 'base',
+        text:
+          '  gate boot [--format json|text] [--tail <N>] [--utterances <N>]\n' +
+          '                       Single-command session bootstrap for agents.\n' +
+          '                       Returns identity + status + tail + your recent\n' +
+          '                       utterances + inbox unread as one JSON payload.\n' +
+          '                       GUILD_ACTOR optional (global view if unset).\n' +
+          '                       Defaults: --tail 5 --utterances 5 (lean for\n' +
+          '                       hot-path session start; pass higher N for deeper\n' +
+          '                       history).',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]\n' +
+          '                    [--format json|text]\n' +
+          '                       Advisory: maps (severity, area, [scope]) → a\n' +
+          '                       recommended flow (fast-track / direct-pr /\n' +
+          '                       full-request) plus reason and alternatives. Pure\n' +
+          '                       read — no substrate writes. Heuristic, not a\n' +
+          '                       directive; the reason field is the load-bearing\n' +
+          '                       output (override when judgement differs).',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate suggest [--format json|text]\n' +
+          '                       Tight-loop sibling of boot: returns ONLY the\n' +
+          '                       suggested_next triple (verb/args/reason) or\n' +
+          '                       null. Use when you want "what\'s the one next\n' +
+          '                       thing?" without the full orientation payload.\n' +
+          '                       Priority ladder is shared with boot, so the\n' +
+          '                       two never disagree.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate summarize <id> [--format text|json]\n' +
+          '                       Compressed view: state, decision, open\n' +
+          '                       concerns, review/thank counts. The "30-second\n' +
+          '                       read" sibling of transcript.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate why <id> [--format text|json]\n' +
+          '                       Trace the decision chain: terminal transition,\n' +
+          '                       reviews that aligned with the outcome, reviews\n' +
+          '                       that contested it. Perception, not judgement.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate transcript <id> [--format text|json]\n' +
+          "                       Narrative prose render of one request's arc,\n" +
+          '                       composed from status_log + reviews. Sibling\n' +
+          "                       of 'gate show' (structured) and 'gate voices'\n" +
+          '                       (per-actor). JSON mode carries both the\n' +
+          '                       narrative and a summary (actors/verdicts/\n' +
+          '                       duration_ms) for programmatic consumers.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate resume [--format json|text]\n' +
+          '                       Reconstruct what the actor was doing when the\n' +
+          '                       last session ended. Returns last utterance,\n' +
+          '                       last transition, open loops (awaiting/\n' +
+          '                       executing/pending review/unreviewed), and a\n' +
+          '                       prose restoration note. Requires GUILD_ACTOR.\n' +
+          '                       Same-actor continuation only — for a newcomer\n' +
+          "                       arriving via handoff, use 'gate boot' to see\n" +
+          '                       cross-actor signals (inbox, --with assignments).',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate unresponded [--for <m>] [--max-age-days <N>] [--format json|text]\n' +
+          "                       Read-only surface for concern/reject verdicts on\n" +
+          "                       the actor's authored or pair-made requests that\n" +
+          '                       have no follow-up record yet. Thin wrapper over\n' +
+          '                       UnrespondedConcernsQuery — same detector that\n' +
+          "                       drives 'gate resume'. Default actor is\n" +
+          '                       GUILD_ACTOR; default window is 30 days. The\n' +
+          '                       detector is deliberately coarse (does not infer\n' +
+          '                       whether a follow-up actually addresses a\n' +
+          "                       concern); 'gate chain <id>' walks the actual\n" +
+          '                       references when the reader wants to verify.',
+      },
+    ],
+  },
+  {
+    heading: 'Calibration:',
+    entries: [
+      {
+        tier: 'extra',
+        text:
+          '  gate lense-stats [--for <m>] [--since <duration>] [--format json|text]\n' +
+          '                       Count review entries per lense in the window.\n' +
+          '                       Highlights the most-frequent and least-frequent\n' +
+          '                       lense so a reader can spot bias ("I keep hitting\n' +
+          '                       auth-access; have I run devil or composition\n' +
+          '                       lately?"). Sources: gate `review` records +\n' +
+          '                       devil-passage entries. Duration: <int><s|m|h|d>\n' +
+          '                       (default 7d). Read-only.',
+      },
+    ],
+  },
+  {
+    heading: 'Templates:',
+    entries: [
+      {
+        tier: 'extra',
+        text:
+          '  gate templates list [--format json|text]\n' +
+          '  gate templates show <name> [--format json|text]',
+      },
+    ],
+  },
+  {
+    heading: 'Presence:',
+    entries: [
+      {
+        tier: 'extra',
+        text:
+          '  gate rest --by <m> [--note <s>] [--dry-run]\n' +
+          '  gate wake --by <m> [--note <s>] [--dry-run]\n' +
+          '  gate farewell --by <m> [--note <s>] [--dry-run]\n' +
+          '                       Session presence verbs. rest pauses, wake\n' +
+          "                       resumes, farewell marks the actor's exit.",
+      },
+    ],
+  },
+  {
+    heading: 'Meta:',
+    entries: [
+      {
+        tier: 'base',
+        text:
+          "  gate schema [--verb <name>] [--format json|text]\n" +
+          "                       Introspection: JSON Schema for every verb's\n" +
+          '                       inputs and outputs. Consumed by LLM tool layers.\n' +
+          '                       Output is exhaustive regardless of profile or\n' +
+          '                       --all — orchestrators see every verb.',
+      },
+      {
+        tier: 'base',
+        text: '  gate --version       Print version and exit',
+      },
+    ],
+  },
+];
+
+const HEADER = `gate — request lifecycle & dialogue CLI`;
+
+const FOOTER = `States: pending | approved | executing | completed | failed | denied
+Verdicts: ok | concern | reject
+Lenses: devil | layer | cognitive | user (configurable via guild.config.yaml)
+
+Values beginning with "--":
+  Bare \`--key <value>\` will not consume a value that itself starts
+  with "--" (the parser can't tell it from the next flag). Use either
+  form below to pass such literals:
+    --key=<value>                            # inline, any content
+    ... -- <value> [<value>...]              # POSIX end-of-options marker
+  Example:
+    gate issues note <id> --by eris -- "the --reason - sentinel is cool"
+
+Environment:
+  GUILD_ACTOR=<name>   If set, used as the default for --from / --by /
+                       --for when those flags are omitted. Explicit flags
+                       always win. Intended for interactive shells
+                       (export it in your shell profile or direnv).
+                       Automations should continue to pass --from / --by
+                       explicitly.
+                       When GUILD_ACTOR differs from the explicit --by
+                       (e.g. an AI agent acting for a human), write
+                       verbs record invoked_by=<GUILD_ACTOR> on the
+                       status_log entry (or review) and print a
+                       one-line delegation notice to stderr. The on-
+                       record actor (--by) still wins for attribution;
+                       invoked_by preserves the delegation for audits.
+                       Same pattern as inbox read_by.`;
+
+export interface RenderHelpOptions {
+  readonly profile: GuildProfile;
+  readonly all: boolean;
+}
+
+function tierVisible(tier: HelpTier, opts: RenderHelpOptions): boolean {
+  if (opts.all) return true;
+  if (tier === 'base') return true;
+  if (tier === 'coordination') return opts.profile === 'swarm';
+  return false;
+}
+
+function tierBanner(opts: RenderHelpOptions): string {
+  if (opts.all) {
+    return '(showing: BASE + COORDINATION + EXTRA — full catalog via --all)';
+  }
+  if (opts.profile === 'swarm') {
+    return '(showing: BASE + COORDINATION — profile=swarm; pass --all for the full catalog)';
+  }
+  return '(showing: BASE — profile=standard; pass --all for the full catalog)';
+}
+
+export function renderHelp(opts: RenderHelpOptions): string {
+  const lines: string[] = [];
+  lines.push(HEADER);
+  lines.push('');
+  lines.push(tierBanner(opts));
+  lines.push('');
+  for (const section of SECTIONS) {
+    const visible = section.entries.filter((e) => tierVisible(e.tier, opts));
+    if (visible.length === 0) continue;
+    lines.push(section.heading);
+    for (const e of visible) {
+      lines.push(e.text);
+    }
+    lines.push('');
+  }
+  lines.push(FOOTER);
+  lines.push('');
+  return lines.join('\n');
+}
+
+// Exposed for the tiered-help test. Returns the set of verb tokens
+// (the first non-trivial word on the first usage line of each entry)
+// rendered under the given tiering options. Keeping this derivation
+// adjacent to renderHelp() rather than re-grepping the rendered text
+// in tests keeps the "what verbs appear" contract grounded in the
+// section data, not in fragile output formatting.
+export function visibleVerbs(opts: RenderHelpOptions): readonly string[] {
+  const seen = new Set<string>();
+  for (const section of SECTIONS) {
+    for (const e of section.entries) {
+      if (!tierVisible(e.tier, opts)) continue;
+      for (const line of e.text.split('\n')) {
+        const m = line.match(/^ {2}gate ([a-z-]+(?:\s+[a-z-]+)?)/);
+        if (m) {
+          const verb = m[1]!.split(/\s+/)[0]!;
+          seen.add(verb);
+        }
+      }
+    }
+  }
+  return [...seen].sort();
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -59,6 +59,7 @@ import { templatesCmd } from './handlers/templates.js';
 import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
+import { renderHelp } from './help.js';
 import type { Container } from '../shared/container.js';
 import type { ParsedArgs } from '../shared/parseArgs.js';
 
@@ -70,225 +71,10 @@ export {
   computeReviewMarkerWidth,
 } from './handlers/request.js';
 
-const HELP = `gate — request lifecycle & dialogue CLI
-
-Getting started:
-  gate register --name <n> [--category <c>] [--display-name <s>]
-                 [--dry-run] [--format json|text]
-                       Register yourself (or another member) as an
-                       actor. Category defaults to "professional";
-                       aliases accepted (pro, prof, member). Host is
-                       NOT registerable via CLI — edit
-                       guild.config.yaml directly. --dry-run shows
-                       the YAML that would be written.
-
-Requests:
-  gate request --from <m> --action <a> --reason <r>
-                 [--executor <m>] [--target <s>] [--auto-review <m>]
-                 [--with <n1>[,<n2>...]] [--depth shallow|standard|deep]
-  gate pending [--for <m>]
-  gate board [--for <m>] [--format json|text]
-                       What's in flight: pending + approved +
-                       executing, grouped by state.
-  gate list --state <state> [--for <m>] [--from <m>]
-                            [--executor <m>] [--auto-review <m>]
-  gate show <id> [--format json|text] [--fields k1,k2,...] [--plain]
-                       --fields trims the JSON payload to just the
-                       requested keys (agent-facing; JSON only).
-                       --plain + --fields <single-key> emits just
-                       the value (no JSON quotes) for shell combos:
-                         state=$(gate show $id --fields state --plain)
-                         [ "$state" = "pending" ] && gate approve $id
-  gate voices <name> [--lense <l>] [--verdict <v>] [--limit <N>]
-                     [--format json|text]          (default: json)
-  gate tail [N]                                   (default 20)
-  gate whoami                                     (needs GUILD_ACTOR)
-  gate chain <id>                                 (request or issue;
-                                                   forward refs + inbound)
-  gate approve <id> --by <m> [--note <s>] [--dry-run]
-  gate deny <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]
-  gate execute <id> --by <m> [--note <s>] [--dry-run]
-  gate complete <id> --by <m> [--note <s>] [--dry-run]
-  gate fail <id> --by <m> [--note <s> | --reason <s> | <reason>] [--dry-run]
-  gate review <id> --by <m> --lense <l> --verdict <v>
-                   [--comment <s> | --comment - | <comment>] [--dry-run]
-  gate claim <id> --by <m> [--dry-run]
-                       Stake a cross-session claim on a pending or
-                       approved request (issue #226 phase 1). Same-
-                       actor re-claim is a no-op; a different actor
-                       attempting to claim while one is already held
-                       is refused. The claim auto-releases when the
-                       request reaches a terminal state (completed /
-                       failed / denied).
-  gate witness <id> --by <m> [--dry-run]
-  gate unwitness <id> --by <m> [--dry-run]
-                       Register / remove a non-exclusive observer on
-                       a pending / approved / executing request
-                       (issue #244). Multiple actors may witness in
-                       parallel and witness coexists with any claim.
-                       Same-actor re-witness is a no-op; unwitness
-                       only removes the caller's own witness (refuses
-                       on a foreign actor). Auto-resets to no
-                       witnesses when the request reaches a terminal
-                       state.
-                       --dry-run on any write verb above emits a
-                       preview JSON envelope (dry_run/verb/would_
-                       transition/preview) without persisting.
-  gate thank <to> --for <id> [--by <m>] [--reason <s> | --reason -]
-                  [--dry-run]
-                       Record cross-actor appreciation against a
-                       specific request. Sibling of 'review' — no
-                       verdict, no state change, no calibration
-                       impact. Reviews track judgement; thanks
-                       track gratitude.
-  gate fast-track --from <m> --action <a> --reason <r>
-                  [--executor <m>] [--auto-review <m>] [--note <s>]
-                  [--with <n1>[,<n2>...]]
-
-Issues:
-  gate issues add --from <m> --severity <s> --area <a>
-                  [--text <s> | --text - | <text>]
-  gate issues list [--state <s>] [--format json|text]
-                       Default --state is open (worklist semantic).
-                       Use --state all to see every state, or pass a
-                       specific state. Note: status.open_issues
-                       counts open+in_progress (triage), so list and
-                       status report different scopes on purpose.
-  gate issues resolve|defer|start|reopen <id>
-  gate issues note <id> --by <m> [--text <s> | --text - | <text>]
-  gate issues promote <id> --from <m> [--executor <m>] [--auto-review <m>]
-                                      [--action <a>] [--reason <r>]
-
-Messages:
-  gate message --from <m> --to <m> [--text <s> | --text -]
-  gate broadcast --from <m> [--text <s> | --text -]
-  gate inbox --for <m> [--unread] [--format json|text]
-  gate inbox mark-read [N] [--for <m>]
-
-States: pending | approved | executing | completed | failed | denied
-Verdicts: ok | concern | reject
-Lenses: devil | layer | cognitive | user (configurable via guild.config.yaml)
-
-Values beginning with "--":
-  Bare \`--key <value>\` will not consume a value that itself starts
-  with "--" (the parser can't tell it from the next flag). Use either
-  form below to pass such literals:
-    --key=<value>                            # inline, any content
-    ... -- <value> [<value>...]              # POSIX end-of-options marker
-  Example:
-    gate issues note <id> --by eris -- "the --reason - sentinel is cool"
-
-Environment:
-  GUILD_ACTOR=<name>   If set, used as the default for --from / --by /
-                       --for when those flags are omitted. Explicit flags
-                       always win. Intended for interactive shells
-                       (export it in your shell profile or direnv).
-                       Automations should continue to pass --from / --by
-                       explicitly.
-                       When GUILD_ACTOR differs from the explicit --by
-                       (e.g. an AI agent acting for a human), write
-                       verbs record invoked_by=<GUILD_ACTOR> on the
-                       status_log entry (or review) and print a
-                       one-line delegation notice to stderr. The on-
-                       record actor (--by) still wins for attribution;
-                       invoked_by preserves the delegation for audits.
-                       Same pattern as inbox read_by.
-
-Diagnostic / Repair:
-  gate doctor [--summary | --format json]
-                       Read-only health check over the content root.
-                       Exits 1 if any malformed records are detected.
-  gate repair [--apply] [--from-doctor <path>] [--format json]
-                       Intervention layer paired with doctor. Reads
-                       'gate doctor --format json' from stdin (or
-                       --from-doctor <file>) and either prints the
-                       proposed plan (default --dry-run) or executes
-                       it (--apply). Quarantine is the only action;
-                       duplicate_id and unknown findings are no-op.
-                       Usage:
-                         gate doctor --format json | gate repair
-                         gate doctor --format json | gate repair --apply
-
-Status:
-  gate status [--for <m>] [--format json|text]
-                       Agent orientation: pending/approved/executing
-                       counts, open issues, unread inbox, last activity.
-                       Default output is JSON (agent-first).
-  gate boot [--format json|text] [--tail <N>] [--utterances <N>]
-                       Single-command session bootstrap for agents.
-                       Returns identity + status + tail + your recent
-                       utterances + inbox unread as one JSON payload.
-                       GUILD_ACTOR optional (global view if unset).
-                       Defaults: --tail 5 --utterances 5 (lean for
-                       hot-path session start; pass higher N for deeper
-                       history).
-  gate flow-suggest --severity <low|med|high> --area <s> [--scope <s>]
-                    [--format json|text]
-                       Advisory: maps (severity, area, [scope]) → a
-                       recommended flow (fast-track / direct-pr /
-                       full-request) plus reason and alternatives. Pure
-                       read — no substrate writes. Heuristic, not a
-                       directive; the reason field is the load-bearing
-                       output (override when judgement differs).
-  gate suggest [--format json|text]
-                       Tight-loop sibling of boot: returns ONLY the
-                       suggested_next triple (verb/args/reason) or
-                       null. Use when you want "what's the one next
-                       thing?" without the full orientation payload.
-                       Priority ladder is shared with boot, so the
-                       two never disagree.
-  gate summarize <id> [--format text|json]
-                       Compressed view: state, decision, open
-                       concerns, review/thank counts. The "30-second
-                       read" sibling of transcript.
-  gate why <id> [--format text|json]
-                       Trace the decision chain: terminal transition,
-                       reviews that aligned with the outcome, reviews
-                       that contested it. Perception, not judgement.
-  gate transcript <id> [--format text|json]
-                       Narrative prose render of one request's arc,
-                       composed from status_log + reviews. Sibling
-                       of 'gate show' (structured) and 'gate voices'
-                       (per-actor). JSON mode carries both the
-                       narrative and a summary (actors/verdicts/
-                       duration_ms) for programmatic consumers.
-  gate resume [--format json|text]
-                       Reconstruct what the actor was doing when the
-                       last session ended. Returns last utterance,
-                       last transition, open loops (awaiting/
-                       executing/pending review/unreviewed), and a
-                       prose restoration note. Requires GUILD_ACTOR.
-                       Same-actor continuation only — for a newcomer
-                       arriving via handoff, use 'gate boot' to see
-                       cross-actor signals (inbox, --with assignments).
-  gate unresponded [--for <m>] [--max-age-days <N>] [--format json|text]
-                       Read-only surface for concern/reject verdicts on
-                       the actor's authored or pair-made requests that
-                       have no follow-up record yet. Thin wrapper over
-                       UnrespondedConcernsQuery — same detector that
-                       drives 'gate resume'. Default actor is
-                       GUILD_ACTOR; default window is 30 days. The
-                       detector is deliberately coarse (does not infer
-                       whether a follow-up actually addresses a
-                       concern); 'gate chain <id>' walks the actual
-                       references when the reader wants to verify.
-
-Calibration:
-  gate lense-stats [--for <m>] [--since <duration>] [--format json|text]
-                       Count review entries per lense in the window.
-                       Highlights the most-frequent and least-frequent
-                       lense so a reader can spot bias ("I keep hitting
-                       auth-access; have I run devil or composition
-                       lately?"). Sources: gate \`review\` records +
-                       devil-passage entries. Duration: <int><s|m|h|d>
-                       (default 7d). Read-only.
-
-Meta:
-  gate schema [--verb <name>] [--format json|text]
-                       Introspection: JSON Schema for every verb's
-                       inputs and outputs. Consumed by LLM tool layers.
-  gate --version       Print version and exit
-`;
+// Top-level `gate --help` text is rendered by `renderHelp` (see
+// ./help.ts): tiered by guild profile, with a `--all` override that
+// shows the full catalog. `gate schema --format json` remains
+// exhaustive regardless of profile or --all.
 
 // Mirror of the switch below for typo suggestions. Keeping it adjacent
 // to the switch (rather than auto-derived) is an obvious-when-broken
@@ -317,8 +103,21 @@ export async function main(argv: readonly string[]): Promise<number> {
     return 0;
   }
   const [cmd, ...rest] = argv;
+  // Top-level help (#324). Tiering uses the guild profile loaded
+  // from disk: standard → BASE only, swarm → BASE + COORDINATION,
+  // `--all` → full catalog regardless. Config load failures fall
+  // back to a standard-profile view so `gate --help` keeps working
+  // even on a misconfigured root (the help payload is purely
+  // informational and must never block diagnosis).
   if (!cmd || cmd === '--help' || cmd === '-h') {
-    process.stdout.write(HELP);
+    const wantAll = rest.includes('--all');
+    let profile: 'standard' | 'swarm' = 'standard';
+    try {
+      profile = GuildConfig.load().profile;
+    } catch {
+      profile = 'standard';
+    }
+    process.stdout.write(renderHelp({ profile, all: wantAll }));
     return 0;
   }
   const args = parseArgs(rest);

--- a/tests/interface/gateHelpTiered.test.ts
+++ b/tests/interface/gateHelpTiered.test.ts
@@ -1,0 +1,215 @@
+// gate --help — tiered output (issue #324, axis 2 of solo/swarm
+// coexistence).
+//
+// Pre-#324, `gate --help` printed every verb in one flat catalog.
+// Solo users on profile=standard saw cross-session coordination
+// surface (claim/witness/wave-status) they had no use for; swarm
+// users saw alpha utilities buried alongside the verbs they actually
+// reach for. The fix is profile-aware tiering with a `--all`
+// override.
+//
+// Coverage:
+//   - profile=standard prints BASE only (no claim/witness/...)
+//   - profile=swarm prints BASE + COORDINATION (claim/witness/
+//     wave-status appear; transcript/voices/rest/... still hidden)
+//   - --all flag prints everything regardless of profile (both
+//     standard and swarm should produce the same superset)
+//   - schema --format json is exhaustive irrespective of profile
+//     or --all (orchestrator contract — principle 11: AI-first)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Bootstrap {
+  readonly root: string;
+  readonly cleanup: () => void;
+}
+
+function bootstrap(profile: 'standard' | 'swarm'): Bootstrap {
+  const root = mkdtempSync(join(tmpdir(), `guild-help-${profile}-`));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    `content_root: .\nhost_names: [eris]\nprofile: ${profile}\n`,
+  );
+  mkdirSync(join(root, 'members'));
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+// Verb tokens (the first word after `gate `) we expect to find on a
+// usage-line. Matching against `^  gate <verb>` rather than free-text
+// search avoids false positives from prose ("see `gate witness`" in
+// some explanatory paragraph).
+const BASE_VERBS = [
+  'request',
+  'approve',
+  'execute',
+  'complete',
+  'fail',
+  'review',
+  'show',
+  'list',
+  'tail',
+  'boot',
+  'register',
+  'doctor',
+  'fast-track',
+  'schema',
+];
+
+const COORDINATION_VERBS = ['claim', 'witness', 'unwitness', 'wave-status'];
+
+// Sample of EXTRA verbs — any one of these appearing in non-`--all`
+// output under profile=standard|swarm would mean the tier filter
+// leaked.
+const EXTRA_SAMPLE = ['transcript', 'voices', 'rest', 'wake', 'farewell'];
+
+function hasUsageLine(text: string, verb: string): boolean {
+  // Match "  gate <verb>" at the start of a line, with the verb
+  // followed by a non-letter (space, end-of-line, or '<arg>').
+  const re = new RegExp(`^ {2}gate ${verb}(?:[^a-z-]|$)`, 'm');
+  return re.test(text);
+}
+
+test('#324: gate --help under profile=standard shows BASE only', (t) => {
+  const b = bootstrap('standard');
+  t.after(() => b.cleanup());
+  const r = run(b.root, ['--help']);
+  assert.equal(r.status, 0);
+  for (const v of BASE_VERBS) {
+    assert.ok(
+      hasUsageLine(r.stdout, v),
+      `expected BASE verb '${v}' in standard --help; got:\n${r.stdout}`,
+    );
+  }
+  for (const v of COORDINATION_VERBS) {
+    assert.ok(
+      !hasUsageLine(r.stdout, v),
+      `coordination verb '${v}' should be hidden under profile=standard`,
+    );
+  }
+  for (const v of EXTRA_SAMPLE) {
+    assert.ok(
+      !hasUsageLine(r.stdout, v),
+      `extra verb '${v}' should be hidden under profile=standard`,
+    );
+  }
+  // Banner reflects the active tier so the operator knows what they
+  // are seeing.
+  assert.match(r.stdout, /profile=standard/);
+});
+
+test('#324: gate --help under profile=swarm shows BASE + COORDINATION', (t) => {
+  const b = bootstrap('swarm');
+  t.after(() => b.cleanup());
+  const r = run(b.root, ['--help']);
+  assert.equal(r.status, 0);
+  for (const v of BASE_VERBS) {
+    assert.ok(
+      hasUsageLine(r.stdout, v),
+      `expected BASE verb '${v}' in swarm --help`,
+    );
+  }
+  for (const v of COORDINATION_VERBS) {
+    assert.ok(
+      hasUsageLine(r.stdout, v),
+      `expected COORDINATION verb '${v}' in swarm --help`,
+    );
+  }
+  for (const v of EXTRA_SAMPLE) {
+    assert.ok(
+      !hasUsageLine(r.stdout, v),
+      `extra verb '${v}' should be hidden under profile=swarm (use --all)`,
+    );
+  }
+  assert.match(r.stdout, /profile=swarm/);
+});
+
+test('#324: gate --help --all shows everything regardless of profile', (t) => {
+  for (const profile of ['standard', 'swarm'] as const) {
+    const b = bootstrap(profile);
+    t.after(() => b.cleanup());
+    const r = run(b.root, ['--help', '--all']);
+    assert.equal(r.status, 0, `--all under ${profile} should exit 0`);
+    for (const v of [...BASE_VERBS, ...COORDINATION_VERBS, ...EXTRA_SAMPLE]) {
+      assert.ok(
+        hasUsageLine(r.stdout, v),
+        `expected verb '${v}' in --all output under profile=${profile}`,
+      );
+    }
+    assert.match(r.stdout, /full catalog/);
+  }
+});
+
+test('#324: gate schema --format json is exhaustive regardless of profile', (t) => {
+  for (const profile of ['standard', 'swarm'] as const) {
+    const b = bootstrap(profile);
+    t.after(() => b.cleanup());
+    const r = run(b.root, ['schema', '--format', 'json']);
+    assert.equal(r.status, 0, `schema under ${profile} should exit 0`);
+    const payload = JSON.parse(r.stdout) as { verbs: { name: string }[] };
+    const names = new Set(payload.verbs.map((v) => v.name));
+    // Every BASE + COORDINATION + at least one EXTRA verb must be
+    // present in the schema payload under both profiles. The
+    // orchestrator contract is "schema sees everything" — tiering
+    // is a human-readable surface only.
+    for (const v of [...BASE_VERBS, ...COORDINATION_VERBS, ...EXTRA_SAMPLE]) {
+      assert.ok(
+        names.has(v),
+        `schema must list verb '${v}' under profile=${profile}`,
+      );
+    }
+  }
+});
+
+test('#324: gate schema --format json output is identical across profiles', (t) => {
+  const standard = bootstrap('standard');
+  const swarm = bootstrap('swarm');
+  t.after(() => standard.cleanup());
+  t.after(() => swarm.cleanup());
+  const a = run(standard.root, ['schema', '--format', 'json']);
+  const b = run(swarm.root, ['schema', '--format', 'json']);
+  assert.equal(a.status, 0);
+  assert.equal(b.status, 0);
+  const aNames = (JSON.parse(a.stdout) as { verbs: { name: string }[] }).verbs
+    .map((v) => v.name)
+    .sort();
+  const bNames = (JSON.parse(b.stdout) as { verbs: { name: string }[] }).verbs
+    .map((v) => v.name)
+    .sort();
+  assert.deepEqual(
+    aNames,
+    bNames,
+    'schema verb list must not vary by profile',
+  );
+});

--- a/tests/interface/voiceBudget.test.ts
+++ b/tests/interface/voiceBudget.test.ts
@@ -141,7 +141,7 @@ const VOICE_BUDGET: readonly BudgetEntry[] = [
     allowed_files: [
       'src/application/concern/UnrespondedConcernsQuery.ts',
       'src/interface/gate/handlers/unresponded.ts',
-      'src/interface/gate/index.ts',
+      'src/interface/gate/help.ts',
     ],
     rationale:
       'principled limitation marker for UnrespondedConcernsQuery — ' +
@@ -150,7 +150,8 @@ const VOICE_BUDGET: readonly BudgetEntry[] = [
       'is enforced), the handler (where it is exposed via the verb), ' +
       'and the help text (where it is announced). budget 3 = current ' +
       'count; new surfaces inheriting this discipline should reuse the ' +
-      'phrase rather than paraphrase.',
+      'phrase rather than paraphrase. (Help text moved from index.ts ' +
+      'to help.ts under #324 tiered-help.)',
   },
   {
     phrase: 'perception, not judgement',

--- a/tests/tools/loreScope.test.ts
+++ b/tests/tools/loreScope.test.ts
@@ -26,8 +26,19 @@ const here = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(here, '..', '..', '..');
 const SCRIPT = resolve(REPO_ROOT, 'tools', 'lore-scope.sh');
 
+// On Windows, .sh files can't be executed directly — the OS doesn't
+// read shebangs. GitHub Actions windows-latest runners ship Git Bash on
+// PATH, so we invoke the script via `bash` there. POSIX hosts use the
+// shebang directly.
+function spawn(args: readonly string[]): ReturnType<typeof spawnSync> {
+  if (process.platform === 'win32') {
+    return spawnSync('bash', [SCRIPT, ...args], { encoding: 'utf8' });
+  }
+  return spawnSync(SCRIPT, args, { encoding: 'utf8' });
+}
+
 function run(audience: string): { status: number; stdout: string; stderr: string } {
-  const result = spawnSync(SCRIPT, [audience], { encoding: 'utf8' });
+  const result = spawn([audience]);
   return {
     status: result.status ?? -1,
     stdout: result.stdout ?? '',
@@ -111,6 +122,6 @@ test('lore-scope.sh exits non-zero on invalid audience', () => {
 });
 
 test('lore-scope.sh exits non-zero on missing argument', () => {
-  const result = spawnSync(SCRIPT, [], { encoding: 'utf8' });
+  const result = spawn([]);
   assert.notEqual(result.status ?? 0, 0, 'no-arg invocation must exit non-zero');
 });

--- a/tests/tools/loreScope.test.ts
+++ b/tests/tools/loreScope.test.ts
@@ -16,7 +16,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { resolve, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -30,11 +30,11 @@ const SCRIPT = resolve(REPO_ROOT, 'tools', 'lore-scope.sh');
 // read shebangs. GitHub Actions windows-latest runners ship Git Bash on
 // PATH, so we invoke the script via `bash` there. POSIX hosts use the
 // shebang directly.
-function spawn(args: readonly string[]): ReturnType<typeof spawnSync> {
+function spawn(args: readonly string[]): SpawnSyncReturns<string> {
   if (process.platform === 'win32') {
     return spawnSync('bash', [SCRIPT, ...args], { encoding: 'utf8' });
   }
-  return spawnSync(SCRIPT, args, { encoding: 'utf8' });
+  return spawnSync(SCRIPT, [...args], { encoding: 'utf8' });
 }
 
 function run(audience: string): { status: number; stdout: string; stderr: string } {


### PR DESCRIPTION
## Summary

Axis 2 of 5 from solo/swarm coexistence proposal. Tiered `gate --help` with profile-aware default + `--all` override. Schema endpoint stays exhaustive (orchestrator contract preserved per principle 11).

## Change

- `src/interface/gate/help.ts` (new) — tiered renderer with `SECTIONS` table tagging each entry as `base | coordination | extra`, `renderHelp({profile, all})`, exhaustive verb-text fixtures
- `src/interface/gate/index.ts` — replaced 218-line static `HELP` constant; `--help`/`-h` branch now loads `GuildConfig.profile` (try/catch fallback to `standard`) and parses `--all` from residual argv
- `tests/interface/gateHelpTiered.test.ts` (new) — 5 tests: base under standard, base+coordination under swarm, all under `--all` regardless of profile, schema unchanged
- `tests/interface/voiceBudget.test.ts` — `index.ts` → `help.ts` in allowed_files (phrase migrated, budget unchanged)

## Verb tier counts (verified by running CLI)

- `profile=standard` → **14 BASE** lines: `request approve execute complete fail review show list tail boot register doctor fast-track schema`
- `profile=swarm` → **18 lines** (14 BASE + 4 COORDINATION: `claim witness unwitness wave-status` — `witness/unwitness` share one block; `slice-complete` not in dispatcher yet, bucket ready)
- `gate --help --all` → **49 lines** (BASE + COORDINATION + EXTRA: `transcript voices rest wake farewell issues* templates ...`), identical under both profiles
- `gate schema --format json` → exhaustive and byte-identical across profiles

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1570/1570 pass (+5 from new tiered test file)
- [x] All 4 acceptance criteria from #324 covered
- [x] schema unchanged (asserted)

## Provenance

- agora play `coexistence-phase-2/2026-05-11-001` move 001-002 (decisions: --all flag, profile auto-tier, BASE/COORDINATION sets)
- gate wave `2026-05-11-0002`, single-executor `agent-help`, critic approve, witness + execute (substrate at local `substrate/swarm-experiments/2026-05-11-solo-swarm-coexistence/`)
- worktree-ledger blindspot pattern (#322): SubAgent did not stamp from worktree

Closes #324

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_