### PR TITLE
feat(doctor): sweep-traps verb + relevant_until on trap memory (axis 5 of solo/swarm coexistence, closes #327)

### DIFF
--- a/lore/traps/README.md
+++ b/lore/traps/README.md
@@ -1,0 +1,43 @@
+# lore/traps/
+
+Trap memory — pinned patterns that aren't yet `lore/principles/`-grade
+but are load-bearing enough to surface in future review (devil-side
+memory MCP lookup, post-PR review prompts).
+
+A trap is a one-page markdown file that names a pattern, sketches the
+mechanism, and lists the trigger conditions a reviewer would use to
+flag it. Traps graduate to `lore/principles/` when two independent
+observations clear the *felt-not-just-read* bar (see lore/README.md
+for the promotion mechanism).
+
+## Frontmatter
+
+Each trap may declare a `relevant_until` field for retirement
+(#327, axis 5 of the solo/swarm coexistence proposal):
+
+```
+---
+relevant_until: 2026-08-01     # ISO date; gate doctor sweep-traps
+                                # quarantines after this date
+relevant_until: indefinite     # never auto-swept (default semantics
+                                # when frontmatter is absent)
+---
+```
+
+`gate doctor sweep-traps` (without `--apply`) lists which traps would
+be retired. `gate doctor sweep-traps --apply` moves expired traps to
+`<content_root>/trap-quarantine/` and appends a `quarantine` event to
+`<content_root>/trap-retirement-log.yaml`. Revive a quarantined trap
+with `gate doctor sweep-traps --revive <filename>` (records a `revive`
+event in the same log).
+
+Per principle 04 (records-outlive-writers), retirement is quarantine,
+not deletion: a future reader can always reconstruct what the trap
+said and why it was retired.
+
+## Naming
+
+`trap_<short_pattern_slug>.md`. The slug should match the pattern
+name as it would surface in a review comment: a reader cross-checking
+"is this the silent-fallback-loses-signal pattern?" should be able
+to find the file by name alone.

--- a/lore/traps/trap_hook_ctx_normalize_vs_doc.md
+++ b/lore/traps/trap_hook_ctx_normalize_vs_doc.md
@@ -1,0 +1,46 @@
+---
+relevant_until: indefinite
+---
+
+# trap: hook ctx normalize vs. doc drift
+
+**Pattern.** A plugin / hook surface accepts a context object whose
+runtime normalization (case-fold, trim, default-fill) is performed by
+the host before invoking the plugin — but the schema / hook docs
+describe the *raw* shape, not the normalized one.
+
+Plugin authors test against documented field semantics, host runs the
+normalized values; the discrepancy hides until a plugin's case-
+sensitive comparison or its strict-equality match against a documented
+literal silently fails. The hook still runs; the verdict it would have
+returned just doesn't fire. Worst kind of silent failure: behaviour
+diverges from contract without an error.
+
+The trap is a specific instance of "schema as contract" (principle
+10): the schema is not what the host normalizes *to*, it's what the
+plugin author reads. Drift between the two erodes the agent-
+dispatchable surface.
+
+## Trigger conditions for review
+
+Flag any change to:
+
+- `HookCtx` field shapes / `HookEvent` payloads where the host
+  applies a transform before invoking the plugin (lowercase actor
+  name, trim path, resolve to absolute) without the schema entry
+  documenting the transform explicitly.
+- New hook subscription points whose context surface differs from
+  the underlying domain object's at-rest field types.
+- `gate schema --verb <name>` output that describes a field as
+  "actor name" without specifying that the runtime value is always
+  lowercase + trimmed (the canonical `MemberName.value` form).
+
+## Promotion history
+
+Surfaced during the PR #243/#244 hook ctx work (claim/witness phase
+1+2). Pinned as a trap rather than a principle because the underlying
+fix — make the schema describe the *normalized* shape and document
+the transform — is a single-cycle ship, not a recurring pattern that
+warrants a new principle. Promotion path: if the same drift recurs
+on a future hook subscription, this trap graduates to a corollary of
+principle 10.

--- a/lore/traps/trap_silent_fallback_loses_signal.md
+++ b/lore/traps/trap_silent_fallback_loses_signal.md
@@ -1,0 +1,47 @@
+---
+relevant_until: indefinite
+---
+
+# trap: silent fallback loses signal
+
+**Pattern.** A code path catches its own error, falls back to a
+default, and continues — but the surface that produced the result
+shows no evidence the fallback fired. The output looks authoritative
+to the next consumer, who has no way to know it isn't.
+
+Surfaced (combo C3, 2026-05-10 dogfood) at four sites in the
+codebase:
+
+- `gate boot` enrichment catches that swallowed transient repository
+  errors and returned an under-populated payload as if it were complete.
+- `agora new` silently created `./agora/` when no content_root was
+  resolvable, leaving the operator pointing at an unintended directory.
+- Devil concern2 on PR #105 (2026-04-16) — error path returned the
+  pre-error draft as if it were the post-fix shape.
+- `formatContentRootDisclosure` originally signalled fallback but
+  didn't suggest a recovery path, so a reader saw the disclosure as
+  noise instead of a `next:` cue.
+
+## Trigger conditions for review
+
+Flag any new code path that:
+
+- Catches an error inside its own boundary AND returns a non-error
+  value to its caller, without recording the catch on a record the
+  caller can inspect (warnings array, status_log entry, stderr line
+  with `next:`).
+- Falls back to a "default" derived from runtime conditions (cwd, env
+  var, `null` config) without disclosing the fallback to the caller.
+- Returns the same shape on success and recovered-from-error, with no
+  discriminator the next consumer can branch on.
+
+The fix shape is `BootPayload.warnings: string[]` (PR #292) — make
+the catch record itself as a structured datum the consumer reads,
+not as a silently-mutated default.
+
+## Promotion history
+
+Partially shipped: combo C3 instance 2 in PR #292 (boot warnings).
+Instance 1 (cwd-fallback `next:` hint) was deferred per single-
+observation evidence. The trap stays pinned so a future fallback-path
+PR review surfaces the pattern without re-derivation.

--- a/lore/traps/trap_swarm_engagement_vs_parallel.md
+++ b/lore/traps/trap_swarm_engagement_vs_parallel.md
@@ -1,0 +1,51 @@
+---
+relevant_until: indefinite
+---
+
+# trap: swarm engagement vs. parallel impl
+
+**Pattern.** "Parallel ≠ swarm. Substrate engagement is what reduces
+coordination context cost, not raw concurrency."
+
+A wave that runs N executors in parallel without each writing back to
+the substrate (claim, witness, status_log timestamps, agora suspensions
+when judgment forks) leaves the orchestrator's working memory holding
+all the cross-actor state. The orchestrator becomes the bottleneck;
+context window fills with who-is-doing-what bookkeeping that should
+have lived in records the substrate provides.
+
+The trap surfaces as: "we ran 3 implementers in worktrees and merged,
+why does the next session feel disoriented?" — because nothing on
+disk explains *which* slice each implementer owned, *when* they
+acknowledged blocking review, or *why* slice B was deferred. The PR
+itself is testimony; the substrate is record. Re-reading PRs to
+reconstruct context is the cost the substrate primitives exist to
+avoid.
+
+## Trigger conditions for review
+
+A reviewer should flag a parallel-impl wave as falling into this trap
+when ANY of:
+
+- The wave has multiple executors but no `gate witness` records per
+  executor — coordination state lives in chat / orchestrator memory.
+- A retrospective talks about "what each Claude did" without pointing
+  at substrate primitives that recorded it (claim notes, witness
+  notes, agora moves, status_log timestamps).
+- The next session needs an oral hand-off to know the wave's state.
+
+## Promotion history
+
+Promoted to `lore/principles/14-substrate-engagement-reduces-coordination-context-cost.md`
+on 2026-05-11 after two independent observations cleared the dogfood
+bar:
+
+1. PR #291 retrospective from a different Claude instance naming the
+   insight after a 2-slice swarm wave.
+2. eris's own 2-slice swarm dogfood
+   (`substrate/swarm-experiments/2026-05-11-eris-swarm-test/`) on the
+   same day, surfacing the same gap from the orchestrator side.
+
+The trap stays pinned so future review can name the pattern by file
+even after the principle is internalised — naming is the affordance,
+not the proof.

--- a/src/application/trapSweep/TrapSweepUseCases.ts
+++ b/src/application/trapSweep/TrapSweepUseCases.ts
@@ -1,0 +1,226 @@
+// TrapSweepUseCases — application layer for `gate doctor sweep-traps` (#327).
+//
+// Trap memory is a markdown file with optional frontmatter:
+//
+//   ---
+//   relevant_until: 2026-04-01     # ISO date OR the literal `indefinite`
+//   ---
+//   <body — free-form markdown>
+//
+// Sweep is the quarantine-based retirement path: when `relevant_until`
+// is an ISO date that has passed, the trap is moved to a sibling
+// `trap-quarantine/` directory and a single line is appended to a
+// `trap-retirement-log.yaml` file. Records-outlive-writers (principle
+// 04): nothing is ever deleted; quarantine + log is the entire shape.
+//
+// Two surfaces:
+//
+//   plan(now, traps)     — pure. Returns one TrapPlanEntry per trap
+//                          describing the action the apply pass would
+//                          take (sweep | keep | invalid).
+//   apply / revive       — interface-layer concerns (use node:fs against
+//                          absolute paths). Live in the handler.
+//
+// Why the split: planning is a function of (now, frontmatter values)
+// and benefits from unit-test isolation. Filesystem I/O is intentionally
+// kept in the handler because it is a single-shot, single-content_root
+// operation — wiring a port abstraction would be more boilerplate than
+// the call site warrants for one verb.
+
+/**
+ * Parsed trap descriptor handed to the planner. The handler scans
+ * `<content_root>/lore/traps/` for `*.md` files and produces one of
+ * these per file before invoking `planTrapSweep`.
+ *
+ * `relevantUntil`:
+ *   - `null`           : no frontmatter, OR frontmatter present but the
+ *                        field is absent. Treated as `indefinite` per
+ *                        principle 04 (safe default — never sweep).
+ *   - `'indefinite'`   : explicit indefinite — never sweep.
+ *   - `Date`           : ISO date parsed from the frontmatter value.
+ *   - `'invalid'`      : a non-empty value that did not parse as an ISO
+ *                        date and was not the literal 'indefinite'.
+ *                        The planner surfaces it as `kept-invalid` so
+ *                        the operator sees the typo without losing the
+ *                        file to a silent default.
+ */
+export type RelevantUntil = null | 'indefinite' | 'invalid' | Date;
+
+export interface TrapDescriptor {
+  /** Filename only (e.g. `trap_silent_fallback_loses_signal.md`). */
+  readonly filename: string;
+  /** Absolute path to the trap on disk. */
+  readonly absolutePath: string;
+  readonly relevantUntil: RelevantUntil;
+  /**
+   * The raw frontmatter string for `relevant_until`, surfaced verbatim
+   * in the plan output and the audit log so the operator sees the
+   * value that triggered the sweep. `null` when no frontmatter or no
+   * field was present.
+   */
+  readonly rawValue: string | null;
+}
+
+export type TrapPlanAction =
+  | 'sweep'           // expired ISO date < now
+  | 'keep-future'     // ISO date in the future
+  | 'keep-indefinite' // explicit indefinite OR no frontmatter (safe default)
+  | 'keep-invalid';   // unparseable value — surfaced for the operator
+
+export interface TrapPlanEntry {
+  readonly trap: TrapDescriptor;
+  readonly action: TrapPlanAction;
+  /**
+   * Human-readable rationale carried into the dry-run report and (when
+   * `action === 'sweep'`) into the audit log entry's `reason:` field.
+   */
+  readonly rationale: string;
+}
+
+export interface TrapSweepPlan {
+  readonly entries: readonly TrapPlanEntry[];
+}
+
+/**
+ * Pure planner: classify each trap by its `relevant_until` against a
+ * fixed `now`. Tests inject a deterministic `now`; production passes
+ * `new Date()`. Day-granularity comparison: a trap with
+ * `relevant_until: 2026-05-11` is NOT swept on 2026-05-11 itself —
+ * it's still relevant *until* that date. Sweep fires the day after.
+ */
+export function planTrapSweep(
+  now: Date,
+  traps: readonly TrapDescriptor[],
+): TrapSweepPlan {
+  const todayUtc = toUtcDayStart(now);
+  const entries: TrapPlanEntry[] = traps.map((trap) => {
+    const ru = trap.relevantUntil;
+    if (ru === null) {
+      return {
+        trap,
+        action: 'keep-indefinite' as const,
+        rationale:
+          'no relevant_until frontmatter — treated as indefinite per principle 04 (safe default).',
+      };
+    }
+    if (ru === 'indefinite') {
+      return {
+        trap,
+        action: 'keep-indefinite' as const,
+        rationale: 'relevant_until: indefinite — never auto-swept.',
+      };
+    }
+    if (ru === 'invalid') {
+      return {
+        trap,
+        action: 'keep-invalid' as const,
+        rationale:
+          `relevant_until value ${JSON.stringify(trap.rawValue)} did not parse as an ISO date or 'indefinite' — kept (safe default).`,
+      };
+    }
+    const dueUtc = toUtcDayStart(ru);
+    if (dueUtc.getTime() < todayUtc.getTime()) {
+      return {
+        trap,
+        action: 'sweep' as const,
+        rationale: `expired (relevant_until: ${trap.rawValue})`,
+      };
+    }
+    return {
+      trap,
+      action: 'keep-future' as const,
+      rationale: `still relevant (relevant_until: ${trap.rawValue}).`,
+    };
+  });
+  return { entries };
+}
+
+/**
+ * Parse a raw `relevant_until` frontmatter string into the typed
+ * `RelevantUntil` shape. Whitespace is trimmed; `indefinite` is matched
+ * case-insensitively; ISO dates are validated by re-rendering and
+ * comparing to reject malformed-but-coercible inputs (`2026-13-99` etc).
+ */
+export function parseRelevantUntil(raw: string | null): RelevantUntil {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.toLowerCase() === 'indefinite') return 'indefinite';
+  // Accept only YYYY-MM-DD (no time/zone). Strict regex avoids
+  // accepting partial dates that Date() would happily coerce.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (!m) return 'invalid';
+  const [, y, mo, d] = m as unknown as [string, string, string, string];
+  const yi = Number.parseInt(y, 10);
+  const mi = Number.parseInt(mo, 10);
+  const di = Number.parseInt(d, 10);
+  // Build a UTC date and validate round-trip — rejects 2026-02-31 etc.
+  const dt = new Date(Date.UTC(yi, mi - 1, di));
+  if (
+    dt.getUTCFullYear() !== yi ||
+    dt.getUTCMonth() !== mi - 1 ||
+    dt.getUTCDate() !== di
+  ) {
+    return 'invalid';
+  }
+  return dt;
+}
+
+/**
+ * Extract the raw string value of a single frontmatter key, or null if
+ * the document has no frontmatter block or the key is absent.
+ *
+ * Frontmatter is the YAML-flavoured `---\n...\n---` opener many
+ * markdown files use. We do NOT pull in a YAML parser for this — the
+ * trap-frontmatter contract is a single scalar field (`relevant_until`)
+ * with no nesting, so a one-line key:value scan is sufficient and
+ * keeps the dependency surface small. Lines beginning with `#` inside
+ * the frontmatter are skipped (YAML comments).
+ */
+export function extractFrontmatterField(
+  raw: string,
+  key: string,
+): string | null {
+  // The opener must be the very first three chars of the file, then
+  // a newline. Many editors strip trailing whitespace; allow optional
+  // trailing whitespace on the opener line.
+  if (!/^---[ \t]*\r?\n/.test(raw)) return null;
+  const afterOpen = raw.slice(raw.indexOf('\n') + 1);
+  // The closer is `---` on its own line. Find the next one.
+  const closeMatch = /(^|\r?\n)---[ \t]*(\r?\n|$)/.exec(afterOpen);
+  if (!closeMatch) return null;
+  const block = afterOpen.slice(0, closeMatch.index);
+  const lines = block.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (trimmed.startsWith('#')) continue;
+    const colon = trimmed.indexOf(':');
+    if (colon < 0) continue;
+    const k = trimmed.slice(0, colon).trim();
+    if (k !== key) continue;
+    let v = trimmed.slice(colon + 1).trim();
+    // Strip surrounding quotes if present.
+    if (
+      (v.startsWith('"') && v.endsWith('"') && v.length >= 2) ||
+      (v.startsWith("'") && v.endsWith("'") && v.length >= 2)
+    ) {
+      v = v.slice(1, -1);
+    }
+    return v;
+  }
+  return null;
+}
+
+/**
+ * Floor a Date to the start of its UTC day. Used by the planner so the
+ * comparison is calendar-day, not millisecond — a trap due on
+ * 2026-05-11 should be considered expired starting 2026-05-12 00:00 UTC,
+ * regardless of the wall-clock time at which `gate doctor sweep-traps`
+ * runs.
+ */
+function toUtcDayStart(d: Date): Date {
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+}

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from 'node:fs';
+import { join, basename } from 'node:path';
 import {
   ParsedArgs,
   optionalOption,
@@ -13,6 +15,13 @@ import {
   DiagnosticAreaSummary,
   DiagnosticFinding,
 } from '../../../domain/diagnostic/DiagnosticReport.js';
+import {
+  TrapDescriptor,
+  TrapPlanEntry,
+  extractFrontmatterField,
+  parseRelevantUntil,
+  planTrapSweep,
+} from '../../../application/trapSweep/TrapSweepUseCases.js';
 
 // `gate doctor` is read-only but still benefits from strict-reject:
 // `--summry` or `--formt json` typos would silently fall through to
@@ -22,6 +31,26 @@ const DOCTOR_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'format',
   'summary',
 ]);
+
+// `gate doctor sweep-traps` is the trap-memory retirement verb (#327).
+// Strict-reject typos for the same reason as the parent: `--aply`
+// would silently fall through to dry-run. `--apply` is boolean (no
+// value); `--revive` takes a trap filename. `--format` lets json
+// consumers (orchestrators, CI pipelines) read the plan/result envelope.
+const SWEEP_TRAPS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'apply',
+  'revive',
+  'format',
+]);
+const SWEEP_TRAPS_BOOLEAN_FLAGS: ReadonlySet<string> = new Set(['apply']);
+
+// Trap memory lives at <content_root>/lore/traps/. Quarantine and the
+// audit log live at content_root root (`trap-quarantine/` and
+// `trap-retirement-log.yaml`) so the operator sees both surfaces in a
+// single `ls` of the substrate root.
+const TRAP_DIR_REL = join('lore', 'traps');
+const QUARANTINE_DIR_REL = 'trap-quarantine';
+const RETIREMENT_LOG_REL = 'trap-retirement-log.yaml';
 
 // gate doctor — read-only diagnostic over the guild content root.
 //
@@ -35,8 +64,23 @@ const DOCTOR_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 // Repair is intentionally a separate verb (not yet implemented).
 // See i-2026-04-15-0015 narrative and the silent_fail_taxonomy
 // principle of separating observation from intervention.
+//
+// Sub-verb (#327):
+//   gate doctor sweep-traps [--apply] [--revive <name>] [--format json]
+//     Trap-memory retirement. Without --apply: dry-run lists what
+//     would be swept. With --apply: moves expired traps to
+//     <content_root>/trap-quarantine/ and appends an audit entry to
+//     <content_root>/trap-retirement-log.yaml. With --revive <name>:
+//     restores a quarantined trap to its original location and
+//     records a revive entry in the same log.
 
 export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
+  // Sub-verb dispatch. The sub-verb takes ownership of flag rejection
+  // so its private flag set doesn't leak into the read-only doctor
+  // strict check.
+  if (args.positional[0] === 'sweep-traps') {
+    return await sweepTrapsCmd(c, args);
+  }
   rejectUnknownFlags(args, DOCTOR_KNOWN_FLAGS, 'doctor');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
@@ -164,3 +208,372 @@ function writeOverall(report: DiagnosticReport): void {
     );
   }
 }
+
+// --- sweep-traps sub-verb (#327) --------------------------------------
+
+/**
+ * `gate doctor sweep-traps` handler. Three modes:
+ *
+ *   --revive <filename>       restore a quarantined trap and log it
+ *   --apply                   move expired traps to quarantine + log
+ *   (neither)                 dry-run plan (default; safe to script)
+ *
+ * `--apply` and `--revive` are mutually exclusive: one is a sweep
+ * direction, the other its inverse, and combining them would have no
+ * coherent meaning.
+ *
+ * Mutability is intentionally narrow: only `<content_root>/lore/traps/`,
+ * `<content_root>/trap-quarantine/`, and `<content_root>/trap-retirement-log.yaml`
+ * are touched. Everything else under content_root is read-only from
+ * this verb.
+ */
+async function sweepTrapsCmd(c: C, args: ParsedArgs): Promise<number> {
+  // Re-parse args so the sweep-only boolean flag (`--apply`) is
+  // recognised — the top-level parseArgs already ran with the gate-
+  // global boolean set, but `apply` is in KNOWN_BOOLEAN_FLAGS so it
+  // already lands as `true`. We only need rejectUnknownFlags here to
+  // gate against typos. The first positional (`sweep-traps`) is
+  // expected and not flagged as unknown.
+  rejectUnknownFlags(args, SWEEP_TRAPS_KNOWN_FLAGS, 'doctor sweep-traps');
+  // Belt-and-braces against future parser changes: SWEEP_TRAPS_BOOLEAN_FLAGS
+  // documents which flags are boolean even though the global
+  // KNOWN_BOOLEAN_FLAGS already covers `apply`. Reading it keeps the
+  // documentation honest without changing behaviour.
+  void SWEEP_TRAPS_BOOLEAN_FLAGS;
+
+  const apply = args.options['apply'] === true;
+  const revive = optionalOption(args, 'revive');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    process.stderr.write(
+      `error: --format must be 'json' or 'text', got: ${format}\n`,
+    );
+    return 1;
+  }
+  if (apply && revive !== undefined) {
+    process.stderr.write(
+      'error: --apply and --revive are mutually exclusive.\n' +
+        '  next: drop --apply (revive is its own write path) or pick one mode.\n',
+    );
+    return 1;
+  }
+
+  const trapDir = join(c.config.contentRoot, TRAP_DIR_REL);
+  const quarantineDir = join(c.config.contentRoot, QUARANTINE_DIR_REL);
+  const logPath = join(c.config.contentRoot, RETIREMENT_LOG_REL);
+
+  if (revive !== undefined) {
+    return await reviveTrap({
+      revive,
+      trapDir,
+      quarantineDir,
+      logPath,
+      format,
+    });
+  }
+
+  // Plan path: scan trap dir, parse frontmatter, build descriptors.
+  let descriptors: TrapDescriptor[];
+  try {
+    descriptors = await loadTrapDescriptors(trapDir);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`error: failed to scan ${trapDir}: ${msg}\n`);
+    return 1;
+  }
+  const plan = planTrapSweep(new Date(), descriptors);
+
+  if (!apply) {
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(planToJson(plan.entries), null, 2) + '\n');
+    } else {
+      writeSweepPlanText(plan.entries, trapDir);
+    }
+    return 0;
+  }
+
+  // Apply path: walk the sweep set, move each file, append one log
+  // entry per move. Errors on individual entries do not abort the
+  // run — each outcome carries its own status, mirroring `gate repair`.
+  const sweeps = plan.entries.filter((e) => e.action === 'sweep');
+  if (sweeps.length === 0) {
+    if (format === 'json') {
+      process.stdout.write(
+        JSON.stringify({ applied: [], skipped: planToJson(plan.entries) }, null, 2) + '\n',
+      );
+    } else {
+      process.stdout.write('gate doctor sweep-traps — apply\n\n');
+      process.stdout.write('✓ no expired traps; nothing to sweep.\n');
+    }
+    return 0;
+  }
+  await fs.mkdir(quarantineDir, { recursive: true });
+  const applied: Array<{ trap: string; destination: string; reason: string }> = [];
+  const errors: Array<{ trap: string; error: string }> = [];
+  for (const entry of sweeps) {
+    const dest = join(quarantineDir, entry.trap.filename);
+    try {
+      await fs.rename(entry.trap.absolutePath, dest);
+      await appendLogEntry(logPath, {
+        action: 'quarantine',
+        trap: entry.trap.filename,
+        at: nowIsoZ(),
+        by: resolveActorForLog(),
+        reason: entry.rationale,
+      });
+      applied.push({
+        trap: entry.trap.filename,
+        destination: dest,
+        reason: entry.rationale,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push({ trap: entry.trap.filename, error: msg });
+    }
+  }
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify({ applied, errors }, null, 2) + '\n',
+    );
+  } else {
+    process.stdout.write('gate doctor sweep-traps — apply\n\n');
+    for (const a of applied) {
+      process.stdout.write(`  → quarantined ${a.trap}\n    reason: ${a.reason}\n`);
+    }
+    for (const e of errors) {
+      process.stdout.write(`  ✗ ${e.trap}: ${e.error}\n`);
+    }
+    process.stdout.write(
+      `\n${applied.length} trap(s) quarantined under ${quarantineDir}\n` +
+        `audit log: ${logPath}\n` +
+        (errors.length > 0
+          ? `${errors.length} error(s) — exit 1\n`
+          : ''),
+    );
+  }
+  return errors.length > 0 ? 1 : 0;
+}
+
+async function reviveTrap(p: {
+  revive: string;
+  trapDir: string;
+  quarantineDir: string;
+  logPath: string;
+  format: string;
+}): Promise<number> {
+  // Restrict --revive to a bare filename (no path components). Lets
+  // the operator type the same string they saw in the dry-run output
+  // without shell-completing into a relative path that could escape
+  // the quarantine dir.
+  if (p.revive.includes('/') || p.revive.includes('\\') || p.revive === '..' || p.revive === '.') {
+    process.stderr.write(
+      `error: --revive expects a bare filename, got: ${p.revive}\n` +
+        '  next: pass just the basename (e.g. trap_silent_fallback_loses_signal.md).\n',
+    );
+    return 1;
+  }
+  const src = join(p.quarantineDir, p.revive);
+  const dest = join(p.trapDir, p.revive);
+  try {
+    const stat = await fs.stat(src);
+    if (!stat.isFile()) {
+      process.stderr.write(
+        `error: ${src} is not a file (expected a quarantined trap).\n`,
+      );
+      return 1;
+    }
+  } catch {
+    process.stderr.write(
+      `error: no quarantined trap named ${p.revive} under ${p.quarantineDir}.\n` +
+        '  next: ls the directory to see what is available for revive.\n',
+    );
+    return 1;
+  }
+  await fs.mkdir(p.trapDir, { recursive: true });
+  // Refuse to overwrite a same-named live trap — revive is a restore,
+  // not a force-replace. The operator should resolve the conflict
+  // explicitly (rename one, choose which to keep).
+  try {
+    await fs.access(dest);
+    process.stderr.write(
+      `error: a live trap named ${p.revive} already exists at ${dest}.\n` +
+        '  next: rename or remove the conflicting file before reviving.\n',
+    );
+    return 1;
+  } catch {
+    // good — destination is free
+  }
+  try {
+    await fs.rename(src, dest);
+    await appendLogEntry(p.logPath, {
+      action: 'revive',
+      trap: p.revive,
+      at: nowIsoZ(),
+      by: resolveActorForLog(),
+      reason: 'manual revive via gate doctor sweep-traps --revive',
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`error: revive failed: ${msg}\n`);
+    return 1;
+  }
+  if (p.format === 'json') {
+    process.stdout.write(
+      JSON.stringify({ revived: p.revive, destination: dest, log: p.logPath }, null, 2) + '\n',
+    );
+  } else {
+    process.stdout.write(
+      `gate doctor sweep-traps — revive\n\n` +
+        `  ← restored ${p.revive}\n` +
+        `    to: ${dest}\n` +
+        `audit log: ${p.logPath}\n`,
+    );
+  }
+  return 0;
+}
+
+async function loadTrapDescriptors(trapDir: string): Promise<TrapDescriptor[]> {
+  let names: string[];
+  try {
+    names = await fs.readdir(trapDir);
+  } catch (e) {
+    if (
+      e !== null &&
+      typeof e === 'object' &&
+      'code' in e &&
+      (e as { code: string }).code === 'ENOENT'
+    ) {
+      // No trap directory: treat as zero traps. Sweep is a no-op,
+      // not an error — fresh content_roots haven't pinned anything yet.
+      return [];
+    }
+    throw e;
+  }
+  const out: TrapDescriptor[] = [];
+  for (const name of names.sort()) {
+    if (!name.endsWith('.md')) continue;
+    if (!name.startsWith('trap_')) continue;
+    const abs = join(trapDir, name);
+    let raw: string;
+    try {
+      raw = await fs.readFile(abs, 'utf8');
+    } catch {
+      continue;
+    }
+    const rawValue = extractFrontmatterField(raw, 'relevant_until');
+    const relevantUntil = parseRelevantUntil(rawValue);
+    out.push({
+      filename: name,
+      absolutePath: abs,
+      relevantUntil,
+      rawValue,
+    });
+  }
+  return out;
+}
+
+function planToJson(entries: readonly TrapPlanEntry[]): unknown {
+  return entries.map((e) => ({
+    trap: e.trap.filename,
+    action: e.action,
+    rationale: e.rationale,
+    relevant_until: e.trap.rawValue,
+  }));
+}
+
+function writeSweepPlanText(
+  entries: readonly TrapPlanEntry[],
+  trapDir: string,
+): void {
+  process.stdout.write('gate doctor sweep-traps — proposed plan (dry-run)\n\n');
+  if (entries.length === 0) {
+    process.stdout.write(`✓ no traps under ${trapDir}\n`);
+    return;
+  }
+  let sweepCount = 0;
+  let keptInvalid = 0;
+  for (const e of entries) {
+    let glyph = '·';
+    if (e.action === 'sweep') {
+      glyph = '→';
+      sweepCount++;
+    } else if (e.action === 'keep-invalid') {
+      glyph = '?';
+      keptInvalid++;
+    }
+    process.stdout.write(
+      `  ${glyph} [${e.action}] ${e.trap.filename}\n` +
+        `    why: ${e.rationale}\n`,
+    );
+  }
+  process.stdout.write(
+    `\n${entries.length} trap(s) — ${sweepCount} would be swept, ${keptInvalid} kept (invalid value)\n` +
+      'note: this is a dry-run. Re-run with --apply to quarantine.\n' +
+      '      revive a trap later with --revive <filename>.\n',
+  );
+}
+
+/**
+ * Append one event entry to the trap-retirement audit log. The file is
+ * a single YAML document with a top-level `events:` list; we append a
+ * line per event without ever rewriting earlier entries (principle 04 —
+ * records outlive writers, and the log is one of the records).
+ *
+ * Byte-stable shape: each entry is a fixed five-key block in the same
+ * order, two-space indent, single quoted reason. Keeps the file diff-
+ * friendly across runs by different tools.
+ */
+async function appendLogEntry(
+  logPath: string,
+  entry: {
+    action: 'quarantine' | 'revive';
+    trap: string;
+    at: string;
+    by: string;
+    reason: string;
+  },
+): Promise<void> {
+  let header = '';
+  try {
+    await fs.access(logPath);
+  } catch {
+    header = 'events:\n';
+  }
+  const lines = [
+    `  - action: ${entry.action}`,
+    `    trap: ${entry.trap}`,
+    `    at: ${entry.at}`,
+    `    by: ${entry.by}`,
+    // YAML double-quoted scalar with backslash escapes for embedded
+    // quotes / backslashes — keeps the value round-trip-safe even
+    // when a reason carries a relevant_until string with a colon.
+    `    reason: ${yamlDoubleQuoted(entry.reason)}`,
+  ].join('\n');
+  await fs.appendFile(logPath, `${header}${lines}\n`, 'utf8');
+}
+
+function yamlDoubleQuoted(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function nowIsoZ(): string {
+  // Trim ms for compactness — the audit log is human-read first.
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function resolveActorForLog(): string {
+  const env = process.env['GUILD_ACTOR'];
+  if (env && env.length > 0) return env;
+  return 'unknown';
+}
+
+// Re-export for tests
+export {
+  TRAP_DIR_REL,
+  QUARANTINE_DIR_REL,
+  RETIREMENT_LOG_REL,
+  loadTrapDescriptors,
+  appendLogEntry,
+  basename as _basename,
+};

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1667,8 +1667,41 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'doctor',
     category: 'admin',
-    summary: 'read-only content-root health check',
-    input: { type: 'object', properties: { summary: { type: 'boolean' }, format: formatField } },
+    summary:
+      'read-only content-root health check. Sub-verb `sweep-traps` (#327) ' +
+      'retires expired trap memory: --apply quarantines, --revive <name> ' +
+      'restores; both write a YAML audit entry to trap-retirement-log.yaml.',
+    input: {
+      type: 'object',
+      properties: {
+        // Sub-verb is positional, not a flag — modeled as `subcommand`
+        // for parity with `gate issues` / `gate templates` schema entries.
+        subcommand: {
+          type: 'string',
+          enum: ['sweep-traps'],
+          description:
+            'optional sub-verb. `sweep-traps` retires expired trap memory; ' +
+            'absence runs the standard read-only diagnostic.',
+        },
+        summary: { type: 'boolean' },
+        apply: {
+          type: 'boolean',
+          description:
+            '[sweep-traps only] when true, move expired traps to ' +
+            '<content_root>/trap-quarantine/ and append an entry to ' +
+            'trap-retirement-log.yaml. Without --apply, sweep-traps is a ' +
+            'dry-run that lists what would happen.',
+        },
+        revive: {
+          type: 'string',
+          description:
+            '[sweep-traps only] bare filename of a quarantined trap to ' +
+            'restore to <content_root>/lore/traps/. Mutually exclusive ' +
+            'with --apply. Records a `revive` event in the audit log.',
+        },
+        format: formatField,
+      },
+    },
     output: { type: 'object' },
   },
   {

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -289,6 +289,24 @@ const SECTIONS: readonly Section[] = [
       {
         tier: 'extra',
         text:
+          '  gate doctor sweep-traps [--apply] [--revive <name>] [--format json]\n' +
+          '                       Trap-memory retirement (#327). Trap files at\n' +
+          '                       <content_root>/lore/traps/*.md may carry a\n' +
+          '                       relevant_until: YYYY-MM-DD or "indefinite"\n' +
+          '                       frontmatter field. Without --apply, lists which\n' +
+          '                       traps would be quarantined (dry-run). With\n' +
+          '                       --apply, moves expired traps to\n' +
+          '                       <content_root>/trap-quarantine/ and appends an\n' +
+          '                       audit entry to\n' +
+          '                       <content_root>/trap-retirement-log.yaml.\n' +
+          '                       --revive <filename> restores a quarantined\n' +
+          '                       trap and records a revive entry. Per principle\n' +
+          '                       04 (records outlive writers): never deletes;\n' +
+          '                       quarantine is the only retirement shape.',
+      },
+      {
+        tier: 'extra',
+        text:
           '  gate repair [--apply] [--from-doctor <path>] [--format json]\n' +
           '                       Intervention layer paired with doctor. Reads\n' +
           "                       'gate doctor --format json' from stdin (or\n" +

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -76,6 +76,7 @@ export {
 // shows the full catalog. `gate schema --format json` remains
 // exhaustive regardless of profile or --all.
 
+
 // Mirror of the switch below for typo suggestions. Keeping it adjacent
 // to the switch (rather than auto-derived) is an obvious-when-broken
 // signal: a new verb forgotten here just loses its did-you-mean entry,

--- a/tests/application/trapSweepPlan.test.ts
+++ b/tests/application/trapSweepPlan.test.ts
@@ -1,0 +1,114 @@
+// Unit tests for the pure trap-sweep planner (#327). The interface-
+// layer test (sweepTraps.test.ts) covers the end-to-end CLI surface;
+// this file pins the day-granularity comparison and the parser
+// boundaries so a future refactor of the I/O layer can't regress
+// the policy.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TrapDescriptor,
+  extractFrontmatterField,
+  parseRelevantUntil,
+  planTrapSweep,
+} from '../../src/application/trapSweep/TrapSweepUseCases.js';
+
+function trap(name: string, raw: string | null): TrapDescriptor {
+  return {
+    filename: name,
+    absolutePath: `/tmp/${name}`,
+    relevantUntil: parseRelevantUntil(raw),
+    rawValue: raw,
+  };
+}
+
+test('planner: expired ISO date → sweep', () => {
+  const now = new Date('2026-05-11T12:00:00Z');
+  const plan = planTrapSweep(now, [trap('trap_a.md', '2026-04-01')]);
+  assert.equal(plan.entries[0]?.action, 'sweep');
+  assert.match(plan.entries[0]?.rationale ?? '', /relevant_until: 2026-04-01/);
+});
+
+test('planner: future-dated ISO → keep-future', () => {
+  const now = new Date('2026-05-11T00:00:00Z');
+  const plan = planTrapSweep(now, [trap('trap_a.md', '2026-12-31')]);
+  assert.equal(plan.entries[0]?.action, 'keep-future');
+});
+
+test('planner: same-day ISO is NOT yet expired (relevant *until* the date)', () => {
+  // A trap due 2026-05-11 is still relevant on 2026-05-11.
+  const now = new Date('2026-05-11T23:59:59Z');
+  const plan = planTrapSweep(now, [trap('trap_a.md', '2026-05-11')]);
+  assert.equal(plan.entries[0]?.action, 'keep-future');
+});
+
+test('planner: day-after the date IS expired', () => {
+  const now = new Date('2026-05-12T00:00:01Z');
+  const plan = planTrapSweep(now, [trap('trap_a.md', '2026-05-11')]);
+  assert.equal(plan.entries[0]?.action, 'sweep');
+});
+
+test('planner: indefinite is never swept', () => {
+  const now = new Date('2099-12-31T00:00:00Z');
+  const plan = planTrapSweep(now, [trap('trap_a.md', 'indefinite')]);
+  assert.equal(plan.entries[0]?.action, 'keep-indefinite');
+});
+
+test('planner: indefinite is case-insensitive', () => {
+  const plan = planTrapSweep(new Date(), [trap('trap_a.md', 'INDEFINITE')]);
+  assert.equal(plan.entries[0]?.action, 'keep-indefinite');
+});
+
+test('planner: null rawValue (no frontmatter) → keep-indefinite (safe default)', () => {
+  const plan = planTrapSweep(new Date(), [trap('trap_a.md', null)]);
+  assert.equal(plan.entries[0]?.action, 'keep-indefinite');
+  assert.match(plan.entries[0]?.rationale ?? '', /principle 04/);
+});
+
+test('planner: invalid value → keep-invalid (surfaced to operator)', () => {
+  const plan = planTrapSweep(new Date(), [trap('trap_a.md', '2026-13-99')]);
+  assert.equal(plan.entries[0]?.action, 'keep-invalid');
+});
+
+test('planner: random non-date string → keep-invalid', () => {
+  const plan = planTrapSweep(new Date(), [trap('trap_a.md', 'next-quarter')]);
+  assert.equal(plan.entries[0]?.action, 'keep-invalid');
+});
+
+test('parser: strips surrounding quotes on frontmatter values', () => {
+  const fm = '---\nrelevant_until: "2026-04-01"\n---\n';
+  const v = extractFrontmatterField(fm, 'relevant_until');
+  assert.equal(v, '2026-04-01');
+});
+
+test('parser: returns null when the key is absent', () => {
+  const fm = '---\nother_field: value\n---\n';
+  assert.equal(extractFrontmatterField(fm, 'relevant_until'), null);
+});
+
+test('parser: returns null when no frontmatter block exists', () => {
+  assert.equal(extractFrontmatterField('# heading\n\nbody', 'relevant_until'), null);
+});
+
+test('parser: tolerates CRLF line endings', () => {
+  const fm = '---\r\nrelevant_until: 2026-04-01\r\n---\r\nbody\r\n';
+  assert.equal(extractFrontmatterField(fm, 'relevant_until'), '2026-04-01');
+});
+
+test('parser: skips YAML comments inside frontmatter', () => {
+  const fm = '---\n# a comment\nrelevant_until: 2026-04-01\n---\n';
+  assert.equal(extractFrontmatterField(fm, 'relevant_until'), '2026-04-01');
+});
+
+test('parseRelevantUntil: rejects 2026-02-31 (round-trip mismatch)', () => {
+  assert.equal(parseRelevantUntil('2026-02-31'), 'invalid');
+});
+
+test('parseRelevantUntil: rejects bare year', () => {
+  assert.equal(parseRelevantUntil('2026'), 'invalid');
+});
+
+test('parseRelevantUntil: trims whitespace', () => {
+  const v = parseRelevantUntil('  2026-04-01  ');
+  assert.ok(v instanceof Date);
+});

--- a/tests/interface/schemaInputDriftDetector.test.ts
+++ b/tests/interface/schemaInputDriftDetector.test.ts
@@ -72,6 +72,12 @@ const SUBCOMMAND_UMBRELLAS: ReadonlySet<string> = new Set([
   // collapses them into a single `templates` entry with a `subcommand`
   // discriminator. Skip in line with the policy comment above.
   'templates',
+  // doctor (#327): doctor + `doctor sweep-traps` sub-verb. The schema
+  // collapses both into one entry with `subcommand`/`apply`/`revive`
+  // properties, but runtime declares two separate KNOWN_FLAGS sets
+  // (DOCTOR_KNOWN_FLAGS for the bare verb, SWEEP_TRAPS_KNOWN_FLAGS for
+  // the sub-verb). Same redesign-not-drift situation as issues/templates.
+  'doctor',
 ]);
 
 // `gate help` and the very top-level positional verb dispatcher

--- a/tests/interface/sweepTraps.test.ts
+++ b/tests/interface/sweepTraps.test.ts
@@ -1,0 +1,343 @@
+// gate doctor sweep-traps — trap-memory retirement (#327, axis 5).
+//
+// Pinned here:
+//   - dry-run lists what would be swept without touching the filesystem
+//   - --apply moves expired traps to <content_root>/trap-quarantine/
+//     and appends a `quarantine` event to trap-retirement-log.yaml
+//   - --revive <name> moves a quarantined trap back AND appends a
+//     `revive` event to the same log
+//   - relevant_until: indefinite is never auto-swept
+//   - relevant_until: <future-date> is not swept
+//   - relevant_until: <past-date> IS swept
+//   - no frontmatter at all → safe default (kept), per principle 04
+//   - --apply and --revive are mutually exclusive
+//   - quarantine + revive round-trip leaves the file at its original
+//     path with byte-identical contents and the log carrying both events
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+  statSync,
+} from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Bootstrap {
+  root: string;
+  trapDir: string;
+  quarantineDir: string;
+  logPath: string;
+  cleanup: () => void;
+}
+
+function bootstrap(): Bootstrap {
+  const root = makeTempRoot('guild-sweep-traps-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox', 'lore', 'lore/traps']) {
+    mkdirSync(join(root, d), { recursive: true });
+  }
+  for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied']) {
+    mkdirSync(join(root, 'requests', s));
+  }
+  // One member so the misconfigured-cwd warning never fires —
+  // sweep-traps doesn't depend on it, but the bootstrap is shared
+  // shape across the doctor test family.
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return {
+    root,
+    trapDir: join(root, 'lore', 'traps'),
+    quarantineDir: join(root, 'trap-quarantine'),
+    logPath: join(root, 'trap-retirement-log.yaml'),
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, GUILD_ACTOR: 'eris' },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function writeTrap(trapDir: string, name: string, frontmatter: string | null, body = 'body\n'): void {
+  const fm = frontmatter === null ? '' : `---\n${frontmatter}\n---\n`;
+  writeFileSync(join(trapDir, name), `${fm}${body}`, 'utf8');
+}
+
+test('sweep-traps dry-run lists expired traps without touching disk', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_old.md', 'relevant_until: 2024-01-01');
+  writeTrap(b.trapDir, 'trap_new.md', 'relevant_until: 2099-01-01');
+  writeTrap(b.trapDir, 'trap_indef.md', 'relevant_until: indefinite');
+  writeTrap(b.trapDir, 'trap_bare.md', null);
+
+  const r = runGate(b.root, ['doctor', 'sweep-traps']);
+  assert.equal(r.status, 0, `stderr=${r.stderr}\nstdout=${r.stdout}`);
+  // Expired one is flagged for sweep
+  assert.match(r.stdout, /\[sweep\] trap_old\.md/);
+  // Future-dated, indefinite, bare are all kept
+  assert.match(r.stdout, /\[keep-future\] trap_new\.md/);
+  assert.match(r.stdout, /\[keep-indefinite\] trap_indef\.md/);
+  assert.match(r.stdout, /\[keep-indefinite\] trap_bare\.md/);
+  // Dry-run must not have created quarantine dir or log
+  assert.equal(existsSync(b.quarantineDir), false);
+  assert.equal(existsSync(b.logPath), false);
+  // The expired trap is still where it was
+  assert.equal(existsSync(join(b.trapDir, 'trap_old.md')), true);
+});
+
+test('sweep-traps --apply quarantines expired and writes audit log', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_expired.md', 'relevant_until: 2020-06-15');
+  writeTrap(b.trapDir, 'trap_indef.md', 'relevant_until: indefinite');
+
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(r.status, 0, `stderr=${r.stderr}\nstdout=${r.stdout}`);
+  // Expired trap moved
+  assert.equal(existsSync(join(b.trapDir, 'trap_expired.md')), false);
+  assert.equal(
+    existsSync(join(b.quarantineDir, 'trap_expired.md')),
+    true,
+  );
+  // Indefinite trap untouched
+  assert.equal(existsSync(join(b.trapDir, 'trap_indef.md')), true);
+  // Log file carries one event
+  const log = readFileSync(b.logPath, 'utf8');
+  assert.match(log, /^events:/);
+  assert.match(log, /action: quarantine/);
+  assert.match(log, /trap: trap_expired\.md/);
+  assert.match(log, /by: eris/);
+  assert.match(log, /reason: ".*relevant_until: 2020-06-15.*"/);
+});
+
+test('sweep-traps --revive restores quarantined trap and appends revive event', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_recall.md', 'relevant_until: 2020-01-01', 'original-body\n');
+
+  // Sweep first
+  const sweep = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(sweep.status, 0, `stderr=${sweep.stderr}`);
+  const quarantined = join(b.quarantineDir, 'trap_recall.md');
+  const quarantinedBytes = readFileSync(quarantined);
+  assert.equal(existsSync(join(b.trapDir, 'trap_recall.md')), false);
+
+  // Revive
+  const revive = runGate(b.root, [
+    'doctor',
+    'sweep-traps',
+    '--revive',
+    'trap_recall.md',
+  ]);
+  assert.equal(revive.status, 0, `stderr=${revive.stderr}\nstdout=${revive.stdout}`);
+  // File back at trap dir with byte-identical content
+  const restored = readFileSync(join(b.trapDir, 'trap_recall.md'));
+  assert.deepEqual(Uint8Array.from(restored), Uint8Array.from(quarantinedBytes));
+  // Quarantine slot is freed (rename, not copy)
+  assert.equal(existsSync(quarantined), false);
+  // Log carries BOTH events in order
+  const log = readFileSync(b.logPath, 'utf8');
+  const quarantineIdx = log.indexOf('action: quarantine');
+  const reviveIdx = log.indexOf('action: revive');
+  assert.notEqual(quarantineIdx, -1);
+  assert.notEqual(reviveIdx, -1);
+  assert.ok(quarantineIdx < reviveIdx, 'expected quarantine event before revive event');
+});
+
+test('sweep-traps treats no-frontmatter trap as indefinite (safe default)', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_bare.md', null, 'no frontmatter at all\n');
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+  // Trap stays put; nothing was quarantined
+  assert.equal(existsSync(join(b.trapDir, 'trap_bare.md')), true);
+  assert.equal(existsSync(b.quarantineDir), false);
+  assert.equal(existsSync(b.logPath), false);
+});
+
+test('sweep-traps does not sweep traps with future relevant_until', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_future.md', 'relevant_until: 2099-12-31');
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(r.status, 0);
+  assert.equal(existsSync(join(b.trapDir, 'trap_future.md')), true);
+  assert.equal(existsSync(b.quarantineDir), false);
+});
+
+test('sweep-traps refuses --apply + --revive together', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  const r = runGate(b.root, [
+    'doctor',
+    'sweep-traps',
+    '--apply',
+    '--revive',
+    'trap_x.md',
+  ]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /mutually exclusive/);
+});
+
+test('sweep-traps --revive rejects path-bearing names', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  // No quarantined file matters — the rejection is at the boundary.
+  const r = runGate(b.root, [
+    'doctor',
+    'sweep-traps',
+    '--revive',
+    '../escape.md',
+  ]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /bare filename/);
+});
+
+test('sweep-traps --revive errors when no such quarantined trap exists', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  const r = runGate(b.root, [
+    'doctor',
+    'sweep-traps',
+    '--revive',
+    'trap_ghost.md',
+  ]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /no quarantined trap/);
+});
+
+test('sweep-traps --apply without expired traps is a no-op', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_indef.md', 'relevant_until: indefinite');
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /no expired traps/);
+  assert.equal(existsSync(b.quarantineDir), false);
+  assert.equal(existsSync(b.logPath), false);
+});
+
+test('sweep-traps --format json on dry-run emits a structured envelope', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_old.md', 'relevant_until: 2020-01-01');
+  writeTrap(b.trapDir, 'trap_indef.md', 'relevant_until: indefinite');
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--format', 'json']);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+  const parsed = JSON.parse(r.stdout) as Array<{
+    trap: string;
+    action: string;
+    rationale: string;
+    relevant_until: string | null;
+  }>;
+  assert.ok(Array.isArray(parsed));
+  const byName = Object.fromEntries(parsed.map((e) => [e.trap, e]));
+  assert.equal(byName['trap_old.md']?.action, 'sweep');
+  assert.equal(byName['trap_indef.md']?.action, 'keep-indefinite');
+  assert.equal(byName['trap_old.md']?.relevant_until, '2020-01-01');
+});
+
+test('sweep-traps with empty trap dir is a clean no-op', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  const r = runGate(b.root, ['doctor', 'sweep-traps']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /no traps under/);
+});
+
+test('sweep-traps tolerates missing trap dir entirely', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  // Remove the trap dir entirely (bootstrap created it)
+  rmSync(b.trapDir, { recursive: true, force: true });
+  const r = runGate(b.root, ['doctor', 'sweep-traps']);
+  assert.equal(r.status, 0, `stderr=${r.stderr}`);
+});
+
+test('sweep-traps invalid relevant_until value is kept and surfaced', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  writeTrap(b.trapDir, 'trap_typo.md', 'relevant_until: 2026-13-99');
+  const r = runGate(b.root, ['doctor', 'sweep-traps']);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[keep-invalid\] trap_typo\.md/);
+  // Apply also leaves it alone
+  const apply = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(apply.status, 0);
+  assert.equal(existsSync(join(b.trapDir, 'trap_typo.md')), true);
+});
+
+test('sweep-traps unknown flag is rejected', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  const r = runGate(b.root, ['doctor', 'sweep-traps', '--bogus']);
+  // Unknown flag rejection lands as a thrown error → exit 1, error
+  // envelope on stderr.
+  assert.equal(r.status, 1);
+});
+
+test('sweep-traps round-trip preserves substrate byte-identically at trap location', (t) => {
+  const b = bootstrap();
+  t.after(b.cleanup);
+  const original = `---\nrelevant_until: 2020-04-01\n---\n# trap body\n\nimportant content with unicode: éèà\n`;
+  writeFileSync(join(b.trapDir, 'trap_rt.md'), original, 'utf8');
+  const beforeBytes = readFileSync(join(b.trapDir, 'trap_rt.md'));
+  const beforeStat = statSync(join(b.trapDir, 'trap_rt.md'));
+
+  // sweep
+  const sweep = runGate(b.root, ['doctor', 'sweep-traps', '--apply']);
+  assert.equal(sweep.status, 0);
+  assert.equal(existsSync(join(b.trapDir, 'trap_rt.md')), false);
+
+  // revive
+  const revive = runGate(b.root, [
+    'doctor',
+    'sweep-traps',
+    '--revive',
+    'trap_rt.md',
+  ]);
+  assert.equal(revive.status, 0, `stderr=${revive.stderr}`);
+
+  // byte-identical contents at trap location
+  const afterBytes = readFileSync(join(b.trapDir, 'trap_rt.md'));
+  assert.deepEqual(Uint8Array.from(afterBytes), Uint8Array.from(beforeBytes));
+  // size match (trivial check; bytewise equal already covers it)
+  const afterStat = statSync(join(b.trapDir, 'trap_rt.md'));
+  assert.equal(afterStat.size, beforeStat.size);
+
+  // log carries BOTH events
+  const log = readFileSync(b.logPath, 'utf8');
+  const occurrences = (s: string, needle: string): number =>
+    s.split(needle).length - 1;
+  assert.equal(occurrences(log, 'trap: trap_rt.md'), 2);
+  assert.equal(occurrences(log, 'action: quarantine'), 1);
+  assert.equal(occurrences(log, 'action: revive'), 1);
+});


### PR DESCRIPTION
## Summary

Axis 5 of 5 from solo/swarm coexistence proposal. Adds trap-memory retirement substrate per #327, **Shape A** (absolute date, simpler) chosen over Shape B (heartbeat, deferred).

## Change

### Trap frontmatter convention

`lore/traps/*.md` accepts `relevant_until: <YYYY-MM-DD>` or `relevant_until: indefinite` (default when absent: indefinite — safe per principle 04).

### New sub-verb: `gate doctor sweep-traps`

```
gate doctor sweep-traps [--apply] [--revive <name>] [--format json]
```

- Without `--apply` → dry-run, lists what would be quarantined
- With `--apply` → moves expired traps to `<content_root>/trap-quarantine/` + appends entry to `<content_root>/trap-retirement-log.yaml`
- With `--revive <filename>` → restores a quarantined trap + appends revive entry
- **Never deletes** — quarantine is the only retirement shape (principle 04)
- Mutex on `--apply` + `--revive`; path-traversal-safe (rejects `../escape.md`)

### Files added

- `lore/traps/` — 4 new files (3 trap memories from eris's earlier `trap_*.md` pins + README documenting the convention). All annotated `relevant_until: indefinite` so no auto-sweep until manual review.
- `src/application/trapSweep/TrapSweepUseCases.ts` — pure planner + frontmatter parser
- `src/interface/gate/handlers/doctor.ts` — sub-verb dispatch
- `src/interface/gate/handlers/schema.ts` — schema entry (umbrella shape, same as `issues`/`templates`)
- `src/interface/gate/help.ts` — help-text entry under Diagnostic/Repair (`extra` tier; appears in `gate --help --all`)
- `tests/application/trapSweepPlan.test.ts` — 17 planner/parser tests
- `tests/interface/sweepTraps.test.ts` — 15 CLI round-trip tests
- `tests/interface/schemaInputDriftDetector.test.ts` — `doctor` added to `SUBCOMMAND_UMBRELLAS`

## Edge cases tested

- past-date / future-date / same-day boundary (same-day inclusive — not expired)
- `indefinite` (case-insensitive)
- no frontmatter (treated as indefinite, never swept)
- invalid date (e.g. `2026-02-31`) — parser refuses
- CRLF frontmatter, YAML comments inside frontmatter, quoted values
- `--apply` + `--revive` mutex enforced
- `--revive ../escape.md` rejected (path traversal)
- Missing trap directory — no-op, not an error
- Round-trip (sweep + revive) leaves trap file byte-identical, log carries both events
- Unknown flag rejection (typo guard: `--aply` fails loudly, not silent dry-run)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1602/1602 pass (+32 new tests: 17 planner + 15 CLI)
- [x] Schema-drift detector picks up new sub-verb correctly

## Conflict resolution note

Cherry-pick onto axis 2 merged base required resolving a static-`HELP`-constant collision: axis 2 (#330) replaced the static `HELP` in `index.ts` with `renderHelp` (from `help.ts`). The original axis-5 commit added the sweep-traps doc to that static `HELP`. Migrated the doc to `help.ts` under the Diagnostic/Repair section, `extra` tier (visible via `gate --help --all`).

## Provenance

- agora play `coexistence-phase-2/2026-05-11-001` move 005 (decision lock: Shape A, defer Shape B; existing traps `indefinite`)
- gate wave `2026-05-11-0005` in local `substrate/swarm-experiments/2026-05-11-solo-swarm-coexistence/`, single-executor `agent-trap`, critic approve, witness + execute
- worktree-ledger blindspot pattern (#322): SubAgent did not stamp from worktree

Closes #327

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_