### PR TITLE
docs: fix 'lens' → 'lense' singular-spelling drift

### DIFF
--- a/docs/swarm.md
+++ b/docs/swarm.md
@@ -42,7 +42,7 @@ agora new --slug ordering-<topic>-<date> --kind quest \
 agora play --slug ordering-<topic>-<date> --by <you>
 # → 2026-MM-DD-NNN
 
-# 2) Deliberate with multi-voice (one move per voice / lens)
+# 2) Deliberate with multi-voice (one move per voice / lense)
 agora move <play-id> --by <you>   --text "candidates + dependencies"
 agora move <play-id> --by <miki>  --text "size + conflict-surface analysis"
 agora move <play-id> --by <noir>  --text "dependency graph: independent vs chained"

--- a/src/interface/gate/handlers/reviewContext.ts
+++ b/src/interface/gate/handlers/reviewContext.ts
@@ -26,12 +26,12 @@ import { RequestDepth } from '../../../domain/request/RequestDepth.js';
 const REVIEW_CONTEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 /**
- * Lens recommendation by depth. Encoded here (not in domain) because
+ * Lense recommendation by depth. Encoded here (not in domain) because
  * the choice is policy that may evolve with reviewer practice — keeping
  * it at the interface layer lets the substrate remain advisory-only.
  *
- *   - shallow:  point-check with the highest-severity general lens.
- *   - standard: 6-lens default mirroring the published /devil contract.
+ *   - shallow:  point-check with the highest-severity general lense.
+ *   - standard: 6-lense default mirroring the published /devil contract.
  *   - deep:     all 10 lenses + memory MCP + state-machine trace.
  *
  * The reviewer is free to widen or narrow this set on a given run
@@ -59,9 +59,9 @@ const LENSES_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
 
 /**
  * Extras the reviewer is invited to exercise at a given depth, beyond
- * the lens set itself. Surfaced separately so a deep reviewer sees
+ * the lense set itself. Surfaced separately so a deep reviewer sees
  * "memory MCP lookup + state-machine trace + prior-review cross-check"
- * as explicit obligations, not just lens names.
+ * as explicit obligations, not just lense names.
  */
 const EXTRAS_BY_DEPTH: Readonly<Record<RequestDepth, readonly string[]>> = {
   shallow: [],
@@ -85,7 +85,7 @@ export interface ReviewContextPayload {
    *  without `--depth` and never re-stamped — reviewer should treat
    *  as standard and surface a warning. */
   depth: RequestDepth | null;
-  /** Recommended lens set derived from depth. Empty when `depth` is
+  /** Recommended lense set derived from depth. Empty when `depth` is
    *  null (reviewer falls back to its own default but can record the
    *  drift). */
   recommended_lenses: readonly string[];
@@ -160,7 +160,7 @@ export function buildReviewContext(r: Request): ReviewContextPayload {
     warning:
       depth === null
         ? 'no depth recorded on this wave — reviewer should default to standard ' +
-          'lens set and surface the missing advisory in its preamble (#310 #221)'
+          'lense set and surface the missing advisory in its preamble (#310 #221)'
         : '',
   };
 }

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -213,7 +213,7 @@ const utteranceSchema: JsonSchema = {
     },
     lense: {
       type: 'string',
-      description: '[review only] reviewer lens (devil/layer/cognitive/user).',
+      description: '[review only] reviewer lense (devil/layer/cognitive/user).',
     },
     verdict: {
       type: 'string',
@@ -755,7 +755,7 @@ const VERBS: readonly VerbSchema[] = [
     name: 'review-context',
     category: 'read',
     summary:
-      'reviewer-facing bundle for a wave: action/reason/target, executors, depth advisory (#221), recommended lens set by depth, and prior reviews. Lets a devil/reviewer agent drive behaviour from substrate state instead of out-of-band prompt content (#310 Layer A). Read-only; depth and lens-set are advisory not directive (principle 02).',
+      'reviewer-facing bundle for a wave: action/reason/target, executors, depth advisory (#221), recommended lense set by depth, and prior reviews. Lets a devil/reviewer agent drive behaviour from substrate state instead of out-of-band prompt content (#310 Layer A). Read-only; depth and lense-set are advisory not directive (principle 02).',
     input: {
       type: 'object',
       properties: {

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -516,7 +516,7 @@ export function computeVoiceCalibration(
         // verdict=reject + state=completed: header calls this
         // `overruled` (you said no, it shipped anyway). counted as
         // missed here — conservative read: from a work-as-evidence
-        // lens, the no was wrong because the work landed. the
+        // lense, the no was wrong because the work landed. the
         // alternative ("the risk you flagged was reviewed and held")
         // is plausible but not separately observable from this
         // record alone, so we don't try to distinguish.

--- a/tests/interface/gateStrictLenses134H2.test.ts
+++ b/tests/interface/gateStrictLenses134H2.test.ts
@@ -9,7 +9,7 @@
 //     extensions). Unknown lenses rejected.
 //   - regression: `--lense devil` always works under default config
 //     (DEFAULT_LENSES include 'devil') AND under strict mode (bundled
-//     catalog includes 'devil-substrate' lenses but NOT a 'devil' lens
+//     catalog includes 'devil-substrate' lenses but NOT a 'devil' lense
 //     — wait — the substrate-side bundled lenses are different from
 //     gate's DEFAULT_LENSES. Strict-mode flip is a real migration step
 //     for teams that used 'devil' as a gate framing label).

--- a/tests/interface/reviewContext310.test.ts
+++ b/tests/interface/reviewContext310.test.ts
@@ -1,7 +1,7 @@
 // #310 — gate review-context regression.
 //
 // Acceptance:
-//   - shallow / standard / deep produce the matching lens recommendation
+//   - shallow / standard / deep produce the matching lense recommendation
 //   - missing depth on a wave surfaces a non-empty warning + empty lenses
 //   - prior reviews are bundled into the payload
 //   - non-existent id → exit 1 with notFoundHint
@@ -74,7 +74,7 @@ test('#310: review-context on wave without depth → empty lenses + warning', (t
   assert.deepEqual(payload.executors, ['alice']);
 });
 
-test('#310: depth=shallow → point-check lens set', (t) => {
+test('#310: depth=shallow → point-check lense set', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   const created = runGate(root, [
@@ -95,7 +95,7 @@ test('#310: depth=shallow → point-check lens set', (t) => {
   assert.equal(payload.warning, '');
 });
 
-test('#310: depth=standard → 6-lens default', (t) => {
+test('#310: depth=standard → 6-lense default', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   const created = runGate(root, [
@@ -174,7 +174,7 @@ test('#310: review-context bundles prior reviews into the payload', (t) => {
   assert.equal(payload.prior_reviews[0].comment, 'first pass clean');
 });
 
-test('#310: text format renders depth + lens recommendation + prior reviews', (t) => {
+test('#310: text format renders depth + lense recommendation + prior reviews', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   const created = runGate(root, [


### PR DESCRIPTION
## Summary

Project standard is `lense` with trailing `-e` throughout (per `docs/concepts-for-newcomers.md:58`). A handful of singular `lens` occurrences had drifted in. Most user-visible was the `gate review-context` warning:

> `⚠ no depth recorded on this wave — reviewer should default to standard lens set ...`

Plural `lenses` is unchanged (same form either way) and the `recommended_lenses` JSON field name is unchanged — no envelope-shape change.

## Changes

- `src/interface/gate/handlers/reviewContext.ts` — JSDoc (4) + ⚠ warning string + `ReviewContextPayload` field comment
- `src/interface/gate/handlers/schema.ts` — `gate review --lense` description + `review-context` verb summary (JSON schema surface)
- `src/interface/gate/voices.ts:519` — internal comment ("work-as-evidence lense")
- `tests/interface/reviewContext310.test.ts` — header comment + 3 test names
- `tests/interface/gateStrictLenses134H2.test.ts:12` — comment
- `docs/swarm.md:45` — shell-example comment

## Scope notes

- `CHANGELOG.md` and `examples/` left alone — append-only history.
- `lore/principles/12-...md:5` "shared GUI lens" left alone — that's the projector/sibling-CLI optical metaphor, distinct from review-lenses.

## Test plan

- [x] `npm run build` clean
- [x] `tests/interface/reviewContext310.test.ts` (19/19 pass)
- [x] `tests/interface/gateStrictLenses134H2.test.ts` + `gateHelpTiered` + `lenseStats305` sanity (all pass)
- [x] `grep -rn '\blens\b' src/ tests/ docs/` returns no hits outside the deliberate GUI-metaphor line

https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_