### PR TITLE
docs(lore): operational guidance for relevant_until + applies_to choice

### DIFF
--- a/lore/README.md
+++ b/lore/README.md
@@ -65,6 +65,27 @@ The `all` default makes the audience filter inclusive by design: a
 solo reader sees everything not explicitly swarm-only; a swarm
 reader sees everything (the universal set plus their own extras).
 
+### When to annotate
+
+Default is to **leave frontmatter absent** (= `all`). Most principles
+are universal stances about the project's shape and apply regardless
+of mode or passage. Annotate only when an unannotated principle
+would *mislead* a reader outside its scope.
+
+Concretely, annotate when:
+
+- The principle is only load-bearing under a specific mode — e.g.
+  principle 14 (substrate engagement) only fires when coordinating
+  multiple actors, so a solo reader reading it without context might
+  think the ceremony applies to their flow. `applies_to: swarm`.
+- The principle is specific to one passage's verbs / shape, and a
+  reader of another passage would file it under the wrong axis.
+  `applies_to: passage:<name>`.
+
+Do not annotate just to be precise. A solo-shaped principle that
+*also* makes sense universally should remain unannotated — the
+absence is the inclusive signal.
+
 ## Why this exists
 
 Every non-trivial codebase accumulates opinions that don't fit in

--- a/lore/traps/README.md
+++ b/lore/traps/README.md
@@ -35,6 +35,34 @@ Per principle 04 (records-outlive-writers), retirement is quarantine,
 not deletion: a future reader can always reconstruct what the trap
 said and why it was retired.
 
+## When to use a date vs `indefinite`
+
+Choose based on **why the trap exists**, not on how cautious you feel:
+
+- **`indefinite`** — the trap names a pattern with no expected
+  resolution event. Anti-patterns rooted in the medium (substrate,
+  filesystem, AI session boundaries, etc.) belong here. A trap is
+  also `indefinite` when it is a candidate for promotion to
+  `lore/principles/`: if the pattern is felt-not-just-read enough
+  to make it into principles, retirement is *graduation*, not
+  expiry — and graduation has no calendar date.
+
+- **`relevant_until: <YYYY-MM-DD>`** — the trap exists because of
+  a specific in-flight situation. Use a concrete date when:
+  - the trap pins a workaround for a bug being actively fixed
+    (date ≈ the bug's expected fix-ship date plus a re-read buffer)
+  - the trap surfaces a friction tied to a feature still in design
+    (date ≈ design-lock date for that feature)
+  - the trap captures a one-off lesson whose relevance fades as
+    the codebase moves past the conditions that produced it
+    (date ≈ "review me by then to decide if this is still load-
+    bearing")
+
+The default when frontmatter is absent is `indefinite` (safe,
+principle-04-aligned). Reach for a date only when you can name the
+event the date is tracking; if you cannot, the trap is `indefinite`
+even if you feel uncertain.
+
 ## Naming
 
 `trap_<short_pattern_slug>.md`. The slug should match the pattern


### PR DESCRIPTION
## Summary

Thin docs additions filling two operational gaps surfaced on 2026-05-12:

1. **`lore/traps/README.md` — When to use a date vs `indefinite`.** The frontmatter spec was documented but the *judgment* of which to pick wasn't. Adds three concrete situations warranting a date (workaround for in-flight bug, friction tied to in-design feature, one-off lesson with fading relevance) and keeps the default explicit: `indefinite` unless you can name the event the date is tracking. No retroactive re-dating of existing principle-grade traps.

2. **`lore/README.md` — When to annotate `applies_to`.** Adds a subsection alongside the existing vocabulary table. Default = absent (= `all`). Annotate only when the unannotated principle would *mislead* a reader outside its scope.

## Why

Both are operational rules; without them, future principle / trap authors re-derive the judgment per file. The PRs that landed `applies_to` (#329) and `sweep-traps` (#331) shipped the mechanism; this PR ships the rule.

## Test plan

- [x] Pure docs.
- [x] `npm test` 1610/1610 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)