### PR TITLE
feat(gate): decisions + self-pattern read verbs (director-axis introspection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate decisions` verb — director-axis decision audit.**
+  Surfaces the approve / deny / execute / complete / fail transitions
+  an actor authored within a window. Decision-shaped sibling of
+  `gate voices` (review-shaped) and `gate lense-stats` (lense-shaped).
+  Defaults `--for` to `GUILD_ACTOR` so a bare `gate decisions` from
+  the calling actor's shell answers "what have I decided in the last
+  7 days?" Dedupes by `(request_id, transition)` — the #294 slice-
+  closure path adds an extra `executing` stamp on `gate complete --by X`
+  which would otherwise inflate raw counts.
+
+- **`gate self-pattern` verb — actor behavioral bias surface.**
+  Aggregates an actor's substrate footprint over a window: decision
+  counts (approve/deny/execute/complete/fail), review verdict ratio
+  (ok / concern / reject), top review lense, `approve_rate`
+  (approve / approve+deny), `ok_rate` (ok / total reviews). For the
+  *full* lense breakdown the verb hints at `gate lense-stats --for
+  <actor>` rather than duplicating it. Defaults `--for` to
+  `GUILD_ACTOR`. Read-only; no schema change — composes from existing
+  `status_log` + `reviews` data.
+
 - **`gate lense-stats` verb — lense rotation diagnostic (closes #305)**
   ([#305](https://github.com/eris-ths/guild-cli/issues/305)).
   Counts review entries per lense over a window (`--since 7d` default),

--- a/src/interface/gate/handlers/decisions.ts
+++ b/src/interface/gate/handlers/decisions.ts
@@ -1,0 +1,188 @@
+// gate decisions — actor's authored state transitions in a window.
+//
+// Sibling of `gate voices` (review-shaped) and `gate lense-stats`
+// (lense-shaped). This verb is decision-shaped: it surfaces the
+// approve / deny / execute / complete / fail transitions an actor
+// performed against the substrate, with one row per transition.
+//
+// Built for the director / orchestrator role: "what have I decided
+// recently?" is answered in one verb rather than by grepping
+// `gate voices --by <me>` output for state lines or walking
+// `gate list --state <s>` per state.
+//
+// `--for <actor>` filters by author of the transition (status_log[i].by).
+// Default: GUILD_ACTOR — `gate decisions` with no flags answers
+// "what have I decided in the last 7 days?" out of the box.
+//
+// `--since <duration>` accepts `7d`, `24h`, `30m`, `45s`. Default 7d.
+//
+// Read-only: no mutation, no state transitions. LOCK_EXEMPT-eligible
+// but registered as READ for now.
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { parseDuration } from './lenseStats.js';
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+
+const DECISIONS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'since',
+  'format',
+]);
+
+/**
+ * The five transition kinds this verb surfaces. `pending` (creation)
+ * is intentionally excluded — request authorship is `gate voices`'s
+ * job. `approved` / `denied` / `executing` / `completed` / `failed`
+ * are decisions an actor *made*, in the sense the director would
+ * audit.
+ */
+export type DecisionKind =
+  | 'approve'
+  | 'deny'
+  | 'execute'
+  | 'complete'
+  | 'fail';
+
+export interface DecisionRow {
+  readonly at: string;
+  readonly request_id: string;
+  readonly transition: DecisionKind;
+  readonly note: string | null;
+}
+
+export interface DecisionsPayload {
+  readonly window: { readonly since: string; readonly duration: string };
+  readonly filter: { readonly actor: string };
+  readonly totals: {
+    readonly entries_counted: number;
+    readonly by_transition: Readonly<Record<DecisionKind, number>>;
+  };
+  readonly decisions: readonly DecisionRow[];
+}
+
+const STATE_TO_KIND: Readonly<Record<string, DecisionKind>> = {
+  approved: 'approve',
+  denied: 'deny',
+  executing: 'execute',
+  completed: 'complete',
+  failed: 'fail',
+};
+
+export async function decisionsCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, DECISIONS_KNOWN_FLAGS, 'decisions');
+  const forActor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
+  if (!forActor) {
+    throw new Error(
+      'gate decisions: --for <actor> is required when GUILD_ACTOR is not set.' +
+        '\n  next: pass --for <name>, or `export GUILD_ACTOR=<you>` once per shell.',
+    );
+  }
+  const sinceRaw = optionalOption(args, 'since') ?? '7d';
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+
+  const now = new Date();
+  const sinceMs = parseDuration(sinceRaw);
+  const cutoff = new Date(now.getTime() - sinceMs);
+  const cutoffIso = cutoff.toISOString();
+
+  const requests = await c.requestUC.listAll();
+  // Dedupe by (request_id, transition) for the calling actor — the
+  // #294 slice-closure path emits a second `executing` status_log
+  // entry on `gate complete --by X` (slice-close stamp), so a raw
+  // count over status_log inflates "executes" by 1 for every slice
+  // that closes. From a director's audit perspective the question
+  // is "how many distinct decisions did I make?", not "how many
+  // status_log entries did I write?". Keep the latest entry per
+  // tuple (later note wins; later `at` wins ties).
+  const dedup = new Map<string, DecisionRow>();
+  for (const r of requests) {
+    const j = r.toJSON() as Record<string, unknown>;
+    const id = String(j['id']);
+    const log = Array.isArray(j['status_log']) ? j['status_log'] : [];
+    for (const e of log) {
+      if (typeof e !== 'object' || e === null) continue;
+      const rec = e as Record<string, unknown>;
+      const at = typeof rec['at'] === 'string' ? (rec['at'] as string) : null;
+      const by = typeof rec['by'] === 'string' ? (rec['by'] as string) : null;
+      const state = typeof rec['state'] === 'string' ? (rec['state'] as string) : null;
+      if (at === null || by === null || state === null) continue;
+      if (by !== forActor) continue;
+      if (at < cutoffIso) continue;
+      const kind = STATE_TO_KIND[state];
+      if (!kind) continue;
+      const note = typeof rec['note'] === 'string' ? (rec['note'] as string) : null;
+      const key = `${id}|${kind}`;
+      const cur = dedup.get(key);
+      if (cur === undefined || at >= cur.at) {
+        dedup.set(key, { at, request_id: id, transition: kind, note });
+      }
+    }
+  }
+  const rows: DecisionRow[] = [...dedup.values()];
+
+  // Sort by `at` desc so the most-recent decision is first — same axis
+  // a director would scan when answering "what did I just do?".
+  rows.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+
+  const byTransition: Record<DecisionKind, number> = {
+    approve: 0,
+    deny: 0,
+    execute: 0,
+    complete: 0,
+    fail: 0,
+  };
+  for (const r of rows) byTransition[r.transition] += 1;
+
+  const payload: DecisionsPayload = {
+    window: { since: cutoffIso, duration: sinceRaw },
+    filter: { actor: forActor },
+    totals: {
+      entries_counted: rows.length,
+      by_transition: byTransition,
+    },
+    decisions: rows,
+  };
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(renderText(payload) + '\n');
+  return 0;
+}
+
+function renderText(p: DecisionsPayload): string {
+  const lines: string[] = [];
+  lines.push(
+    `decisions  actor=${p.filter.actor}  window=${p.window.duration}  ` +
+      `entries=${p.totals.entries_counted}`,
+  );
+  lines.push(`since: ${p.window.since}`);
+  lines.push('');
+  const t = p.totals.by_transition;
+  lines.push(
+    `  approve: ${t.approve}   deny: ${t.deny}   execute: ${t.execute}   ` +
+      `complete: ${t.complete}   fail: ${t.fail}`,
+  );
+  if (p.decisions.length === 0) {
+    lines.push('');
+    lines.push(
+      '(no decisions in window — try a longer --since, or check --for is correct)',
+    );
+    return lines.join('\n');
+  }
+  lines.push('');
+  for (const r of p.decisions) {
+    const noteSuffix = r.note ? `  — ${r.note.replace(/[\r\n]+/g, ' ')}` : '';
+    lines.push(`  ${r.at}  ${r.request_id}  ${r.transition}${noteSuffix}`);
+  }
+  return lines.join('\n');
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -799,6 +799,123 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'decisions',
+    category: 'read',
+    summary:
+      "actor's authored state transitions (approve / deny / execute / complete / fail) within a window. Decision-shaped sibling of `voices` (review-shaped) and `lense-stats` (lense-shaped). Defaults --for to GUILD_ACTOR.",
+    input: {
+      type: 'object',
+      properties: {
+        for: { type: 'string', description: "filter by status_log[].by (default: GUILD_ACTOR)" },
+        since: {
+          type: 'string',
+          description: 'window size as <int><s|m|h|d>; default 7d',
+        },
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        window: {
+          type: 'object',
+          properties: {
+            since: str,
+            duration: str,
+          },
+        },
+        filter: {
+          type: 'object',
+          properties: { actor: str },
+        },
+        totals: {
+          type: 'object',
+          properties: {
+            entries_counted: { type: 'integer' },
+            by_transition: {
+              type: 'object',
+              properties: {
+                approve: { type: 'integer' },
+                deny: { type: 'integer' },
+                execute: { type: 'integer' },
+                complete: { type: 'integer' },
+                fail: { type: 'integer' },
+              },
+            },
+          },
+        },
+        decisions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              at: str,
+              request_id: str,
+              transition: { type: 'string', enum: ['approve', 'deny', 'execute', 'complete', 'fail'] },
+              note: { type: 'string', description: 'null when no note recorded' },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'self-pattern',
+    category: 'read',
+    summary:
+      "actor's behavioral bias surface across a window: decision counts, review verdict ratio (ok/concern/reject), top review lense, approve-rate, ok-rate. Composes from existing substrate; for the *full* lense breakdown see `gate lense-stats --for <actor>`. Defaults --for to GUILD_ACTOR.",
+    input: {
+      type: 'object',
+      properties: {
+        for: { type: 'string', description: 'filter by author of status_log / review entries (default: GUILD_ACTOR)' },
+        since: { type: 'string', description: 'window size as <int><s|m|h|d>; default 7d' },
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        window: { type: 'object', properties: { since: str, duration: str } },
+        filter: { type: 'object', properties: { actor: str } },
+        decisions: {
+          type: 'object',
+          properties: {
+            total: { type: 'integer' },
+            by_transition: {
+              type: 'object',
+              properties: {
+                approve: { type: 'integer' },
+                deny: { type: 'integer' },
+                execute: { type: 'integer' },
+                complete: { type: 'integer' },
+                fail: { type: 'integer' },
+              },
+            },
+          },
+        },
+        reviews: {
+          type: 'object',
+          properties: {
+            total: { type: 'integer' },
+            by_verdict: {
+              type: 'object',
+              description: 'verdict-keyed counts; keys present only when verdict was observed in window',
+            },
+            top_lense: { type: 'string', description: 'most-reached-for lense in window; null when no reviews' },
+          },
+        },
+        ratios: {
+          type: 'object',
+          properties: {
+            approve_rate: { type: 'number', description: 'approve / (approve + deny); null when both zero' },
+            ok_rate: { type: 'number', description: 'ok / total reviews; null when no reviews' },
+          },
+        },
+        hint: str,
+      },
+    },
+  },
+  {
     name: 'summarize',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/selfPattern.ts
+++ b/src/interface/gate/handlers/selfPattern.ts
@@ -1,0 +1,227 @@
+// gate self-pattern — actor's behavioral bias surface across a window.
+//
+// Aggregates an actor's substrate footprint over a window: decision
+// counts (approve/deny/execute/complete/fail), review verdict ratio
+// (ok/concern/reject), and the top review lense the actor reached for.
+//
+// Aimed at the director / orchestrator role's introspection question:
+// "what does my pattern look like? am I biased toward `concern`? am
+// I always pulling the same lense? what fraction of my decisions are
+// approvals vs denials?"
+//
+// Composes from existing substrate (status_log entries + reviews) —
+// no schema change. Read-only.
+//
+// For the *full* lense distribution see `gate lense-stats --for <actor>`
+// (#305). This verb surfaces the *top* lense only, as a bias hint;
+// it does not try to be a second copy of lense-stats.
+//
+// Defaults to `--for <GUILD_ACTOR>` so a bare `gate self-pattern` from
+// the calling actor's shell answers "show me my own pattern."
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { C } from './internal.js';
+import { parseDuration } from './lenseStats.js';
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+
+const SELF_PATTERN_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'for',
+  'since',
+  'format',
+]);
+
+type DecisionKind = 'approve' | 'deny' | 'execute' | 'complete' | 'fail';
+
+export interface SelfPatternPayload {
+  readonly window: { readonly since: string; readonly duration: string };
+  readonly filter: { readonly actor: string };
+  readonly decisions: {
+    readonly total: number;
+    readonly by_transition: Readonly<Record<DecisionKind, number>>;
+  };
+  readonly reviews: {
+    readonly total: number;
+    readonly by_verdict: Readonly<Record<string, number>>;
+    readonly top_lense: string | null;
+  };
+  readonly ratios: {
+    /** approve / (approve + deny). null when (approve + deny) === 0. */
+    readonly approve_rate: number | null;
+    /** ok / total reviews. null when no reviews in window. */
+    readonly ok_rate: number | null;
+  };
+  readonly hint: string;
+}
+
+const STATE_TO_KIND: Readonly<Record<string, DecisionKind>> = {
+  approved: 'approve',
+  denied: 'deny',
+  executing: 'execute',
+  completed: 'complete',
+  failed: 'fail',
+};
+
+export async function selfPatternCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, SELF_PATTERN_KNOWN_FLAGS, 'self-pattern');
+  const forActor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
+  if (!forActor) {
+    throw new Error(
+      'gate self-pattern: --for <actor> is required when GUILD_ACTOR is not set.' +
+        '\n  next: pass --for <name>, or `export GUILD_ACTOR=<you>` once per shell.',
+    );
+  }
+  const sinceRaw = optionalOption(args, 'since') ?? '7d';
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+
+  const now = new Date();
+  const sinceMs = parseDuration(sinceRaw);
+  const cutoff = new Date(now.getTime() - sinceMs);
+  const cutoffIso = cutoff.toISOString();
+
+  const requests = await c.requestUC.listAll();
+
+  const decisionCounts: Record<DecisionKind, number> = {
+    approve: 0,
+    deny: 0,
+    execute: 0,
+    complete: 0,
+    fail: 0,
+  };
+  const verdictCounts: Record<string, number> = {};
+  const lenseCounts = new Map<string, number>();
+  let reviewTotal = 0;
+
+  // Dedupe by (request_id, kind) — see decisions.ts for rationale.
+  // Slice-closure emits an extra `executing` stamp on `gate complete
+  // --by X`, which inflates raw counts. Director-axis question is
+  // "distinct decisions" not "status_log entries".
+  for (const r of requests) {
+    const j = r.toJSON() as Record<string, unknown>;
+    const id = String(j['id']);
+    const log = Array.isArray(j['status_log']) ? j['status_log'] : [];
+    const seen = new Set<string>();
+    for (const e of log) {
+      if (typeof e !== 'object' || e === null) continue;
+      const rec = e as Record<string, unknown>;
+      const at = typeof rec['at'] === 'string' ? (rec['at'] as string) : null;
+      const by = typeof rec['by'] === 'string' ? (rec['by'] as string) : null;
+      const state = typeof rec['state'] === 'string' ? (rec['state'] as string) : null;
+      if (at === null || by === null || state === null) continue;
+      if (by !== forActor) continue;
+      if (at < cutoffIso) continue;
+      const kind = STATE_TO_KIND[state];
+      if (!kind) continue;
+      const key = `${id}|${kind}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      decisionCounts[kind] += 1;
+    }
+
+    const reviews = Array.isArray(j['reviews']) ? j['reviews'] : [];
+    for (const rv of reviews) {
+      if (typeof rv !== 'object' || rv === null) continue;
+      const rec = rv as Record<string, unknown>;
+      const at = typeof rec['at'] === 'string' ? (rec['at'] as string) : null;
+      const by = typeof rec['by'] === 'string' ? (rec['by'] as string) : null;
+      const verdict = typeof rec['verdict'] === 'string' ? (rec['verdict'] as string) : null;
+      const lense = typeof rec['lense'] === 'string' ? (rec['lense'] as string) : null;
+      if (at === null || by === null || verdict === null || lense === null) continue;
+      if (by !== forActor) continue;
+      if (at < cutoffIso) continue;
+      reviewTotal += 1;
+      verdictCounts[verdict] = (verdictCounts[verdict] ?? 0) + 1;
+      lenseCounts.set(lense, (lenseCounts.get(lense) ?? 0) + 1);
+    }
+  }
+
+  // Top lense: highest count, ties broken alphabetically. null when
+  // no reviews in window. Surface the most-reached-for lense as a
+  // bias hint, not as a substitute for the full breakdown.
+  let topLense: string | null = null;
+  let topCount = -1;
+  const lenseEntries = [...lenseCounts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  if (lenseEntries.length > 0) {
+    [topLense, topCount] = lenseEntries[0]!;
+  }
+
+  const decisionTotal =
+    decisionCounts.approve +
+    decisionCounts.deny +
+    decisionCounts.execute +
+    decisionCounts.complete +
+    decisionCounts.fail;
+
+  const apDeny = decisionCounts.approve + decisionCounts.deny;
+  const approveRate = apDeny === 0 ? null : decisionCounts.approve / apDeny;
+  const okRate =
+    reviewTotal === 0 ? null : (verdictCounts['ok'] ?? 0) / reviewTotal;
+
+  const payload: SelfPatternPayload = {
+    window: { since: cutoffIso, duration: sinceRaw },
+    filter: { actor: forActor },
+    decisions: { total: decisionTotal, by_transition: decisionCounts },
+    reviews: {
+      total: reviewTotal,
+      by_verdict: verdictCounts,
+      top_lense: topLense,
+    },
+    ratios: { approve_rate: approveRate, ok_rate: okRate },
+    hint: `see \`gate lense-stats --for ${forActor} --since ${sinceRaw}\` for the full lense distribution`,
+  };
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(renderText(payload, topCount) + '\n');
+  return 0;
+}
+
+function renderText(p: SelfPatternPayload, topLenseCount: number): string {
+  const lines: string[] = [];
+  lines.push(
+    `self-pattern  actor=${p.filter.actor}  window=${p.window.duration}`,
+  );
+  lines.push(`since: ${p.window.since}`);
+  lines.push('');
+  const t = p.decisions.by_transition;
+  lines.push(
+    `decisions (${p.decisions.total}):  approve=${t.approve}  ` +
+      `deny=${t.deny}  execute=${t.execute}  ` +
+      `complete=${t.complete}  fail=${t.fail}`,
+  );
+  if (p.ratios.approve_rate !== null) {
+    const pct = Math.round(p.ratios.approve_rate * 100);
+    lines.push(`  approve_rate: ${pct}%  (approve / (approve+deny))`);
+  }
+  lines.push('');
+  if (p.reviews.total === 0) {
+    lines.push('reviews (0): (none in window)');
+  } else {
+    const verdictPairs = Object.entries(p.reviews.by_verdict)
+      .sort((a, b) => b[1] - a[1])
+      .map(([v, n]) => `${v}=${n}`)
+      .join('  ');
+    lines.push(`reviews (${p.reviews.total}):  ${verdictPairs}`);
+    if (p.ratios.ok_rate !== null) {
+      const pct = Math.round(p.ratios.ok_rate * 100);
+      lines.push(`  ok_rate: ${pct}%`);
+    }
+    if (p.reviews.top_lense !== null) {
+      lines.push(`  top lense: ${p.reviews.top_lense}  (${topLenseCount}×)`);
+    }
+  }
+  lines.push('');
+  lines.push(`hint: ${p.hint}`);
+  return lines.join('\n');
+}

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -52,6 +52,8 @@ import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
 import { lenseStatsCmd } from './handlers/lenseStats.js';
 import { reviewContextCmd } from './handlers/reviewContext.js';
+import { decisionsCmd } from './handlers/decisions.js';
+import { selfPatternCmd } from './handlers/selfPattern.js';
 import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
@@ -96,6 +98,8 @@ const KNOWN_COMMANDS = [
   'wave-status',
   'lense-stats',
   'review-context',
+  'decisions',
+  'self-pattern',
 ] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
@@ -290,6 +294,10 @@ async function dispatch(
       return await lenseStatsCmd(c, args);
     case 'review-context':
       return await reviewContextCmd(c, args);
+    case 'decisions':
+      return await decisionsCmd(c, args);
+    case 'self-pattern':
+      return await selfPatternCmd(c, args);
     case 'summarize':
       return await summarizeCmd(c, args);
     case 'why':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -41,6 +41,8 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'lense-stats',
   'wave-status',
   'review-context',
+  'decisions',
+  'self-pattern',
 ]);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set([

--- a/tests/interface/decisionsAndSelfPattern.test.ts
+++ b/tests/interface/decisionsAndSelfPattern.test.ts
@@ -1,0 +1,218 @@
+// Regression for `gate decisions` and `gate self-pattern` (eris-first
+// director-role read verbs).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-decisions-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob', 'critic']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+// -------------------- decisions --------------------
+
+test('#bC: decisions on empty substrate → entries=0, all counts zero', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['decisions', '--for', 'alice', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const p = JSON.parse(r.stdout);
+  assert.equal(p.totals.entries_counted, 0);
+  assert.deepEqual(p.totals.by_transition, {
+    approve: 0, deny: 0, execute: 0, complete: 0, fail: 0,
+  });
+  assert.equal(p.filter.actor, 'alice');
+});
+
+test('#bC: decisions reflects approve / execute / complete transitions', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'wave 1', '--reason', 'decision test',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+  runGate(root, ['execute', id, '--by', 'alice']);
+  runGate(root, ['complete', id, '--by', 'alice', '--note', 'done']);
+
+  // critic: 1 approve
+  const cr = runGate(root, ['decisions', '--for', 'critic', '--format', 'json']);
+  const cp = JSON.parse(cr.stdout);
+  assert.equal(cp.totals.by_transition.approve, 1);
+  assert.equal(cp.totals.by_transition.execute, 0);
+
+  // alice: 1 execute + 1 complete
+  const ar = runGate(root, ['decisions', '--for', 'alice', '--format', 'json']);
+  const ap = JSON.parse(ar.stdout);
+  assert.equal(ap.totals.by_transition.execute, 1);
+  assert.equal(ap.totals.by_transition.complete, 1);
+  assert.equal(ap.totals.by_transition.approve, 0);
+});
+
+test('#bC: decisions --for defaults to GUILD_ACTOR when flag absent', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request', '--from', 'bob', '--executors', 'bob',
+    '--action', 'default-for', '--reason', 'env default test',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'critic']);
+
+  const r = runGate(root, ['decisions', '--format', 'json'], { GUILD_ACTOR: 'critic' });
+  assert.equal(r.status, 0, r.stderr);
+  const p = JSON.parse(r.stdout);
+  assert.equal(p.filter.actor, 'critic');
+  assert.equal(p.totals.by_transition.approve, 1);
+});
+
+test('#bC: decisions errors when neither --for nor GUILD_ACTOR is provided', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['decisions', '--format', 'json'], { GUILD_ACTOR: '' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--for <actor> is required/);
+});
+
+test('#bC: decisions rejects unknown flag', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['decisions', '--for', 'alice', '--bogus']);
+  assert.notEqual(r.status, 0);
+});
+
+test('#bC: decisions --since rejects malformed duration', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['decisions', '--for', 'alice', '--since', '7days']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--since must match/);
+});
+
+// -------------------- self-pattern --------------------
+
+test('#bC: self-pattern on empty substrate → zero counts, null ratios, no reviews', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['self-pattern', '--for', 'alice', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const p = JSON.parse(r.stdout);
+  assert.equal(p.decisions.total, 0);
+  assert.equal(p.reviews.total, 0);
+  assert.equal(p.ratios.approve_rate, null);
+  assert.equal(p.ratios.ok_rate, null);
+  assert.equal(p.reviews.top_lense, null);
+});
+
+test('#bC: self-pattern surfaces approve_rate + verdict distribution + top_lense', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Two waves: critic approves one, denies one. critic also reviews
+  // (layer, ok) twice and (devil, concern) once → top lense = layer.
+  const r1 = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'wave 1', '--reason', 'r1',
+  ]);
+  const id1 = extractRequestId(r1.stdout + r1.stderr);
+  runGate(root, ['approve', id1, '--by', 'critic']);
+  runGate(root, ['review', id1, '--by', 'critic', '--lense', 'layer', '--verdict', 'ok', '--note', 'ok 1']);
+  runGate(root, ['review', id1, '--by', 'critic', '--lense', 'layer', '--verdict', 'ok', '--note', 'ok 2']);
+  runGate(root, ['review', id1, '--by', 'critic', '--lense', 'devil', '--verdict', 'concern', '--note', 'concern 1']);
+
+  const r2 = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'wave 2', '--reason', 'r2',
+  ]);
+  const id2 = extractRequestId(r2.stdout + r2.stderr);
+  runGate(root, ['deny', id2, '--by', 'critic', '--reason', 'no']);
+
+  const r = runGate(root, ['self-pattern', '--for', 'critic', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const p = JSON.parse(r.stdout);
+
+  assert.equal(p.decisions.by_transition.approve, 1);
+  assert.equal(p.decisions.by_transition.deny, 1);
+  assert.equal(p.ratios.approve_rate, 0.5);
+
+  assert.equal(p.reviews.total, 3);
+  assert.equal(p.reviews.by_verdict.ok, 2);
+  assert.equal(p.reviews.by_verdict.concern, 1);
+  assert.equal(p.ratios.ok_rate, 2 / 3);
+  assert.equal(p.reviews.top_lense, 'layer');
+});
+
+test('#bC: self-pattern hint references gate lense-stats for full breakdown', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['self-pattern', '--for', 'alice', '--since', '24h', '--format', 'json']);
+  const p = JSON.parse(r.stdout);
+  assert.match(p.hint, /gate lense-stats --for alice --since 24h/);
+});
+
+test('#bC: self-pattern defaults --for to GUILD_ACTOR', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['self-pattern', '--format', 'json'], {
+    GUILD_ACTOR: 'critic',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const p = JSON.parse(r.stdout);
+  assert.equal(p.filter.actor, 'critic');
+});
+
+test('#bC: self-pattern errors when no actor resolved', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['self-pattern', '--format', 'json'], { GUILD_ACTOR: '' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--for <actor> is required/);
+});
+
+test('#bC: self-pattern text format renders decisions + reviews + hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['self-pattern', '--for', 'alice', '--format', 'text']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /self-pattern\s+actor=alice/);
+  assert.match(r.stdout, /decisions \(0\)/);
+  assert.match(r.stdout, /hint:/);
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -44,6 +44,7 @@ const GATE_ALL = [
   'boot', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
   'wave-status', 'lense-stats', 'review-context',
+  'decisions', 'self-pattern',
 ] as const;
 
 const AGORA_ALL = [


### PR DESCRIPTION
## Summary

Two new read-only verbs aimed at the director / orchestrator role's introspection axis:

| Verb | Question it answers |
|---|---|
| `gate decisions --for <actor>` | What state transitions did I author recently? (approve / deny / execute / complete / fail rows) |
| `gate self-pattern --for <actor>` | What does my pattern look like — decision counts, verdict ratio, top lense, approve_rate, ok_rate |

Both default `--for` to `GUILD_ACTOR` so a bare `gate decisions` / `gate self-pattern` answers the calling actor's own-pattern questions without flag boilerplate.

## Why

`gate voices` is review-shaped (utterances by an actor), `gate lense-stats` is lense-shaped (review bias by lens). Neither answers "what *decisions* did I make?" — that question needed a third axis. `self-pattern` is the 1-page bias mirror; `decisions` is the row-by-row audit feed.

For the **full** lense breakdown, `self-pattern` deliberately points at `gate lense-stats --for <actor>` rather than duplicating it.

## Edge: slice-closure dedupe

The #294 slice-closure path adds an extra `executing` status_log entry on `gate complete --by X`. A raw count over status_log inflates "executes" by 1 for every slice that closes. Both verbs dedupe by `(request_id, transition)`; the semantic is "distinct decisions," not "log entries."

## Test plan

- [x] 12 new node:test cases in `decisionsAndSelfPattern.test.ts`:
  - empty-substrate behavior for both verbs
  - decisions surfaces approve / execute / complete correctly per actor
  - GUILD_ACTOR fallback for `--for`
  - error when neither flag nor env is set
  - duration parsing rejects malformed input
  - self-pattern: approve_rate + verdict distribution + top_lense
  - self-pattern hint references lense-stats
  - text-format render smoke
- [x] `npm test` → 1622 / 1622 pass
- [x] verbs-consistency, schema, KNOWN_COMMANDS, READ_VERBS all updated

## Audience

Per the audience priority axis: this is item #1 (eris-first) but the surface is generic enough that any director-role AI agent benefits. No human-only affordances added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)