### PR TITLE
docs(help): surface 4 missing entries in `gate --help` output

### DIFF
--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -217,6 +217,19 @@ const SECTIONS: readonly Section[] = [
           '                       and aggregate state. Companion to claim /\n' +
           '                       witness for swarm coordination.',
       },
+      {
+        tier: 'coordination',
+        text:
+          '  gate review-context <id> [--format text|json]\n' +
+          '                       Reviewer-facing bundle for a wave: action /\n' +
+          '                       reason / target, executors, depth advisory,\n' +
+          '                       recommended lens set by depth, prior reviews.\n' +
+          '                       Lets a reviewer agent drive behaviour from\n' +
+          '                       substrate state instead of out-of-band prompt\n' +
+          '                       content. depth=shallow→[Logic], standard→6\n' +
+          '                       lenses, deep→all 10 + memory MCP + state-\n' +
+          '                       machine + cross-check. Advisory not directive.',
+      },
     ],
   },
   {
@@ -396,7 +409,7 @@ const SECTIONS: readonly Section[] = [
       {
         tier: 'extra',
         text:
-          '  gate resume [--format json|text]\n' +
+          '  gate resume [--with-doctor [--auto-repair]] [--format json|text]\n' +
           '                       Reconstruct what the actor was doing when the\n' +
           '                       last session ended. Returns last utterance,\n' +
           '                       last transition, open loops (awaiting/\n' +
@@ -404,7 +417,12 @@ const SECTIONS: readonly Section[] = [
           '                       prose restoration note. Requires GUILD_ACTOR.\n' +
           '                       Same-actor continuation only — for a newcomer\n' +
           "                       arriving via handoff, use 'gate boot' to see\n" +
-          '                       cross-actor signals (inbox, --with assignments).',
+          '                       cross-actor signals (inbox, --with assignments).\n' +
+          '                       --with-doctor folds a gate doctor summary\n' +
+          '                       into the payload (substrate health at session\n' +
+          '                       re-entry); --auto-repair (requires --with-\n' +
+          '                       doctor) processes quarantineable findings\n' +
+          '                       inline via gate repair.',
       },
       {
         tier: 'extra',
@@ -437,6 +455,30 @@ const SECTIONS: readonly Section[] = [
           '                       lately?"). Sources: gate `review` records +\n' +
           '                       devil-passage entries. Duration: <int><s|m|h|d>\n' +
           '                       (default 7d). Read-only.',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate decisions [--for <m>] [--since <duration>] [--format json|text]\n' +
+          '                       Surface authored state transitions (approve /\n' +
+          '                       deny / execute / complete / fail) by an actor\n' +
+          '                       within a window. Decision-shaped sibling of\n' +
+          '                       voices (review-shaped) and lense-stats (lense-\n' +
+          "                       shaped). Defaults --for to GUILD_ACTOR — bare\n" +
+          '                       `gate decisions` answers "what did I decide?"\n' +
+          '                       Dedupes by (request_id, transition).',
+      },
+      {
+        tier: 'extra',
+        text:
+          '  gate self-pattern [--for <m>] [--since <duration>] [--format json|text]\n' +
+          '                       Behavioral bias surface: decision counts,\n' +
+          '                       review verdict ratio (ok/concern/reject), top\n' +
+          '                       review lense, approve_rate, ok_rate. Composes\n' +
+          '                       from status_log + reviews; no schema change.\n' +
+          '                       For the FULL lense breakdown, the verb hints\n' +
+          '                       at gate lense-stats rather than duplicating.\n' +
+          '                       Defaults --for to GUILD_ACTOR.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

`gate --help` was silently dropping 4 entries added by recent PRs:

| Missing | Added by |
|---|---|
| `gate decisions` | #336 |
| `gate self-pattern` | #336 |
| `gate review-context` | #321 bundle (originally #320) |
| `gate resume --with-doctor [--auto-repair]` flag | #321 bundle (originally #316) |

All four were wired into the dispatcher (`index.ts`), `verbs.ts` READ_VERBS, and `schema.ts`. `gate schema --format json` was already exhaustive (the AI-agent contract). The gap was only in `src/interface/gate/help.ts` — the human-facing CLI surface text.

## Audience alignment

Per audience priority: this serves audience #3 (humans) but more importantly #2 (AI agents reading `--help` instead of the schema dump). Audience #1 (eris-first) was unaffected since I (eris) already knew about these — but the next session / colleague AI reading the source would not.

## Test plan

- [x] `gate --help --all` now lists all 4 entries.
- [x] `npm test` → 1614/1614 pass (no test changes — pure CLI text).
- [x] CI's docs-only filter (#337) will NOT skip the test step because `src/` was touched, so full validation still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)