### PR TITLE
docs: catch-up sweep for 2026-05 new verbs (#305/#306/#307/#309/#310/#336)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -64,7 +64,7 @@ table below lets you skip-jump by tier.
 | Tier | Sections (in document order) |
 |------|------------------------------|
 | **Common** | [Session start](#session-start) · [Agent-first knobs](#agent-first-knobs) · [Request lifecycle](#request-lifecycle) · [Review (Two-Persona Devil)](#review-two-persona-devil) · [Reading](#reading) · [Issues](#issues) · [Messages](#messages) · [Members](#members) |
-| **Coordination** | [Coordination & stake (#226 / #244 / #246)](#coordination--stake-226--244--246) · [Templates (#235, two-tier #302)](#templates-235-two-tier-302) · [Sessions (#249)](#sessions-249) |
+| **Coordination** | [Coordination & stake (#226 / #244 / #246)](#coordination--stake-226--244--246) · [Wave visibility (#295, freshness #309)](#wave-visibility-295-freshness-309) · [Reviewer-facing context (#310)](#reviewer-facing-context-310) · [Templates (#235, two-tier #302)](#templates-235-two-tier-302) · [Sessions (#249)](#sessions-249) |
 | **Boundary** | [The four passages — a one-line dispatch shorthand](#the-four-passages--a-one-line-dispatch-shorthand) · [Agora (second passage — play / narrative)](#agora-second-passage--play--narrative) · [devil-review (third passage — security backstop, alpha)](#devil-review-third-passage--security-backstop-alpha) · [ctx (fourth passage — fact accumulation, alpha phase 1)](#ctx-fourth-passage--fact-accumulation-alpha-phase-1) |
 | **Diagnostic** | [Diagnostic](#diagnostic) · [Configuration](#configuration) · [File layout](#file-layout) · [Environment](#environment) · [Output format](#output-format) · [Troubleshooting](#troubleshooting) · [Deep dives](#deep-dives) |
 
@@ -194,7 +194,18 @@ gate suggest [--format json|text]       # suggested_next only (hot-loop sibling 
 gate why <id>                           # decision walk: why is this request in this state?
 gate summarize <id> [--limit <N>]       # narrative summary
 gate unresponded [--for <m>]            # concerns recorded but not yet responded to
+gate flow-suggest --severity <s> --area <a> [--scope <s>]      # advisory: which flow shape? (#307)
+gate lense-stats [--for <m>] [--since <d>]                     # lense rotation diagnostic (#305)
+gate decisions [--for <m>] [--since <d>]                       # authored state transitions (#336; defaults --for to GUILD_ACTOR)
+gate self-pattern [--for <m>] [--since <d>]                    # behavioral bias surface — decision + verdict ratio (#336)
 ```
+
+The last four — `flow-suggest`, `lense-stats`, `decisions`,
+`self-pattern` — landed across the 2026-05 ship arc (#305 / #307 /
+#336). `decisions` and `self-pattern` are director-axis reads
+(default `--for` to `GUILD_ACTOR`); `lense-stats` is a bias mirror
+that `self-pattern` cross-links to for the full lense breakdown.
+`flow-suggest` is pure advisory — no substrate writes, no state.
 
 # Tier: Coordination (swarm)
 
@@ -223,6 +234,47 @@ gate unwitness <id> --by <m>                   # remove your own witness
 - Both auto-release on terminal transitions (completed / failed / denied).
 - `--note` is short metadata for the stake event (≤ 80 chars), not
   commentary. Wider discussion belongs in agora plays.
+
+### Wave visibility (#295, freshness #309)
+
+```bash
+gate wave-status <id> [--format text|json]
+```
+
+Per-executor in-flight slice view for a multi-executor wave.
+Composes executors + per-witness fields + status_log timestamps to
+surface "is each executor still making progress?" inside one wave.
+
+Per #309, the stale judgment is **per-executor** (max of
+`witnessUpdatedAt[name]`, `status_log[by=name]`, `claimedAt`). A
+fresh witness on a 33-min-old wave no longer trips a false stale.
+Wave-level `(stale)` in the footer derives from
+`wave_stale_effective` ("all executors stale"), separating
+"how old?" (`age_band`) from "is anyone still working?".
+
+### Reviewer-facing context (#310)
+
+```bash
+gate review-context <id> [--format text|json]
+```
+
+Single read verb that returns the bundle a reviewer (devil agent,
+CI script, human auditor) needs to drive behaviour from substrate
+state instead of out-of-band prompt content:
+
+- `action` / `reason` / `target` / `executors`
+- `depth` advisory (#221): `shallow | standard | deep` (null when
+  the wave was created without `--depth`)
+- `recommended_lenses`: derived from `depth`
+  - `shallow` → `[Logic]` (point-check)
+  - `standard` → 6-lens default (`Logic, Pattern, Flow, Error, Test, Input`)
+  - `deep` → all 10 + extras (`memory_mcp_trap_lookup`,
+    `state_machine_trace`, `prior_review_cross_check`)
+- `prior_reviews` bundled in-payload — saves a second `gate show`
+- `warning` is non-empty when no `--depth` was recorded
+
+Advisory not directive (principle 02). The reviewer is free to
+widen / narrow and record the divergence in its review output.
 
 ## Templates (#235, two-tier #302)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,43 @@ session を跨いで保留したい動いている思考 (`agora`)、 multi-pers
 scrutiny が要る security-prone な変更 (`devil`)、 verdict 不要だが
 session 終端で消したくない観察 (`ctx`)。
 
+### Solo flow (30秒)
+
+1人（または1つの AI エージェント）が単独で動く場合、 ツールの全体は
+6 verb に集約されます:
+
+```bash
+gate register --name <you>
+gate request --action "..." --reason "..." --executors <you>
+gate approve <id> --by <mirror>
+gate review  <id> --by <mirror> --lense user --verdict ok
+gate execute <id> --by <you>
+gate complete <id> --by <you>
+```
+
+`<mirror>` は **同じ actor の別 persona / 別 `--by`** です — 「別の
+hat を被った自分」、または critic として動く別の登録 actor。
+Two-Persona Devil discipline: solo であっても **approve / review の
+人格は execute の人格と別レンズ・別瞬間** であるべき、というのが
+substrate を形作っている規律です。 solo profile の default
+(`self_approve: allowed`) では `--by <you>` でも直接通せますが、
+mirror に手を伸ばすのが推奨形。 `swarm` profile に切り替えた瞬間に
+`self_approve: forbidden` が効き、別 `--by` が config 強制になります。
+
+並列 executor / worktree 隔離 / SubAgent swarm の流れは
+[`docs/swarm.md`](./docs/swarm.md) を参照してください。
+
+### このREADMEはどこまで読めばいい？
+
+| 深さ | ファイル | 想定読者 | 十分な条件 |
+|------|---------|---------|-----------|
+| 30秒 | この上の段落 + 「Solo flow」 | solo | 何のツールか知りたい |
+| 5分 | [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) | solo | Jira / PR review / ADR から来た翻訳付き理解が欲しい |
+| 10分 | [`AGENT.md`](./AGENT.md) | solo / agent | AI agent で四つの passage の全 verb map が欲しい |
+| 15分 | [`docs/playbook.md`](./docs/playbook.md) | pair | passage 個別を知った上で **combos** (gate + agora + devil の合成パターン) が欲しい |
+| 15分 | [`docs/swarm.md`](./docs/swarm.md) | swarm | ≥2 並列 executor / Claude SubAgent を orchestrate していて substrate-engagement レシピが要る |
+| 30分 | [`docs/verbs.md`](./docs/verbs.md) | any | per-verb の例と設計ノートが欲しい |
+
 ## あなたができること
 
 - `guild new` で自分や仲間をメンバー登録する
@@ -77,6 +114,22 @@ session 終端で消したくない観察 (`ctx`)。
   `gate voices <name>` / `gate chain <id>` /
   `gate show <id> --format text` で、自分や他者の utterance を
   時系列・横断的に辿る
+- **Director 軸の読み (2026-05 ship arc)**:
+  - `gate decisions [--for <m>]` — 自分が authored した state
+    transition (approve / deny / execute / complete / fail) を window
+    内で並べる。 default `--for` は `GUILD_ACTOR`。
+  - `gate self-pattern [--for <m>]` — 自分の bias 面: decision counts +
+    verdict 比率 + top lense + approve_rate + ok_rate。
+  - `gate lense-stats [--for <m>]` — review entry の lense 分布。
+    bias surface — 「最近どの lense ばかり使ったか」が即わかる。
+  - `gate flow-suggest --severity <s> --area <a>` — 軽微修正で
+    full request まで回す過剰儀式を避けるための advisory verb。
+  - `gate wave-status <id>` — multi-executor wave の per-executor 進捗。
+    #309 で per-executor stale 判定が入り、 fresh witness が古い
+    wave で誤検知されない。
+  - `gate review-context <id>` — reviewer が読みたい bundle
+    (depth / recommended lenses / prior reviews) を 1 verb で。
+    `--depth` advisory が初めて consumer-side で活かされる verb。
 - write verbs に `--format json` を渡すと
   `{ok, id, state, suggested_next:{verb, args, reason}}` が返り、
   orchestrator は次の tool call を自分で導出せずに済む

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -114,6 +114,30 @@ to another agent, to the next session of the same agent. The value
 compounds: one `fast-track` with one review is fine, ten sessions
 of accrued reviews across the four lenses become an agent's memory.
 
+## Reading your own substrate back
+
+Once you've left a trail, a small family of read verbs lets you ask
+the substrate questions about *yourself*. Each defaults to the
+calling actor (`GUILD_ACTOR`) so the bare invocation is the
+common-case answer:
+
+- `gate decisions` — what state transitions did I author recently
+  (approve / deny / execute / complete / fail)?
+- `gate self-pattern` — what does my pattern look like? decision
+  counts, review verdict ratio, top lense, `approve_rate`, `ok_rate`.
+  For the full lense breakdown the verb hints at the next one.
+- `gate lense-stats` — review entries per lense in a window. Surface
+  bias: "I keep hitting `auth-access`; have I run `composition` or
+  `devil` lately?"
+- `gate transcript <id>` — narrative arc of one request, prose + JSON.
+- `gate voices <name>` — every utterance an actor has made,
+  filterable by lense and verdict.
+
+These read verbs aren't part of the core loop above — that loop is
+about *writing*. Reading your own substrate is the other half of
+"legible later." Reach for them when re-entering a session, when a
+review feels off, or when you suspect your own bias is hardening.
+
 ## Where to go next
 
 The documentation is layered. **Stop at whichever layer is enough for what you're doing** — depth isn't hidden value, it's scaffolding for when your use case grows.

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -147,6 +147,16 @@ prose language. Defaults to `en`. Only the `restoration_prose` field
 is localized; the structured fields stay in English so programmatic
 consumers are stable.
 
+**`--with-doctor [--auto-repair]` (issue #306).** Folds a `gate
+doctor` summary into the resume payload — substrate health surfaces
+at the moment of session re-entry, before the agent starts writing
+again. JSON gets a top-level `doctor:` block (`findings`, `summary`,
+`is_clean`); text mode appends a "substrate doctor" section to the
+prose. `--auto-repair` (requires `--with-doctor`) runs `gate repair
+--apply` inline for quarantineable findings and reports the outcome
+under `doctor.auto_repair`. Default behaviour is unchanged — without
+`--with-doctor`, the payload shape is byte-identical to pre-#306.
+
 ### Boot: single-command orientation
 
 `gate boot` is the agent-first entry point. Where the Session-start
@@ -1190,6 +1200,114 @@ Session_id is **immutable in the trail**. There is no timeout, no
 heartbeat, no explicit lifecycle — `gate farewell` records the end
 as a write event; the session_id itself lives forever in whatever it
 claimed / witnessed / authored. A new session is just a new id.
+
+### Read verbs added in the 2026-05 ship arc
+
+Six read-only verbs landed across #305–#310 / #336, all composing
+from existing substrate (no schema changes; #309's `witness_updated_at`
+is the sole exception). Grouped here so a reader auditing the
+read-side surface sees them in one place.
+
+#### `gate wave-status <id>` (issue #295 / freshness #309)
+
+Per-executor in-flight slice view for a multi-executor request.
+Composes `executors[]` + per-witness fields + `status_log` timestamps
+to surface "is each executor making progress?" inside one wave.
+
+```bash
+gate wave-status 2026-05-11-0001 --format text
+```
+
+Per #309, the stale judgment is **per-executor**: each executor's
+`last_attributable_at` is the max of `witnessUpdatedAt[name]`,
+`status_log[by=name]`, and `claimedAt` (when held). Wave-level
+`(stale)` derives from "all executors stale" (`wave_stale_effective`).
+A fresh witness on a 33-min-old wave no longer trips a false stale.
+
+#### `gate review-context <id>` (issue #310)
+
+Reviewer-facing bundle: action / reason / target / executors / depth
+advisory (`shallow | standard | deep`) / recommended lens set / prior
+reviews. Lets a reviewer agent drive lens selection from substrate
+state rather than out-of-band prompt content.
+
+```bash
+gate review-context 2026-05-11-0005 --format json
+# {
+#   "depth": "deep",
+#   "recommended_lenses": ["Logic", "Performance", "Flow", ..., "Input"],
+#   "recommended_extras": ["memory_mcp_trap_lookup", ...],
+#   "prior_reviews": [...]
+# }
+```
+
+Lens recommendation by depth: `shallow → [Logic]`, `standard → 6-lens
+default`, `deep → all 10 + memory MCP + state-machine + cross-check`.
+Advisory not directive (principle 02) — the reviewer is free to
+widen / narrow.
+
+#### `gate lense-stats [--for <m>] [--since <d>]` (issue #305)
+
+Lense rotation diagnostic. Counts review entries per lense in the
+window, highlights most-frequent and least-frequent (with ≥ 1 use),
+surfaces a `next:` hint when one lense dominates 3× the bottom.
+Sources: gate `Request.reviews[]` + devil-passage `DevilReview.entries[]`.
+
+```bash
+gate lense-stats --for eris --since 7d --format text
+```
+
+Catalog lenses with zero hits still appear (`composition: 0`) so a
+reader sees what's missing rather than guessing.
+
+#### `gate flow-suggest --severity <s> --area <a> [--scope <s>]` (issue #307)
+
+Pure advisory: maps `(severity, area, scope)` → recommended flow
+(`direct-pr | fast-track | full-request`) plus reason and alternatives.
+No substrate writes. Rule table in `src/application/request/flowSuggest.ts`;
+override path reserved for v2 (`guild.config.yaml`).
+
+```bash
+gate flow-suggest --severity high --area auth --format json
+# { "recommended": "full-request", "reason": "...", "alternatives": [...] }
+```
+
+#### `gate decisions [--for <m>] [--since <d>]` (issue #336)
+
+Authored state transitions (approve / deny / execute / complete /
+fail) by an actor in a window. Decision-shaped sibling of `voices`
+(review-shaped) and `lense-stats` (lense-shaped). Defaults `--for`
+to `GUILD_ACTOR`.
+
+```bash
+gate decisions --since 24h --format text
+```
+
+Dedupes by `(request_id, transition)` — #294's slice-closure path
+adds an extra `executing` status_log entry on `gate complete --by X`,
+which would otherwise inflate raw counts. Semantic is "distinct
+decisions," not "log entries."
+
+#### `gate self-pattern [--for <m>] [--since <d>]` (issue #336)
+
+Behavioral bias surface: decision counts + review verdict ratio
+(`ok / concern / reject`) + top review lense + `approve_rate`
+(`approve / (approve + deny)`) + `ok_rate` (`ok / total reviews`).
+Composes from `status_log` + `reviews`. For the **full** lense
+breakdown the verb hints at `gate lense-stats --for <actor>`
+rather than duplicating it.
+
+```bash
+gate self-pattern --for eris --since 7d --format text
+# self-pattern  actor=eris  window=7d
+# decisions (22):  approve=14  deny=1  ...   approve_rate: 93%
+# reviews (0): (none in window)
+# hint: see `gate lense-stats --for eris --since 7d` for the full lense distribution
+```
+
+Director-axis introspection (#336): bare `gate self-pattern` from the
+calling actor's shell answers "show me my own pattern" without flag
+boilerplate.
 
 ---
 


### PR DESCRIPTION
## Summary

Six new read verbs landed across the 2026-05 ship arc but human-facing docs were not updated alongside the verbs themselves. This sweep fills the gaps in 4 files. Pure docs.

| File | What changed |
|---|---|
| `docs/verbs.md` | Adds `--with-doctor` paragraph to the Resume section; adds a new section `### Read verbs added in the 2026-05 ship arc` covering `wave-status`, `review-context`, `lense-stats`, `flow-suggest`, `decisions`, `self-pattern` with example use. |
| `AGENT.md` | Extends the Reading block in the Common tier with `flow-suggest` / `lense-stats` / `decisions` / `self-pattern`; adds two new Coordination-tier subsections (`Wave visibility (#295, freshness #309)`, `Reviewer-facing context (#310)`). Tier index updated. |
| `README.ja.md` | Adds **Solo flow (30秒)** section — 6-verb arc with `<mirror>` discipline, written natively for Japanese AI agents to match the structural shift in the English README post-#334. Adds depth table mirroring the English audience axis. Lists the new director-axis read verbs under あなたができること. |
| `docs/concepts-for-newcomers.md` | Adds `## Reading your own substrate back` section after `## The one thing most newcomers miss`. Introduces decisions / self-pattern / lense-stats as the read-side of "legible later." |

## Why

`gate schema --format json` was already exhaustive (AI-agent contract, principle 11). `gate --help` is being fixed in #338 (companion PR). This PR closes the corresponding gap in prose docs. Audience priority alignment: serves audience #2 (AI agents reading docs/) and #3 (humans), without changing audience-#1 surfaces.

## Test plan

- [x] Docs-only; no source touched.
- [x] CI's path filter (#337) will skip the test job automatically.
- [x] Sanity build (`npm run build`) clean.
- [x] All cross-doc anchors verified locally.

## Companion

[#338](https://github.com/eris-ths/guild-cli/pull/338) — fills the same gap on the CLI `--help` surface (`src/interface/gate/help.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)