### PR TITLE
chore(devil): fix stale '11 bundled defaults' comment (actual 12)

### DIFF
--- a/src/passages/devil/infrastructure/BundledLenseCatalog.ts
+++ b/src/passages/devil/infrastructure/BundledLenseCatalog.ts
@@ -3,12 +3,13 @@ import { buildDefaultLenses, DEFAULT_LENSE_NAMES } from '../domain/defaultLenses
 import { LenseCatalog } from '../application/LenseCatalog.js';
 
 /**
- * v0 lense catalog: just the 11 bundled defaults from
- * domain/defaultLenses.ts. The content_root override loader (per
- * issue #126) lands later as a separate adapter — likely a
- * ComposedLenseCatalog that merges this with a YAML reader for
- * `<content_root>/devil/lenses/<custom>.yaml`. Until then, this is
- * the only adapter wired into the CLI.
+ * v0 lense catalog: just the 12 bundled defaults from
+ * domain/defaultLenses.ts (injection / injection-parser / path-network
+ * / auth-access / memory-safety / crypto / deserialization /
+ * protocol-encoding / supply-chain / composition / temporal /
+ * coherence). The content_root override loader (per issue #126)
+ * lands as a separate adapter (ComposedLenseCatalog) that merges
+ * this with a YAML reader for `<content_root>/devil/lenses/<custom>.yaml`.
  */
 export class BundledLenseCatalog implements LenseCatalog {
   private readonly map: ReadonlyMap<string, Lense>;


### PR DESCRIPTION
## Summary

`BundledLenseCatalog.ts` docstring claimed 11 bundled defaults but the catalog has been **12** since the v1 surface lock (#126):

`injection / injection-parser / path-network / auth-access / memory-safety / crypto / deserialization / protocol-encoding / supply-chain / composition / temporal / coherence`

Other docs (`docs/concepts-for-newcomers.md`, `docs/playbook.md`, `AGENT.md`) all consistently say "12 lenses". Only this source comment drifted.

Single-line fix, no behavior change. Found during the 2026-05-12 doc maintenance sweep.

## Test plan

- [x] `npm run build` clean (comment-only).
- [x] No tests added — comment change.
- [x] CI's path filter (#337) will run the full test step because `src/` was touched, but only the build is needed for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)