### PR TITLE
lore(traps): pin 3 friction patterns from 2026-05-12 doc audit

### DIFF
--- a/lore/traps/trap_dist_stale_after_branch_switch.md
+++ b/lore/traps/trap_dist_stale_after_branch_switch.md
@@ -1,0 +1,84 @@
+---
+relevant_until: indefinite
+---
+
+# trap: stale `dist/` after branch switch
+
+**Pattern.** `git checkout` swaps `src/` and `tests/` source files
+but leaves `dist/` alone. `dist/` is `.gitignore`-d and lives outside
+the version-controlled tree, so a branch that adds new files,
+deletes others, or changes which verbs exist on disk leaves `dist/`
+holding a **superposition** — compiled artifacts from both branches.
+`tsc` re-emits the files it sees in `src/`, but it never removes
+`.js` files that have no `src/` counterpart anymore.
+
+The downstream symptom: `node tests/run.mjs` enumerates everything
+under `dist/tests/` and runs every `.test.js` it finds. If a test
+file existed on the previous branch and references a verb that
+doesn't exist on the current branch (because the handler was added
+in a feature branch and the test file got compiled there), the test
+runs, fails with "unknown verb", and inflates the failure count by
+a multiple no one expects.
+
+Surfaced (2026-05-12 doc audit) when a serial benchmark of
+`tests/run.mjs` reported `1622` tests where main only had `1610`:
+the extra 12 were the compiled `decisionsAndSelfPattern.test.js` from
+a pre-merge feat branch still living in `dist/tests/interface/`.
+
+## Trigger conditions for review
+
+Flag any of:
+
+- Test count drifts up or down between consecutive `npm test` runs
+  on the *same* branch without source changes (`dist/` carry-over).
+- Test failures naming a verb the dispatcher doesn't recognise
+  on the current branch (`unknown verb: <name>`).
+- Build-then-test pipelines that don't clean `dist/` between
+  branch operations (`tsc` is incremental — it adds, doesn't prune).
+- CI configurations that cache `dist/` across branches without
+  invalidation (no current example in this repo, but worth pinning
+  before someone adds one).
+
+## Honest mitigation
+
+`tsc` itself does not support "remove orphans" — `--clean` removes
+the output dir, then `tsc` rebuilds everything. That is the
+correct hammer. Cheap fixes that don't actually fix:
+
+- Adding `rm -rf dist` to a script: works locally, no recourse on
+  CI where the cache is opaque.
+- "Rebuild before test" pre-step: doesn't help when the orphan
+  `.test.js` *is* the thing being run.
+
+The right policy is to **never trust a stale `dist/` after a branch
+switch**. `npm run build -- --clean` (or equivalent) is the only
+safe path. The `verbs-consistency` test does catch the symmetric
+case (verb in dispatcher but not in `verbs.ts`), but it cannot see
+test files that reference verbs no longer wired up.
+
+## Recovery in the moment
+
+```
+$ find dist -type f -delete
+$ npm run build
+$ npm test
+```
+
+Three lines. The first is the load-bearing one — `tsc` alone won't
+do it.
+
+## Why this is `indefinite`
+
+The pattern is rooted in the medium (`tsc`'s incremental contract,
+not in this repo's choice of layout) and will recur every time
+someone switches branches without rebuilding from scratch. No
+calendar-date event will "resolve" it. The mitigation is awareness,
+not a fix.
+
+## Related
+
+- `lore/traps/trap_silent_fallback_loses_signal.md` — sibling: a
+  build runs, tests run, output looks authoritative, but the
+  artifact under measurement is wrong.
+- principle 04 (records-outlive-writers) — `dist/` is the inverse:
+  artifacts that **outlive their branch context** and silently mislead.

--- a/lore/traps/trap_doc_coverage_drift_post_ship.md
+++ b/lore/traps/trap_doc_coverage_drift_post_ship.md
@@ -1,0 +1,87 @@
+---
+relevant_until: indefinite
+---
+
+# trap: prose-doc coverage drift after a new verb ships
+
+**Pattern.** A new verb passes CI and merges. The dispatcher
+works, `gate schema --format json` exposes it, `gate --help` may
+or may not list it (see `trap_help_text_drift_on_new_verb`),
+CHANGELOG has an entry, and the verb is **fully shipped from a
+runtime standpoint**.
+
+But the prose layer — `docs/verbs.md`, `AGENT.md`, `README.md`,
+`docs/playbook.md`, `docs/concepts-for-newcomers.md`,
+`README.ja.md` — is hand-curated and does not auto-update. The
+default trajectory is: new verb → its tests are present → CHANGELOG
+entry is present → **no prose-doc entry anywhere**.
+
+A reader looking up "what read-side verbs exist?" via `grep -r
+'^### ' docs/verbs.md` will not find the verb. A reader of
+`AGENT.md`'s Reading block will see an outdated list. A reader of
+`README.ja.md` (which is structurally independent, not a
+mechanical translation of `README.md`) will see a yet-older shape.
+
+Surfaced (2026-05-12 doc audit): six new read verbs across the
+2026-05 ship arc (`gate decisions`, `self-pattern`, `lense-stats`,
+`flow-suggest`, `review-context`, `wave-status`, plus the
+`resume --with-doctor` flag) had **zero** prose-doc coverage. The
+gap was caught by the audit, not by CI.
+
+## Trigger conditions for review
+
+Flag any merged PR that:
+
+- Adds an entry to `src/interface/gate/handlers/schema.ts` (the
+  schema registry is updated) but does **not** touch any of:
+  `docs/verbs.md`, `AGENT.md`, `README.md`, `README.ja.md`,
+  `docs/concepts-for-newcomers.md`, `docs/playbook.md`,
+  `docs/swarm.md`.
+- Adds a new file under `src/interface/gate/handlers/` without a
+  corresponding "Added" entry in a prose doc.
+- Updates `CHANGELOG.md` with a new `### Added` bullet that
+  references a verb whose first occurrence in `docs/verbs.md` is
+  also in the same PR (good case) vs no occurrence at all (bad
+  case, this trap).
+
+## Honest mitigation
+
+Two paths, both partial:
+
+1. **PR checklist item**: "If this PR adds a verb, did you update
+   `docs/verbs.md` and `AGENT.md`?" — relies on author discipline.
+   Catches genuinely-forgotten cases; doesn't catch "I'll do the
+   docs in a follow-up" intentions that never come.
+2. **Soft CI lint**: warn (not block) if `src/interface/gate/handlers/*.ts`
+   added without `docs/*.md` modified in the same PR. Same
+   limitation — author can bypass with intent.
+
+Neither is bulletproof. The real fix is **audience priority
+clarity**: per the project's audience-priority memo (audience #1 is
+eris-first; audience #2 is AI agents using `gate schema`; audience
+#3 is humans reading prose docs), the gap is acceptable for
+audience #1 (eris remembers what she shipped) and audience #2
+(`gate schema` is the source of truth for AI agents). The drift
+only hurts audience #3.
+
+**Decision rule**: a prose-doc update is required when the verb is
+likely to be read by audience #3 (a human onboarding to the tool).
+For private dogfood-only verbs, ship without prose doc updates is
+acceptable. For verbs that show up in README's "30-second tour" or
+playbook combos, prose doc updates are required pre-merge.
+
+## Why this is `indefinite`
+
+The pattern is rooted in the medium (hand-curated prose docs vs
+machine-generated schema) and recurs whenever a new audience-#3-
+relevant verb ships. Mitigation is discipline, not a code fix.
+
+## Related
+
+- `lore/traps/trap_help_text_drift_on_new_verb.md` — sibling for
+  the `--help` text gap (different surface, same shape of drift).
+- principle 11 (ai-first-human-as-projection) — explicitly permits
+  the audience-#3 surface to lag behind audience-#1 and audience-#2
+  surfaces. This trap is the operational form of that principle:
+  the lag is expected, but should be observed and closed in
+  periodic doc sweeps rather than left forever.

--- a/lore/traps/trap_help_text_drift_on_new_verb.md
+++ b/lore/traps/trap_help_text_drift_on_new_verb.md
@@ -1,0 +1,91 @@
+---
+relevant_until: indefinite
+---
+
+# trap: `gate --help` drift on new verb
+
+**Pattern.** Adding a verb to `gate` requires wiring it through
+several registries:
+
+- `src/interface/gate/index.ts` — `KNOWN_COMMANDS` array + the
+  dispatcher switch.
+- `src/interface/gate/verbs.ts` — `READ_VERBS` / `WRITE_VERBS` /
+  `LOCK_EXEMPT_VERBS` (lock middleware classification).
+- `src/interface/gate/handlers/schema.ts` — verb entry consumed by
+  `gate schema --format json`.
+- `tests/interface/verbs-consistency.test.ts` — `GATE_ALL` array
+  pinning the union against dispatcher names.
+- `src/interface/gate/help.ts` — **the only registry not pinned by
+  any test**.
+
+The `verbs-consistency` test enforces three of the five sites. It
+does NOT check `help.ts`. So a new verb can be:
+
+- Fully wired in the dispatcher (runs correctly)
+- Present in `gate schema` (LLM tool layers see it)
+- Listed in `verbs.ts` (lock middleware classifies it)
+- Tested by `verbs-consistency` (CI passes)
+- **Invisible to `gate --help` and `gate --help --all`**
+
+The CI passes, the verb works, but the human-facing CLI text
+silently drops it.
+
+Surfaced (2026-05-12 doc audit) when four entries shipped without
+`help.ts` updates: `gate decisions` (#336), `gate self-pattern`
+(#336), `gate review-context` (PR #320 → #321 bundle),
+`gate resume --with-doctor [--auto-repair]` (PR #316 → #321 bundle).
+All four passed CI on their original PRs; the gap took 5 days to
+surface, by which time the verbs were live and the gap was a
+release-blocker for documentation pass alignment.
+
+## Trigger conditions for review
+
+Flag any PR / commit that:
+
+- Adds an entry to `KNOWN_COMMANDS` (in `src/interface/gate/index.ts`)
+  but does **not** add an entry under `SECTIONS` in
+  `src/interface/gate/help.ts`.
+- Adds a flag to an existing handler (e.g. `--with-doctor` on
+  `gate resume`) but does **not** update the corresponding entry's
+  signature line in `help.ts`.
+- Adds a new write verb (`READ_VERBS` / `WRITE_VERBS` extension)
+  whose Tier is non-obvious from the registry alone — `help.ts`
+  needs a explicit `tier:` field per entry, which the registry
+  doesn't carry.
+
+## Honest mitigation
+
+Two paths, neither shipped yet:
+
+1. **Make `verbs-consistency` extend to `help.ts`** — parse
+   `SECTIONS` and assert every `KNOWN_COMMANDS` entry has a
+   `help.ts` entry. Fails CI on the gap. Best fix, single test
+   file change.
+2. **Auto-generate the relevant parts of `help.ts` from the
+   `schema.ts` registry** — single source of truth. Larger change,
+   loses the hand-tuned line-by-line text that `help.ts` currently
+   carries (which is a feature, not a bug — tiered prose is
+   editorial).
+
+Until either lands, the operational rule is: **after wiring a new
+verb, run `node bin/gate.mjs --help --all | grep <verb>` and verify
+the entry exists.** The check is 1 grep; the cost of forgetting is
+5 days of drift.
+
+## Why this is `indefinite`
+
+Until path 1 or path 2 ships, the trap recurs every new-verb PR.
+After the fix, this trap retires (graduates to docs/verbs.md or
+gets quarantined via `gate doctor sweep-traps --apply`).
+
+## Related
+
+- `lore/traps/trap_silent_fallback_loses_signal.md` — sibling
+  pattern (look-authoritative-but-incomplete output).
+- principle 09 (orientation-disclosure) — surfaces must disclose
+  what they know; `--help` failing to list a verb is the opposite
+  of orientation disclosure.
+- principle 10 (schema-as-contract) — `gate schema` is the
+  authoritative agent-facing contract, so the gap mainly hurts
+  audience #3 (humans reading `--help`) and audience #2 (AI agents
+  that read text help instead of the schema dump).


### PR DESCRIPTION
## Summary

Three friction patterns surfaced during the 2026-05-12 doc maintenance sweep, captured as `lore/traps/*` so future review prompts can flag them before recurrence.

| Trap | What it names |
|---|---|
| `trap_dist_stale_after_branch_switch` | `tsc` is incremental — switching branches leaves orphan `.test.js` from the previous branch in `dist/tests/`, inflating test counts and producing "unknown verb" failures. Manifested when a serial benchmark of `tests/run.mjs` reported 1622 tests where main only had 1610. |
| `trap_help_text_drift_on_new_verb` | `gate --help` is the only verb registry not pinned by the `verbs-consistency` test. Four entries shipped invisible to `--help` (caught by #338): `decisions`, `self-pattern`, `review-context`, `resume --with-doctor`. |
| `trap_doc_coverage_drift_post_ship` | Prose docs (`docs/verbs.md`, `AGENT.md`, `README.ja.md`, …) are hand-curated and don't auto-update. 7 new audience-#3-relevant verbs landed without prose coverage; caught by #339. |

Each follows the `lore/traps/README.md` format conventions: frontmatter `relevant_until: indefinite` (rooted in the medium, no calendar-date resolution), pattern + trigger conditions + honest mitigation + related principles.

## Why pin these as traps

Per the audience priority memo, traps are the substrate where reusable patterns live before they graduate to `lore/principles/`. These three are operational hygiene patterns that recur whenever a new verb / new file / branch switch happens — flagging them in trap memory means future review prompts (including `gate doctor sweep-traps`'s metadata) can surface them without the human having to re-derive each time.

## Test plan

- [x] No source touched; pure `lore/traps/` additions.
- [x] Build clean.
- [x] Format follows the existing trap files' shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)