### PR TITLE
feat(playbook+e2e): Synergy S1 Mirror Persona Loop — test + doc co-shipped

### DIFF
--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -443,6 +443,70 @@ references.
 
 ---
 
+## Synergies
+
+The combos above are *recipes for situations* — when a bug appears,
+when a PR needs review, when a wave needs ordering. **Synergies** are
+the other direction: pairings of verbs that, once you've seen them,
+start to feel less like ceremony and more like a move you reach for.
+Each one pins a small principle of the substrate in a single arc.
+
+Three things each synergy ships with:
+
+- **Purpose** — what becomes legible afterward that wasn't before.
+- **Trade-off** — what's preserved vs what's traded for the ergonomic shape.
+- **E2E test** — the synergy's contract is pinned by a runnable test
+  under `tests/e2e/`, so the doc and the substrate stay synced.
+
+### S1: Mirror Persona Loop — two `--by` names, one body of work
+
+```bash
+# Two registered names, one person:
+gate register --name <you>
+gate register --name <you-mirror>
+
+# Author, approve (by mirror), review (by mirror), execute, complete.
+gate request  --from <you>     --executors <you>           --action "..." --reason "..."
+gate approve  <id> --by <you-mirror>
+gate review   <id> --by <you-mirror> --lense user --verdict ok --note "..."
+gate execute  <id> --by <you>
+gate complete <id> --by <you> --note "..."
+```
+
+**Purpose.** Stamp authorship and review on the *same body of work*
+under *different `--by` names*. The substrate ends up carrying two
+distinct perspectives on one request — author and mirror — without
+inflating ceremony to a multi-actor wave. This is the minimal
+expression of Two-Persona Devil discipline
+([principle 02](../lore/principles/02-advisory-not-directive.md) +
+[principle 08](../lore/principles/08-voice-as-doctrine.md)) when
+you're solo.
+
+**Trade-off.** Review depth is operator discipline, not enforced.
+The mirror is the same actor wearing a different hat; if the
+hat-swap is shallow, the discipline degrades to a self-stamp. The
+`self_approve: allowed` default on the solo profile means a flat
+`--by <you>` arc *also* succeeds (just with a "notice: claude
+approved their own request" surfaced on the approve event). The
+synergy is the *practiced shape*, not a code-enforced one. Flip to
+`profile: swarm` and `self_approve: forbidden` makes the separate
+`--by` mandatory — same arc, different enforcement.
+
+**E2E test.** [`tests/e2e/synergy_s1_mirror_persona_loop.test.ts`](../tests/e2e/synergy_s1_mirror_persona_loop.test.ts)
+pins three contracts:
+
+1. The mirror arc completes (`state: completed`, both personas
+   recorded on `status_log[]`, one review by the mirror).
+2. The same-actor degenerate arc *also* completes — documenting the
+   trade-off surface (substrate cannot tell after the fact whether
+   the operator exercised the discipline).
+3. The swarm-profile flip refuses self-approve, requires the mirror.
+
+If you change the verb surface in a way that breaks any of those
+three, the test fails loud. The doc and the substrate move together.
+
+---
+
 ## When NOT to use devil (honest limits)
 
 devil is **shape-mismatched for general bug review**. Routine

--- a/tests/_e2e_helpers.ts
+++ b/tests/_e2e_helpers.ts
@@ -1,0 +1,116 @@
+// Shared bootstrap / runGate / extractRequestId for E2E synergy tests.
+//
+// E2E tests (under tests/e2e/) intentionally drive the CLI as a
+// subprocess — they verify the substrate from outside, like a real
+// AI agent would. tests/interface/ already has near-duplicate
+// helpers per-file; consolidating here keeps the synergy tests
+// DRY without forcing the interface tests to migrate (their
+// duplication is intentional — each interface test pins the verb
+// it owns, in isolation).
+//
+// Path note: this file is compiled to `dist/tests/_e2e_helpers.js`
+// and imported by `dist/tests/e2e/synergy_*.test.js`. The `GATE`
+// constant climbs 3 levels (`dist/tests/e2e/X.js` → repo root →
+// `bin/gate.mjs`), which matches the interface-test pattern.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+/** Absolute path to the `gate` CLI entrypoint (`bin/gate.mjs`). */
+export const GATE = resolve(here, '../../bin/gate.mjs');
+
+export interface GateResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number;
+}
+
+/**
+ * Invoke `gate <args>` in the given content_root. Env is merged
+ * onto the parent process env so `GUILD_ACTOR` etc. can be set
+ * per-call. Output captured as strings.
+ */
+export function runGate(
+  cwd: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = {},
+): GateResult {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+export interface BootstrapOptions {
+  /** Member names to register under `members/<name>.yaml`. */
+  readonly members?: readonly string[];
+  /** Host names declared in `guild.config.yaml`. */
+  readonly hosts?: readonly string[];
+  /** Extra YAML to append to `guild.config.yaml` (e.g. `profile: swarm`). */
+  readonly extraConfig?: string;
+}
+
+/**
+ * Create a fresh tmpdir as a `content_root`, write a minimal
+ * `guild.config.yaml`, and register the requested members.
+ * Returns the root path plus a `cleanup()` to register with
+ * `t.after()` in the test.
+ *
+ * Defaults: hosts=['eris'], members=['alice','bob','critic'] —
+ * the common solo+critic shape. Override `members` / `hosts` for
+ * synergy-specific personas.
+ */
+export function bootstrap(opts: BootstrapOptions = {}): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), 'guild-e2e-'));
+  const hosts = opts.hosts ?? ['eris'];
+  const hostsYaml = hosts.map((h) => `  - ${h}`).join('\n');
+  let config = `content_root: .\nhost_names:\n${hostsYaml}\n`;
+  if (opts.extraConfig) {
+    config += opts.extraConfig.endsWith('\n')
+      ? opts.extraConfig
+      : opts.extraConfig + '\n';
+  }
+  writeFileSync(join(root, 'guild.config.yaml'), config);
+
+  mkdirSync(join(root, 'members'));
+  const members = opts.members ?? ['alice', 'bob', 'critic'];
+  for (const name of members) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Extract the first request id (YYYY-MM-DD-NNNN) from CLI output
+ * — typically `gate request --action ...` emits the id on
+ * `✓ created: 2026-MM-DD-NNNN ...`. Throws if no id is found, so
+ * a test that expected creation but got an error message fails
+ * with a precise message.
+ */
+export function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) {
+    throw new Error(`could not find request id in output: ${output}`);
+  }
+  return m[0];
+}

--- a/tests/e2e/synergy_s1_mirror_persona_loop.test.ts
+++ b/tests/e2e/synergy_s1_mirror_persona_loop.test.ts
@@ -1,0 +1,222 @@
+// Synergy S1 — Mirror Persona Loop
+// =================================
+//
+// E2E test for the solo flow's load-bearing pattern: the same human-
+// or-AI actor running both `executor` and `mirror` roles within one
+// content_root, by using two distinct `--by` names. This is the
+// minimal expression of the Two-Persona Devil discipline (principle
+// 02 + principle 08).
+//
+// The verb arc (post-#334, six verbs):
+//
+//   register --name <you>
+//   register --name <you-mirror>
+//   request   --from <you>     --executors <you>          ...
+//   approve   <id> --by <you-mirror>
+//   review    <id> --by <you-mirror> --lense user --verdict ok
+//   execute   <id> --by <you>
+//   complete  <id> --by <you>
+//
+// What we assert end-to-end:
+//
+//   - The final wave state is `completed`.
+//   - Each verb succeeds (exit 0).
+//   - `executors[]` carries `<you>` only — the mirror is NOT recorded
+//     as an executor; their stake lives on the approve/review entries.
+//   - `status_log[]` records both `<you>` and `<you-mirror>` as `by`
+//     values, on the transitions each owned.
+//   - `reviews[]` contains exactly one entry, authored by the mirror.
+//
+// Why this synergy is in the catalog:
+//
+//   Purpose: keep authorship and review legible inside a solo flow,
+//   without inflating ceremony — one body of work, two perspectives
+//   stamped on it.
+//
+//   Trade-off: review depth is operator discipline, not enforced.
+//   The mirror is the same actor wearing a different hat; if the
+//   hat-swap is shallow, the discipline degrades to a self-stamp.
+//   Devil review (audience-#1 dogfood) catches this when the
+//   mirror's `--verdict concern` ratio collapses to zero.
+//
+// Linked playbook section: `docs/playbook.md` § "Synergies" → S1.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  bootstrap,
+  runGate,
+  extractRequestId,
+} from '../_e2e_helpers.js';
+
+const YOU = 'claude';
+const MIRROR = 'claude-mirror';
+
+test('S1: mirror persona loop — solo arc completes with two --by personas', (t) => {
+  const { root, cleanup } = bootstrap({
+    members: [YOU, MIRROR],
+  });
+  t.after(cleanup);
+
+  // Step 1: file the request as the executor persona.
+  const created = runGate(root, [
+    'request',
+    '--from', YOU,
+    '--executors', YOU,
+    '--action', 'mirror persona loop smoke',
+    '--reason', 'verify two-persona-devil discipline end-to-end',
+  ]);
+  assert.equal(created.status, 0, `request failed: ${created.stderr}`);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  // Step 2: approve as mirror — the discipline is the
+  // executor-and-approver-are-different rule, enforced here by
+  // operator choice (self_approve: allowed by default in solo
+  // profile, so this would technically work with --by YOU too).
+  const approved = runGate(root, ['approve', id, '--by', MIRROR]);
+  assert.equal(approved.status, 0, `approve failed: ${approved.stderr}`);
+
+  // Step 3: review as mirror, lense=user, verdict=ok.
+  const reviewed = runGate(root, [
+    'review', id,
+    '--by', MIRROR,
+    '--lense', 'user',
+    '--verdict', 'ok',
+    '--note', 'first-pass mirror review',
+  ]);
+  assert.equal(reviewed.status, 0, `review failed: ${reviewed.stderr}`);
+
+  // Step 4: execute as the executor persona.
+  const executed = runGate(root, ['execute', id, '--by', YOU]);
+  assert.equal(executed.status, 0, `execute failed: ${executed.stderr}`);
+
+  // Step 5: complete as the executor.
+  const completed = runGate(root, [
+    'complete', id, '--by', YOU, '--note', 'done',
+  ]);
+  assert.equal(completed.status, 0, `complete failed: ${completed.stderr}`);
+
+  // Final state inspection via show --format json.
+  const shown = runGate(root, ['show', id, '--format', 'json']);
+  assert.equal(shown.status, 0, shown.stderr);
+  const record = JSON.parse(shown.stdout);
+
+  assert.equal(record.state, 'completed', 'final state should be completed');
+  // executors[] carries the executor only — the mirror is NOT an executor.
+  // Post-#294, executors may serialize as objects or as a flat name array
+  // depending on whether slice closure ran; normalise both shapes.
+  const execNames = (record.executors as Array<unknown>).map((e) =>
+    typeof e === 'string' ? e : (e as { name: string }).name,
+  );
+  assert.deepEqual(execNames, [YOU], 'executor list should be [YOU] only');
+
+  // status_log records BOTH personas, on their respective transitions.
+  const log = record.status_log as Array<{ by: string; state: string }>;
+  const transitionsByActor = new Map<string, Set<string>>();
+  for (const e of log) {
+    if (!transitionsByActor.has(e.by)) transitionsByActor.set(e.by, new Set());
+    transitionsByActor.get(e.by)!.add(e.state);
+  }
+  assert.ok(
+    transitionsByActor.get(MIRROR)?.has('approved'),
+    `mirror should have approved; got log: ${JSON.stringify(log)}`,
+  );
+  assert.ok(
+    transitionsByActor.get(YOU)?.has('executing'),
+    `executor should have executed; got log: ${JSON.stringify(log)}`,
+  );
+  assert.ok(
+    transitionsByActor.get(YOU)?.has('completed'),
+    `executor should have completed; got log: ${JSON.stringify(log)}`,
+  );
+
+  // reviews[] carries exactly one entry, authored by the mirror.
+  const reviews = record.reviews as Array<{ by: string; lense: string; verdict: string }>;
+  assert.equal(reviews.length, 1, 'should have exactly one review');
+  assert.equal(reviews[0]?.by, MIRROR);
+  assert.equal(reviews[0]?.lense, 'user');
+  assert.equal(reviews[0]?.verdict, 'ok');
+});
+
+test('S1: same-actor approve+execute (no mirror) also works — discipline is operator choice', (t) => {
+  // This case documents the trade-off: with default solo profile
+  // (`self_approve: allowed`), the verb arc runs even when one
+  // actor wears both hats. The synergy's *value* is the discipline
+  // of using a separate --by, not a hard enforcement.
+  const { root, cleanup } = bootstrap({ members: [YOU] });
+  t.after(cleanup);
+
+  const created = runGate(root, [
+    'request',
+    '--from', YOU,
+    '--executors', YOU,
+    '--action', 'self-approve smoke',
+    '--reason', 'document trade-off',
+  ]);
+  assert.equal(created.status, 0, created.stderr);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  // No mirror — approve/review by YOU.
+  assert.equal(runGate(root, ['approve', id, '--by', YOU]).status, 0);
+  assert.equal(
+    runGate(root, [
+      'review', id, '--by', YOU,
+      '--lense', 'user', '--verdict', 'ok',
+      '--note', 'self-stamped (no mirror) — trade-off arm',
+    ]).status,
+    0,
+  );
+  assert.equal(runGate(root, ['execute', id, '--by', YOU]).status, 0);
+  assert.equal(runGate(root, ['complete', id, '--by', YOU]).status, 0);
+
+  const shown = runGate(root, ['show', id, '--format', 'json']);
+  const record = JSON.parse(shown.stdout);
+  assert.equal(record.state, 'completed');
+
+  // status_log only carries YOU — the trade-off surface is that
+  // the substrate cannot tell after the fact whether the operator
+  // exercised the mirror discipline or stamped through.
+  const distinctActors = new Set(
+    (record.status_log as Array<{ by: string }>).map((e) => e.by),
+  );
+  assert.deepEqual([...distinctActors], [YOU]);
+});
+
+test('S1: swarm profile flip — self_approve: forbidden requires a separate --by', (t) => {
+  // Forward-compat anchor: the same arc on `profile: swarm` REQUIRES
+  // the mirror. `gate approve --by YOU` is rejected; the mirror call
+  // succeeds. This pins the contract documented in README's Solo
+  // flow ("when you later flip to swarm profile, self_approve:
+  // forbidden kicks in and a separate --by is required by config").
+  const { root, cleanup } = bootstrap({
+    members: [YOU, MIRROR],
+    extraConfig: 'profile: swarm\n',
+  });
+  t.after(cleanup);
+
+  const created = runGate(root, [
+    'request',
+    '--from', YOU,
+    '--executors', YOU,
+    '--action', 'swarm-profile smoke',
+    '--reason', 'verify self_approve: forbidden contract',
+  ]);
+  assert.equal(created.status, 0, created.stderr);
+  const id = extractRequestId(created.stdout + created.stderr);
+
+  // Self-approve refused under swarm profile.
+  const selfApprove = runGate(root, ['approve', id, '--by', YOU]);
+  assert.notEqual(
+    selfApprove.status,
+    0,
+    `swarm profile must refuse self-approve; got status ${selfApprove.status} stderr=${selfApprove.stderr}`,
+  );
+
+  // Mirror succeeds.
+  const mirrorApprove = runGate(root, ['approve', id, '--by', MIRROR]);
+  assert.equal(
+    mirrorApprove.status,
+    0,
+    `mirror approve must succeed: ${mirrorApprove.stderr}`,
+  );
+});


### PR DESCRIPTION
## Summary

Introduces the **Synergies** section in `docs/playbook.md` as a sibling to the existing combos C1-C6. Combos are recipes for *situations* (bug-killing, ordering, bundle PR); **synergies are verb pairings that pin a small substrate principle in one arc**.

**S1: Mirror Persona Loop** is the first synergy: two registered names (`<you>` / `<you-mirror>`) running the solo flow's 6-verb arc with author and review distinct on `--by`. Pins the minimal Two-Persona Devil discipline (principle 02 + 08) inside a single-actor flow.

## What ships in one PR

- **`tests/_e2e_helpers.ts`** — shared `bootstrap` / `runGate` / `extractRequestId` for E2E synergy tests. `tests/interface/` keeps its per-file duplicates intentionally (each interface test pins its verb in isolation); E2E tests share the helper.
- **`tests/e2e/synergy_s1_mirror_persona_loop.test.ts`** — three test cases:
  1. Mirror arc completes (`state: completed`; `status_log[]` records both personas; `reviews[]` has one mirror entry; `executors[]` is `<you>` only).
  2. Same-actor degenerate arc also completes — pins the *trade-off* surface (substrate cannot retroactively distinguish disciplined-mirror from self-stamp).
  3. Swarm profile flip rejects self-approve and requires the mirror — pins the forward-compat contract documented in README's Solo flow.
- **`docs/playbook.md`** — new `## Synergies` section with the **Purpose / Trade-off / E2E test** triple. S1 entry written as the template the next 3 (S2-S4) will follow.

## Provenance

Designed in agora play [`combo-gamification-2026-05-12/2026-05-12-001`](../../agora/plays/combo-gamification-2026-05-12/2026-05-12-001.yaml) (local substrate, eris/miki/noir/devil/leysia 5-voice deliberation). The conclude note locked the synergy list (S1-S4) and the test-first / doc-mirrors-test convention; this PR ships the first slice.

## Why "synergy" not "combo"

Combos in the playbook are diagnostic / load-bearing — "the bug-killing flow," "ordering N items," "bundle PR cherry-pick." Synergies sit alongside as the *exploration-flavored* layer: verb pairings that, once you've seen them, start to feel less like ceremony and more like a move you reach for. Doc framing stays sober (side-notes texture, not gamification chrome) — audience #1 / #2 get the dogfood ergonomics, audience #3 just sees more clearly-named patterns.

## Follow-up

S2 (Cross-Session Body Switch — principle 14 + #249), S3 (Agora-to-Gate Lift — principle 04 + #232), S4 (Swarm Slice Closure — principle 14 + #294 + #309) each ship as separate PRs, using the same `_e2e_helpers.ts` and playbook template.

## Test plan

- [x] `npm test` — 1617 / 1617 pass.
- [x] `node --test dist/tests/e2e/synergy_s1_mirror_persona_loop.test.js` — 3 / 3 pass in isolation.
- [x] Playbook anchor (`#s1-mirror-persona-loop--two---by-names-one-body-of-work`) checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
