### PR TITLE
feat(playbook+e2e): Synergy S3 Agora-to-Gate Lift — cross-passage relay

### DIFF
--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -557,6 +557,63 @@ pins three contracts:
    stderr and proceeds with the session unstamped — silent strip is
    refused.
 
+### S3: Agora-to-Gate Lift — bridge thought-in-motion into a request
+
+```bash
+# A explores in agora, hits an inflection, suspends with cliff + invitation.
+agora new   --slug <topic> --kind sandbox --title "..." --by <A>
+agora play  --slug <topic> --by <A>
+agora move  <play-id> --game <topic> --by <A> --text "..."
+agora suspend <play-id> --game <topic> --by <A> \
+  --cliff "what was being figured out" \
+  --invitation "what to do next"
+
+# B (or A later, or another body of A) lifts the suspension.
+gate request --from <B> --executors <B> --from-agora <play-id>
+# action  ← invitation
+# reason  ← cliff
+# source_agora_play = <play-id>
+```
+
+**Purpose.** Keep *thought-in-motion* and *judgment moments*
+connected on the substrate. Agora carries "what was being figured
+out"; gate carries "what we decided to do." Without the bridge, a
+request that inherits intent from a long agora session loses the
+trail — you'd paraphrase the cliff into `--reason` by hand and the
+link is lossy. With `--from-agora`, the substrate itself preserves
+the pivot: read the request, follow `source_agora_play` back to the
+deliberation. Pins
+[principle 04](../lore/principles/04-records-outlive-writers.md):
+the act of stopping (suspend) and the act of acting (request) are
+linked records, not separately remembered moments.
+
+**Trade-off.** The lift is one-shot but the substrate does not
+enforce "one request per suspension" or "one suspension per
+request." Re-lifting the same suspension produces a second request
+that shares the same `source_agora_play`. Operators have to keep
+the play's life cycle visible: file the request, then conclude
+the play (or re-suspend with a fresh cliff for the next slice).
+Leaving it suspended after a lift makes accidental double-lifts
+easy. Override is allowed on either axis (`--action` overrides
+invitation, `--reason` overrides cliff) but the structural link
+(`source_agora_play`) cannot be overridden — `--from-agora` always
+stamps the field, so a hand-overridden request that came *from* a
+play is still substrate-discoverable as such.
+
+**E2E test.** [`tests/e2e/synergy_s3_agora_to_gate_lift.test.ts`](../tests/e2e/synergy_s3_agora_to_gate_lift.test.ts)
+pins four contracts:
+
+1. A suspends, B lifts → request's `action` / `reason` /
+   `source_agora_play` carry the bridge correctly; relay carries
+   *intent*, not authorship (`from` is B even though the play was
+   A's).
+2. A concluded play refuses the lift — closed-thread contract.
+3. A playing-but-not-suspended play refuses the lift — nothing to
+   bridge.
+4. Explicit `--action` overrides the invitation lift but `--reason`
+   still lifts from cliff; `source_agora_play` survives the
+   partial override.
+
 ---
 
 ## When NOT to use devil (honest limits)

--- a/tests/e2e/synergy_s3_agora_to_gate_lift.test.ts
+++ b/tests/e2e/synergy_s3_agora_to_gate_lift.test.ts
@@ -1,0 +1,251 @@
+// Synergy S3 — Agora-to-Gate Lift
+// ================================
+//
+// E2E test for the cross-passage relay pattern: actor A explores in
+// agora, suspends with a cliff + invitation, and actor B (or A
+// later) lifts the suspension into a `gate request` via `--from-agora
+// <play-id>`. The cliff lands as the request's `reason`; the
+// invitation lands as the `action`; the play_id is stamped on
+// `source_agora_play` so the request links back to its origin.
+//
+// What we assert:
+//
+//   - A `gate request --from-agora <id>` succeeds when the play is
+//     suspended, and the resulting record carries:
+//       * `action` ← invitation
+//       * `reason` ← cliff
+//       * `source_agora_play` ← play_id
+//   - The `--from` actor on the gate side can differ from the agora
+//     `--by` actor — the relay carries *intent*, not authorship.
+//   - A concluded play refuses the lift (records the closed-thread
+//     contract surfaced in the request handler's error catalog).
+//   - A playing-but-not-yet-suspended play refuses the lift (no
+//     cliff/invitation to bridge).
+//
+// Why this synergy is in the catalog:
+//
+//   Purpose: keep thought-in-motion and judgment moments connected.
+//   Agora carries the "what was being figured out"; gate carries the
+//   "what we decided to do." Without the bridge, a request that
+//   inherits intent from a long agora session loses the trail —
+//   you'd paraphrase the cliff into --reason by hand and the link is
+//   lossy. With `--from-agora`, the substrate itself preserves the
+//   pivot: read the request and follow `source_agora_play` back to
+//   the deliberation.
+//
+//   Trade-off: the lift is one-shot — re-suspending the play and
+//   lifting again produces a new request that shares the same
+//   source_agora_play, but the substrate does not enforce
+//   "one request per suspension" or "one suspension per request."
+//   Operators have to keep the play's life cycle visible: file
+//   the request, then conclude or fresh-suspend the play; leaving
+//   it suspended after a lift makes it easy to accidentally lift
+//   the same cliff twice.
+//
+// Linked playbook section: `docs/playbook.md` § "Synergies" → S3.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  bootstrap,
+  runGate,
+  extractRequestId,
+} from '../_e2e_helpers.js';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+
+function runAgora(
+  cwd: string,
+  args: readonly string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [AGORA, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function extractPlayId(output: string): string {
+  // agora play emits e.g. "✓ play started: 2026-05-12-001 [playing]"
+  const m = output.match(/\b(\d{4}-\d{2}-\d{2}-\d{3})\b/);
+  if (!m) throw new Error(`could not find play id in output: ${output}`);
+  return m[1] as string;
+}
+
+const A = 'alice';
+const B = 'bob';
+
+test('S3: A suspends play, B lifts via --from-agora → request inherits cliff/invitation', (t) => {
+  const { root, cleanup } = bootstrap({ members: [A, B] });
+  t.after(cleanup);
+
+  // A creates a game and a play, makes a move, suspends with a
+  // substantive cliff + invitation.
+  const newGame = runAgora(root, [
+    'new', '--slug', 'auth-redesign', '--kind', 'sandbox',
+    '--title', 'auth flow redesign exploration', '--by', A,
+  ]);
+  assert.equal(newGame.status, 0, newGame.stderr);
+
+  const startPlay = runAgora(root, ['play', '--slug', 'auth-redesign', '--by', A]);
+  assert.equal(startPlay.status, 0, startPlay.stderr);
+  const playId = extractPlayId(startPlay.stdout + startPlay.stderr);
+
+  assert.equal(runAgora(root, [
+    'move', playId, '--game', 'auth-redesign', '--by', A,
+    '--text', 'session A: revisited the cookie vs JWT trade-off',
+  ]).status, 0);
+
+  const susp = runAgora(root, [
+    'suspend', playId, '--game', 'auth-redesign', '--by', A,
+    '--cliff', 'JWT path leaves us with a stateless refresh problem unresolved',
+    '--invitation', 'ship a spike on session-cookie path so concrete data informs the call',
+  ]);
+  assert.equal(susp.status, 0, susp.stderr);
+
+  // B (different --from) lifts the suspension into a gate request.
+  const lifted = runGate(root, [
+    'request',
+    '--from', B,
+    '--executors', B,
+    '--from-agora', playId,
+  ]);
+  assert.equal(lifted.status, 0, `--from-agora lift failed: ${lifted.stderr}`);
+  const reqId = extractRequestId(lifted.stdout + lifted.stderr);
+
+  // Inspect the record: action ← invitation, reason ← cliff,
+  // source_agora_play ← play_id.
+  const shown = runGate(root, ['show', reqId, '--format', 'json']);
+  const record = JSON.parse(shown.stdout);
+
+  assert.equal(
+    record.action,
+    'ship a spike on session-cookie path so concrete data informs the call',
+    `action should lift from invitation; got: ${record.action}`,
+  );
+  assert.equal(
+    record.reason,
+    'JWT path leaves us with a stateless refresh problem unresolved',
+    `reason should lift from cliff; got: ${record.reason}`,
+  );
+  assert.equal(
+    record.source_agora_play,
+    playId,
+    `source_agora_play should stamp the play id; got: ${record.source_agora_play}`,
+  );
+  // The relay carries intent, not authorship: --from is B, not A.
+  assert.equal(record.from, B);
+});
+
+test('S3: a concluded play refuses the lift — closed-thread contract', (t) => {
+  const { root, cleanup } = bootstrap({ members: [A, B] });
+  t.after(cleanup);
+
+  assert.equal(runAgora(root, [
+    'new', '--slug', 'closed-thread', '--kind', 'sandbox',
+    '--title', 't', '--by', A,
+  ]).status, 0);
+  const startPlay = runAgora(root, ['play', '--slug', 'closed-thread', '--by', A]);
+  const playId = extractPlayId(startPlay.stdout + startPlay.stderr);
+  assert.equal(runAgora(root, [
+    'move', playId, '--game', 'closed-thread', '--by', A, '--text', 'thinking',
+  ]).status, 0);
+  assert.equal(runAgora(root, [
+    'conclude', playId, '--game', 'closed-thread', '--by', A, '--note', 'closed',
+  ]).status, 0);
+
+  const lifted = runGate(root, [
+    'request',
+    '--from', B,
+    '--executors', B,
+    '--from-agora', playId,
+  ]);
+  assert.notEqual(
+    lifted.status,
+    0,
+    `concluded play should refuse lift; got status ${lifted.status}`,
+  );
+  assert.match(
+    lifted.stderr,
+    /concluded/i,
+    `stderr should name the closed-thread refusal; got: ${lifted.stderr}`,
+  );
+});
+
+test('S3: a play with no suspension refuses the lift — nothing to bridge', (t) => {
+  const { root, cleanup } = bootstrap({ members: [A, B] });
+  t.after(cleanup);
+
+  assert.equal(runAgora(root, [
+    'new', '--slug', 'no-cliff', '--kind', 'sandbox',
+    '--title', 't', '--by', A,
+  ]).status, 0);
+  const startPlay = runAgora(root, ['play', '--slug', 'no-cliff', '--by', A]);
+  const playId = extractPlayId(startPlay.stdout + startPlay.stderr);
+  assert.equal(runAgora(root, [
+    'move', playId, '--game', 'no-cliff', '--by', A, '--text', 'thinking',
+  ]).status, 0);
+  // No suspend — play is still playing.
+
+  const lifted = runGate(root, [
+    'request',
+    '--from', B,
+    '--executors', B,
+    '--from-agora', playId,
+  ]);
+  assert.notEqual(
+    lifted.status,
+    0,
+    `playing-but-not-suspended play should refuse lift; got status ${lifted.status}`,
+  );
+  assert.match(
+    lifted.stderr,
+    /no suspension|suspend/i,
+    `stderr should name the no-suspension refusal; got: ${lifted.stderr}`,
+  );
+});
+
+test('S3: explicit --action overrides the invitation lift; --reason overrides cliff', (t) => {
+  const { root, cleanup } = bootstrap({ members: [A, B] });
+  t.after(cleanup);
+
+  assert.equal(runAgora(root, [
+    'new', '--slug', 'override-test', '--kind', 'sandbox',
+    '--title', 't', '--by', A,
+  ]).status, 0);
+  const startPlay = runAgora(root, ['play', '--slug', 'override-test', '--by', A]);
+  const playId = extractPlayId(startPlay.stdout + startPlay.stderr);
+  assert.equal(runAgora(root, [
+    'move', playId, '--game', 'override-test', '--by', A, '--text', 'm',
+  ]).status, 0);
+  assert.equal(runAgora(root, [
+    'suspend', playId, '--game', 'override-test', '--by', A,
+    '--cliff', 'auto-cliff',
+    '--invitation', 'auto-invitation',
+  ]).status, 0);
+
+  // Override action; reason should still lift from cliff.
+  const lifted = runGate(root, [
+    'request',
+    '--from', B,
+    '--executors', B,
+    '--from-agora', playId,
+    '--action', 'manually-overridden action',
+  ]);
+  assert.equal(lifted.status, 0, lifted.stderr);
+  const reqId = extractRequestId(lifted.stdout + lifted.stderr);
+
+  const record = JSON.parse(runGate(root, ['show', reqId, '--format', 'json']).stdout);
+  assert.equal(record.action, 'manually-overridden action');
+  assert.equal(record.reason, 'auto-cliff', 'unspecified axis still lifts');
+  // Source link survives the partial override.
+  assert.equal(record.source_agora_play, playId);
+});


### PR DESCRIPTION
## Summary

Third entry in the **Synergies** catalog (#347 S1, #348 S2). **S3: Agora-to-Gate Lift** pins the cross-passage bridge: `agora suspend` carries thought-in-motion; `gate request --from-agora <play-id>` threads the play's cliff/invitation into the request's reason/action and stamps `source_agora_play` so the link survives in the substrate.

## What S3 contracts

The E2E test (`tests/e2e/synergy_s3_agora_to_gate_lift.test.ts`) pins four behaviours:

1. **A suspends, B lifts.** A creates a play, makes a move, suspends with cliff + invitation. B (different `--from`) lifts via `--from-agora <play-id>`. The resulting request carries:
   - `action` ← invitation
   - `reason` ← cliff
   - `source_agora_play` ← play_id
   - `from` = B (the relay carries **intent**, not authorship)
2. **Concluded play refuses the lift** — closed-thread contract (#232 design).
3. **Playing-but-not-suspended play refuses the lift** — nothing to bridge.
4. **Override mechanics.** Explicit `--action` overrides the invitation lift but `--reason` still lifts from cliff; `source_agora_play` survives the partial override — the structural link cannot be hand-stripped.

## Playbook entry

`docs/playbook.md § Synergies → S3` follows S1/S2 template (Purpose / Trade-off / E2E test). Trade-off paragraph explicitly names the substrate's lack of one-shot enforcement: re-lifting the same suspension produces a duplicate request sharing `source_agora_play`. Operator discipline is required — file the request, then conclude or fresh-suspend.

Pins [principle 04](../blob/main/lore/principles/04-records-outlive-writers.md) at the cross-passage level: the act of stopping (suspend) and the act of acting (request) are linked records, not separately remembered moments.

## Provenance

Designed in agora play `combo-gamification-2026-05-12/2026-05-12-001` as the third S in the S1-S4 selection — chosen because the agora-gate bridge is the substrate's most visible cross-passage move and `--from-agora` (#232) is the verb that ships it.

## Test plan

- [x] `npm test` — 1624 / 1624 pass.
- [x] `node --test dist/tests/e2e/synergy_s3_agora_to_gate_lift.test.js` — 4 / 4 pass in isolation.
- [x] S3 uses an additional `runAgora` helper inline (the agora bin is a sibling of gate; helper kept local since S3 is the only synergy that drives both passages — promoting to `_e2e_helpers.ts` if S4 or later need it).

## Follow-up

- **S4: Swarm Slice Closure** (principle 14 + #294 + #309) — next and final PR in the S1-S4 series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
