### PR TITLE
docs(glossary): consolidate scattered vocab into docs/glossary.md as the authoritative reference

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -8,6 +8,9 @@
 > devil for real work** (combos, recipes, bug-killing flow), see
 > [`docs/playbook.md`](./docs/playbook.md). For **multi-executor /
 > SubAgent swarm coordination**, see [`docs/swarm.md`](./docs/swarm.md).
+> For **project-specific term definitions** (passage / wave / slice /
+> mirror / synergy / axis / lore / etc.), see
+> [`docs/glossary.md`](./docs/glossary.md).
 
 File-based coordination for AI agents. No daemon, no DB, no network.
 State lives in YAML files under a `content_root`. Git gives you history.

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,6 +90,7 @@ mirror に手を伸ばすのが推奨形。 `swarm` profile に切り替えた�
 | 15分 | [`docs/playbook.md`](./docs/playbook.md) | pair | passage 個別を知った上で **combos** (gate + agora + devil の合成パターン) が欲しい |
 | 15分 | [`docs/swarm.md`](./docs/swarm.md) | swarm | ≥2 並列 executor / Claude SubAgent を orchestrate していて substrate-engagement レシピが要る |
 | 30分 | [`docs/verbs.md`](./docs/verbs.md) | any | per-verb の例と設計ノートが欲しい |
+| reference | [`docs/glossary.md`](./docs/glossary.md) | any | project 固有の用語に当たって正典が欲しい |
 
 ## あなたができること
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Pick a depth. Every layer works on its own.
 | 15 min | [`docs/playbook.md`](./docs/playbook.md) | pair | you know each passage; you want **combos** (gate + agora + devil flows; ctx-inclusive patterns arrive in phase 2), recipes, and the bug-killing flow |
 | 15 min | [`docs/swarm.md`](./docs/swarm.md) | swarm | you orchestrate ≥2 parallel executors / Claude SubAgents and need the substrate-engagement recipe |
 | 30 min | [`docs/verbs.md`](./docs/verbs.md) | any | you want per-verb examples and design notes |
+| reference | [`docs/glossary.md`](./docs/glossary.md) | any | you hit a project-specific term and want the authoritative definition |
 | 1 hour | [`examples/dogfood-session/`](./examples/dogfood-session/) | any | you're adopting this seriously and want to see real sessions |
 | working notes | [`docs/domain-fit/`](./docs/domain-fit/) | any | you're curious whether gate fits a non-standard domain |
 | when needed | [`docs/POLICY.md`](./docs/POLICY.md) / [`docs/storage-format.md`](./docs/storage-format.md) / [`SECURITY.md`](./SECURITY.md) | embedder | you're embedding guild-cli and need the stability / on-disk shape / threat contract |

--- a/docs/concepts-for-newcomers.md
+++ b/docs/concepts-for-newcomers.md
@@ -51,18 +51,17 @@ sections in [`AGENT.md`](../AGENT.md) and worked examples in
 
 ## Quick vocabulary
 
-- **actor** — a human or AI agent. Has a `MemberName` (lowercase ASCII) and lives as `members/<name>.yaml`.
-- **host** — an actor that runs the content_root (not a member, but can `--by` / `--from` anything). Listed under `host_names:` in `guild.config.yaml`.
-- **request** — a decision-in-motion. Has `action`, `reason`, optional `executors` (one or more) / `auto-review`, and moves through `pending → approved → executing → completed` (or `denied` / `failed`). Even single-actor requests use the plural `executors:` field for uniformity — same shape across single and parallel waves means downstream tools never branch on arity. See [#230](https://github.com/eris-ths/guild-cli/issues/230) for the attribution rationale.
-- **review** — multi-perspective feedback on a request. Carries a `lense` (one of `devil | layer | cognitive | user` by default — extend via config) and a `verdict` (`ok | concern | reject`).
-- **lense** — the angle a reviewer is taking. (Spelled with a trailing `e` throughout this project — the value object, the CLI flag, and prose all align.) `devil` = "what breaks?", `layer` = "which structural layer is this on?", `cognitive` = "where would someone hesitate?", `user` = "whose happiness (LDD)?". Add domain lenses (`security`, `perf`, `a11y`, ...) in `guild.config.yaml`'s `lenses:` list, or — for the devil-side catalog — drop one YAML file per custom lense under `<content_root>/devil/lenses/<name>.yaml` (see #134 G).
-  - **gate vs devil enforcement.** Gate review's allowed-lense set comes from `guild.config.yaml`'s `lenses:` list by default — host project picks the vocabulary. Devil's `devil entry` requires a name from a strict bundled catalog (12 lenses in v1, see `docs/verbs.md` § Lenses) merged with content_root extensions. Same word, different enforcement: gate's lense is a label the team agrees on; devil's lense is a covered axis of the security-knowledge floor.
-  - **strict mode (#134 H2, opt-in).** Set `gate.strict_lenses: true` in `guild.config.yaml` to flip gate review's allowed-lense set from `lenses:` over to the unified devil catalog (bundled defaults + `<content_root>/devil/lenses/*.yaml` extensions). Default is permanently `false` — each team picks its own enforcement timing; we never auto-flip. Coverage gating stays devil-side.
-- **verdict** — `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). The word is deliberately soft — `concern` is usable, not a veto.
-- **fast-track** — single-actor shortcut for the full lifecycle when self-approved work is appropriate. Still requires `reason`; `review`s can be attached after.
-- **issue** — a standalone observation that has not yet become a decision. Lightweight, optional `severity` / `area`. Promote to `request` via `gate issues promote <id>`.
-- **pair-mode (`--with`)** — records who you were thinking with when you shaped a request. Surfaces in `show`, `voices`, and `resume` prose ("shaped with eris").
-- **content_root** — the YAML directory gate reads from. Contains `members/`, `requests/`, `issues/`, `inbox/`, and `guild.config.yaml`. Git it for history. See AGENT.md § File layout.
+A short primer for new readers. The **authoritative** reference is [`docs/glossary.md`](./glossary.md) — reach for it whenever a term feels under-defined here.
+
+- **actor** — a human or AI agent. Has a `MemberName` (lowercase ASCII) and lives as `members/<name>.yaml`. Hosts (listed in `guild.config.yaml#host_names`) are a related but distinct kind.
+- **request** — a decision-in-motion. Has `action`, `reason`, `executors` (one or more), and moves through `pending → approved → executing → completed` (or `denied` / `failed`). The plural `executors:` field is used uniformly across single-actor and parallel waves.
+- **review** — multi-perspective feedback on a request. Carries a `lense` and a `verdict`. **`lense` is spelled with a trailing `e`** throughout this project — the value object, the CLI flag, and prose all align.
+- **verdict** — `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). Deliberately soft — `concern` is usable, not a veto.
+- **fast-track** — single-actor shortcut for the full lifecycle when self-approved work is appropriate.
+- **issue** — a standalone observation that has not yet become a decision. Promote to a request via `gate issues promote <id>`.
+- **content_root** — the YAML directory gate reads from. Contains `members/`, `requests/`, `issues/`, `inbox/`, `agora/`, `devil/`, `ctx/`, and `guild.config.yaml`. Git it for history.
+
+For the full inventory — including `passage` / `substrate` / `wave` / `slice` / `mirror` / `claim` / `witness` / `lore` / `principle` / `trap` / `combo` / `synergy` / `tier` / `audience` / `axis` / `VerbPlugin` / `HookPlugin` / etc. — see [`docs/glossary.md`](./glossary.md).
 
 ## The 30-second first touch
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,81 @@
+# Glossary
+
+Authoritative reference for project-specific terms. Where a term has a deeper write-up, the entry links to it; this file stays short on each, long on coverage.
+
+If you are reading the codebase for the first time, the [`Quick vocabulary`](./concepts-for-newcomers.md#quick-vocabulary) section in `concepts-for-newcomers.md` is the 5-minute primer; this file is the full reference.
+
+## Structure
+
+- **passage** — one of four shapes of work the substrate carries: `gate` (judgment), `agora` (exploration), `devil` (defense), `ctx` (fact). Each passage has its own CLI entrypoint (`bin/<passage>.mjs`) and writes under `<content_root>/<passage>/`. See [`playbook.md`](./playbook.md) § "Dispatch in one breath".
+- **substrate** — the file-based coordination layer: YAML records on disk under `<content_root>/`. Distinct from *surface* (CLI verbs, JSON output) which renders / mutates the substrate.
+- **surface** — externally-visible faces of the substrate: verbs, `gate schema`, `gate --help` text, prose docs. Per [principle 11](../lore/principles/11-ai-first-human-as-projection.md), `gate schema --format json` is the authoritative AI-agent contract; help text and prose docs are projections.
+- **record** — one YAML file on disk (a request, an issue, an inbox entry, an agora play, a devil review, …). Append-only in spirit per [principle 04](../lore/principles/04-records-outlive-writers.md).
+- **wave** — a `gate request` record. Carries one or more executors. Single-executor and multi-executor waves share the same shape (per #230).
+- **slice** — a single executor's portion of a multi-executor wave. First-class on the substrate post-#294: `executors[]` carries per-slice `status` / `completed_at` / `note`. `gate complete --by <X>` closes one slice; the wave reaches `completed` when all slices close.
+- **content_root** — the YAML directory `gate` reads from. Contains `members/`, `requests/`, `issues/`, `inbox/`, `agora/`, `devil/`, `ctx/`, and `guild.config.yaml`. Git it for history. See [`AGENT.md`](../AGENT.md) § "File layout".
+- **profile** — `standard` (solo default) or `swarm` (multi-executor). Set in `guild.config.yaml`. Drives `self_approve: allowed / forbidden`, `worktree_required_for_parallel`, and the default tier of `gate --help`. See [`docs/swarm.md`](./swarm.md) and [`docs/POLICY.md`](./POLICY.md).
+
+## Roles / actors
+
+- **actor** — anything with a `members/<name>.yaml` file: human, AI agent, or composite (a `mirror` persona of an AI, a session_id-stamped body, …). Lowercase ASCII identifier (`MemberName`).
+- **host** — a config-level actor declared under `host_names:` in `guild.config.yaml`. Not a member file; the privileges differ (e.g. can `--from` any member for delegation flows).
+- **mirror** — a second registered `--by` name used by the same actor to play the reviewer role on their own work. Pins the Two-Persona Devil discipline ([principle 02](../lore/principles/02-advisory-not-directive.md) + [principle 08](../lore/principles/08-voice-as-doctrine.md)) inside a solo flow. See [`playbook.md`](./playbook.md) § "S1: Mirror Persona Loop".
+- **director / orchestrator** — informal role: the actor who designs / monitors / closes waves rather than executing them. `gate decisions` and `gate self-pattern` are director-axis read verbs (#336).
+- **session_id** — cross-session attribution stamp (`opened_by_session`, `claimed_by_session`, `witness_sessions[<actor>]`). Format: `^[a-z0-9][a-z0-9_:.-]{0,63}$`. Set via `GUILD_SESSION_ID` env or `gate boot --session-id`. See `docs/verbs.md` § "Sessions (#249)".
+
+## Lore / thinking
+
+- **lore** — `lore/principles/` (numbered axioms) + `lore/traps/` (operational patterns not yet principle-grade). The "thinking around the code" — not the code itself, not user docs.
+- **principle** — numbered, named, load-bearing axiom. 14 ship as of 2026-05-12. Promotion bar: *felt-not-just-read*, two independent dogfood observations. See [`lore/README.md`](../lore/README.md).
+- **trap** — a reusable operational pattern flagged for future review. Lives at `lore/traps/<trap_name>.md` with `relevant_until: <date> | indefinite` frontmatter. Quarantined (not deleted) when expired via `gate doctor sweep-traps`. See [`lore/traps/README.md`](../lore/traps/README.md).
+- **felt-not-just-read** — the graduation bar from trap to principle: the pattern is named consistently from independent observations, not just read from someone else's notes.
+- **advisory** — a record field that downstream consumers MAY read to alter behaviour, but enforcement is not built into the substrate. Pinned by [principle 02](../lore/principles/02-advisory-not-directive.md). Examples: `Request.depth` (consumed by `gate review-context` #310), issue `severity`, `auto_review`. The "stamped but unread" audit lives at [#344](https://github.com/eris-ths/guild-cli/issues/344).
+- **applies_to** — optional YAML frontmatter on `lore/principles/*.md` declaring audience scope. Values: `all` (default), `swarm`, `passage:<gate|agora|devil|ctx>`. Filter via `tools/lore-scope.sh`. See [`lore/README.md`](../lore/README.md) § "`applies_to:` frontmatter convention".
+
+## Review / judgment
+
+- **lense** — the angle a reviewer is taking. **Spelled with a trailing `e` throughout this project** — the value object, the CLI flag, and prose all align. Default gate lenses: `devil | layer | cognitive | user`. Devil-side catalog (12, v1): `injection / injection-parser / path-network / auth-access / memory-safety / crypto / deserialization / protocol-encoding / supply-chain / composition / temporal / coherence`.
+- **verdict** — review outcome: `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). The word is deliberately soft — `concern` is usable, not a veto.
+- **claim** — exclusive stake on a wave: "I'm working on this." `gate claim <id> --by <m>` is refused if another actor holds the claim. Auto-released on terminal transition. See #226.
+- **witness** — non-exclusive observation: "I'm watching this." Multiple actors can witness one wave. `gate witness <id> --by <m>` is idempotent (same-actor re-witness no-op unless note/session differs). See #244 / #246.
+- **depth** — reviewer-depth advisory on a wave: `shallow | standard | deep`. Stamped at `gate request --depth <v>`. Consumed by `gate review-context` (#310) to recommend a lens set. See #221.
+- **strict_lenses** — opt-in `guild.config.yaml` setting that flips `gate review`'s allowed-lense set from the team-chosen `lenses:` list to the bundled devil catalog. Default `false`. See `docs/verbs.md` § "Strict lense vocabulary".
+
+## Cross-passage / time
+
+- **cliff / invitation** — the two prose halves of an `agora suspend`: cliff = "what was happening when I stopped," invitation = "what the next opener should attempt." Carries the Zeigarnik substrate that lets a different instance pick up the play. See #117.
+- **from-agora** — `gate request --from-agora <play-id>` lifts a suspended play's cliff/invitation into the new request: `action ← invitation`, `reason ← cliff`. The request's `source_agora_play` field stamps the play_id for back-links. See #232 and [`playbook.md`](./playbook.md) § "S3: Agora-to-Gate Lift".
+- **source_agora_play** — record field on a `gate request` set by `--from-agora`, pointing back to the agora play the request was lifted from. Cannot be hand-overridden — the structural link is preserved even when `--action` / `--reason` override the lift.
+- **axis** — multi-PR coordinated effort. Examples: the *Solo/Swarm coexistence* proposal (5 axes: boot text / help tier / docs split / lore frontmatter / trap retirement, #323-#327), the *#294 slice closure* (3 axes: design lock A1 / migration A2 / followup B). An axis is the unit of coordinated landing, not a record on disk.
+
+## Doc organization
+
+- **combo** — situational recipe in `docs/playbook.md` (C1-C6). When a specific situation arises (bug-killing flow, ordering N items, bundle PR), reach for the matching combo. See `docs/playbook.md` § "Combos (multi-passage workflows)".
+- **synergy** — exploratory verb pairing in `docs/playbook.md` (S1-S4). Where combos are *recipes for situations*, synergies are *verb pairings that pin a substrate principle in one arc*. Each ships with a runnable E2E test under `tests/e2e/synergy_*.test.ts`.
+- **tier** — `AGENT.md`'s reading hierarchy: **Common** (solo-usable) / **Coordination** (swarm) / **Boundary** (agora / devil / ctx) / **Diagnostic** (doctor / config / troubleshooting). Sections are ordered by topic, not tier; the [Tier index](../AGENT.md#tier-index) lets readers skip-jump.
+- **audience** — design priority axis (private memory, surfaced briefly in `lore/principles/11-ai-first-human-as-projection.md`): #1 eris-first / #2 AI agent first / #3 humans tertiary. The priority decides which surfaces grow first when capacity is finite.
+
+## Extension surfaces
+
+- **VerbPlugin** — add a new `gate <verb>` without forking the core dispatcher. Schema declared in the plugin module; loaded from paths in `guild.config.yaml`. See [`docs/plugin-schema.md`](./plugin-schema.md) and [`examples/plugins/verbs/`](../examples/plugins/).
+- **HookPlugin** — subscribe to the 18 lifecycle events (`before:` / `after:` × approve / deny / execute / complete / fail / review / rest / wake / farewell). Plugin can observe or veto. Sandbox model: in-process, full Node capabilities, no sandbox — load only what you trust (`plugins.trusted: true`). See `SECURITY.md` § "Plugin trust model".
+
+## Operational vocabulary
+
+- **dogfood** — using the tool on its own development. `requests/` in the repo carries the project's own gate records as the canonical example.
+- **ship** — merge a PR to `main`.
+- **silent fallback** — an anti-pattern named in [`lore/traps/trap_silent_fallback_loses_signal.md`](../lore/traps/trap_silent_fallback_loses_signal.md): catching an error, returning a default, and producing output indistinguishable from the success path. The substrate's preferred form is `principle 09 orientation-disclosure` — surface the fallback.
+
+---
+
+## Where else does vocabulary live?
+
+This file is the **authoritative** reference. Other docs that introduce the same terms:
+
+- [`docs/concepts-for-newcomers.md`](./concepts-for-newcomers.md) § "Quick vocabulary" — a 10-line primer for newcomers; pointers in to here.
+- [`docs/verbs.md`](./verbs.md) — per-verb examples and design notes.
+- [`lore/README.md`](../lore/README.md) — principle / trap conventions.
+- [`docs/playbook.md`](./playbook.md) — combo / synergy / tier vocabulary in context.
+- [`docs/swarm.md`](./swarm.md) — swarm / slice / session_id vocabulary in context.
+
+A term's authoritative definition lives here. If a definition in another doc drifts from this one, the other doc is wrong — patches welcome via [#344](https://github.com/eris-ths/guild-cli/issues/344)'s advisory audit pattern.


### PR DESCRIPTION
## Summary

Adds **`docs/glossary.md`** as the authoritative reference for project-specific terms — ~35 entries across 7 categories: Structure, Roles, Lore, Review, Cross-passage, Doc organization, Extension surfaces, Operational vocabulary.

Surfaced during the 2026-05-12 sweep: vocabulary definitions for `passage / actor / lense / verdict / wave / slice / mirror / claim / witness / cliff / invitation / combo / synergy / tier / audience / axis / VerbPlugin / HookPlugin / etc.` live scattered across `docs/concepts-for-newcomers.md` (Quick vocabulary), `docs/verbs.md`, `lore/README.md`, `docs/playbook.md`, and `docs/swarm.md`. A new reader hitting a term has no canonical place to land. This PR fixes that.

## What changes

- **`docs/glossary.md` (new)** — single source of truth, ~150 lines, 35 entries grouped by category, each linking to the deeper write-up where one exists.
- **`docs/concepts-for-newcomers.md` § "Quick vocabulary"** — trimmed from a 10-bullet sprawl (with 3 sub-bullets on `lense` covering gate-vs-devil enforcement and `strict_lenses` inline) to a 7-bullet primer + pointer to the glossary. Same set of terms remains discoverable on the onramp; depth lives in one place.
- **`README.md` + `README.ja.md`** — gain a `reference` row in their reading-depth table pointing at the glossary.
- **`AGENT.md`** — adds the glossary to the top-of-file doc map alongside playbook / swarm / concepts.

## Authoritative-source contract

The glossary's last section names every other doc that introduces vocabulary and pins the rule: definitions in `docs/glossary.md` are authoritative; drift elsewhere is a patch target, not a duplication source.

## Test plan

- [x] Pure docs; CI's path filter (#337) skips the test step automatically.
- [x] `npm test` — 1628 / 1628 pass (sanity).
- [x] All anchor links verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
