### PR TITLE
docs(audience): scrub 'eris-first' / 'audience #1' from public surfaces

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -53,7 +53,7 @@ If you are reading the codebase for the first time, the [`Quick vocabulary`](./c
 - **combo** — situational recipe in `docs/playbook.md` (C1-C6). When a specific situation arises (bug-killing flow, ordering N items, bundle PR), reach for the matching combo. See `docs/playbook.md` § "Combos (multi-passage workflows)".
 - **synergy** — exploratory verb pairing in `docs/playbook.md` (S1-S4). Where combos are *recipes for situations*, synergies are *verb pairings that pin a substrate principle in one arc*. Each ships with a runnable E2E test under `tests/e2e/synergy_*.test.ts`.
 - **tier** — `AGENT.md`'s reading hierarchy: **Common** (solo-usable) / **Coordination** (swarm) / **Boundary** (agora / devil / ctx) / **Diagnostic** (doctor / config / troubleshooting). Sections are ordered by topic, not tier; the [Tier index](../AGENT.md#tier-index) lets readers skip-jump.
-- **audience** — design priority axis (private memory, surfaced briefly in `lore/principles/11-ai-first-human-as-projection.md`): #1 eris-first / #2 AI agent first / #3 humans tertiary. The priority decides which surfaces grow first when capacity is finite.
+- **audience** — design priority axis pinned by [principle 11](../lore/principles/11-ai-first-human-as-projection.md): **AI-agent first; humans as projection.** When a surface choice has to favour one over the other, the AI-agent-readable shape wins; the human-readable version is layered on top. Decides which surfaces grow first when capacity is finite.
 
 ## Extension surfaces
 

--- a/lore/traps/trap_doc_coverage_drift_post_ship.md
+++ b/lore/traps/trap_doc_coverage_drift_post_ship.md
@@ -57,18 +57,18 @@ Two paths, both partial:
    limitation — author can bypass with intent.
 
 Neither is bulletproof. The real fix is **audience priority
-clarity**: per the project's audience-priority memo (audience #1 is
-eris-first; audience #2 is AI agents using `gate schema`; audience
-#3 is humans reading prose docs), the gap is acceptable for
-audience #1 (eris remembers what she shipped) and audience #2
-(`gate schema` is the source of truth for AI agents). The drift
-only hurts audience #3.
+clarity**: per [principle 11](../principles/11-ai-first-human-as-projection.md),
+AI agents are the primary audience (`gate schema` is the source of
+truth), with humans-as-projection the secondary surface. The drift
+this trap names mainly hurts the human-readable layer; the AI-
+agent contract stays consistent because `gate schema` is exhaustive
+by construction.
 
 **Decision rule**: a prose-doc update is required when the verb is
-likely to be read by audience #3 (a human onboarding to the tool).
-For private dogfood-only verbs, ship without prose doc updates is
-acceptable. For verbs that show up in README's "30-second tour" or
-playbook combos, prose doc updates are required pre-merge.
+likely to be read by a human onboarding to the tool (README's
+"30-second tour" verbs, playbook combos). For dogfood-only verbs
+that AI agents will primarily reach through `gate schema`,
+shipping without immediate prose-doc updates is acceptable.
 
 ## Why this is `indefinite`
 


### PR DESCRIPTION
## Summary

Follow-up to #351. The audience-priority fix I tried to bundle into #351 was pushed *after* the squash-merge took effect, so main still carries the original 3-tier framing in two places.

This PR re-applies the fix on top of post-merge main, scoped to:

- **`docs/glossary.md` 'audience' entry** — was a 3-tier explanation (`#1 eris-first / #2 AI agent first / #3 humans tertiary`) referencing private memory; now states only the [principle 11](../blob/main/lore/principles/11-ai-first-human-as-projection.md) framing visible in public lore ("AI-agent first; humans as projection"). The internal prioritization stays as eris's design rule, not as a published surface.
- **`lore/traps/trap_doc_coverage_drift_post_ship.md`** — same paragraph in the 'audience priority clarity' section, also trimmed to the principle-11 framing.

Grep confirms no remaining `eris-first` / `#1 eris` / `audience #1` mention in `docs/` / `README.md` / `README.ja.md` / `AGENT.md` / `lore/`.

## Why

The 3-tier framing was internal-only and surfaced inadvertently in #341 (trap memo) and again in #351's glossary entry. Public-facing docs should match what `principle 11` actually publishes ("AI-agent first; humans as projection"), not the private design rule it derives from.

## Test plan

- [x] Pure docs/lore; no source touched. CI path filter (#337) skips test step.
- [x] `grep -rnE "eris-first|#1 eris|audience #1"` across docs/lore/README/AGENT — empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)