### PR TITLE
feat(gate): read-verb symmetry catchup (issues show, chain --format, cross-passage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,10 @@ data/sync/
 examples/*/data/
 
 # Local gate dogfood records (actor names + session content — do not publish)
-# Root-anchored so examples/*/requests/ fixtures stay tracked.
+# Root-anchored so examples/*/requests/ + examples/*/issues/ + examples/*/agora/
+# fixtures stay tracked. Same rationale across stores — issues and agora
+# plays carry actor names and free-form session content the same way
+# requests do.
 /requests/
+/issues/
+/agora/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate issues show <id>` — per-id issue reader.** Sibling of
+  `gate show <id>` (request) and `agora show <id>` (play); closes the
+  asymmetry where `issues` had list/add/note/transition but no per-id
+  detail view. Supports `--format text|json`. Text renders the full
+  body (no list-row truncation) plus a notes block; JSON returns the
+  full issue `toJSON()`. Callers wired into muscle memory for
+  `gate show <id>` no longer bounce when reaching for the issue
+  equivalent.
+
+- **`gate chain --format text|json`.** Previously text-only by
+  design — the asymmetry vs every other read verb made `chain` an
+  outlier for pipeline writers. JSON shape: `{root, forward: {issues,
+  requests}, inbound: {issues, requests}}`, each item carrying `id /
+  found / bidirectional / summary / cross_passage`.
+
+- **Cross-passage chain resolution (gate → agora).** Request-shaped
+  ids (`YYYY-MM-DD-NNN`) that miss the gate request store are now
+  probed against the agora play store. Found plays render as
+  `→ agora play (game=<slug>, <state>)` instead of the previous
+  bare `(referenced but not found)`. Multi-game match (same play id
+  in multiple games) surfaces every candidate. The JSON shape carries
+  the matches under each item's `cross_passage.matches[]`.
+
+- **`gate issues <unknown-sub>` suggests the closest valid sub.**
+  Previously the error was bare `unknown issues sub: X`; readers
+  reaching for `issues show` got no orientation. Now the error
+  includes a `did you mean 'gate issues <best>'?` hint when the typo
+  has ≥50% overlap with a known sub, plus the full catalog inline.
+
 - **`gate decisions` verb — director-axis decision audit.**
   Surfaces the approve / deny / execute / complete / fail transitions
   an actor authored within a window. Decision-shaped sibling of

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -26,6 +26,13 @@ const ISSUES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'state',
   'format',
 ]);
+// `gate issues show <id>` mirrors `gate show <id>` for requests and
+// `agora show <id>` for plays. Read-only detail view: looks up one
+// issue by id, surfaces its full body + notes. --format text|json
+// matches `gate issues list` so a caller wiring a json pipeline can
+// drop in `show` next to `list` without flag rework. See
+// asymmetry-catchup landed in this PR for the gap this closes.
+const ISSUES_SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 const ISSUES_PROMOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
   'executor',
@@ -63,9 +70,10 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stderr.write(
       'gate issues needs a subcommand. common ones:\n' +
         '  gate issues list                  # what is open\n' +
+        '  gate issues show <id>             # full body + notes\n' +
         '  gate issues add --from <m> --severity <s> --area <a> --text <s>\n' +
         '  gate issues note <id> --by <m> --text <s>\n' +
-        '  full set: add|list|note|resolve|defer|start|reopen|promote ' +
+        '  full set: add|list|show|note|resolve|defer|start|reopen|promote ' +
         '(gate --help)\n',
     );
     return 1;
@@ -209,6 +217,55 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     }
     return 0;
   }
+  if (sub === 'show') {
+    rejectUnknownFlags(args, ISSUES_SHOW_KNOWN_FLAGS, 'issues show');
+    const id = args.positional[1];
+    if (!id) {
+      throw new Error(
+        'Usage: gate issues show <id> [--format text|json]',
+      );
+    }
+    const format = optionalOption(args, 'format') ?? 'text';
+    if (format !== 'text' && format !== 'json') {
+      throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+    }
+    const issue = await c.issueUC.find(id);
+    if (!issue) {
+      process.stderr.write(notFoundMessage('issue', id));
+      return 1;
+    }
+    const j = issue.toJSON();
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(j, null, 2) + '\n');
+      return 0;
+    }
+    // Text: full body without list-row truncation. Header line mirrors
+    // the list row format so a caller who eyeballed `issues list` and
+    // reached for `show` sees the same prefix shape, then the full
+    // text below as a body block. Notes follow with their full text
+    // (the list rendering already flattens notes inline; show keeps
+    // that shape for continuity).
+    const proxyTag = j['invoked_by'] ? ` [invoked_by=${j['invoked_by']}]` : '';
+    process.stdout.write(
+      `${j['id']} [${j['severity']}/${j['area']}] ${j['state']} from=${j['from']}${proxyTag}\n`,
+    );
+    process.stdout.write(`  created: ${j['created_at']}\n`);
+    process.stdout.write(`\n  ${String(j['text']).replace(/\n/g, '\n  ')}\n`);
+    const notes = Array.isArray(j['notes']) ? j['notes'] : [];
+    if (notes.length > 0) {
+      process.stdout.write(`\n  notes (${notes.length}):\n`);
+      for (const n of notes as Array<Record<string, unknown>>) {
+        const noteProxy = n['invoked_by']
+          ? ` [invoked_by=${n['invoked_by']}]`
+          : '';
+        process.stdout.write(
+          `    └ ${n['by']}${noteProxy} at ${n['at']}\n` +
+            `      ${String(n['text']).replace(/\n/g, '\n      ')}\n`,
+        );
+      }
+    }
+    return 0;
+  }
   // State transitions: resolve, defer, start, reopen.
   const nextState = resolveIssueVerb(sub);
   if (nextState !== undefined) {
@@ -224,7 +281,67 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(`✓ issue ${issue.id.value}: → ${nextState} by ${by}\n`);
     return 0;
   }
-  throw new Error(`unknown issues sub: ${sub}`);
+  // Unknown sub: suggest the closest match plus a gesture at the full
+  // catalog. The bare-list of valid subs is more useful than 'unknown
+  // sub: X' alone — without a hint a caller wired into muscle memory
+  // for `gate show <id>` reaches for `issues show` and bounces with
+  // no orientation. principle 09 (orientation-disclosure) applied to
+  // the error path.
+  const validSubs = [
+    'add', 'list', 'show', 'note',
+    'resolve', 'defer', 'start', 'reopen', 'promote',
+  ];
+  const suggestion = closestSub(sub, validSubs);
+  const hint = suggestion ? ` — did you mean 'gate issues ${suggestion}'?` : '';
+  throw new Error(
+    `unknown issues sub: ${sub}${hint}\n` +
+      `  valid: ${validSubs.join(' | ')}`,
+  );
+}
+
+// Levenshtein-ish closest-match: simple character-overlap heuristic
+// sufficient for short subcommand names. Returns the best candidate
+// when the input shares at least half its characters with one of the
+// valid subs; otherwise undefined so we don't suggest at random.
+function closestSub(input: string, valid: readonly string[]): string | undefined {
+  if (!input) return undefined;
+  const lower = input.toLowerCase();
+  let best: string | undefined;
+  let bestScore = 0;
+  for (const v of valid) {
+    const score = overlapScore(lower, v);
+    if (score > bestScore) {
+      bestScore = score;
+      best = v;
+    }
+  }
+  // Threshold: at least 50% character overlap with the candidate.
+  // Below this we'd be suggesting noise (e.g. `gate issues xyz` →
+  // 'add' is not helpful).
+  return bestScore >= Math.max(2, Math.ceil(input.length / 2)) ? best : undefined;
+}
+
+function overlapScore(a: string, b: string): number {
+  // Substring containment is the strongest signal — if the user
+  // typed a prefix of a valid sub, that's almost certainly what
+  // they meant. Otherwise count shared characters in order.
+  if (b.startsWith(a)) return a.length + 1; // boost prefix match
+  if (a.startsWith(b)) return b.length + 1;
+  let i = 0;
+  let j = 0;
+  let score = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      score += 1;
+      i += 1;
+      j += 1;
+    } else if (a.length - i > b.length - j) {
+      i += 1;
+    } else {
+      j += 1;
+    }
+  }
+  return score;
 }
 
 async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -339,13 +339,19 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   return 0;
 }
 
-// gate chain takes only positionals (id), no flags. Strict-reject keeps
-// noise like `--format json` from being silently ignored — chain is
-// text-only by design, and a typo should fail closed.
-const CHAIN_KNOWN_FLAGS: ReadonlySet<string> = new Set();
+// gate chain accepts --format text|json. Previously text-only by
+// design (strict-reject on --format kept noise out), but the asymmetry
+// vs every other read verb made `chain` an outlier — pipeline writers
+// branched their --format json composition around chain alone. This
+// PR makes chain symmetric with the rest of the read surface.
+const CHAIN_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, CHAIN_KNOWN_FLAGS, 'chain');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
   const rootId = args.positional[0];
   if (!rootId) {
     throw new Error('Usage: gate chain <request-id | issue-id>');
@@ -541,6 +547,97 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
       .filter((i) => !bidirIssueIds.has(i.id.value))
       .map((i) => ({ id: i.id.value, record: i, bidirectional: false }));
 
+  // Cross-passage resolution: agora play ids match the request id
+  // regex (both are YYYY-MM-DD-NNN[N]), so they come through as
+  // `linkedRequestIds` but miss the request store. Before rendering,
+  // probe the play repo for any "not found" id so we can label it
+  // as an agora play instead of leaving the reader with the
+  // unhelpful "(referenced but not found)" status. Only the ids that
+  // missed the request store are probed — issues have a distinct
+  // i- prefix and never collide with agora.
+  const unresolvedRequestIds = linkedRequestIds.filter(
+    (id) => !requestById.has(id),
+  );
+  type CrossPassageMatch = { gameSlug: string; state: string };
+  type CrossPassage = { passage: 'agora'; matches: CrossPassageMatch[] };
+  const crossPassageById = new Map<string, CrossPassage>();
+  for (const id of unresolvedRequestIds) {
+    const plays = await c.playRepo.findAllById(id);
+    if (plays.length > 0) {
+      const matches: CrossPassageMatch[] = plays.map((p) => {
+        const pj = p.toJSON() as Record<string, unknown>;
+        return {
+          gameSlug: String(pj['game'] ?? ''),
+          state: String(pj['state'] ?? ''),
+        };
+      });
+      crossPassageById.set(id, { passage: 'agora', matches });
+    }
+  }
+
+  // JSON rendering: a structured shape mirroring the four sections
+  // plus a `cross_passage` view of any ids resolved outside gate.
+  // Each item has {id, found, bidirectional, summary?} so the
+  // pipeline consumer sees the same content the text tree shows,
+  // minus the glyphs.
+  if (format === 'json') {
+    type JsonItem = {
+      id: string;
+      found: boolean;
+      bidirectional: boolean;
+      summary: Record<string, unknown> | null;
+      cross_passage: CrossPassage | null;
+    };
+    const toJsonItem = (
+      r: typeof linkedRequests[number] | typeof linkedIssues[number],
+      kind: 'request' | 'issue',
+    ): JsonItem => {
+      const xp = crossPassageById.get(r.id) ?? null;
+      let summary: Record<string, unknown> | null = null;
+      if (r.record) {
+        const j = r.record.toJSON() as Record<string, unknown>;
+        if (kind === 'issue') {
+          summary = {
+            severity: j['severity'],
+            area: j['area'],
+            state: j['state'],
+            text: j['text'],
+          };
+        } else {
+          summary = {
+            state: j['state'],
+            from: j['from'],
+            action: j['action'],
+          };
+        }
+      }
+      return {
+        id: r.id,
+        found: r.record !== undefined,
+        bidirectional: r.bidirectional,
+        summary,
+        cross_passage: xp,
+      };
+    };
+    const payload = {
+      root: {
+        id: rootId,
+        kind: isIssueId ? 'issue' : 'request',
+        header: rootHeader,
+      },
+      forward: {
+        issues: linkedIssues.map((i) => toJsonItem(i, 'issue')),
+        requests: linkedRequests.map((r) => toJsonItem(r, 'request')),
+      },
+      inbound: {
+        issues: inboundIssues.map((i) => toJsonItem(i, 'issue')),
+        requests: inboundRequests.map((r) => toJsonItem(r, 'request')),
+      },
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+
   process.stdout.write(`${rootHeader}\n`);
 
   // Assemble the four possible sections. Rendered only when non-empty;
@@ -602,9 +699,27 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
               `  ${truncateCodePoints(String(j['action'] ?? ''), 70)}`;
         process.stdout.write(`${childPrefix}${glyph} ${summary}\n`);
       } else {
-        process.stdout.write(
-          `${childPrefix}${glyph} ${bidirMark}${item.id}  (referenced but not found)\n`,
-        );
+        // Cross-passage hint: when an id misses the gate stores but
+        // resolves in agora, label it so the reader doesn't read
+        // 'not found' as a broken link. Only request-shaped ids
+        // collide with agora (issues carry the i- prefix).
+        const xp = section.kind === 'request' ? crossPassageById.get(item.id) : undefined;
+        if (xp) {
+          // Multi-match: each game has its own play-id sequence so the
+          // same id can resolve to plays in multiple games. Render all
+          // — the reader needs every candidate to disambiguate.
+          const labels = xp.matches
+            .map((m) => `game=${m.gameSlug}, ${m.state}`)
+            .join(' | ');
+          process.stdout.write(
+            `${childPrefix}${glyph} ${bidirMark}${item.id}  ` +
+              `→ agora play (${labels})\n`,
+          );
+        } else {
+          process.stdout.write(
+            `${childPrefix}${glyph} ${bidirMark}${item.id}  (referenced but not found)\n`,
+          );
+        }
       }
     }
   }

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1231,10 +1231,13 @@ const VERBS: readonly VerbSchema[] = [
     name: 'chain',
     category: 'read',
     summary:
-      'walk cross-references one hop in both directions (forward: ids the root mentions; inbound: records that mention the root)',
+      'walk cross-references one hop in both directions (forward: ids the root mentions; inbound: records that mention the root). Cross-passage: request-shaped ids that miss the gate store are probed against the agora play store and labelled when found.',
     input: {
       type: 'object',
-      properties: { id: idStr },
+      properties: {
+        id: idStr,
+        format: formatField,
+      },
       required: ['id'],
     },
     output: { type: 'object' },
@@ -1682,15 +1685,16 @@ const VERBS: readonly VerbSchema[] = [
   {
     name: 'issues',
     category: 'write',
-    summary: 'subcommands: add|list|note|resolve|defer|start|reopen|promote',
+    summary: 'subcommands: add|list|show|note|resolve|defer|start|reopen|promote',
     input: {
       type: 'object',
       properties: {
         subcommand: {
           type: 'string',
-          enum: ['add', 'list', 'note', 'resolve', 'defer', 'start', 'reopen', 'promote'],
+          enum: ['add', 'list', 'show', 'note', 'resolve', 'defer', 'start', 'reopen', 'promote'],
           description:
-            "`note` appends an annotation without mutating severity/area/text — the issue record is otherwise immutable.",
+            "`note` appends an annotation without mutating severity/area/text — the issue record is otherwise immutable. " +
+            "`show <id>` is the per-id reader, sibling of `gate show <id>` / `agora show <id>` — full body + nested notes.",
         },
         state: {
           type: 'string',
@@ -1705,7 +1709,7 @@ const VERBS: readonly VerbSchema[] = [
           type: 'string',
           enum: ['text', 'json'],
           description:
-            "`list` only. text (default) flattens notes for human reading; " +
+            "`list` and `show`. text (default) flattens notes for human reading; " +
             'json keeps notes nested per issue.',
         },
         note: strOpt(

--- a/tests/interface/chainFormatAndCrossPassage.test.ts
+++ b/tests/interface/chainFormatAndCrossPassage.test.ts
@@ -1,0 +1,155 @@
+// gate chain — read-verb symmetry catchup:
+//   (1) --format text|json (previously rejected --format outright)
+//   (2) cross-passage: request-shaped ids resolving to agora plays
+//       no longer render as "referenced but not found"; they label
+//       the agora play instead.
+//
+// Surfaces this test pins:
+//   - --format json emits the structured payload
+//   - --format text remains the default
+//   - an agora play id referenced from a request resolves to the
+//     play (game + state) in both formats
+//   - multi-game match: same play id in two games surfaces both
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+const AGORA = resolve(here, '../../../bin/agora.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-chain-xpass-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    `name: alice\ncategory: professional\nactive: true\n`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runBin(
+  bin: string,
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [bin, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function seedAgoraPlay(root: string, slug: string, title: string): string {
+  // Create game then play. Returns the play id (today + 001 for a
+  // fresh content_root scoped to this slug).
+  runBin(AGORA, root, [
+    'new', '--slug', slug, '--kind', 'sandbox',
+    '--title', title, '--by', 'eris',
+  ]);
+  runBin(AGORA, root, [
+    'play', '--slug', slug, '--by', 'eris',
+  ]);
+  const today = new Date().toISOString().slice(0, 10);
+  return `${today}-001`;
+}
+
+function seedGateRequestMentioning(root: string, mentionId: string): string {
+  // Fast-track a request whose reason text mentions the given id.
+  // Chain's extractor pulls the request-id-shaped substring out of
+  // free text — this is what real cross-passage references look like.
+  runBin(GATE, root, [
+    'fast-track',
+    '--from', 'eris',
+    '--action', 'cross-passage smoke',
+    '--reason', `see agora play ${mentionId} for the deliberation`,
+    '--executors', 'alice',
+  ]);
+  const today = new Date().toISOString().slice(0, 10);
+  return `${today}-0001`;
+}
+
+test('gate chain <id> --format text remains the default tree render', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const playId = seedAgoraPlay(root, 'a-game', 'a game');
+  const reqId = seedGateRequestMentioning(root, playId);
+  const r = runBin(GATE, root, ['chain', reqId]);
+  assert.equal(r.status, 0);
+  // Tree characters present.
+  assert.match(r.stdout, /referenced requests/);
+  assert.match(r.stdout, new RegExp(playId));
+  // The agora play id should label as a cross-passage hit instead of
+  // bare "referenced but not found".
+  assert.match(r.stdout, /agora play \(game=a-game/);
+  assert.doesNotMatch(r.stdout, /referenced but not found/);
+});
+
+test('gate chain <id> --format json emits the structured payload', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const playId = seedAgoraPlay(root, 'b-game', 'b game');
+  const reqId = seedGateRequestMentioning(root, playId);
+  const r = runBin(GATE, root, ['chain', reqId, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.root.id, reqId);
+  assert.equal(payload.root.kind, 'request');
+  // Forward request section has the agora-resolved id.
+  const fwd = payload.forward.requests;
+  assert.ok(Array.isArray(fwd));
+  assert.equal(fwd.length, 1);
+  assert.equal(fwd[0].id, playId);
+  assert.equal(fwd[0].found, false); // not found in gate request store
+  // Cross-passage marker present and well-shaped.
+  assert.ok(fwd[0].cross_passage);
+  assert.equal(fwd[0].cross_passage.passage, 'agora');
+  assert.equal(fwd[0].cross_passage.matches.length, 1);
+  assert.equal(fwd[0].cross_passage.matches[0].gameSlug, 'b-game');
+});
+
+test('gate chain --format unknown is rejected with a clear error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const playId = seedAgoraPlay(root, 'c-game', 'c game');
+  const reqId = seedGateRequestMentioning(root, playId);
+  const r = runBin(GATE, root, ['chain', reqId, '--format', 'yaml']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+});
+
+test('agora play id present in multiple games surfaces every match', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Two games created on the same day, each plays starts at -001 in
+  // its own per-game sequence space. So both end up with the same
+  // play id but different game slugs.
+  const playId = seedAgoraPlay(root, 'd-game', 'd game');
+  const playId2 = seedAgoraPlay(root, 'e-game', 'e game');
+  assert.equal(playId, playId2, 'sanity: per-game seq starts at 001 so ids collide');
+  const reqId = seedGateRequestMentioning(root, playId);
+  const r = runBin(GATE, root, ['chain', reqId, '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  const matches = payload.forward.requests[0].cross_passage.matches;
+  assert.equal(matches.length, 2);
+  const slugs = matches.map((m: { gameSlug: string }) => m.gameSlug).sort();
+  assert.deepEqual(slugs, ['d-game', 'e-game']);
+});

--- a/tests/interface/issuesListSurface.test.ts
+++ b/tests/interface/issuesListSurface.test.ts
@@ -99,7 +99,7 @@ test('gate issues (no subcommand) emits a hint + exit 1', (t) => {
   assert.match(r.stderr, /gate issues add/);
   assert.match(r.stderr, /gate issues note/);
   // Gestures at the full catalog without listing it inline.
-  assert.match(r.stderr, /add\|list\|note\|resolve\|defer\|start\|reopen\|promote/);
+  assert.match(r.stderr, /add\|list\|show\|note\|resolve\|defer\|start\|reopen\|promote/);
 });
 
 test('gate issues list (default) emits a stderr hint disclosing the open-only filter', (t) => {

--- a/tests/interface/issuesShowSurface.test.ts
+++ b/tests/interface/issuesShowSurface.test.ts
@@ -1,0 +1,176 @@
+// gate issues show — per-id reader, sibling of `gate show <id>` and
+// `agora show <id>`.
+//
+// Surfaces this test pins:
+//   - text format: full body + notes block, no list-row truncation
+//   - json format: full toJSON() of the issue
+//   - not-found id: helpful stderr + exit 1
+//   - unknown sub: closest-match suggestion in the error
+//
+// Why this exists: `gate issues` had list/add/note/transition subs but
+// no per-id reader. Callers wired into muscle memory for `gate show <id>`
+// reached for `gate issues show <id>` and bounced with no orientation.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-issues-show-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    `name: alice\ncategory: professional\nactive: true\n`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function seedOneIssue(root: string, text: string): string {
+  runGate(
+    root,
+    [
+      'issues', 'add',
+      '--from', 'alice',
+      '--severity', 'med',
+      '--area', 'docs',
+      '--text', text,
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const today = new Date().toISOString().slice(0, 10);
+  return `i-${today}-0001`;
+}
+
+test('gate issues show <id> renders the full body and notes in text', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Use multi-line text so the body block (not just the list row)
+  // is observable. A list-row render would truncate or single-line
+  // collapse; show should print the body as-is.
+  const longText = 'first line\nsecond line\nthird line';
+  const id = seedOneIssue(root, longText);
+  runGate(
+    root,
+    ['issues', 'note', id, '--by', 'alice', '--text', 'observed-later'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(root, ['issues', 'show', id], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  // Header line with severity/area/state matches list-row prefix shape.
+  assert.match(r.stdout, /i-.* \[med\/docs\] open from=alice/);
+  // Body lines all present, on separate lines (no collapse).
+  assert.match(r.stdout, /first line/);
+  assert.match(r.stdout, /second line/);
+  assert.match(r.stdout, /third line/);
+  // Notes block surfaces with the note text.
+  assert.match(r.stdout, /notes \(1\):/);
+  assert.match(r.stdout, /alice/);
+  assert.match(r.stdout, /observed-later/);
+});
+
+test('gate issues show <id> --format json returns the full issue toJSON', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const id = seedOneIssue(root, 'first observation');
+  runGate(
+    root,
+    ['issues', 'note', id, '--by', 'alice', '--text', 'second observation'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  const r = runGate(
+    root,
+    ['issues', 'show', id, '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const j = JSON.parse(r.stdout);
+  assert.equal(j.id, id);
+  assert.equal(j.severity, 'med');
+  assert.equal(j.area, 'docs');
+  assert.equal(j.state, 'open');
+  assert.equal(j.from, 'alice');
+  assert.equal(j.text, 'first observation');
+  assert.ok(Array.isArray(j.notes));
+  assert.equal(j.notes.length, 1);
+  assert.equal(j.notes[0].text, 'second observation');
+  // created_at is a runtime field; just ensure it is present and string.
+  assert.equal(typeof j.created_at, 'string');
+});
+
+test('gate issues show <missing-id> returns a not-found stderr and exit 1', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const today = new Date().toISOString().slice(0, 10);
+  const missingId = `i-${today}-9999`;
+  const r = runGate(
+    root,
+    ['issues', 'show', missingId],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.notEqual(r.status, 0);
+  // notFoundHint shape: mentions the kind (issue) and the missing id.
+  assert.match(r.stderr, /issue/);
+  assert.match(r.stderr, new RegExp(missingId));
+});
+
+test('gate issues show without an id emits a usage error and exit 1', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['issues', 'show'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Usage: gate issues show/);
+});
+
+test('gate issues <typo> suggests the closest valid sub', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // `sho` is a prefix of `show` — closest-sub should fire.
+  const r = runGate(root, ['issues', 'sho'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown issues sub: sho/);
+  assert.match(r.stderr, /did you mean 'gate issues show'/);
+  // The error also gestures at the full set.
+  assert.match(r.stderr, /add \| list \| show \| note/);
+});
+
+test('gate issues <noise> falls back to listing valid subs without a wrong suggestion', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // `xyzzy` shares no meaningful overlap with any sub. The error
+  // should list the catalog but NOT fabricate a "did you mean" hint.
+  const r = runGate(root, ['issues', 'xyzzy'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown issues sub: xyzzy/);
+  assert.doesNotMatch(r.stderr, /did you mean/);
+  assert.match(r.stderr, /add \| list \| show \| note/);
+});


### PR DESCRIPTION
## Summary

Four small UX gaps in the read surface, fixed together. They share the same flavor of asymmetry — `gate issues` and `gate chain` were missing affordances every other read verb has.

- **`gate issues show <id>`** — per-id reader. Sibling of `gate show <id>` (request) and `agora show <id>` (play). `--format text|json`.
- **`gate chain --format text|json`** — chain was the only read verb rejecting `--format` outright. Now symmetric. JSON shape: `{root, forward:{issues,requests}, inbound:{issues,requests}}` with per-item `cross_passage`.
- **Cross-passage chain resolution (gate → agora)** — request-shaped ids that miss the gate store are now probed against the agora play store. Found plays render as `→ agora play (game=<slug>, <state>)` instead of bare `(referenced but not found)`. Multi-game match surfaces every candidate.
- **`gate issues <unknown-sub>` suggests the closest sub** — `gate issues sho` → `did you mean 'gate issues show'?` plus the full catalog inline. Principle 09 (orientation-disclosure) applied to the error path.

Plus `/issues/` and `/agora/` added to `.gitignore` parallel to the existing `/requests/` — same rationale (actor names + free-form session content in the dogfooder's substrate should not be republished); same root-anchoring so `examples/*/{issues,agora}/` fixtures stay tracked.

## Why now

These came out of a 2nd-touch dogfood session that surfaced friction by *using* the substrate twice (filed via agora play `eris-portability-2026-05-12/2026-05-12-001` and `second-touch-2026-05-12/2026-05-12-001`, observation pinned at issue `i-2026-05-12-0001`). The pattern named: 1→2 round of touching the same verb surfaces audience-awareness, friction-as-teacher, substrate-as-space, and motive-mediation shifts — and along the way exposes asymmetries that read-once would miss.

## Test plan

- [ ] `npm run build && npm test` — all 1638 / 1638 pass (10 new tests in `issuesShowSurface` + `chainFormatAndCrossPassage`)
- [ ] Manual smoke: `gate issues show <id>` text + json; `gate issues sho` produces `did you mean` hint
- [ ] Manual smoke: `gate chain <request-id-referencing-agora-play-id> --format json` shows the play under `cross_passage.matches[]`
- [ ] Re-verify: examples/*/issues + examples/*/agora fixtures are still tracked (root-anchor preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)