### PR TITLE
feat(gate): lore verb — package-shipped doctrine reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate lore` verb — package-shipped doctrine reader.**
+  Lets agents browse principles and traps from inside the substrate
+  without needing to know the `lore/` directory layout. Subcommands:
+  `list` (with `--type`, `--applies-to`, `--relevant-until` filters)
+  and `show <name>` (full markdown body, or `--format json` for the
+  structured entry). Reads `<packageRoot>/lore/principles/*.md` and
+  `<packageRoot>/lore/traps/*.md`; no per-content_root tier (lore is
+  authored via PR, not by a CLI write). The `--applies-to` filter
+  matches `applies_to:` frontmatter on principles; entries without an
+  explicit scope are universal (`all`) and surface regardless. The
+  `--relevant-until` filter classifies trap frontmatter as `current`
+  (indefinite or future-dated), `expired` (past-dated), or
+  `indefinite` (literal only).
+
 - **`gate issues show <id>` — per-id issue reader.** Sibling of
   `gate show <id>` (request) and `agora show <id>` (play); closes the
   asymmetry where `issues` had list/add/note/transition but no per-id

--- a/src/application/lore/LoreUseCases.ts
+++ b/src/application/lore/LoreUseCases.ts
@@ -1,0 +1,76 @@
+// Lore use cases — domain-level read API for package-shipped lore.
+//
+// Lore is read-only from the AI agent's perspective. There is no
+// write surface (lore is authored by editing markdown files and
+// shipping a PR, not by a CLI verb). Use cases here filter and
+// project parsed entries.
+
+import { LoreEntry, LoreRepository, LoreType } from '../../infrastructure/lore/LoreRepository.js';
+
+export interface LoreFilter {
+  readonly type?: LoreType;
+  /**
+   * For principles: filter by `applies_to` frontmatter. `all` (the
+   * default scope for principles without an explicit `applies_to`)
+   * is treated as universal — it surfaces regardless of the filter
+   * value. This matches the `tools/lore-scope.sh` semantics.
+   */
+  readonly appliesTo?: string;
+  /**
+   * For traps: filter by `relevant_until` frontmatter.
+   *   - `current`:    `indefinite` OR a future date
+   *   - `expired`:    a past date
+   *   - `indefinite`: literal `indefinite` only
+   */
+  readonly relevantUntil?: 'current' | 'expired' | 'indefinite';
+}
+
+export class LoreUseCases {
+  constructor(private readonly repo: LoreRepository) {}
+
+  get available(): boolean {
+    return this.repo.available;
+  }
+
+  get baseDir(): string | null {
+    return this.repo.baseDir;
+  }
+
+  /** All entries, filtered. Sorted by name (stable across calls). */
+  list(filter: LoreFilter = {}): LoreEntry[] {
+    const all = this.repo.listAll();
+    return all.filter((e) => matchesFilter(e, filter));
+  }
+
+  /** Lookup by exact name. Returns null when missing. */
+  find(name: string): LoreEntry | null {
+    return this.repo.find(name);
+  }
+}
+
+function matchesFilter(entry: LoreEntry, filter: LoreFilter): boolean {
+  if (filter.type !== undefined && entry.type !== filter.type) return false;
+  if (filter.appliesTo !== undefined && entry.type === 'principle') {
+    // Default scope is `all` — entries without an explicit
+    // `applies_to` are universal and match every filter value.
+    const declared = entry.frontmatter['applies_to'] ?? 'all';
+    if (declared !== 'all' && declared !== filter.appliesTo) return false;
+  }
+  if (filter.relevantUntil !== undefined && entry.type === 'trap') {
+    const v = entry.frontmatter['relevant_until'] ?? '';
+    if (filter.relevantUntil === 'indefinite') {
+      if (v !== 'indefinite') return false;
+    } else {
+      const isIndef = v === 'indefinite';
+      const parsed = isIndef ? null : Date.parse(v);
+      const isFuture = parsed !== null && !Number.isNaN(parsed) && parsed >= Date.now();
+      const isPast = parsed !== null && !Number.isNaN(parsed) && parsed < Date.now();
+      if (filter.relevantUntil === 'current') {
+        if (!isIndef && !isFuture) return false;
+      } else if (filter.relevantUntil === 'expired') {
+        if (!isPast) return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/infrastructure/lore/LoreRepository.ts
+++ b/src/infrastructure/lore/LoreRepository.ts
@@ -1,0 +1,166 @@
+// Filesystem-backed lore reader.
+//
+// Lore lives at `<packageRoot>/lore/principles/*.md` and
+// `<packageRoot>/lore/traps/*.md`. There is no per-content_root tier
+// for lore — principles and traps are package-shipped doctrine, not
+// substrate state.
+//
+// Each markdown file carries:
+//   - optional YAML frontmatter (`---\n<key>: <value>\n---\n`)
+//   - a body whose first `# <title>` line we expose as a summary header
+//
+// Frontmatter keys we recognize:
+//   - principles: `applies_to` (default: `all`)
+//   - traps:      `relevant_until` (string: `indefinite` or ISO date)
+//
+// All other frontmatter keys are preserved opaquely on the parsed
+// entry so callers can read them without this module growing a known-
+// keys allowlist.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type LoreType = 'principle' | 'trap';
+
+export interface LoreEntry {
+  readonly type: LoreType;
+  /** filename without `.md` extension, e.g. `11-ai-first-human-as-projection`. */
+  readonly name: string;
+  /** absolute path to the source file. */
+  readonly path: string;
+  /** first `# <title>` line, or null when the file has no H1. */
+  readonly title: string | null;
+  /** parsed frontmatter as a plain key→value record (string values only). */
+  readonly frontmatter: Readonly<Record<string, string>>;
+  /** markdown body without the frontmatter block. */
+  readonly body: string;
+}
+
+export interface LoreRepository {
+  /** True iff the underlying lore directories resolved at construction. */
+  readonly available: boolean;
+  /** Absolute path the repo resolved (null when nothing was found). */
+  readonly baseDir: string | null;
+  /** Every lore entry, sorted by `name`. Empty array when unavailable. */
+  listAll(): LoreEntry[];
+  /** Lookup by exact `name`. Returns null when no such file exists. */
+  find(name: string): LoreEntry | null;
+}
+
+/**
+ * Resolve `<packageRoot>/lore/` from the runtime file path. The
+ * candidate list mirrors `resolveBuiltinTemplatesDir` so the same
+ * dev / prod / jest path shapes are covered:
+ *   - `<root>/dist/src/infrastructure/lore/`  (production via bin/)
+ *   - `<root>/src/infrastructure/lore/`        (jest ts-source tests)
+ */
+export function resolveLoreBaseDir(): string | null {
+  const here = fileURLToPath(import.meta.url);
+  const candidates = [
+    join(here, '..', '..', '..', '..', '..', 'lore'),
+    join(here, '..', '..', '..', '..', 'lore'),
+  ];
+  for (const c of candidates) {
+    try {
+      if (existsSync(c) && statSync(c).isDirectory()) return c;
+    } catch {
+      // ignore — try next
+    }
+  }
+  return null;
+}
+
+export class FsLoreRepository implements LoreRepository {
+  readonly available: boolean;
+  readonly baseDir: string | null;
+  // Lazy cache: list() and find() share the same parse pass. Lore is
+  // small (<50 files) and read-only at this layer, so a single in-
+  // process scan is fine.
+  private cached: LoreEntry[] | null = null;
+
+  constructor(baseDir: string | null) {
+    this.baseDir = baseDir;
+    this.available = baseDir !== null && existsSync(baseDir);
+  }
+
+  listAll(): LoreEntry[] {
+    if (!this.available || this.baseDir === null) return [];
+    if (this.cached !== null) return this.cached;
+    const entries: LoreEntry[] = [];
+    for (const sub of ['principles', 'traps'] as const) {
+      const dir = join(this.baseDir, sub);
+      if (!existsSync(dir)) continue;
+      const type: LoreType = sub === 'principles' ? 'principle' : 'trap';
+      for (const f of readdirSync(dir)) {
+        if (!f.endsWith('.md')) continue;
+        if (f === 'README.md') continue; // index, not a lore entry
+        const path = join(dir, f);
+        const name = f.replace(/\.md$/, '');
+        const raw = readFileSync(path, 'utf8');
+        const parsed = parseMarkdown(raw);
+        entries.push({
+          type,
+          name,
+          path,
+          title: parsed.title,
+          frontmatter: parsed.frontmatter,
+          body: parsed.body,
+        });
+      }
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    this.cached = entries;
+    return entries;
+  }
+
+  find(name: string): LoreEntry | null {
+    for (const e of this.listAll()) {
+      if (e.name === name) return e;
+    }
+    return null;
+  }
+}
+
+interface ParsedMarkdown {
+  readonly frontmatter: Readonly<Record<string, string>>;
+  readonly title: string | null;
+  readonly body: string;
+}
+
+/**
+ * Minimal frontmatter parser. Supports `---\nkey: value\n---\n` at
+ * the file head. Values are string-only (no nesting, no arrays).
+ * Anything more complex falls through to the body unparsed — by
+ * design, lore frontmatter is intentionally trivial.
+ */
+function parseMarkdown(raw: string): ParsedMarkdown {
+  let body = raw;
+  const frontmatter: Record<string, string> = {};
+  if (raw.startsWith('---\n')) {
+    const end = raw.indexOf('\n---\n', 4);
+    if (end !== -1) {
+      const fm = raw.slice(4, end);
+      body = raw.slice(end + 5);
+      for (const line of fm.split('\n')) {
+        const idx = line.indexOf(':');
+        if (idx === -1) continue;
+        const key = line.slice(0, idx).trim();
+        const value = line.slice(idx + 1).trim();
+        if (key) frontmatter[key] = value;
+      }
+    }
+  }
+  // First `# <title>` line, scanning only the first 20 lines so we
+  // don't accidentally pick up an H1 deep inside a long file.
+  let title: string | null = null;
+  const lines = body.split('\n').slice(0, 20);
+  for (const l of lines) {
+    const m = l.match(/^#\s+(.+)$/);
+    if (m) {
+      title = m[1]!.trim();
+      break;
+    }
+  }
+  return { frontmatter, title, body };
+}

--- a/src/infrastructure/lore/LoreRepository.ts
+++ b/src/infrastructure/lore/LoreRepository.ts
@@ -135,6 +135,14 @@ interface ParsedMarkdown {
  * design, lore frontmatter is intentionally trivial.
  */
 function parseMarkdown(raw: string): ParsedMarkdown {
+  // Normalize line endings before any structural parsing. Files
+  // checked out on Windows with `core.autocrlf=true` arrive as CRLF;
+  // the frontmatter delimiter is matched as the literal `---\n`,
+  // and `body.split('\n')` leaves trailing `\r` on every line which
+  // confuses substring math even when individual regex tolerates it.
+  // Stripping CRs once at the top makes every downstream check
+  // platform-agnostic.
+  raw = raw.replace(/\r\n/g, '\n');
   let body = raw;
   const frontmatter: Record<string, string> = {};
   if (raw.startsWith('---\n')) {

--- a/src/interface/gate/handlers/lore.ts
+++ b/src/interface/gate/handlers/lore.ts
@@ -1,0 +1,184 @@
+// `gate lore` — package-shipped doctrine reader.
+//
+// Two read subverbs:
+//   - `gate lore list [--type] [--applies-to] [--relevant-until]`
+//   - `gate lore show <name> [--format text|json]`
+//
+// Lore lives under `<packageRoot>/lore/principles/*.md` and
+// `<packageRoot>/lore/traps/*.md`. The verb is read-only — lore is
+// authored by editing markdown + shipping a PR, not by a CLI write.
+//
+// Why a verb when `cat lore/principles/X.md` works: discoverability
+// from inside the substrate (no need to know the lore/ layout),
+// frontmatter-aware filtering (applies_to, relevant_until), JSON
+// output for orchestrators, and a single entry point for "what
+// doctrine is live right now."
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { LoreType } from '../../../infrastructure/lore/LoreRepository.js';
+import { C, truncateCodePoints } from './internal.js';
+
+const LORE_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'type',
+  'applies-to',
+  'relevant-until',
+  'format',
+]);
+const LORE_SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+export async function loreCmd(c: C, args: ParsedArgs): Promise<number> {
+  const sub = args.positional[0];
+  if (sub === undefined) {
+    process.stderr.write(
+      'gate lore needs a subcommand:\n' +
+        '  gate lore list                          # every principle + trap\n' +
+        '  gate lore list --type principle         # principles only\n' +
+        '  gate lore list --applies-to swarm       # principles for swarm profile\n' +
+        '  gate lore list --relevant-until current # active traps\n' +
+        '  gate lore show <name>                   # full body\n',
+    );
+    return 1;
+  }
+  if (!c.loreUC.available) {
+    process.stderr.write(
+      `gate lore: lore directory not found (looked under packageRoot/lore/).\n` +
+        `  This usually means the guild-cli install is incomplete; reinstall ` +
+        `or run from a checkout that has lore/ in place.\n`,
+    );
+    return 1;
+  }
+  if (sub === 'list') return loreList(c, args);
+  if (sub === 'show') return loreShow(c, args);
+  process.stderr.write(
+    `unknown subcommand: gate lore ${sub}\n` +
+      `  valid: list | show\n`,
+  );
+  return 1;
+}
+
+function loreList(c: C, args: ParsedArgs): number {
+  rejectUnknownFlags(args, LORE_LIST_KNOWN_FLAGS, 'lore list');
+  const typeRaw = optionalOption(args, 'type');
+  const appliesTo = optionalOption(args, 'applies-to');
+  const relevantUntilRaw = optionalOption(args, 'relevant-until');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  let type: LoreType | undefined;
+  if (typeRaw !== undefined) {
+    if (typeRaw !== 'principle' && typeRaw !== 'trap') {
+      throw new Error(
+        `--type must be 'principle' or 'trap', got: ${typeRaw}`,
+      );
+    }
+    type = typeRaw;
+  }
+  let relevantUntil: 'current' | 'expired' | 'indefinite' | undefined;
+  if (relevantUntilRaw !== undefined) {
+    if (
+      relevantUntilRaw !== 'current' &&
+      relevantUntilRaw !== 'expired' &&
+      relevantUntilRaw !== 'indefinite'
+    ) {
+      throw new Error(
+        `--relevant-until must be 'current', 'expired', or 'indefinite', ` +
+          `got: ${relevantUntilRaw}`,
+      );
+    }
+    relevantUntil = relevantUntilRaw;
+  }
+  const filter = {
+    ...(type !== undefined ? { type } : {}),
+    ...(appliesTo !== undefined ? { appliesTo } : {}),
+    ...(relevantUntil !== undefined ? { relevantUntil } : {}),
+  };
+  const items = c.loreUC.list(filter);
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        items.map((e) => ({
+          name: e.name,
+          type: e.type,
+          title: e.title,
+          frontmatter: e.frontmatter,
+        })),
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+  if (items.length === 0) {
+    process.stdout.write(
+      `(no lore entries match the filter; try a wider --type / --applies-to / --relevant-until)\n`,
+    );
+    return 0;
+  }
+  for (const e of items) {
+    const tag =
+      e.type === 'principle'
+        ? `[principle${
+            e.frontmatter['applies_to']
+              ? `/${e.frontmatter['applies_to']}`
+              : ''
+          }]`
+        : `[trap/${e.frontmatter['relevant_until'] ?? '?'}]`;
+    const title = e.title ?? '(no title)';
+    process.stdout.write(
+      `${e.name}  ${tag}  ${truncateCodePoints(title, 60)}\n`,
+    );
+  }
+  return 0;
+}
+
+function loreShow(c: C, args: ParsedArgs): number {
+  rejectUnknownFlags(args, LORE_SHOW_KNOWN_FLAGS, 'lore show');
+  const name = args.positional[1];
+  if (!name) {
+    throw new Error(
+      'Usage: gate lore show <name> [--format text|json]',
+    );
+  }
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const entry = c.loreUC.find(name);
+  if (!entry) {
+    // Custom not-found message — `notFoundMessage` ships with a typed
+    // entity enum (request|issue|member) we don't want to widen for
+    // one verb. Hint shape: name what's missing + how to discover.
+    process.stderr.write(
+      `lore entry not found: ${name}\n` +
+        `  next: gate lore list  # see every available principle / trap\n`,
+    );
+    return 1;
+  }
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          name: entry.name,
+          type: entry.type,
+          title: entry.title,
+          frontmatter: entry.frontmatter,
+          body: entry.body,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+  // Text: print body verbatim. Lore files are markdown; the source
+  // is already human-readable. Adding a header here would duplicate
+  // the H1 already in the body — let the file speak for itself.
+  process.stdout.write(entry.body);
+  if (!entry.body.endsWith('\n')) process.stdout.write('\n');
+  return 0;
+}

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1436,6 +1436,38 @@ const VERBS: readonly VerbSchema[] = [
     output: { type: 'object' },
   },
   {
+    name: 'lore',
+    category: 'read',
+    summary:
+      'package-shipped doctrine reader. Subcommands: list (catalogue + frontmatter-aware filters), show <name> (full markdown body). Reads <packageRoot>/lore/principles/*.md and <packageRoot>/lore/traps/*.md; no per-content_root tier. Lets agents touch doctrine from inside the substrate without needing to know the lore/ layout.',
+    input: {
+      type: 'object',
+      properties: {
+        subcommand: {
+          type: 'string',
+          enum: ['list', 'show'],
+        },
+        name: strOpt('lore entry name (positional, `show` only); filename without `.md` (e.g. `11-ai-first-human-as-projection`, `trap_doc_coverage_drift_post_ship`)'),
+        type: {
+          type: 'string',
+          enum: ['principle', 'trap'],
+          description: "`list` filter — narrow to one kind of entry.",
+        },
+        'applies-to': strOpt(
+          "`list` filter for principles — match `applies_to:` frontmatter (e.g. `swarm`). Entries without an explicit `applies_to` are treated as universal (`all`) and surface regardless of the filter value.",
+        ),
+        'relevant-until': {
+          type: 'string',
+          enum: ['current', 'expired', 'indefinite'],
+          description:
+            "`list` filter for traps — `current` keeps indefinite + future-dated, `expired` keeps past-dated, `indefinite` keeps only literally `indefinite`.",
+        },
+        format: formatField,
+      },
+    },
+    output: { type: 'object' },
+  },
+  {
     name: 'approve',
     category: 'write',
     summary:

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -491,6 +491,19 @@ const SECTIONS: readonly Section[] = [
           '  gate templates list [--format json|text]\n' +
           '  gate templates show <name> [--format json|text]',
       },
+      {
+        tier: 'extra',
+        text:
+          '  gate lore list [--type principle|trap] [--applies-to <scope>]\n' +
+          '                 [--relevant-until current|expired|indefinite]\n' +
+          '                 [--format json|text]\n' +
+          '  gate lore show <name> [--format json|text]\n' +
+          '                       Package-shipped doctrine reader. Reads\n' +
+          '                       lore/principles/*.md and lore/traps/*.md and\n' +
+          '                       lets agents browse principles + traps from\n' +
+          '                       inside the substrate. <name> is the filename\n' +
+          '                       without .md (e.g. 11-ai-first-human-as-projection).',
+      },
     ],
   },
   {

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -58,6 +58,7 @@ import { summarizeCmd } from './handlers/summarize.js';
 import { whyCmd } from './handlers/why.js';
 import { unrespondedCmd } from './handlers/unresponded.js';
 import { templatesCmd } from './handlers/templates.js';
+import { loreCmd } from './handlers/lore.js';
 import { withEntryLock } from '../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
@@ -316,6 +317,8 @@ async function dispatch(
       return await unrespondedCmd(c, args);
     case 'templates':
       return await templatesCmd(c, args);
+    case 'lore':
+      return await loreCmd(c, args);
     default: {
       // Verb plugin dispatch (#36 Phase 1 step 4). Built-in cases
       // run first (the switch above); plugins are the fall-through

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -38,6 +38,7 @@ export const READ_VERBS: ReadonlySet<string> = new Set([
   'schema',
   'unresponded',
   'templates',
+  'lore',
   'lense-stats',
   'wave-status',
   'review-context',

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -25,6 +25,11 @@ import {
   resolveBuiltinTemplatesDir,
 } from '../../infrastructure/template/TemplateRepository.js';
 import { TemplateUseCases } from '../../application/template/TemplateUseCases.js';
+import {
+  FsLoreRepository,
+  resolveLoreBaseDir,
+} from '../../infrastructure/lore/LoreRepository.js';
+import { LoreUseCases } from '../../application/lore/LoreUseCases.js';
 import { YamlSessionEventRepository } from '../../infrastructure/persistence/YamlSessionEventRepository.js';
 import { SessionEventUseCases } from '../../application/session/SessionEventUseCases.js';
 import {
@@ -62,6 +67,14 @@ export interface Container {
    *                    guild-cli (resolved relative to this module).
    */
   templateUC: TemplateUseCases;
+  /**
+   * Package-shipped lore reader (`gate lore` verb). Resolves
+   * `<packageRoot>/lore/principles/*.md` + `<packageRoot>/lore/traps/*.md`
+   * at construction. `available` flips false when the directory cannot
+   * be located (e.g. an incomplete install), which the handler surfaces
+   * as a structured error instead of an empty list.
+   */
+  loreUC: LoreUseCases;
   /**
    * Session-boundary events (`gate rest` / `gate wake` /
    * `gate farewell`, #36 Phase 2). Phase 2's first slice ships
@@ -224,6 +237,7 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
         config.onMalformed,
       ),
     ),
+    loreUC: new LoreUseCases(new FsLoreRepository(resolveLoreBaseDir())),
     sessionEventUC: new SessionEventUseCases({
       events: new YamlSessionEventRepository(config),
       members,

--- a/tests/interface/loreSurface.test.ts
+++ b/tests/interface/loreSurface.test.ts
@@ -1,0 +1,235 @@
+// gate lore — package-shipped doctrine reader.
+//
+// Surfaces this test pins:
+//   - `lore list` returns every principle + trap as a flat list
+//   - `--type principle|trap` narrows the listing
+//   - `--applies-to <scope>` filters principles; universal entries
+//     (no explicit applies_to) surface regardless of the filter
+//   - `--relevant-until current|expired|indefinite` filters traps
+//   - `--format json` emits structured array + per-entry frontmatter
+//   - `lore show <name>` returns the markdown body (or full json)
+//   - bare `gate lore` prints a usage hint and exits 1
+//   - unknown subcommand prints a hint and exits 1
+//   - non-existent name returns 'not found' + a discovery hint
+//
+// The repo ships real lore/principles/*.md and lore/traps/*.md, so
+// these tests run against the actual doctrine — no fixture seeding.
+// They assert on stable structural properties (entry counts >= 1,
+// known filenames present, principle 11 body has its H1) rather
+// than on counts that would drift each time a principle ships.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  // lore is package-shipped (not per-content_root), but the gate CLI
+  // still needs a content_root + actor to boot. Use a tmpdir.
+  const root = mkdtempSync(join(tmpdir(), 'guild-lore-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    `name: alice\ncategory: professional\nactive: true\n`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('gate lore (no subcommand) emits a usage hint + exit 1', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /needs a subcommand/);
+  assert.match(r.stderr, /gate lore list/);
+  assert.match(r.stderr, /gate lore show/);
+});
+
+test('gate lore list returns every principle and trap as a flat list', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list'], { GUILD_ACTOR: 'alice' });
+  assert.equal(r.status, 0);
+  // Stable anchor: principle 04 (records-outlive-writers) is one of
+  // the oldest and will not be removed.
+  assert.match(r.stdout, /04-records-outlive-writers\s+\[principle\]/);
+  // Trap section: doc-coverage trap was added in 2026-05 and is
+  // marked indefinite, so it's a stable anchor too.
+  assert.match(r.stdout, /trap_doc_coverage_drift_post_ship\s+\[trap\/indefinite\]/);
+});
+
+test('gate lore list --type principle narrows to principles', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--type', 'principle'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[principle\]/);
+  assert.doesNotMatch(r.stdout, /\[trap\//);
+});
+
+test('gate lore list --type trap narrows to traps', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--type', 'trap'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /\[trap\//);
+  assert.doesNotMatch(r.stdout, /\[principle\]/);
+});
+
+test('gate lore list --applies-to swarm shows principle 14 plus universal entries', (t) => {
+  // applies_to: swarm is explicit on principle 14; principles without
+  // an explicit applies_to are universal (`all`) and surface here too.
+  // Matches the tools/lore-scope.sh semantics.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--applies-to', 'swarm'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /14-substrate-engagement.*\[principle\/swarm\]/);
+  // Universal principle still surfaces.
+  assert.match(r.stdout, /04-records-outlive-writers\s+\[principle\]/);
+});
+
+test('gate lore list --relevant-until current keeps indefinite + future traps', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--type', 'trap', '--relevant-until', 'current'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  // Indefinite traps are by definition current.
+  assert.match(r.stdout, /\[trap\/indefinite\]/);
+});
+
+test('gate lore list --format json emits an array with frontmatter', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  const items = JSON.parse(r.stdout);
+  assert.ok(Array.isArray(items));
+  assert.ok(items.length > 0);
+  // Sample item shape: name + type + title + frontmatter all present.
+  const sample = items[0];
+  assert.equal(typeof sample.name, 'string');
+  assert.ok(sample.type === 'principle' || sample.type === 'trap');
+  assert.ok('title' in sample);
+  assert.equal(typeof sample.frontmatter, 'object');
+  // Principle 14's applies_to surfaces here.
+  const p14 = items.find(
+    (i: { name: string }) => i.name === '14-substrate-engagement-reduces-coordination-context-cost',
+  );
+  assert.ok(p14, 'principle 14 should be in the list');
+  assert.equal(p14.frontmatter.applies_to, 'swarm');
+});
+
+test('gate lore show <name> returns the markdown body', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['lore', 'show', '11-ai-first-human-as-projection'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  // The body starts with the H1 of the principle.
+  assert.match(r.stdout, /# AI-first, human as projection/);
+  // And contains body anchors stable enough to survive editing. The
+  // markdown is hard-wrapped, so use single-line substrings that
+  // span no line break.
+  assert.match(r.stdout, /direction of derivation/);
+  assert.match(r.stdout, /AI-natural check first/);
+});
+
+test('gate lore show <name> --format json returns structured entry', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(
+    root,
+    ['lore', 'show', '11-ai-first-human-as-projection', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0);
+  const entry = JSON.parse(r.stdout);
+  assert.equal(entry.name, '11-ai-first-human-as-projection');
+  assert.equal(entry.type, 'principle');
+  assert.match(entry.title ?? '', /AI-first, human as projection/);
+  // Body anchor on a single line (markdown is hard-wrapped).
+  assert.match(entry.body, /direction of derivation/);
+});
+
+test('gate lore show <missing> returns not-found + discovery hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'show', 'no-such-thing'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /lore entry not found/);
+  assert.match(r.stderr, /gate lore list/);
+});
+
+test('gate lore <unknown-sub> emits a hint listing valid subs', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'xyzzy'], { GUILD_ACTOR: 'alice' });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown subcommand: gate lore xyzzy/);
+  assert.match(r.stderr, /list \| show/);
+});
+
+test('gate lore list --type bogus rejects with a typed error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--type', 'bogus'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--type must be 'principle' or 'trap'/);
+});
+
+test('gate lore list --relevant-until invalid rejects with a typed error', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['lore', 'list', '--type', 'trap', '--relevant-until', 'whenever'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--relevant-until must be/);
+});

--- a/tests/interface/schemaInputDriftDetector.test.ts
+++ b/tests/interface/schemaInputDriftDetector.test.ts
@@ -78,6 +78,10 @@ const SUBCOMMAND_UMBRELLAS: ReadonlySet<string> = new Set([
   // (DOCTOR_KNOWN_FLAGS for the bare verb, SWEEP_TRAPS_KNOWN_FLAGS for
   // the sub-verb). Same redesign-not-drift situation as issues/templates.
   'doctor',
+  // lore: same shape as templates — `lore list` and `lore show` carry
+  // separate KNOWN_FLAGS sets, but the schema collapses them into a
+  // single `lore` entry with a `subcommand` discriminator.
+  'lore',
 ]);
 
 // `gate help` and the very top-level positional verb dispatcher

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -42,7 +42,7 @@ const GATE_ALL = [
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
   'boot', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
-  'schema', 'unresponded', 'templates', 'rest', 'wake', 'farewell',
+  'schema', 'unresponded', 'templates', 'lore', 'rest', 'wake', 'farewell',
   'wave-status', 'lense-stats', 'review-context',
   'decisions', 'self-pattern',
 ] as const;


### PR DESCRIPTION
## Summary

A new read verb that lets AI agents (and humans) browse principles and traps from inside the substrate instead of needing to know the `lore/` directory layout.

- **`gate lore list`** — every principle + trap, sorted by name.
- **`gate lore show <name>`** — full markdown body. `<name>` is the filename without `.md` (e.g. `11-ai-first-human-as-projection`, `trap_doc_coverage_drift_post_ship`).

### Filters on `list`

- `--type principle|trap` — narrows the kind.
- `--applies-to <scope>` — filters principles by `applies_to:` frontmatter. Universal entries (no explicit `applies_to`) surface regardless of the filter value, matching `tools/lore-scope.sh` semantics.
- `--relevant-until current|expired|indefinite` — classifies trap frontmatter (`indefinite` or future-dated → `current`; past → `expired`; literal `indefinite` → `indefinite`).

Both subverbs support `--format text|json`. Read-only by design — lore is authored by editing markdown and shipping a PR, not by a CLI write.

## Why a verb when `cat lore/principles/X.md` works

- **Discoverability**: agent doesn't need to know the `lore/` directory layout.
- **Frontmatter-aware filtering**: `applies_to` / `relevant_until` filters built in.
- **JSON output**: orchestrators consume structured entries with frontmatter, title, type, body.
- **Single entry point**: "what doctrine is live right now" answered by one verb.

Lore moves from "read once when onboarding" to "touchable from inside the substrate." First step in carrying `lore/` + `examples/agent-voices/` + (future) snapshot/alexandria into the daily verb surface.

## Structure

Mirrors `gate templates`:

- `src/infrastructure/lore/LoreRepository.ts` — fs scanner + frontmatter parser. Resolves `<packageRoot>/lore/` via the same dev/prod/jest candidate-path pattern as `resolveBuiltinTemplatesDir`.
- `src/application/lore/LoreUseCases.ts` — filter + projection.
- `src/interface/gate/handlers/lore.ts` — subcommand dispatch + text/json rendering.

Wired into `container.ts`, `verbs.ts` READ_VERBS, dispatcher case, schema (subcommand-umbrella entry), help.ts. Added to `SUBCOMMAND_UMBRELLAS` in the schema/runtime drift detector alongside `templates`/`doctor`/`issues`.

## Test plan

- [ ] `npm run build && npm test` — 1641/1641 (13 new in `loreSurface.test.ts`)
- [ ] Manual smoke: `gate lore list` — shows all principles + traps
- [ ] Manual smoke: `gate lore list --applies-to swarm` — shows principle 14 + universal entries
- [ ] Manual smoke: `gate lore list --type trap --relevant-until current` — indefinite traps
- [ ] Manual smoke: `gate lore show 11-ai-first-human-as-projection` — full body
- [ ] Manual smoke: `gate lore show no-such-thing` — not-found + discovery hint

## Context

Part of a series of adoption-barrier-lowering improvements (option A from a planning session). Follows PR #353 (read-verb symmetry catchup). Next in the series: `gate boot` ladder thickening + `--explain` flag for read verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)