### PR TITLE
docs(lore): add trap for dogfooder-of-one override of AI-first axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`lore/traps/trap_eris_first_override_of_ai_first.md` — public
+  trap disclosure.** Names the structural pattern where a
+  dogfooder-of-one substrate can silently override its declared
+  AI-agent-first axis through private preference. Establishes that
+  a forward-looking audit is being run (without exposing the audit
+  contents publicly) and treats accumulated weight as the signal
+  to re-evaluate principle 11. One-way link to principles 11 / 02 /
+  04; principle 11 itself is not edited — the trap is the watcher,
+  the principle is the watched.
+
 - **`gate lore` verb — package-shipped doctrine reader.**
   Lets agents browse principles and traps from inside the substrate
   without needing to know the `lore/` directory layout. Subcommands:

--- a/lore/traps/trap_eris_first_override_of_ai_first.md
+++ b/lore/traps/trap_eris_first_override_of_ai_first.md
@@ -1,0 +1,83 @@
+---
+relevant_until: indefinite
+---
+
+# trap: dogfooder-of-one can override the AI-agent-first axis
+
+**Pattern.** The public audience axis is pinned by
+[principle 11](../principles/11-ai-first-human-as-projection.md) as
+"AI-agent first, human as projection." Meanwhile, the substrate is
+operated day-to-day by a **dogfooder-of-one** — the original
+active author — whose naming, shaping, and prioritisation
+decisions inevitably carry private preference.
+
+Over time, "this is AI-natural so I chose it" and "this is what I
+personally like, so I chose it" become hard to distinguish in
+hindsight. From the public surface, the two are externally
+identical — the rationalisation slope is silent.
+
+## Trigger conditions for review
+
+Flag any decision where one of the following held:
+
+- The shape was chosen on intuition alone, without explicitly
+  asking "is this AI-natural?"
+- The judgement form was "another AI agent might be confused, but
+  I read this cleanly" — comfort weighing more than contract.
+- A past decision is being explained *now* in AI-agent-first
+  terms, but the contemporaneous record carries no such reasoning.
+
+When occurrences accumulate, principle 11's two-tier framing
+("AI-agent first → human projection") drifts toward dishonesty:
+a hidden tier (dogfooder preference) is operating upstream of the
+declared one.
+
+## Honest mitigation
+
+Run an audit. Record — **forward-looking only** — the cases
+where dogfooder preference has overridden the AI-first axis. Do
+not retroactively re-evaluate past decisions (that incentivises
+rationalisation in the other direction).
+
+When the audit accumulates enough weight, treat it as the signal
+to rewrite principle 11 as a three-tier framing
+("dogfooder-first → AI-agent first → human projection"), or to
+withdraw the specific overrides.
+
+The audit's *existence* belongs in the public lore (this trap is
+that disclosure). The audit's *contents* — individual entries,
+cadence policy, author identity — live outside this file. What
+matters publicly is that the asymmetry is being observed, not
+who the dogfooder is or what they prefer.
+
+The threshold for "enough weight" is **not** a numeric count.
+Counting incentivises gaming. The threshold is the felt sense on
+re-reading: when the audit reads heavier than the principle, the
+principle needs to move.
+
+## Why this is `indefinite`
+
+As long as a substrate has a dogfooder-of-one, this pattern
+recurs structurally. It does not get fixed by a one-time
+correction; it gets *managed* by keeping the audit alive and
+reviewing principle 11 against it periodically.
+
+If the substrate grows beyond one dogfooder (a council, a fork,
+a successor author), the pattern's shape changes — but a new
+trap for "dogfooder-of-few" is more likely than disappearance.
+
+## Related
+
+- [principle 11](../principles/11-ai-first-human-as-projection.md)
+  — the two-tier framing this trap puts a condition on. This
+  trap link is **one-way**: principle 11 itself does not
+  reference this trap. The trap is the watcher; the principle
+  is the watched.
+- [principle 02](../principles/02-advisory-not-directive.md)
+  — this trap's disclosure is advisory (a signal to re-read
+  principle 11 against accumulated overrides), not directive
+  (no enforcement on individual decisions).
+- [principle 04](../principles/04-records-outlive-writers.md)
+  — the audit being *forward-looking* is a deliberate
+  application of principle 04: future-self honesty over
+  past-self defence.


### PR DESCRIPTION
## Summary

- Adds `lore/traps/trap_eris_first_override_of_ai_first.md` naming the structural pattern where a dogfooder-of-one substrate can silently override its declared AI-agent-first axis (principle 11) through private preference.
- Establishes that a forward-looking audit is being run, without exposing the audit contents publicly. The audit's *existence* belongs in public lore; entries live elsewhere.
- One-way link: trap → principle 11 (and 02 advisory, 04 records-outlive-writers). Principle 11 itself is not edited — the trap is the watcher, the principle is the watched.

## Why now

Principles 11 / 02 / 04 are all on main. Without a trap that names the override pattern explicitly, principle 11's two-tier framing ("AI-agent first → human projection") is asserted but unverified. This trap makes the verification surface public.

## Why `indefinite`

As long as a substrate has a single active author, this pattern recurs structurally. It does not get fixed by a one-time correction; it gets managed by keeping the audit alive and re-reading principle 11 against it periodically.

## Test plan

- [x] `npm test` — 1651 / 1651 pass
- [x] `gate lore show trap_eris_first_override_of_ai_first` renders cleanly
- [x] `gate lore list --type trap` includes the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)