### PR TITLE
feat(gate): --explain — universal orientation flag on read verbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **Universal `--explain` flag on read verbs.** Callers append
+  `--explain` to a registered read verb to receive a one-line
+  orientation message on stderr describing what the verb returns
+  and which related verbs to reach for. Stdout output is
+  unchanged, so `--explain` composes with `--format json` and
+  shell pipelines — orientation is a sibling channel. Initial
+  coverage: `gate boot`, `gate list`, `gate pending`,
+  `gate show`, `gate chain`, `gate lore list`, `gate lore show`.
+  Adding more verbs is a two-line change (an entry in
+  `EXPLAIN_MESSAGES` + a `maybeEmitExplain(args, verb)` call after
+  `rejectUnknownFlags`). Shaped by principle 09 (orientation-
+  disclosure): instead of waiting for friction to teach, callers
+  can ask for orientation up front at the cost of one stderr line.
+
 - **`lore/traps/trap_eris_first_override_of_ai_first.md` — public
   trap disclosure.** Names the structural pattern where a
   dogfooder-of-one substrate can silently override its declared

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -6,6 +6,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { maybeEmitExplain } from '../../shared/explain.js';
 import { C, loadAllRequestsAsJson, parseOptionalIntOption } from './internal.js';
 import { SESSION_ID_RE } from '../../../domain/request/Request.js';
 
@@ -401,6 +402,7 @@ interface BootPayload {
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, BOOT_KNOWN_FLAGS, 'boot');
+  maybeEmitExplain(args, 'boot');
   const format = optionalOption(args, 'format') ?? 'json';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);

--- a/src/interface/gate/handlers/lore.ts
+++ b/src/interface/gate/handlers/lore.ts
@@ -19,6 +19,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { maybeEmitExplain } from '../../shared/explain.js';
 import { LoreType } from '../../../infrastructure/lore/LoreRepository.js';
 import { C, truncateCodePoints } from './internal.js';
 
@@ -62,6 +63,7 @@ export async function loreCmd(c: C, args: ParsedArgs): Promise<number> {
 
 function loreList(c: C, args: ParsedArgs): number {
   rejectUnknownFlags(args, LORE_LIST_KNOWN_FLAGS, 'lore list');
+  maybeEmitExplain(args, 'lore list');
   const typeRaw = optionalOption(args, 'type');
   const appliesTo = optionalOption(args, 'applies-to');
   const relevantUntilRaw = optionalOption(args, 'relevant-until');
@@ -138,6 +140,7 @@ function loreList(c: C, args: ParsedArgs): number {
 
 function loreShow(c: C, args: ParsedArgs): number {
   rejectUnknownFlags(args, LORE_SHOW_KNOWN_FLAGS, 'lore show');
+  maybeEmitExplain(args, 'lore show');
   const name = args.positional[1];
   if (!name) {
     throw new Error(

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -7,6 +7,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { maybeEmitExplain } from '../../shared/explain.js';
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
@@ -348,6 +349,7 @@ const CHAIN_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, CHAIN_KNOWN_FLAGS, 'chain');
+  maybeEmitExplain(args, 'chain');
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'text' && format !== 'json') {
     throw new Error(`--format must be 'text' or 'json', got: ${format}`);

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -8,6 +8,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { maybeEmitExplain } from '../../shared/explain.js';
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import {
   fireBeforeHook,
@@ -473,6 +474,7 @@ export async function reqList(
     verb === 'pending' ? PENDING_KNOWN_FLAGS : LIST_KNOWN_FLAGS,
     verb,
   );
+  maybeEmitExplain(args, verb);
   const fromFilter = optionalOption(args, 'from');
   const executorFilter = optionalOption(args, 'executor');
   const autoReviewFilter = optionalOption(args, 'auto-review');
@@ -598,6 +600,7 @@ function describeFilters(filters: Record<string, string | undefined>): string {
 
 export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SHOW_KNOWN_FLAGS, 'show');
+  maybeEmitExplain(args, 'show');
   const id = args.positional[0];
   if (!id)
     throw new Error(

--- a/src/interface/shared/explain.ts
+++ b/src/interface/shared/explain.ts
@@ -1,0 +1,66 @@
+// `--explain` — universal orientation flag on read verbs.
+//
+// A caller (typically an AI agent on a cold session) appends
+// `--explain` to a read verb to receive a one-line orientation
+// message on stderr describing what the verb returns and which
+// related verbs to reach for. The verb's normal output is
+// unchanged on stdout, so `--explain` is composable with `--format
+// json` and shell pipelines — orientation is a sibling channel.
+//
+// Principle 09 (orientation-disclosure) shaped this: instead of
+// waiting for friction to teach (an unknown verb, a malformed
+// flag), the caller can ask for orientation up front. The cost is
+// one stderr line; the payoff is fewer second-trip help lookups.
+//
+// Mechanism:
+//   1. `--explain` is registered in `rejectUnknownFlags` as a
+//      universal pass-through (alongside `--help`), so individual
+//      handlers do not need to add it to their `KNOWN_FLAGS` set.
+//   2. Each opted-in handler calls `maybeEmitExplain(args, verb)`
+//      after `rejectUnknownFlags` and before producing output.
+//   3. Verbs without a registered message silently skip; the flag
+//      is still accepted (no unknown-flag error).
+//
+// To opt a verb in:
+//   - Add an entry to `EXPLAIN_MESSAGES` keyed by the same verb
+//     string passed to `rejectUnknownFlags`.
+//   - Call `maybeEmitExplain(args, '<verb>')` from the handler.
+
+import type { ParsedArgs } from './parseArgs.js';
+
+/**
+ * Registry of one-line orientation messages, keyed by the verb
+ * string. The key matches the second argument to
+ * `rejectUnknownFlags` so the two stay in lock-step.
+ *
+ * Style: one sentence, present tense, names the primary output
+ * and at most one related verb. Avoids re-documenting flags
+ * (`--help` does that).
+ */
+export const EXPLAIN_MESSAGES: Readonly<Record<string, string>> = {
+  boot: 'session-start orientation; surfaces actor identity, recent wave activity, and the next verb to reach for.',
+  list: 'lists requests filtered by --state/--from/--executors/--target; pair with `gate show <id>` for full body.',
+  pending: 'lists requests in state=pending — the approval queue; subset of `gate list --state pending`.',
+  show: 'reads one request (or other id) by id; use --fields for projection or --plain for shell-friendly output.',
+  chain: 'traces id references forward and inbound across requests/issues/plays — cross-passage by design.',
+  'lore list': 'lists every package-shipped principle + trap, sorted by name; filter via --type/--applies-to/--relevant-until.',
+  'lore show': 'reads one principle or trap markdown body by name; `--format json` returns the structured entry.',
+};
+
+/**
+ * Write the orientation line for `verb` to stderr if and only if
+ * `--explain` was passed and a message is registered. Returns
+ * whether a message was emitted so callers (or tests) can branch
+ * if they need to.
+ *
+ * Stderr (not stdout) so the line never mingles with structured
+ * output. Pipelines that capture stdout into a JSON parser stay
+ * working when `--explain` is added.
+ */
+export function maybeEmitExplain(args: ParsedArgs, verb: string): boolean {
+  if (args.options['explain'] !== true) return false;
+  const msg = EXPLAIN_MESSAGES[verb];
+  if (!msg) return false;
+  process.stderr.write(`(explain: ${msg})\n`);
+  return true;
+}

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -270,9 +270,15 @@ export function rejectUnknownFlags(
   if (args.options['help'] === true) {
     throw new HelpRequested(verb, [...known].sort(), extras);
   }
+  // `--explain` is universal: every verb accepts it without listing
+  // it in its known set. The handler decides whether to emit an
+  // orientation line (via `maybeEmitExplain`); when no message is
+  // registered for the verb, the flag still passes silently rather
+  // than tripping unknown-flag rejection. See shared/explain.ts.
   const unknown: string[] = [];
   for (const key of Object.keys(args.options)) {
     if (key === 'help') continue;
+    if (key === 'explain') continue;
     if (!known.has(key)) unknown.push(key);
   }
   if (unknown.length === 0) return;

--- a/tests/interface/explainFlag.test.ts
+++ b/tests/interface/explainFlag.test.ts
@@ -1,0 +1,109 @@
+// --explain — universal orientation flag.
+//
+// Surfaces this test pins:
+//   - `--explain` on a registered verb writes the orientation line
+//     to stderr, leaving stdout untouched.
+//   - `--explain` composes with `--format json` without corrupting
+//     the stdout JSON payload (a pipeline reading stdout into a
+//     JSON parser stays working).
+//   - `--explain` is universal: it passes through
+//     `rejectUnknownFlags` even on verbs that don't list it in
+//     their KNOWN_FLAGS set. When the verb has no message
+//     registered, the flag is accepted silently (no error, no
+//     output).
+//   - `--explain` does NOT short-circuit: the verb's normal output
+//     still runs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-explain-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('gate lore list --explain emits orientation to stderr, leaves stdout intact', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = spawnSync(process.execPath, [GATE, 'lore', 'list', '--explain'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /^\(explain: lists every package-shipped/);
+    // stdout is the actual list — does NOT carry the explain line.
+    assert.doesNotMatch(r.stdout, /^\(explain:/);
+    assert.match(r.stdout, /\[principle\]/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate lore list --explain --format json keeps stdout parseable as JSON', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = spawnSync(
+      process.execPath,
+      [GATE, 'lore', 'list', '--explain', '--format', 'json'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /^\(explain:/);
+    // stdout must parse — the orientation line stayed on stderr.
+    const parsed = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(parsed));
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate lore show --explain emits show-specific orientation', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = spawnSync(
+      process.execPath,
+      [GATE, 'lore', 'show', '01-silent-calibration', '--explain'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /^\(explain: reads one principle or trap/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('--explain on a verb with no registered message is accepted silently (no unknown-flag error)', () => {
+  // `gate voices` is a read verb without an EXPLAIN_MESSAGES entry.
+  // The flag must still pass rejectUnknownFlags — universal flags
+  // are never rejected, even when no message is registered. The
+  // contract: register a message later, no callsite change needed.
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = spawnSync(
+      process.execPath,
+      [GATE, 'voices', '--explain'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    // We don't pin exit code (voices may fail for other reasons in a
+    // bare tmpdir), but the stderr must NOT contain an "unknown
+    // flag" complaint about `--explain`.
+    assert.doesNotMatch(r.stderr, /unknown flag.*--explain/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a universal `--explain` flag on read verbs: writes a one-line orientation to **stderr** describing what the verb returns, while leaving stdout untouched. Composes cleanly with `--format json` and shell pipelines.
- Initial coverage: `gate boot` / `list` / `pending` / `show` / `chain` / `lore list` / `lore show`. Other read verbs accept the flag silently (no unknown-flag rejection) so the rollout is incremental.
- Universal pass-through is implemented at `rejectUnknownFlags`, mirroring `--help`. Per-verb opt-in is two lines: one `EXPLAIN_MESSAGES` entry + one `maybeEmitExplain(args, verb)` call after the rejection guard.

## Why

Shaped by principle 09 (orientation-disclosure). Today a cold-session AI agent learns the verb surface by either reading `--help` (loud) or by tripping a friction error (load-bearing but late). `--explain` is the voluntary middle: a caller can ask for orientation up front and get one stderr line back.

## Why stderr

A pipeline that captures stdout into a JSON parser must not break when the caller adds `--explain`. Stderr keeps the structured payload pristine.

## Test plan

- [x] `npm test` — 1655 / 1655 pass (4 new in `explainFlag.test.ts`)
- [x] `gate lore list --explain --format json` — stdout parses as JSON, stderr carries the orientation
- [x] `gate voices --explain` — flag accepted silently on a verb without a registered message (no unknown-flag error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)