### PR TITLE
feat(gate): boot ladder thickening — lore_stats + alternative next steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Added
 
+- **`gate boot` ladder thickening — lore stats + alternative
+  next steps.** Two surface improvements to the orientation
+  payload:
+  1. **`lore_stats`** is now part of the boot payload (JSON:
+     `{ available, principles, traps }`; text: a `lore: N
+     principles, M traps  (gate lore list)` line below
+     `queues:`). Cold AI agents learn that `gate lore` exists at
+     orientation time, without having to grep the verb catalog.
+  2. **Alternative ladder** in text mode: when
+     `verbs_available_now.actionable` carries more than one
+     entry, the renderer surfaces up to two siblings as `→ or:`
+     lines beneath the primary `→ next:`. Previously the
+     catalog was JSON-only — callers reading text saw a single
+     suggestion and had to round-trip through `--format json`
+     to see what else they could do. The primary is de-duped
+     from the ladder via verb + id match. JSON shape unchanged.
+
 - **Universal `--explain` flag on read verbs.** Callers append
   `--explain` to a registered read verb to receive a one-line
   orientation message on stderr describing what the verb returns

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -398,6 +398,20 @@ interface BootPayload {
    * (a condition to notice).
    */
   suggested_next: BootSuggestedNextOrPendingResponse | null;
+  /**
+   * Counts of package-shipped lore the caller can read via
+   * `gate lore list` / `gate lore show <name>`. Surfaces the
+   * presence of doctrine in the orientation payload so a cold
+   * AI agent learns the lore reader exists without having to
+   * grep the verb list. `available` is false when the lore
+   * directory could not be resolved (an unusual install state);
+   * in that case both counts are 0.
+   */
+  lore_stats: {
+    available: boolean;
+    principles: number;
+    traps: number;
+  };
 }
 
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -638,6 +652,19 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   const crossPassage = await collectCrossPassage(c.config);
   const activeOverlappingTargets = computeActiveOverlappingTargets(allRequests);
 
+  // Lore stats: count principles + traps shipped with this package.
+  // Cheap (one fs scan, already cached by FsLoreRepository) and lets
+  // the boot text surface a one-line discoverability hint for the
+  // `gate lore` verb. Unavailable lore (unusual install state) reads
+  // as zeros + available=false so consumers can branch.
+  const loreStats = c.loreUC.available
+    ? {
+        available: true,
+        principles: c.loreUC.list({ type: 'principle' }).length,
+        traps: c.loreUC.list({ type: 'trap' }).length,
+      }
+    : { available: false, principles: 0, traps: 0 };
+
   const sessionIdUnset = actor !== null && sessionId === null;
 
   const payload: BootPayload = {
@@ -663,6 +690,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     active_overlapping_targets: activeOverlappingTargets,
     suggested_next: suggestedNext,
     verbs_available_now: verbsAvailableNow,
+    lore_stats: loreStats,
   };
 
   if (format === 'json') {
@@ -1437,6 +1465,15 @@ function renderBootText(p: BootPayload, profile: GuildProfile): string {
   lines.push(
     `queues: pending=${p.status.pending.total} approved=${p.status.approved.total} executing=${p.status.executing.total} open_issues=${p.status.open_issues} unreviewed=${p.status.unreviewed}`,
   );
+  // Lore discoverability hint: one line below queues so a cold
+  // session sees `gate lore` exists without having to consult
+  // `--help`. Suppressed when lore is unavailable — the (rare)
+  // mis-install path would otherwise render as a confusing `0/0`.
+  if (p.lore_stats.available) {
+    lines.push(
+      `lore: ${p.lore_stats.principles} principles, ${p.lore_stats.traps} traps  (gate lore list)`,
+    );
+  }
   if (p.inbox_unread.length > 0) {
     lines.push(`inbox unread: ${p.inbox_unread.length}`);
     for (const m of p.inbox_unread.slice(0, 3)) {
@@ -1577,6 +1614,26 @@ function renderBootText(p: BootPayload, profile: GuildProfile): string {
       lines.push(`→ next: gate ${n.verb}${argsStr ? ' ' + argsStr : ''}`);
     }
     lines.push(`  (${n.reason})`);
+    // Alternative ladder: surface up to two sibling actionable verbs
+    // beneath the primary suggestion. `verbs_available_now.actionable`
+    // is the JSON catalog of every state-transition verb whose
+    // preconditions the caller already meets; `suggested_next` picks
+    // ONE to lead with. Without rendering the rest in text mode, the
+    // caller has to round-trip through `gate boot --format json` to
+    // see the siblings. Limited to two so the ladder stays scannable.
+    //
+    // We filter out the primary itself (matched on verb + id) so the
+    // ladder doesn't echo `→ next:` as `→ or:`. The id sits in the
+    // primary suggestion's `args.id` when present.
+    const primaryId =
+      'args' in n && typeof n.args['id'] === 'string' ? n.args['id'] : null;
+    const alts = p.verbs_available_now.actionable
+      .filter((a) => !(a.verb === n.verb && a.id === primaryId))
+      .slice(0, 2);
+    for (const a of alts) {
+      lines.push(`→ or:   gate ${a.verb} ${a.id}`);
+      lines.push(`        (${a.reason})`);
+    }
   }
   return lines.join('\n') + '\n';
 }

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -59,6 +59,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'hints',
         'inbox_unread',
         'last_activity',
+        'lore_stats',
         'role',
         'session_id',
         'session_id_source',

--- a/tests/interface/bootLadderThickening.test.ts
+++ b/tests/interface/bootLadderThickening.test.ts
@@ -1,0 +1,201 @@
+// gate boot — ladder thickening surfaces (lore_stats + alternative
+// next steps in text mode).
+//
+// What this test pins:
+//   1. `lore_stats` is present in JSON, shape { available, principles,
+//      traps }, with non-zero counts when run against the real
+//      package-shipped lore directory.
+//   2. Text mode renders a `lore: <N> principles, <M> traps  (gate
+//      lore list)` line below `queues:`.
+//   3. When a registered actor has multiple actionable transitions,
+//      text mode renders up to two `→ or: gate <verb> <id>` lines
+//      beneath `→ next:` — the alternative ladder.
+//   4. The primary suggestion is NOT duplicated in the ladder (filter
+//      on verb + id matches the suggested_next).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-boot-ladder-');
+  // Host-only actor (eris) sits in host_names but NOT in members,
+  // so role resolves to 'host' (not 'member') and approve becomes
+  // actionable for pending requests. alice/bob are the executors.
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  for (const d of ['members', 'requests', 'issues', 'inbox']) {
+    mkdirSync(join(root, d));
+  }
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+test('boot JSON carries lore_stats with non-zero counts (package lore is present)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = run(root, ['boot']);
+    assert.equal(r.status, 0, r.stderr);
+    const payload = JSON.parse(r.stdout);
+    assert.ok(payload.lore_stats, 'lore_stats missing from payload');
+    assert.equal(payload.lore_stats.available, true);
+    // Lower bound is intentional — the count grows as principles/
+    // traps are added. Pinning an exact value would force this test
+    // to update on every lore PR, defeating the purpose.
+    assert.ok(
+      payload.lore_stats.principles >= 10,
+      `expected ≥10 principles, got ${payload.lore_stats.principles}`,
+    );
+    assert.ok(
+      payload.lore_stats.traps >= 1,
+      `expected ≥1 trap, got ${payload.lore_stats.traps}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot text renders the lore line below queues with the gate lore list hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = run(root, ['boot', '--format', 'text']);
+    assert.equal(r.status, 0, r.stderr);
+    // Order matters: lore line must follow the queues line, not
+    // float somewhere else in the payload. Use a regex anchored on
+    // both so the relative position is pinned.
+    assert.match(
+      r.stdout,
+      /queues:.*\nlore: \d+ principles, \d+ traps  \(gate lore list\)/,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot text shows alternative ladder when actor has multiple actionable transitions', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // Build state where alice has 2+ approved-for-me actionables.
+    // Each request is filed by alice with alice as executor, then
+    // approved by host eris. After approval, alice's actionable
+    // list carries one entry per approved-for-me — the primary
+    // suggestion picks one, the ladder must surface at least one
+    // alternative.
+    const ids: string[] = [];
+    for (const i of [1, 2, 3]) {
+      const r = run(
+        root,
+        [
+          'request',
+          '--action',
+          `task-${i}`,
+          '--reason',
+          'test',
+          '--executors',
+          'alice',
+          '--from',
+          'alice',
+          '--target',
+          `t-${i}`,
+          '--format',
+          'json',
+        ],
+        { GUILD_ACTOR: 'alice' },
+      );
+      const id = JSON.parse(r.stdout).id;
+      ids.push(id);
+    }
+    // Host approves each so alice's queue holds 3 approved-for-me.
+    for (const id of ids) {
+      run(root, ['approve', id, '--by', 'eris'], { GUILD_ACTOR: 'eris' });
+    }
+    const r = run(root, ['boot', '--format', 'text'], { GUILD_ACTOR: 'alice' });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /^→ next: gate /m);
+    assert.match(r.stdout, /^→ or:   gate /m);
+  } finally {
+    cleanup();
+  }
+});
+
+test('alternative ladder does not echo the primary suggestion', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const ids: string[] = [];
+    for (const i of [1, 2]) {
+      const r = run(
+        root,
+        [
+          'request',
+          '--action',
+          `task-${i}`,
+          '--reason',
+          'test',
+          '--executors',
+          'alice',
+          '--from',
+          'alice',
+          '--target',
+          `t-${i}`,
+          '--format',
+          'json',
+        ],
+        { GUILD_ACTOR: 'alice' },
+      );
+      ids.push(JSON.parse(r.stdout).id);
+    }
+    for (const id of ids) {
+      run(root, ['approve', id, '--by', 'eris'], { GUILD_ACTOR: 'eris' });
+    }
+    const r = run(root, ['boot', '--format', 'text'], { GUILD_ACTOR: 'alice' });
+    assert.equal(r.status, 0, r.stderr);
+    // Extract the id named on the `→ next:` line and assert that
+    // exact id never appears on a `→ or:` line. Without the dedup,
+    // the primary would render twice (the catalog still lists it
+    // among the actionable set).
+    const nextMatch = r.stdout.match(/^→ next: gate \w+ ([0-9-]+)/m);
+    if (nextMatch) {
+      const primaryId = nextMatch[1];
+      const orLines = r.stdout
+        .split('\n')
+        .filter((l) => l.startsWith('→ or:'));
+      for (const line of orLines) {
+        assert.ok(
+          !line.includes(primaryId!),
+          `ladder echoed primary id ${primaryId}: ${line}`,
+        );
+      }
+    }
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Two improvements to `gate boot`'s orientation surface, paired because both lower the friction of "what can I do from here":

1. **`lore_stats`** — new JSON field `{ available, principles, traps }` plus a text line below `queues:` of the form `lore: 14 principles, 7 traps  (gate lore list)`. Cold AI agents discover the `gate lore` reader at orientation time without hunting through `--help`.
2. **Alternative ladder in text mode** — when `verbs_available_now.actionable` carries more than one entry, the renderer now surfaces up to two siblings as `→ or:` lines beneath the primary `→ next:`. Previously the catalog was JSON-only.

```
→ next: gate execute 2026-05-13-0001
  (your approved request — ready to start)
→ or:   gate execute 2026-05-13-0002
  (your approved request — ready to start)
→ or:   gate execute 2026-05-13-0003
  (your approved request — ready to start)
```

The dedup filter matches on verb + id so the primary never echoes as an alternative.

## Forward-compat

JSON payload grew by one top-level key (`lore_stats`); the existing top-level-keys pin in `boot.test.ts` was updated. No rename, no removal.

## Test plan

- [x] `npm test` — 1659 / 1659 pass (4 new in `bootLadderThickening.test.ts`)
- [x] `gate boot --format text` — lore line renders below queues
- [x] `gate boot --format text` as actor with 3 approved requests — primary + 2 `→ or:` lines, no duplicate of primary id

🤖 Generated with [Claude Code](https://claude.com/claude-code)