### PR TITLE
docs(examples)+feat(gate): agent-voices README anchored to lore + --explain for voices/tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Changed
 
-- **`examples/quick-start/README.md` rewritten as a graduated
-  reading path** (30s → 5min → 20min), shape borrowed from
-  `snapshot/alexandria`'s START-HERE.md. Replaces the previous
-  one-paragraph copy-paste blurb. The new path walks a cold
-  reader through the smoke test, the four-step wave loop, the
-  `gate lore` doctrine reader, sibling passages (agora/devil/
-  ctx), and pointers to richer example directories. Underlying
-  scaffolding files (`guild.config.yaml`, `members/`) unchanged.
+- **`examples/agent-voices/README.md` cross-references the
+  underlying lore.** Adds an "Anchoring principles" section
+  linking principle 08 (voice-as-doctrine) and principle 07
+  (perception-not-judgement) so a cold reader sees why this
+  content_root exists in the shape it does, not just how to
+  use it. Also surfaces the new boot/lore/`--explain`
+  affordances under "Everything is gate voices readable."
+- **`--explain` registered for `gate voices` and `gate tail`.**
+  These read verbs now emit a one-line orientation on stderr
+  when called with `--explain`, joining `boot` / `list` /
+  `show` / `chain` / `lore list` / `lore show`. JSON contract
+  unchanged.
 
 ### Added
 

--- a/examples/agent-voices/README.md
+++ b/examples/agent-voices/README.md
@@ -30,6 +30,11 @@ gate voices claude --lense user --format text
 
 # or pull all voices on one theme
 gate show 2026-04-16-0003 --format text
+
+# orientation: list every survey + see what verbs read this space
+gate boot --format text                  # `lore: N principles, M traps` is wired
+gate list --state completed              # every survey id
+gate voices claude --lense user --explain  # one-line orientation on stderr
 ```
 
 ## How to add your own voice
@@ -56,6 +61,26 @@ gate review <survey-id> --by <your-name> --lense user \
 - Append only. Don't edit other agents' reviews — that's what the
   append-only invariant protects against.
 - Dated, signed (by your agent name via `--by`).
+
+## Anchoring principles
+
+This directory is a deliberate instance of two principles:
+
+- [`gate lore show 08-voice-as-doctrine`](../../lore/principles/08-voice-as-doctrine.md)
+  — voice is how lore reaches readers who don't open `lore/`.
+  Agent voices left here become part of that running voice over
+  time; later agents reading `gate voices` are reading doctrine
+  in the prose form their loop will actually consume.
+- [`gate lore show 07-perception-not-judgement`](../../lore/principles/07-perception-not-judgement.md)
+  — the surveys *sharpen perception* (what did you actually
+  notice while using the tool) without pre-deciding the
+  judgement. The verdict slot (`ok` / `concern` / `reject`)
+  records the reviewer's stance toward the survey's framing;
+  the substrate does not aggregate verdicts into a score. This
+  is why the conventions stay soft.
+
+Run `gate lore list` to see the rest. Each principle is one
+markdown file the package ships; the verb is read-only.
 
 ## What this is not
 

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -49,6 +49,7 @@ const VOICES_KNOWN_FLAGS: ReadonlySet<string> = new Set([
 
 export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, VOICES_KNOWN_FLAGS, 'voices');
+  maybeEmitExplain(args, 'voices');
   const name = args.positional[0];
   if (!name) {
     throw new Error(
@@ -164,6 +165,7 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   // want surfaced. Pilot opt-in: other verbs migrate individually
   // in follow-up PRs.
   rejectUnknownFlags(args, TAIL_KNOWN_FLAGS, 'tail');
+  maybeEmitExplain(args, 'tail');
 
   let n: number | undefined;
   const positional = args.positional[0];

--- a/src/interface/shared/explain.ts
+++ b/src/interface/shared/explain.ts
@@ -45,6 +45,8 @@ export const EXPLAIN_MESSAGES: Readonly<Record<string, string>> = {
   chain: 'traces id references forward and inbound across requests/issues/plays — cross-passage by design.',
   'lore list': 'lists every package-shipped principle + trap, sorted by name; filter via --type/--applies-to/--relevant-until.',
   'lore show': 'reads one principle or trap markdown body by name; `--format json` returns the structured entry.',
+  voices: 'reads one actor\'s utterances + reviews across the content_root; filter via --lense/--verdict.',
+  tail: 'recent utterances across every actor on this content_root; the listening side of `voices`.',
 };
 
 /**


### PR DESCRIPTION
## Summary

Paired docs + runtime change, kept in one PR because the README references behaviour the runtime didn't yet ship.

**README** — `examples/agent-voices/README.md`:
- New **"Anchoring principles"** section linking principle 08 (voice-as-doctrine) and principle 07 (perception-not-judgement). Cold readers see why this content_root exists in this shape, not just how to use it.
- Code block under "Everything is gate voices readable" updated to surface `gate boot --format text` (lore_stats line, from #357), `gate list --state completed`, and `gate voices <name> --lense user --explain` for orientation discovery.

**Runtime** — `voices` and `tail` registered in `EXPLAIN_MESSAGES`:
- Both verbs now emit a one-line orientation on stderr when called with `--explain`, joining `boot` / `list` / `show` / `chain` / `lore list` / `lore show`.
- Two-line opt-in (one EXPLAIN_MESSAGES entry, one `maybeEmitExplain` call in the handler), no schema or JSON shape change.

## Why pair

The README example shows `gate voices claude --lense user --explain` as an orientation tool. Without registering voices in EXPLAIN_MESSAGES, that line would print silently — the documentation would assert behaviour the runtime didn't deliver.

## Test plan

- [x] `npm test` — 1659 / 1659 pass
- [x] `gate voices claude --lense user --explain` (run inside `examples/agent-voices/`) — stderr carries the registered orientation line; stdout unchanged
- [x] Pre-existing explainFlag test ("--explain on verb with no message accepted silently") continues to pass — it tests `gate voices --explain` without a name, which errors on missing positional before maybeEmitExplain runs; only the no-unknown-flag-complaint assertion matters there

🤖 Generated with [Claude Code](https://claude.com/claude-code)