### PR TITLE
docs(readme): maintain depth ladder — quick-start + gate lore

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -208,7 +208,7 @@ passage 固有の records はそれぞれ `<content_root>/agora/` /
 各ディレクトリは自己完結した `content_root` で、`cd` してそのまま
 verb を叩けます:
 
-- [`examples/quick-start/`](./examples/quick-start/) — 最小の config + members
+- [`examples/quick-start/`](./examples/quick-start/) — 最小の config + members。 README は 30秒 → 5分 → 20分 の graduated reading path
 - [`examples/dogfood-session/`](./examples/dogfood-session/) — 多 actor の長い実セッション（このツール自身が自分を拡張した完全な記録）
 - [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON envelope を中心とした agent-driven flow
 - [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona の voice 表現

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ Pick a depth. Every layer works on its own.
 | Depth | File | Audience | When it's enough |
 |-------|------|----------|------------------|
 | 30 sec | the paragraphs + "Solo flow" above | solo | you want to know what this is |
+| 1 min | [`examples/quick-start/`](./examples/quick-start/) | solo / agent | you want to run gate against a content_root and see something happen — graduated 30s → 5min → 20min path inside |
 | 5 min | [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) | solo | you came from Jira / PR review / ADR and want the translation |
 | 10 min | [`AGENT.md`](./AGENT.md) | solo / agent | you're an AI agent and want the full verb map across all four passages |
 | 15 min | [`docs/playbook.md`](./docs/playbook.md) | pair | you know each passage; you want **combos** (gate + agora + devil flows; ctx-inclusive patterns arrive in phase 2), recipes, and the bug-killing flow |
 | 15 min | [`docs/swarm.md`](./docs/swarm.md) | swarm | you orchestrate ≥2 parallel executors / Claude SubAgents and need the substrate-engagement recipe |
 | 30 min | [`docs/verbs.md`](./docs/verbs.md) | any | you want per-verb examples and design notes |
 | reference | [`docs/glossary.md`](./docs/glossary.md) | any | you hit a project-specific term and want the authoritative definition |
+| reference | [`lore/principles/`](./lore/principles/) (or `gate lore list`) | any | the 14 load-bearing ideas behind the design — read when you want to know why a choice was made, not how |
 | 1 hour | [`examples/dogfood-session/`](./examples/dogfood-session/) | any | you're adopting this seriously and want to see real sessions |
 | working notes | [`docs/domain-fit/`](./docs/domain-fit/) | any | you're curious whether gate fits a non-standard domain |
 | when needed | [`docs/POLICY.md`](./docs/POLICY.md) / [`docs/storage-format.md`](./docs/storage-format.md) / [`SECURITY.md`](./SECURITY.md) | embedder | you're embedding guild-cli and need the stability / on-disk shape / threat contract |
@@ -83,6 +85,11 @@ Pick a depth. Every layer works on its own.
 behind the design. One principle per file, ~30 lines each. Read these
 when you need to know why a choice was made, not how. Append-only in
 spirit, like the records `gate` itself produces.
+
+Also reachable from the CLI without leaving the substrate: `gate lore
+list` shows every principle + trap; `gate lore show <name>` reads
+one. Frontmatter-aware filtering (`--type`, `--applies-to`,
+`--relevant-until`) is supported.
 
 Recent: [`principle 14`](./lore/principles/14-substrate-engagement-reduces-coordination-context-cost.md)
 extends principle 04 to coordination state — when multiple SubAgents


### PR DESCRIPTION
## Summary

Two additive rows on `README.md`'s "How much of this do I need to read?" ladder, plus a short paragraph on the existing "### Lore" section.

The depth ladder predated:
- #354 (`gate lore` verb — package-shipped doctrine reader)
- #358 (graduated quick-start README — 30s → 5min → 20min path)

Both surfaces were documented elsewhere but missing from the table a new reader scans first.

## Changes

**README.md** — two new rows:
- `1 min | examples/quick-start/` between the 30-sec README intro and the 5-min conceptual translation. Audience: solo / agent who wants to *run* something.
- `reference | lore/principles/ (or gate lore list)` near the glossary row. Cross-references the existing "### Lore" section.

**README.md "### Lore"** — gains a paragraph naming `gate lore list` / `gate lore show <name>` plus the `--type` / `--applies-to` / `--relevant-until` filters. The markdown files and the CLI affordance are now linked from the same callout.

**README.ja.md** — short note on quick-start's graduated path under 実例, for parity with the English example list.

## Test plan

- [x] No row renamed or removed — purely additive
- [x] Links: all paths exist (`examples/quick-start/`, `lore/principles/`)
- [x] `gate lore list` / `gate lore show` work as described (shipped in #354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)