### PR TITLE
fix(boot): skip inbox enrichment for host actors (no more 7-line warning per session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **`gate boot` no longer raises the 7-line
+  "inbox-enrichment-failed" warning when the actor is a host.**
+  Hosts have no inbox by design (`MessageUseCases.inbox` throws
+  "hosts do not have inboxes"). Before this fix, every host-side
+  boot recapped that fact as a warning block, inverting
+  principle 09 (orientation-disclosure: surface surprising
+  cases, stay quiet otherwise). The fact is already conveyed by
+  `role: 'host'` in the payload. Inbox enrichment now skips on
+  the host path; the warning still fires for an unknown actor
+  (typo diagnostic), so the no-inbox surface remains useful
+  where it actually disambiguates.
 - **`gate boot` no longer steers the author of an executing
   wave toward `gate complete --by <author>` when a different
   actor is the named executor.** The actionable-transition

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -494,7 +494,17 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   }
 
   const inboxUnread: BootPayload['inbox_unread'] = [];
-  if (actor) {
+  // Skip inbox enrichment when the actor is a host — hosts do not
+  // have inboxes by design (MessageUseCases.inbox throws with
+  // "hosts do not have inboxes"). Before this guard, every boot
+  // run by a host emitted a 7-line warning block recapping the
+  // by-design no-inbox fact — principle 09 (orientation-disclosure:
+  // surface surprising cases, stay quiet otherwise) inverted. The
+  // host's role is already conveyed via the `role: 'host'` field;
+  // suppressing the redundant warning is the orientation-clean
+  // shape. role='unknown' still attempts inbox so the throw
+  // produces a real warning for typo'd actor names.
+  if (actor && role !== 'host') {
     try {
       const msgs = await c.messageUC.inbox(actor);
       const unread = msgs.filter((m) => !m.read);

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -822,6 +822,50 @@ test('gate boot: reviewed-authored is suppressed when a higher-priority transiti
   }
 });
 
+test('gate boot: host actor does NOT emit the "hosts have no inbox" warning', () => {
+  // Pre-fix, every boot run by a host actor produced a 7-line warning
+  // block ("inbox enrichment failed for actor=eris ... hosts do not
+  // have inboxes"). That fact is already conveyed by `role: 'host'`
+  // in the payload; emitting it as a warning every session inverts
+  // principle 09 (orientation-disclosure: surface surprising cases,
+  // stay quiet otherwise — being a host is not surprising state).
+  // The fix skips inbox enrichment for role='host' so the warning
+  // never fires on the host path.
+  const { root, cleanup } = bootstrap(); // host_names: [human]
+  try {
+    const { stdout, status } = runGate(root, ['boot'], {
+      GUILD_ACTOR: 'human',
+    });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.role, 'host', 'host bootstrap precondition');
+    const inboxWarning = (payload.warnings as string[]).find((w) =>
+      w.includes('inbox enrichment failed'),
+    );
+    assert.equal(
+      inboxWarning,
+      undefined,
+      'host boot must NOT raise inbox-enrichment warning (by-design no-inbox)',
+    );
+    // Sanity: a typo'd actor still surfaces the warning (the fix only
+    // suppresses the host path, not unknown-actor diagnostics).
+    const { stdout: typoStdout } = runGate(root, ['boot'], {
+      GUILD_ACTOR: 'nope-typo',
+    });
+    const typoPayload = JSON.parse(typoStdout);
+    assert.equal(typoPayload.role, 'unknown');
+    const typoWarning = (typoPayload.warnings as string[]).find((w) =>
+      w.includes('inbox enrichment failed'),
+    );
+    assert.ok(
+      typoWarning,
+      'unknown actor must still surface inbox-enrichment warning (typo diagnostic)',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('gate boot: executing wave where author≠executor does NOT surface to the author', () => {
   // Regression for the actionable-misattribution friction observed
   // 2026-05-13 on req 2026-05-08-0012 (author=eris, executors=[miki]).


### PR DESCRIPTION
## Summary

Observed during today's dogfood pass (one item the user prompted me to look back for): every `gate boot` invocation by a host actor (eris on this machine) opens with a 7-line warning block recapping that hosts have no inbox.

```
⚠ 1 warning(s) raised while assembling this snapshot:
   inbox enrichment failed for actor=eris (inbox_unread may be inaccurate): "eris" is a host, not a member — hosts do not have inboxes.
  To observe the guild activity instead:
    gate tail                # last events across all actors
    gate voices <member>     # one actor's utterances
    gate list --state <s>    # requests in a given state
   (counts in 'queues:' / 'inbox unread:' may be inaccurate;
    run 'gate doctor' to inspect the underlying repos)
```

The fact is already on the payload (`role: 'host'`). Surfacing it as a *warning* every session inverts **principle 09 (orientation-disclosure)** — "stay quiet on expected states; surface only the surprising ones." Being a host on a host-configured content_root is not surprising.

## Fix

Gate inbox enrichment on `role !== 'host'`. The `MessageUseCases.inbox` throw is what was being caught and reformatted into a warning — by not calling it for hosts, no warning is generated. For `role: 'unknown'` (typo'd `GUILD_ACTOR`), inbox enrichment still runs, so the same warning continues to fire as a real diagnostic in the case it actually disambiguates.

## Tests

- New `gate boot: host actor does NOT emit the "hosts have no inbox" warning` (boot.test.ts) — asserts both sides:
  - host boot → `warnings` array contains no inbox-enrichment entry
  - unknown-actor boot → warning still surfaces (typo diagnostic preserved)
- Full suite **1662 pass** (was 1661 + 1 new).

## Test plan

- [x] `npm run build && npm test` clean
- [x] `GUILD_ACTOR=<host> gate boot --format text` no longer prints the 7-line warning block (verified locally on this repo with eris as host)
- [x] `GUILD_ACTOR=typo-name gate boot --format text` still surfaces the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)