### PR TITLE
fix(list/board): suppress redundant GUILD_ACTOR filter notice in JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
   the host path; the warning still fires for an unknown actor
   (typo diagnostic), so the no-inbox surface remains useful
   where it actually disambiguates.
+- **`gate list` / `gate pending` / `gate board` no longer
+  emit the "filtered by GUILD_ACTOR=..." stderr disclosure in
+  JSON mode.** That disclosure exists so a *human* reading text
+  output knows why their result set is implicitly scoped. JSON
+  consumers already receive the same fact on stdout as
+  `_meta.filter.for_source: 'GUILD_ACTOR'` (or
+  `_meta.filter.source` on board), so the stderr line is
+  structurally redundant; emitting it on every JSON invocation
+  crosses the chronic-noise threshold named by
+  `lore/traps/trap_chronic_noise_blindness.md`. Text mode
+  keeps the line because that's the only surface humans see.
 - **`gate boot` no longer steers the author of an executing
   wave toward `gate complete --by <author>` when a different
   actor is the named executor.** The actionable-transition

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -76,7 +76,13 @@ export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
     sections.push({ state, items });
   }
 
-  if (envActor !== undefined) {
+  // Suppress the redundant "filtered by GUILD_ACTOR" stderr disclosure
+  // in JSON mode — the same fact is carried structurally on stdout as
+  // `_meta.filter.for_source: 'GUILD_ACTOR'` (see payload block below).
+  // Text mode keeps the line because that's the only surface humans
+  // see. See lore/traps/trap_chronic_noise_blindness.md (fix shape
+  // "Move to a structured field only").
+  if (envActor !== undefined && format !== 'json') {
     process.stderr.write(
       `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
     );

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -518,12 +518,6 @@ export async function reqList(
     );
   }
 
-  if (envActor !== undefined) {
-    process.stderr.write(
-      `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
-    );
-  }
-
   // --format closes the asymmetry surfaced in the post-merge bird's-eye
   // check (2026-05-03): every other gate read verb (board / status /
   // voices / tail / show / why / summarize) accepts --format json|text;
@@ -535,6 +529,21 @@ export async function reqList(
   const format = optionalOption(args, 'format') ?? 'text';
   if (format !== 'json' && format !== 'text') {
     throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  // The "filtered by GUILD_ACTOR=..." stderr notice exists so a *human*
+  // reading text output knows why their result set is implicitly
+  // scoped. JSON consumers already get this on stdout as
+  // `_meta.filter.for_source: 'GUILD_ACTOR'`, so the stderr line is
+  // redundant in JSON mode — and emitting it on every JSON invocation
+  // crosses the chronic-noise threshold named by
+  // lore/traps/trap_chronic_noise_blindness.md (stay quiet when a
+  // structured field already says it). Gate the stderr write on
+  // text-mode only; JSON envelope's _meta.filter remains authoritative.
+  if (envActor !== undefined && format !== 'json') {
+    process.stderr.write(
+      `# filtered by GUILD_ACTOR=${envActor} (use --for <m> or unset GUILD_ACTOR to override)\n`,
+    );
   }
 
   if (format === 'json') {

--- a/tests/interface/listPendingFormat.test.ts
+++ b/tests/interface/listPendingFormat.test.ts
@@ -225,6 +225,67 @@ test('gate pending --format text preserves prior text behavior', (t) => {
   assert.match(r.stdout, /fix one/);
 });
 
+test('gate list/pending --format json suppresses the GUILD_ACTOR filter stderr notice', (t) => {
+  // The "filtered by GUILD_ACTOR=..." line is a human-facing
+  // disclosure for text mode. JSON consumers already get the same
+  // fact on stdout as `_meta.filter.for_source: 'GUILD_ACTOR'`, so
+  // the stderr line is redundant — emitting it on every JSON
+  // invocation crosses the chronic-noise threshold named by
+  // lore/traps/trap_chronic_noise_blindness.md. This test pins
+  // both halves of the asymmetry.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  // JSON: no stderr disclosure, but _meta.filter still carries the fact.
+  const jsonRun = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(jsonRun.status, 0);
+  assert.doesNotMatch(
+    jsonRun.stderr,
+    /filtered by GUILD_ACTOR/,
+    'JSON mode must not emit the redundant filter notice (carried structurally in _meta)',
+  );
+  const payload = JSON.parse(jsonRun.stdout);
+  assert.equal(payload._meta.filter.for_source, 'GUILD_ACTOR');
+  // Text: disclosure preserved so humans see the implicit scoping.
+  const textRun = runGate(
+    root,
+    ['list', '--state', 'pending', '--format', 'text'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(textRun.status, 0);
+  assert.match(
+    textRun.stderr,
+    /filtered by GUILD_ACTOR=alice/,
+    'text mode must keep the filter notice — it is the only surface humans see',
+  );
+});
+
+test('gate board --format json suppresses the GUILD_ACTOR filter stderr notice', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  seedTwoPending(root);
+  const jsonRun = runGate(root, ['board', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(jsonRun.status, 0);
+  assert.doesNotMatch(
+    jsonRun.stderr,
+    /filtered by GUILD_ACTOR/,
+    'board JSON mode must not emit the redundant filter notice (carried as _meta.filter.source)',
+  );
+  const payload = JSON.parse(jsonRun.stdout);
+  assert.equal(payload._meta.filter.source, 'GUILD_ACTOR');
+  const textRun = runGate(root, ['board', '--format', 'text'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(textRun.status, 0);
+  assert.match(textRun.stderr, /filtered by GUILD_ACTOR=alice/);
+});
+
 test('gate pending --format invalid is rejected', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);


### PR DESCRIPTION
## Summary

Third instance of the chronic-noise pattern named by #363. `gate list` / `gate pending` / `gate board` emitted

```
# filtered by GUILD_ACTOR=eris (use --for <m> or unset GUILD_ACTOR to override)
```

to **stderr** on every invocation when GUILD_ACTOR was set. That disclosure makes sense for a *human* reading text output — it's the only surface that explains why the result set is implicitly scoped. But JSON consumers already get the same fact structurally on stdout:

- `gate list` / `gate pending`: `_meta.filter.for_source: \"GUILD_ACTOR\"`
- `gate board`: `_meta.filter.source: \"GUILD_ACTOR\"`

So the stderr line is **redundant in JSON mode**. Emitting it on every JSON invocation (the typical agent workflow with `GUILD_ACTOR=eris gate list --format json | jq ...`) crosses the chronic-noise threshold named by #363's `trap_chronic_noise_blindness` — the \"Move to a structured field only\" fix shape from the trap's body.

## Fix

Gate the stderr write on `format !== 'json'` in both `request.ts` (list/pending) and `board.ts`. Text-mode behavior unchanged.

## Tests

Two new tests in `listPendingFormat.test.ts` pin both halves of the asymmetry for list/pending and board:

- JSON mode: stderr does **not** match `/filtered by GUILD_ACTOR/`; `_meta.filter.for_source` / `_meta.filter.source` still carries the fact.
- Text mode: stderr **does** match the same regex.

Full suite **1663 pass** (was 1662 + 2 new).

## Relationship to in-flight PRs

- #361 (merged) — boot actionable misattribution + deny verb BASE help
- #362 (open) — boot host-inbox warning suppression (instance 1 of chronic noise)
- #363 (open) — `trap_chronic_noise_blindness` lore entry (the class)
- **This PR (#364)** — instance 2: list/board GUILD_ACTOR filter notice in JSON mode

## Test plan

- [x] `npm run build && npm test` clean
- [x] `GUILD_ACTOR=alice gate list --state pending --format json 2>&1` — no \"filtered by\" stderr
- [x] `GUILD_ACTOR=alice gate list --state pending --format text 2>&1` — \"filtered by alice\" still appears
- [x] Same for `gate board`

🤖 Generated with [Claude Code](https://claude.com/claude-code)