### PR TITLE
fix(voices): surface typo diagnostic for unknown actor names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **`gate voices <typo>` now surfaces a "did you typo the
+  name?" diagnostic instead of returning identical empty output
+  to a registered-but-quiet actor.** Pre-fix, the two cases were
+  shape-indistinguishable — a silent-fallback signal-loss named
+  by `lore/traps/trap_silent_fallback_loses_signal.md`. Text
+  mode adds a 3-line hint pointing at `gate tail` / `gate
+  register`; JSON mode wraps the output in `{utterances: [],
+  _meta: {actor_unknown: true}}` only on the typo branch.
+  Registered members and hosts with no utterances keep the
+  pre-fix shape unchanged (array form for JSON consumers, plain
+  empty-line for text).
 - **`gate boot` no longer raises the 7-line
   "inbox-enrichment-failed" warning when the actor is a host.**
   Hosts have no inbox by design (`MessageUseCases.inbox` throws

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -84,6 +84,24 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   }
   const utterances = collectUtterances(allJson, filter);
 
+  // Typo diagnostic: a `name` that matches neither a current member
+  // nor a configured host AND produced zero utterances is almost
+  // certainly a typo. Pre-fix, `gate voices ghost-actor` returned
+  // identical empty output to `gate voices <registered-but-quiet>`,
+  // a silent-fallback signal-loss (trap_silent_fallback_loses_signal).
+  // The fix surfaces a structured `_meta.actor_unknown` field in JSON
+  // mode and a one-line hint in text mode. A name that *does* produce
+  // utterances is left alone — historical authors who are no longer
+  // current members keep working without false-flagging.
+  let actorUnknown = false;
+  if (utterances.length === 0) {
+    const nameLower = name.toLowerCase();
+    const members = await c.memberUC.list();
+    const isMember = members.some((m) => m.name.value === nameLower);
+    const isHost = c.config.hostNames.some((h) => h.toLowerCase() === nameLower);
+    actorUnknown = !isMember && !isHost;
+  }
+
   // Voice calibration: per-(actor, lense) score derived from historical
   // verdicts vs outcomes. Hidden when viewing your own voice (the
   // voter shouldn't game their own score); shown otherwise. See the
@@ -103,10 +121,28 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
     // consumers don't break. `--with-calibration` opts into an object
     // shape that carries both. The flag is registered in
     // KNOWN_BOOLEAN_FLAGS so its presence doesn't swallow positionals.
+    //
+    // Typo diagnostic: when `actorUnknown` is true (zero utterances
+    // AND not a current member/host), wrap the output in an object
+    // envelope carrying `_meta.actor_unknown: true`. Existing JSON
+    // consumers reading the array shape continue to work for the
+    // common path (registered actor with results); the envelope shape
+    // only triggers on the typo case, where the consumer is already
+    // re-interpreting an empty result anyway.
     if (withCalibration) {
       process.stdout.write(
         JSON.stringify(
-          { utterances, calibration: calibration },
+          actorUnknown
+            ? { utterances, calibration, _meta: { actor_unknown: true } }
+            : { utterances, calibration },
+          null,
+          2,
+        ) + '\n',
+      );
+    } else if (actorUnknown) {
+      process.stdout.write(
+        JSON.stringify(
+          { utterances, _meta: { actor_unknown: true } },
           null,
           2,
         ) + '\n',
@@ -125,7 +161,17 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
     filterDesc.length > 0 ? ` (${filterDesc.join(', ')})` : '';
 
   if (utterances.length === 0) {
-    process.stdout.write(`(no utterances from ${name}${filterSuffix})\n`);
+    if (actorUnknown) {
+      process.stdout.write(
+        `(no utterances from ${name}${filterSuffix})\n` +
+          `  note: '${name}' is not a registered member or host — ` +
+          `did you typo the name?\n` +
+          `  next: gate tail        # see actors with recent activity\n` +
+          `        gate register    # see how to register a new actor\n`,
+      );
+    } else {
+      process.stdout.write(`(no utterances from ${name}${filterSuffix})\n`);
+    }
     return 0;
   }
 

--- a/tests/interface/voicesTypoDiagnostic.test.ts
+++ b/tests/interface/voicesTypoDiagnostic.test.ts
@@ -1,0 +1,148 @@
+// gate voices <name> — typo diagnostic for unknown actors.
+//
+// Pre-fix, `gate voices <typo>` returned identical empty output to
+// `gate voices <registered-but-quiet>`. A caller could not tell
+// whether the name was wrong or whether the actor simply had nothing
+// to say — classic silent-fallback signal-loss
+// (lore/traps/trap_silent_fallback_loses_signal).
+//
+// Fix: when the result set is empty AND the name matches neither a
+// member nor a host, surface a typo diagnostic — `_meta.actor_unknown`
+// in JSON mode, a 3-line "did you typo the name?" hint in text mode.
+// A registered actor with no utterances is left alone (unchanged
+// shape), so existing consumers reading the array form keep working.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-voices-typo-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+test('gate voices <typo> --format text surfaces a "did you typo" hint', () => {
+  const b = bootstrap();
+  try {
+    const r = run(b.root, ['voices', 'ghost-actor', '--format', 'text']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\(no utterances from ghost-actor\)/);
+    assert.match(r.stdout, /not a registered member or host/);
+    assert.match(r.stdout, /did you typo the name\?/);
+    assert.match(r.stdout, /gate tail/);
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate voices <registered-quiet> --format text does NOT surface the typo hint', () => {
+  const b = bootstrap();
+  try {
+    const r = run(b.root, ['voices', 'alice', '--format', 'text']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /\(no utterances from alice\)/);
+    assert.doesNotMatch(
+      r.stdout,
+      /typo/,
+      'registered actor with no utterances must not be flagged as a typo',
+    );
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate voices <host-name> --format text does NOT surface the typo hint', () => {
+  // Hosts can have utterances (authored requests). When eris has none
+  // recorded yet, the empty result must stay quiet — eris is a
+  // configured host, not a typo.
+  const b = bootstrap();
+  try {
+    const r = run(b.root, ['voices', 'eris', '--format', 'text']);
+    assert.equal(r.status, 0);
+    assert.doesNotMatch(r.stdout, /typo/);
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate voices <typo> --format json emits _meta.actor_unknown envelope', () => {
+  const b = bootstrap();
+  try {
+    const r = run(b.root, ['voices', 'ghost-actor', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    assert.deepEqual(payload.utterances, []);
+    assert.equal(payload._meta.actor_unknown, true);
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate voices <registered-quiet> --format json keeps array shape', () => {
+  // Existing JSON consumers depend on the array shape for the common
+  // path (registered actor with results). The envelope shape only
+  // triggers on the typo branch — registered-but-quiet stays as `[]`.
+  const b = bootstrap();
+  try {
+    const r = run(b.root, ['voices', 'alice', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(payload), 'registered actor must keep array shape');
+    assert.equal(payload.length, 0);
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate voices <typo> --format json --with-calibration carries _meta.actor_unknown', () => {
+  const b = bootstrap();
+  try {
+    const r = run(b.root, [
+      'voices',
+      'ghost-actor',
+      '--format',
+      'json',
+      '--with-calibration',
+    ]);
+    assert.equal(r.status, 0);
+    const payload = JSON.parse(r.stdout);
+    assert.deepEqual(payload.utterances, []);
+    assert.equal(payload._meta.actor_unknown, true);
+    // calibration field still present (null is fine; the contract is
+    // that the object envelope is the shape).
+    assert.ok('calibration' in payload);
+  } finally {
+    b.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Probing read-verb edge cases under \"/goal 楽しくdogfooding\" surfaced this: `gate voices <typo>` and `gate voices <registered-but-quiet>` returned shape-identical empty output.

```
$ gate voices ghost-actor --format json
[]
$ gate voices bob --format json   # bob is a registered member with no utterances
[]
```

Classic silent-fallback signal-loss (named by `trap_silent_fallback_loses_signal`). A caller pipelining `gate voices` into anything can't disambiguate \"nothing to say\" from \"I misspelled the name.\"

## Fix

When the result set is empty AND the name matches neither a configured member nor a configured host, surface a typo diagnostic:

- **text mode**: 3-line hint
  ```
  (no utterances from ghost-actor)
    note: 'ghost-actor' is not a registered member or host — did you typo the name?
    next: gate tail        # see actors with recent activity
          gate register    # see how to register a new actor
  ```
- **JSON mode**: wrap on the typo branch only —
  ```
  {\"utterances\": [], \"_meta\": {\"actor_unknown\": true}}
  ```
  Registered-but-quiet keeps the array shape (`[]`) so existing JSON consumers don't break on the common path. The envelope shape only triggers on the typo branch where the consumer is already re-interpreting an empty result.

A name that *does* produce utterances is left alone — historical authors who are no longer current members keep working (no false-flagging).

## Tests

6 new tests in `voicesTypoDiagnostic.test.ts`:

- text typo → diagnostic appears
- text registered-quiet → diagnostic absent
- text host name → diagnostic absent
- JSON typo → envelope with `_meta.actor_unknown`
- JSON registered-quiet → array shape preserved
- JSON `--with-calibration` typo → calibration field + `_meta.actor_unknown` together

Full suite **1670 pass** (was 1664 + 6 new).

## Relationship to recent PRs

This continues the 2026-05-13 dogfood arc:

- **#361** (merged) — boot actionable + deny BASE help
- **#362** (merged) — boot host inbox warning suppression (chronic noise instance 1)
- **#363** (merged) — `trap_chronic_noise_blindness`
- **#364** (merged) — list/board JSON filter notice suppression (instance 2)
- **#365** (this PR) — voices typo diagnostic (different trap: `trap_silent_fallback_loses_signal`)

Different trap, same shape of inquiry: \"what do the verbs do at their edges, and do those edges carry signal or lose it?\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)