### PR TITLE
fix(tail): disambiguate N=0 from source-empty; reject extra positionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to the versioning policy described in [docs/POLICY.md](
 
 ### Fixed
 
+- **`gate tail 0` no longer falsely claims the content_root is
+  empty.** Pre-fix, `gate tail 0` on a rich substrate rendered
+  the same `(no utterances on this content_root yet)` line as a
+  truly-empty root — a false claim about source state
+  (`trap_silent_fallback_loses_signal`). The empty-result branch
+  now disambiguates: `(0 utterances requested)` when the caller
+  asked for zero, the original message only when source is
+  actually empty.
+- **`gate tail` rejects extra positional arguments instead of
+  silently dropping them.** Pre-fix, `gate tail 3 extra`
+  returned the first 3 utterances and threw `extra` on the
+  floor — the same fail-open shape that `rejectUnknownFlags`
+  exists to prevent for flags. The rejection now fires
+  symmetrically for positionals, naming the unexpected values
+  in the error message.
 - **`gate voices <typo>` now surfaces a "did you typo the
   name?" diagnostic instead of returning identical empty output
   to a registered-but-quiet actor.** Pre-fix, the two cases were

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -213,6 +213,20 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, TAIL_KNOWN_FLAGS, 'tail');
   maybeEmitExplain(args, 'tail');
 
+  // Symmetric with the unknown-flag rejection above: extra positional
+  // arguments are silently dropped pre-fix (e.g. `gate tail 3 extra`
+  // returned the first 3 utterances ignoring `extra`). That's the
+  // same fail-open shape — the caller's intent is lost without any
+  // hint that it was lost. Reject with a usage line so a typo or
+  // misremembered flag surfaces immediately.
+  if (args.positional.length > 1) {
+    throw new Error(
+      `gate tail: takes at most one positional (N), got ${args.positional.length}: ` +
+        `${args.positional.map((p) => JSON.stringify(p)).join(', ')}\n` +
+        `  next: gate tail [N]                            # default N=20`,
+    );
+  }
+
   let n: number | undefined;
   const positional = args.positional[0];
   if (positional !== undefined) {
@@ -250,7 +264,18 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   }
 
   if (utterances.length === 0) {
-    process.stdout.write('(no utterances on this content_root yet)\n');
+    // Disambiguate "source is empty" from "caller asked for zero":
+    // pre-fix, `gate tail 0` on a rich content_root rendered the
+    // same "(no utterances on this content_root yet)" message as a
+    // truly-empty root — a false claim about the source state
+    // (lore/traps/trap_silent_fallback_loses_signal). An explicit
+    // limit=0 from the caller is the only path that yields empty-
+    // without-source-emptiness, so the limit alone disambiguates.
+    if (limit === 0) {
+      process.stdout.write('(0 utterances requested)\n');
+    } else {
+      process.stdout.write('(no utterances on this content_root yet)\n');
+    }
     return 0;
   }
   process.stdout.write(

--- a/tests/interface/tailFormat.test.ts
+++ b/tests/interface/tailFormat.test.ts
@@ -155,6 +155,71 @@ test('gate tail --format json: positional N still controls limit', (t) => {
   assert.equal(arr.length, 2);
 });
 
+test('gate tail 0 on rich content_root says "(0 utterances requested)", not "no utterances yet"', (t) => {
+  // Pre-fix, `gate tail 0` on a content_root with plenty of records
+  // rendered the same "(no utterances on this content_root yet)"
+  // message as a truly-empty root — a false claim about the source
+  // state (trap_silent_fallback_loses_signal). The fix disambiguates
+  // using `limit === 0` since that's the only path producing empty
+  // results without source-emptiness.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Seed via fast-track so there's at least one utterance on the root.
+  const seeded = runGate(
+    root,
+    [
+      'fast-track',
+      '--action',
+      'seed',
+      '--reason',
+      'rich-root pin',
+      '--format',
+      'json',
+    ],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(seeded.status, 0);
+
+  const zero = runGate(root, ['tail', '0']);
+  assert.equal(zero.status, 0);
+  assert.match(zero.stdout, /\(0 utterances requested\)/);
+  assert.doesNotMatch(
+    zero.stdout,
+    /no utterances on this content_root yet/,
+    'rich root must not falsely claim source-emptiness when N=0',
+  );
+
+  // Sanity: a truly-empty content_root still gets the source-empty
+  // message (limit defaults to 20, so the disambiguator picks the
+  // honest "yet" branch).
+  const empty = mkdtempSync(join(tmpdir(), 'guild-tail-empty-'));
+  try {
+    writeFileSync(
+      join(empty, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [eris]\n',
+    );
+    mkdirSync(join(empty, 'members'));
+    const r = runGate(empty, ['tail']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /no utterances on this content_root yet/);
+  } finally {
+    rmSync(empty, { recursive: true, force: true });
+  }
+});
+
+test('gate tail rejects extra positionals instead of silently dropping them', (t) => {
+  // `gate tail 3 extra` pre-fix returned the first 3 utterances
+  // ignoring `extra` — the same fail-open shape that
+  // rejectUnknownFlags exists to prevent for flags. Symmetric
+  // rejection now fires for positionals.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['tail', '3', 'extra']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr + r.stdout, /takes at most one positional/);
+  assert.match(r.stderr + r.stdout, /"3", "extra"/);
+});
+
 test('gate schema declares tail format flag (orchestrator contract)', (t) => {
   // MCP wirings consume `gate schema` to discover what flags each
   // verb accepts. Pre-fix tail's schema entry was bare `input: {}`;


### PR DESCRIPTION
## Summary

Two `gate tail` edge cases surfaced during /goal-driven edge-case dogfood (siblings of #365's voices typo diagnostic — same trap, different verb).

### 1. `gate tail 0` false claim

```
$ gate tail 0   # on a content_root with plenty of records
(no utterances on this content_root yet)
```

The message claims source-emptiness when actually the caller asked for zero records. That's `trap_silent_fallback_loses_signal` shape: the failure mode (empty result) and the input shape (limit=0) are conflated into one message that's right in one case and wrong in the other.

**Fix**: disambiguate using `limit` (the only signal that yields empty without source-emptiness):

| input | source has records | source empty |
|-------|--------------------|--------------|
| `tail 0` | `(0 utterances requested)` | `(0 utterances requested)` |
| `tail N>0` | utterances rendered | `(no utterances on this content_root yet)` |

### 2. `gate tail 3 extra` silent positional drop

```
$ gate tail 3 extra   # extra is silently ignored
3 most recent utterance(s)
...
```

Symmetric with the existing `rejectUnknownFlags` guard for flags — typo'd positionals were the remaining fail-open path. The caller's intent ("did I want `tail 3` or `tail extra`?") is silently flattened.

**Fix**: when `args.positional.length > 1`, throw a usage error naming the offending values:

```
error: gate tail: takes at most one positional (N), got 2: \"3\", \"extra\"
  next: gate tail [N]                            # default N=20
```

## Tests

2 new tests in `tailFormat.test.ts`:

- `gate tail 0` on a rich root says `(0 utterances requested)`; on a truly-empty root, `tail` (no arg) still emits the source-empty message.
- `gate tail 3 extra` exits non-zero with the \"takes at most one positional\" message naming both values.

Full suite **1666 pass**.

## Relationship

Continues the 2026-05-13 dogfood arc on read-verb edges:

- **#365** (open) — voices typo diagnostic (`trap_silent_fallback_loses_signal` instance 1)
- **This PR (#366)** — tail N=0 + extra positional (same trap, different verb)
- **Follow-up** — voices' own extra-positional silent drop (`gate voices alice bob` ignores `bob`) deferred to after #365 merges to avoid file-conflict; surface noted here.

## Test plan

- [x] `npm run build && npm test` clean
- [x] `gate tail 0` on rich root says \"(0 utterances requested)\"
- [x] `gate tail` (default 20) on empty root still says \"(no utterances ... yet)\"
- [x] `gate tail 3 extra` exits 1 with explanatory message

🤖 Generated with [Claude Code](https://claude.com/claude-code)