### PR TITLE
fix(schema): declare inbox mark-read subcommand in structured contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   <id> --by <m> --reason <s>` directly, so the next verb is
   one line away instead of a translation step. Pairs with the
   help-tier promotion below.
+- **`gate schema` now declares `inbox mark-read` as a
+  subcommand on the `inbox` entry.** Pre-fix, the schema's
+  `summary` claimed "mark-read as subcommand" but the
+  `input.properties` carried no `subcommand` field — an MCP
+  orchestrator reading the structured contract saw no way to
+  invoke `gate inbox mark-read`. The prose and the structured
+  contract disagreed (`trap_help_text_drift_on_new_verb`).
+  Pattern aligns with the existing `doctor` / `issues` /
+  `templates` / `lore` schema entries which carry a
+  `subcommand` enum.
 
 ### Changed
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1803,6 +1803,22 @@ const VERBS: readonly VerbSchema[] = [
     input: {
       type: 'object',
       properties: {
+        // Sub-verb is positional ('mark-read'), modeled here as
+        // `subcommand` for parity with `gate doctor` / `gate issues`
+        // / `gate templates` schema entries. Without this field, the
+        // `summary` claim "mark-read as subcommand" was unbacked by
+        // the structured contract — an MCP orchestrator reading the
+        // schema would see no way to invoke `inbox mark-read`
+        // (trap_help_text_drift_on_new_verb: the registry-of-
+        // surfaces drifted past one of the entries).
+        subcommand: {
+          type: 'string',
+          enum: ['mark-read'],
+          description:
+            'optional sub-verb. `mark-read [N]` marks the Nth-most-' +
+            "recent entry (or all when N omitted) as read; absence " +
+            'runs the standard list view.',
+        },
         for: str,
         unread: { type: 'boolean' },
         format: formatField,

--- a/tests/interface/schema.test.ts
+++ b/tests/interface/schema.test.ts
@@ -98,6 +98,35 @@ test('gate schema: input required fields are a subset of declared properties', (
 
 // --- issue #36 Phase 1: source: 'core' | 'plugin' discriminator ---
 
+test('gate schema --format json: inbox declares mark-read as a subcommand', (t) => {
+  // Pre-fix, the `inbox` schema's `summary` claimed "mark-read as
+  // subcommand" but the input.properties carried no `subcommand`
+  // field — an MCP orchestrator reading the structured schema saw
+  // no way to invoke `gate inbox mark-read`. The prose said one
+  // thing, the structured contract said another
+  // (trap_help_text_drift_on_new_verb). This regression pins both:
+  // mark-read appears in the subcommand enum AND the runtime
+  // dispatches it (covered by tests/interface/messageSurface.test.ts).
+  const { root, cleanup } = bootstrapMinimal('gate-schema-inbox-sub-');
+  t.after(cleanup);
+  const r = spawnSync(process.execPath, [GATE, 'schema', '--format', 'json'], {
+    cwd: root,
+    env: { ...process.env },
+    encoding: 'utf8',
+  });
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  const inbox = payload.verbs.find((v: { name: string }) => v.name === 'inbox');
+  assert.ok(inbox, 'inbox must be in schema');
+  const sub = inbox.input.properties.subcommand;
+  assert.ok(sub, 'inbox must declare a `subcommand` field in schema.input.properties');
+  assert.deepEqual(
+    sub.enum,
+    ['mark-read'],
+    'inbox subcommand enum must list `mark-read` (the only sub-handler)',
+  );
+});
+
 test('gate schema --format json: every verb carries source = "core" (built-in surface)', (t) => {
   // The runtime payload must always emit `source` so consumers can
   // filter built-in vs plugin verbs without cross-checking another


### PR DESCRIPTION
## Summary

Probing schema-vs-runtime symmetry under /goal-driven dogfood surfaced this: `gate schema --format json`'s `inbox` entry has

```json
{
  \"name\": \"inbox\",
  \"summary\": \"list messages for a member; mark-read as subcommand\",
  \"input\": {
    \"properties\": {
      \"for\": {\"type\": \"string\"},
      \"unread\": {\"type\": \"boolean\"},
      \"format\": {...}
    }
  }
}
```

The summary's prose claims \"mark-read as subcommand\" but the structured contract carries no `subcommand` field. An MCP orchestrator reading the schema sees no way to invoke `gate inbox mark-read` — the discoverability surface drifted past one of its entries while the runtime kept dispatching it. Classic `trap_help_text_drift_on_new_verb`.

The pattern is already established by `doctor` (sweep-traps), `issues`, `templates`, and `lore` — each declares a `subcommand` enum. `inbox` was the lone hold-out.

## Fix

Add the field, aligned with the existing pattern:

```ts
subcommand: {
  type: 'string',
  enum: ['mark-read'],
  description:
    'optional sub-verb. `mark-read [N]` marks the Nth-most-' +
    \"recent entry (or all when N omitted) as read; absence \" +
    'runs the standard list view.',
},
```

The runtime dispatcher already handles `inbox mark-read` (covered by `tests/interface/messageSurface.test.ts`); this PR only closes the gap on the structured contract.

## Tests

1 new test in `schema.test.ts`:

- `gate schema --format json: inbox declares mark-read as a subcommand` — asserts `inbox.input.properties.subcommand` exists and `subcommand.enum` contains `'mark-read'`.

Full suite **1671 pass**.

## Relationship to recent PRs

Continues the 2026-05-13 dogfood arc — different trap (`trap_help_text_drift_on_new_verb` rather than the silent-fallback / chronic-noise pair from earlier PRs), same investigative shape: probe a registry-of-surfaces, find where structured field and prose disagree, align them.

- **#361** (merged) — boot actionable + deny BASE help
- **#362** (merged) — boot host-inbox warning
- **#363** (merged) — `trap_chronic_noise_blindness`
- **#364** (merged) — list/board JSON filter notice
- **#365** (merged) — voices typo diagnostic
- **#366** (open) — tail N=0 + extra positional
- **#367** (this PR) — inbox schema mark-read subcommand

## Test plan

- [x] `npm run build && npm test` clean
- [x] `gate schema --format json | jq '.verbs[] | select(.name == \"inbox\")'` shows `subcommand` with `enum: [\"mark-read\"]`
- [x] `gate inbox mark-read` continues to dispatch correctly (existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)