### PR TITLE
chore(changelog): adopt append-to-end convention to reduce PR conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `guild-cli` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the versioning policy described in [docs/POLICY.md](./docs/POLICY.md).
 
+<!--
+Convention for the `## [Unreleased]` block:
+APPEND new entries to the END of each section (Fixed / Changed /
+Added / Removed / Deprecated / Security). Do NOT insert at the top.
+
+Why: top-insertion makes every concurrently-open PR collide on the
+same anchor (HEAD's "next line" after the section heading). Appending
+to the end lets concurrent PRs merge without textual conflict —
+git's three-way merge resolves "two PRs appended" automatically when
+their content doesn't overlap.
+
+At release time, the `## [Unreleased]` block is renamed to the
+version heading; ordering within the section can be tidied during
+that same edit if a curator wants reverse-chronological prose.
+For day-to-day Unreleased churn, raw chronological append is fine.
+-->
+
 ## [Unreleased]
 
 ### Fixed


### PR DESCRIPTION
## Summary

Every PR opened in today's 2026-05-13 dogfood arc (#362 / #364 / #366 / #367) hit the same conflict: two open PRs both inserted a new entry at the top of `## [Unreleased]`, and git's three-way merge couldn't resolve them. The conflict was always **structural**, never semantic — different verbs, different sections, but the same insertion anchor.

The fix is a documented convention: **append new entries to the END of each section** instead of inserting at the top.

## Why this works

Top-insertion races on the same anchor (HEAD's \"next line\" after the section heading). When two PRs both try to insert at line N, git can't pick one without a conflict marker.

Append-to-end is naturally additive: PR A adds line N+1, PR B adds line N+2, and git merges both. The only way to conflict is if the appended *content* overlaps — which is the semantic case worth surfacing, not a structural artifact of where the cursor was.

Reverse-chronological prose ordering (the implicit Keep a Changelog default for human readability) can happen at **release time**, during the `[Unreleased] → version` rename. That's a single curator's edit, not a per-PR collision point.

## What this PR changes

- Adds a 14-line HTML comment to `CHANGELOG.md`, immediately above `## [Unreleased]`, documenting the convention with rationale.
- **Does not reorder existing entries** — touching them would itself create a conflict point for any in-flight PR. The convention starts from PRs *after* this one.

## What this PR does NOT do

- No tooling change (no linter, no PR template, no commit hook). The convention is honor-system for now; if the cost of forgetting is high, a follow-up can add a CI check that fails when `## [Unreleased]` has a new line inserted at the top rather than appended.
- No retroactive cleanup of existing entries.

## Test plan

- [x] Renders correctly on GitHub (HTML comment is hidden, the heading reflow is clean)
- No code changes, so no test suite impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)