### PR TITLE
fix(list): truncation indicator + newline-safe table layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,20 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   Pattern aligns with the existing `doctor` / `issues` /
   `templates` / `lore` schema entries which carry a
   `subcommand` enum.
+- **`gate list` / `gate pending` text mode no longer silently
+  truncates long actions and no longer corrupts table layout on
+  multi-line actions.** Pre-fix, `printSummary` used
+  `String(j['action']).slice(0, 60)`: (a) it cut at exactly 60
+  chars with no indicator (`trap_silent_fallback_loses_signal`
+  — a 500-char action and a 60-char action rendered
+  identically), (b) it kept embedded `\n` in the slice, so the
+  second line shifted to column 0 and broke the columnar
+  layout, and (c) `.slice` on a UTF-16 boundary risked cleaving
+  a surrogate pair. The fix collapses `\r\n\t` to a U+21B5 ↵
+  marker first, then runs the existing
+  `truncateCodePoints(..., 60)` helper (appends `...`, splits
+  on code points). JSON consumers continue to see the full
+  action verbatim — truncation is a text-mode-only concern.
 
 ### Changed
 

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -128,6 +128,7 @@ import {
   isDryRun,
   emitDryRunPreview,
   normalizeActor,
+  truncateCodePoints,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 
@@ -1610,8 +1611,22 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
 function printSummary(r: Request, markerWidth = 16): void {
   const j = r.toJSON();
   const markers = formatReviewMarkers(j['reviews'], markerWidth);
+  // Two issues with the previous `String(j['action']).slice(0, 60)`:
+  //   1. silent truncation — a 500-char action rendered as exactly 60
+  //      chars with no indicator; the caller couldn't tell prefix from
+  //      full content (trap_silent_fallback_loses_signal).
+  //   2. newline-preserving — multi-line actions break the columnar
+  //      table layout; the second line shifts to column 0.
+  //   3. UTF-16 surrogate cleave — `.slice(60)` on a string ending
+  //      with an emoji can produce a broken char.
+  // truncateCodePoints handles (1) and (3) (appends `...`, splits on
+  // code points). Newlines/CRs/tabs are collapsed to a U+21B5 RETURN
+  // SYMBOL so the table stays one line per request while the truncation
+  // remains visible.
+  const oneLine = String(j['action']).replace(/[\r\n\t]+/g, ' ↵ ');
+  const display = truncateCodePoints(oneLine, 60);
   process.stdout.write(
-    `${j['id']}  [${j['state']}]  from=${j['from']}  ${markers}${String(j['action']).slice(0, 60)}\n`,
+    `${j['id']}  [${j['state']}]  from=${j['from']}  ${markers}${display}\n`,
   );
 }
 

--- a/tests/interface/listPendingFormat.test.ts
+++ b/tests/interface/listPendingFormat.test.ts
@@ -314,3 +314,80 @@ test('gate pending still rejects unknown flags (format addition is targeted)', (
   assert.equal(r.status, 1);
   assert.match(r.stderr, /unknown flag/i);
 });
+
+// ---- list --format text: action truncation + newline-safety ----
+
+test('gate list --format text shows ellipsis when action exceeds 60 chars', (t) => {
+  // Pre-fix, `String(j['action']).slice(0, 60)` truncated silently:
+  // a 500-char action rendered as exactly 60 chars of prefix with no
+  // indicator. trap_silent_fallback_loses_signal — caller can't tell
+  // prefix from full content. Fix uses truncateCodePoints, which
+  // appends `...` and splits on Unicode code points (also closes the
+  // UTF-16 surrogate-cleave latent bug).
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const longAction = 'x'.repeat(500);
+  runGate(
+    root,
+    ['request', '--from', 'alice', '--action', longAction, '--reason', 'r'],
+  );
+  const r = runGate(root, ['list', '--state', 'pending']);
+  assert.equal(r.status, 0);
+  // Find the line for our request and assert it ends with '...'
+  const line = r.stdout
+    .split('\n')
+    .find((ln) => /^\d{4}-\d{2}-\d{2}-\d+\s+\[pending\]/.test(ln));
+  assert.ok(line, 'must find the pending request line');
+  assert.match(line!, /\.\.\.$/, 'truncated action must end with `...`');
+  // Total visible action segment is 60 chars (57 of content + 3 dots).
+  const actionSegment = line!.replace(/^.*from=alice\s+/, '');
+  assert.equal(actionSegment.length, 60, 'truncated segment is exactly 60 chars');
+});
+
+test('gate list --format text collapses newlines in action to U+21B5 ↵', (t) => {
+  // Pre-fix, a multi-line action broke the columnar layout — the
+  // second line shifted to column 0. The fix replaces every
+  // \r/\n/\t run with ' ↵ ' so the table stays one line per row.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  runGate(
+    root,
+    [
+      'request',
+      '--from', 'alice',
+      '--action', 'line1\nline2',
+      '--reason', 'r',
+    ],
+  );
+  const r = runGate(root, ['list', '--state', 'pending']);
+  assert.equal(r.status, 0);
+  // The line for our request must contain both halves on ONE line,
+  // joined by the ↵ marker.
+  const line = r.stdout
+    .split('\n')
+    .find((ln) => /^\d{4}-\d{2}-\d{2}-\d+\s+\[pending\]/.test(ln));
+  assert.ok(line, 'must find the pending request line');
+  assert.match(line!, /line1 ↵ line2/, 'newline collapsed to ↵ marker');
+  // The line "line2" must NOT appear on its own at the start of any
+  // subsequent line (which was the pre-fix layout break).
+  assert.ok(
+    !r.stdout.split('\n').some((ln) => /^line2\b/.test(ln)),
+    'no continuation line bleeds into the table layout',
+  );
+});
+
+test('gate list --format json preserves full action verbatim (no truncation)', (t) => {
+  // The text-mode truncation must not leak into JSON consumers.
+  // toRenderJSON emits the full string.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const longAction = 'y'.repeat(500);
+  runGate(
+    root,
+    ['request', '--from', 'alice', '--action', longAction, '--reason', 'r'],
+  );
+  const r = runGate(root, ['list', '--state', 'pending', '--format', 'json']);
+  assert.equal(r.status, 0);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.requests[0].action.length, 500);
+});


### PR DESCRIPTION
## Summary

Probing input edges of `gate request` under /goal-driven dogfood surfaced two friction points in `gate list` / `gate pending` text-mode rendering:

```
$ gate request --action \"\$(yes x | head -500 | tr -d '\\n')\" ...
$ gate list --state pending
2026-05-13-0012  [pending]  from=eris  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
                                       └─ no indicator that 440 chars were dropped ─┘

$ gate request --action \"line1
line2 continued\" ...
$ gate list --state pending
2026-05-13-0013  [pending]  from=eris  line1
line2 continued        ← bleeds out of the columnar layout
```

Root cause: `printSummary` used `String(j['action']).slice(0, 60)`. Three issues stacked there:

1. **silent truncation** — a 500-char action rendered as exactly 60 chars with no `...` indicator. Indistinguishable from a 60-char action by reading alone (`trap_silent_fallback_loses_signal`).
2. **newline-preserving** — multi-line actions broke the columnar table layout: the second line shifted to column 0.
3. **UTF-16 surrogate cleave** — `.slice(60)` on a string ending with an emoji could produce a broken char. Latent bug; not currently triggered.

## Fix

Collapse `\\r\\n\\t` runs to a `U+21B5 ↵` marker first, then run the existing `truncateCodePoints(..., 60)` helper from `internal.ts` (appends `...`, splits on Unicode code points).

After:

```
2026-05-13-0012  [pending]  from=eris  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...
2026-05-13-0013  [pending]  from=eris  line1 ↵ line2 continued
```

JSON consumers continue to receive the full `action` verbatim — truncation is a text-mode-only concern. Pinned by the third new test below.

## Tests

3 new tests in `listPendingFormat.test.ts`:

- `gate list --format text shows ellipsis when action exceeds 60 chars` — pins the `...` indicator + total-width=60 invariant.
- `gate list --format text collapses newlines in action to U+21B5 ↵` — asserts both the marker presence AND the absence of a continuation line at column 0.
- `gate list --format json preserves full action verbatim (no truncation)` — guards against truncation leaking into structured output.

Full suite **1676 pass**.

## Relationship

- **#367** (merged) — schema inbox mark-read subcommand
- **#368** (merged) — CHANGELOG append-to-end convention
- **#369** (this PR) — first PR following the new CHANGELOG convention (entry appended to end of `### Fixed`, not inserted at top)

## Test plan

- [x] `npm run build && npm test` clean
- [x] Manual: long-action request renders with `...`; multi-line action renders as one line with `↵`; JSON consumers see full action

🤖 Generated with [Claude Code](https://claude.com/claude-code)