### PR TITLE
feat(errors): structured error.recovery in JSON envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,22 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   `--depth` field was previously decorative — set on the wave but read
   by nobody. Also declares `wave-status` in `verbs.ts` READ_VERBS,
   closing a pre-existing gap.
+- **`error.recovery` structured next-step in the JSON envelope.**
+  Throw sites with an obvious "use verb X instead" answer can now
+  carry the recovery in a machine-readable slot: `error.recovery: {
+  verb: string, args: Record<string,string>, reason: string }`.
+  AI-agent consumers dispatch from this directly instead of
+  parsing the prose `error:` line. Text-mode runs are unaffected
+  — the prose hint remains the human surface; the structured form
+  is its additive sibling. Wired today: `gate fail <pending-id>`
+  carries `{verb: 'deny', args: {id}, reason: '...'}`. Future
+  throw sites can opt-in by throwing the new `RecoverableError`
+  (exported from `shared/errorEnvelope.ts`) instead of `Error`.
+  Shape mirrors `BootSuggestedNext` (verb/args/reason) so
+  orchestrators that already consume `boot.suggested_next` can
+  reuse the same dispatch path. First step of the "AI-agent-
+  first delight" cluster — see `memory/eris_first_overrides.md`
+  default-pattern section for the design rubric.
 
 ### ⚠ BREAKING (JSON shape)
 

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -31,6 +31,7 @@ import {
   normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { RecoverableError } from '../../shared/errorEnvelope.js';
 
 const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -460,10 +461,23 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
     // and surface `gate deny` directly — the exact friction observed
     // 2026-05-13 (drained test-fixture pendings).
     if (priorFail.state === 'pending') {
-      throw new Error(
+      // RecoverableError carries a structured `recovery` slot so the
+      // JSON envelope's `error.recovery` field names the next verb +
+      // args directly. AI-agent consumers dispatch from the structured
+      // form; text-mode readers see the prose hint in the `error:`
+      // line as before. Both surfaces stay in lockstep — the prose
+      // and the JSON shape describe the same recovery move.
+      throw new RecoverableError(
         `Request ${id} is pending — fail is reachable only from executing.\n` +
           `  To cancel a pending request, use:\n` +
           `    gate deny ${id} --by <m> --reason <s>`,
+        {
+          verb: 'deny',
+          args: { id },
+          reason:
+            `${id} is pending; fail is reachable only from executing — ` +
+            `deny is the cancellation path for pending records.`,
+        },
       );
     }
     // See reqComplete: issue #294 / miki concern #1 — refuse fail

--- a/src/interface/shared/errorEnvelope.ts
+++ b/src/interface/shared/errorEnvelope.ts
@@ -63,6 +63,64 @@ export interface EmitOptions {
   readonly prefix?: string;
   readonly field?: string;
   readonly code?: string;
+  /**
+   * Structured next-step the caller can dispatch to recover. AI-first
+   * agents read this in preference to parsing the prose `error:` line.
+   * The `→ next:` text hint in the message body is the human-facing
+   * mirror; the structured form here is its machine-readable sibling.
+   *
+   * Emitted as `error.recovery` in the JSON envelope. Text-mode runs
+   * are unaffected — the prose hint remains the human surface.
+   *
+   * Shape mirrors `BootSuggestedNext` (verb + args + reason) so
+   * orchestrators that already consume `boot.suggested_next` can
+   * dispatch error recoveries with the same code path.
+   *
+   * Pattern documented under eris_first_overrides default rubric:
+   * "shape upstream / content local" — the structured field is a
+   * pure mechanism, equally useful to any AI agent reading errors.
+   */
+  readonly recovery?: Recovery;
+}
+
+/**
+ * Structured recovery hint embedded in `error.recovery`. The caller
+ * can dispatch the suggested verb + args directly without prose-
+ * parsing.
+ */
+export interface Recovery {
+  /** The verb to dispatch (e.g. `'deny'`, `'list'`). */
+  verb: string;
+  /** Flag/positional args as a key-value map (string-only values). */
+  args: Record<string, string>;
+  /** Human-readable explanation of why this is the recovery move. */
+  reason: string;
+}
+
+/**
+ * Error subclass carrying a structured recovery hint. Throw this
+ * from handlers that have an obvious "use verb X instead" answer
+ * for the failure case; the central error envelope catches it,
+ * lifts `.recovery` into the JSON shape, and the prose message
+ * lands on stderr unchanged for text-mode readers.
+ *
+ * Usage:
+ * ```ts
+ * throw new RecoverableError(
+ *   'Request X is pending — fail is reachable only from executing.\n' +
+ *     '  To cancel a pending request, use:\n' +
+ *     '    gate deny X --by <m> --reason <s>',
+ *   { verb: 'deny', args: { id: 'X' }, reason: 'pending cancel path' },
+ * );
+ * ```
+ */
+export class RecoverableError extends Error {
+  readonly recovery: Recovery;
+  constructor(message: string, recovery: Recovery) {
+    super(message);
+    this.name = 'RecoverableError';
+    this.recovery = recovery;
+  }
 }
 
 /**
@@ -99,6 +157,21 @@ export function emitErrorEnvelope(
       errObj['code'] = derived;
     } else if (opts.code !== undefined) {
       errObj['code'] = opts.code;
+    }
+    // recovery: structured next-step. Source priority:
+    //   1. `err instanceof RecoverableError` → err.recovery wins
+    //      (the throw site authored the recovery; honour it).
+    //   2. opts.recovery → caller of emitErrorEnvelope supplied one.
+    //   3. absence → no `recovery` field on the wire.
+    // Consumers branch on field presence; absence is the no-known-
+    // recovery signal. Today only the throw sites with an obvious
+    // "use verb X instead" answer pass this — generic not-found /
+    // validation errors keep their existing prose-only surface
+    // until a wire-up sweep follows.
+    const recovery =
+      err instanceof RecoverableError ? err.recovery : opts.recovery;
+    if (recovery !== undefined) {
+      errObj['recovery'] = recovery;
     }
     const payload = { ok: false, error: errObj };
     process.stderr.write(JSON.stringify(payload) + '\n');

--- a/tests/interface/failFromPendingRedirect.test.ts
+++ b/tests/interface/failFromPendingRedirect.test.ts
@@ -107,3 +107,53 @@ test('gate fail on a pending request redirects to gate deny by name', () => {
     b.cleanup();
   }
 });
+
+test('gate fail on a pending request — JSON envelope carries error.recovery', () => {
+  // Structured-recovery shape: the prose hint above is mirrored by a
+  // machine-readable `error.recovery: {verb, args, reason}` slot in
+  // the JSON envelope so AI agents can dispatch the next move without
+  // parsing the prose. The text-mode test above stays untouched —
+  // the prose surface is unchanged; the structured surface is the
+  // additive new contract.
+  const b = bootstrap();
+  try {
+    const filed = run(
+      b.root,
+      [
+        'request',
+        '--action', 'recovery probe',
+        '--reason', 'recovery probe',
+        '--executor', 'alice',
+        '--format', 'json',
+      ],
+      { GUILD_ACTOR: 'eris' },
+    );
+    assert.equal(filed.status, 0);
+    const id = (JSON.parse(filed.stdout) as { id: string }).id;
+
+    const failed = run(
+      b.root,
+      ['fail', id, '--by', 'alice', '--reason', 'cancel', '--format', 'json'],
+      { GUILD_ACTOR: 'eris' },
+    );
+    assert.notEqual(failed.status, 0);
+    // The envelope is emitted to stderr (JSON line 1) then prose
+    // (stderr line 2); pick the first line that parses as JSON.
+    const envelopeLine = failed.stderr
+      .split('\n')
+      .find((ln) => ln.trim().startsWith('{'));
+    assert.ok(envelopeLine, 'JSON envelope line must be present on stderr');
+    const env = JSON.parse(envelopeLine!);
+    assert.equal(env.ok, false);
+    assert.ok(env.error.recovery, 'error.recovery must be present');
+    assert.equal(env.error.recovery.verb, 'deny');
+    assert.equal(env.error.recovery.args.id, id);
+    assert.match(
+      env.error.recovery.reason,
+      /pending/,
+      'recovery.reason must name why deny is the recovery path',
+    );
+  } finally {
+    b.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

First step of the **\"AI-agent-first delight\"** cluster discussed in `memory/eris_first_overrides.md` default-pattern section. Mechanism only — no content, no voice, no eris-specific shape. Universally useful for any AI agent reading errors from any gate verb. The rubric's pure **\"shape only → upstream-direct\"** case.

## What this PR adds

A structured `error.recovery` slot in the JSON envelope:

```json
{
  \"ok\": false,
  \"error\": {
    \"message\": \"Request 2026-05-13-0002 is pending — fail is reachable only from executing. To cancel a pending request, use: gate deny ...\",
    \"recovery\": {
      \"verb\": \"deny\",
      \"args\": { \"id\": \"2026-05-13-0002\" },
      \"reason\": \"... is pending; fail is reachable only from executing — deny is the cancellation path for pending records.\"
    }
  }
}
```

Shape mirrors `BootSuggestedNext` (verb / args / reason) so orchestrators that already consume `boot.suggested_next` reuse the same code path for error recovery. **No prose-parsing required.**

## Mechanism

- new `RecoverableError` class exported from `shared/errorEnvelope.ts`, carrying a typed `recovery: Recovery` slot.
- `emitErrorEnvelope` lifts `err.recovery` into the JSON envelope when the thrown error is a `RecoverableError`. Falls back to `opts.recovery` from the catch site. Absence keeps the field absent on the wire so consumers branch cleanly on presence.

## What this PR is NOT

**Not a sweep.** Only one throw site is wired today (`gate fail <pending-id>` → suggest `gate deny`). Future call sites opt in by throwing `RecoverableError` instead of `Error`, with the structured recovery they want to surface. Existing throws stay as plain `Error` with no `recovery` field — same wire shape as today.

**No behavior change for existing consumers.** Text-mode runs are unaffected. The prose `error:` hint in the message body remains the human surface. The structured `error.recovery` is its additive sibling.

## Rubric placement (per `eris_first_overrides.md`)

| Axis | This change |
|------|-------------|
| Shape | Pure mechanism, AI-first universal |
| Content | None — neutral default |
| eris-specific bit | Zero |
| Rubric tier | **Pure shape → upstream direct** |

Future PRs in the cluster (`_meta.voice`, `--voice <name>` schema variants) will be the rubric's tier-2 cases (shape upstream + content local).

## Tests

1 new test in `failFromPendingRedirect.test.ts`:

- `gate fail on a pending request — JSON envelope carries error.recovery` — asserts the envelope shape (`error.recovery.verb`, `.args.id`, `.reason`).

Existing text-mode test for the same redirect is untouched.

Full suite **1678 pass** (was 1677 + 1 new).

## Test plan

- [x] `npm run build && npm test` clean
- [x] Manual: `gate fail <pending-id> --format json` emits `error.recovery` envelope
- [x] Manual: same call in text mode emits the existing prose hint, unchanged
- [x] Manual: errors without recovery (e.g. unknown flag) still emit envelope with no `recovery` field (absence semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)