### PR TITLE
feat(boot): `gate boot --since <ISO-ts>` delta surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1126,6 +1126,24 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   invalid-state error now also names `|all` so the option is
   discoverable from the failure itself.
 
+- **`gate boot --since <ISO-timestamp>` delta surface.** Token-cost
+  lever for long sessions: agents that re-boot mid-flow now pass the
+  previous boot's `last_activity` (or any ISO-8601 UTC timestamp the
+  substrate would emit) and receive `tail`, `your_recent`, and
+  `inbox_unread` filtered to entries strictly newer than the cutoff.
+  Validation is strict — the value must match
+  `YYYY-MM-DDTHH:MM:SS(.sss)?Z` so the echoed `since` field is always
+  directly comparable to substrate timestamps; malformed input is
+  rejected with a `next:` hint pointing at the previous boot's
+  `last_activity` as the canonical chain value. Two invariants
+  preserved across the filter: (1) `status.inbox_unread` SCALAR
+  reflects the TRUE unread count, not the filtered slice, so the
+  orientation counter never undercounts; (2) `last_activity` itself
+  is NOT filtered, so the next boot can chain
+  `--since=$last_activity` without a second read. AI-agent-first
+  delight cluster #2; pure shape (rubric tier-1), no eris-specific
+  content. (#37x)
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -61,7 +61,15 @@ const BOOT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'tail',
   'utterances',
   'session-id',
+  'since',
 ]);
+
+// Strict ISO-8601 with milliseconds, UTC. Matches what Date.toISOString()
+// emits and what the substrate stamps onto status_log / reviews /
+// inbox / created_at. Stricter than Date.parse — we reject loose
+// formats so the timestamp echoed back in payload.since is always
+// directly comparable to the substrate's own timestamps.
+const ISO_TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
 
 /**
  * gate boot [--format json|text] [--tail <N>] [--utterances <N>]
@@ -96,6 +104,25 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   // orchestrator's explicit override is honoured even when the shell
   // exported a stale value. Validation matches resolveGuildSessionId
   // (the env-side helper) so the two resolution paths use one regex.
+  // --since <ISO-timestamp>: delta-filter for tail/your_recent/
+  // inbox_unread. Reduces token cost across a long session — a returning
+  // agent passes the previous boot's `last_activity` and gets only what
+  // changed. last_activity itself is left intact so consumers can wire
+  // the next boot's --since without round-tripping a separate read.
+  const sinceFlag = optionalOption(args, 'since');
+  let since: string | null = null;
+  if (sinceFlag !== undefined && sinceFlag.length > 0) {
+    if (!ISO_TS_RE.test(sinceFlag)) {
+      throw new Error(
+        `--since "${sinceFlag}" must be ISO-8601 UTC (e.g. ` +
+          `2026-05-14T01:02:03.456Z). next: pass the previous boot's ` +
+          `last_activity verbatim, or any ISO timestamp the substrate ` +
+          `would emit.`,
+      );
+    }
+    since = sinceFlag;
+  }
+
   const sessionIdFlag = optionalOption(args, 'session-id');
   let sessionId: string | null = null;
   let sessionIdSource: 'flag' | 'env' | null = null;
@@ -166,8 +193,16 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     try {
       const msgs = await c.messageUC.inbox(actor);
       const unread = msgs.filter((m) => !m.read);
+      // status.inbox_unread reflects the TRUE unread count for
+      // orientation accuracy — --since filters the surfaced entries
+      // but the counter must not undercount or the agent will think
+      // there's less waiting than there is. Filter the entries array
+      // only; keep the scalar truthful.
       status.inbox_unread = unread.length;
-      for (const m of unread) {
+      const visibleUnread = since !== null
+        ? unread.filter((m) => m.at > since!)
+        : unread;
+      for (const m of visibleUnread) {
         inboxUnread.push({
           at: m.at,
           from: m.from,
@@ -205,10 +240,24 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   // request corpus so collectUtterances isn't double-invoked on the
   // same data — it's O(N*status_log) and N grows with history.
   const allJson = allRequests.map((r) => r.toJSON() as unknown as Parameters<typeof collectUtterances>[0][number]);
-  const tail = collectUtterances(allJson, { limit: tailLimit, order: 'desc' });
-  const yourRecent = actor
+  // When --since is set, collect first then filter by `at > since`.
+  // We apply the limit AFTER the time filter so the limit governs the
+  // returned delta window, not the pre-filter pool.
+  let tail = collectUtterances(allJson, { limit: tailLimit, order: 'desc' });
+  let yourRecent = actor
     ? collectUtterances(allJson, { name: actor, limit: personalLimit, order: 'desc' })
     : null;
+  if (since !== null) {
+    const cutoff = since;
+    tail = collectUtterances(allJson, { order: 'desc' })
+      .filter((u) => u.at > cutoff)
+      .slice(0, tailLimit);
+    if (yourRecent !== null) {
+      yourRecent = collectUtterances(allJson, { name: actor!, order: 'desc' })
+        .filter((u) => u.at > cutoff)
+        .slice(0, personalLimit);
+    }
+  }
 
   // Misconfigured-cwd detection: warn ONLY when no config file was
   // found AND the fallback content_root is empty. This distinguishes
@@ -340,6 +389,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     role,
     session_id: sessionId,
     session_id_source: sessionIdSource,
+    since,
     status,
     tail,
     your_recent: yourRecent,

--- a/src/interface/gate/handlers/bootTypes.ts
+++ b/src/interface/gate/handlers/bootTypes.ts
@@ -176,6 +176,18 @@ export interface BootPayload {
   role: 'member' | 'host' | 'unknown' | null;
   session_id: string | null;
   session_id_source: 'flag' | 'env' | null;
+  /**
+   * Delta-filter timestamp (--since). When set, `tail`, `your_recent`,
+   * and `inbox_unread` only contain entries whose `at` is strictly
+   * greater than `since` (ISO-8601 lexicographic compare). Null when
+   * no filter was applied — payload is the full snapshot.
+   *
+   * Typical agent usage: pass the previous boot's `last_activity` so
+   * successive boots within one session return only what's new.
+   * `last_activity` itself is NOT filtered — readers can always see
+   * the most recent activity timestamp for next-call wiring.
+   */
+  since: string | null;
   status: StatusSummary;
   tail: ReturnType<typeof collectUtterances>;
   your_recent: ReturnType<typeof collectUtterances> | null;

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -256,6 +256,21 @@ const VERBS: readonly VerbSchema[] = [
         format: formatField,
         tail: { type: 'string', description: 'utterances to include in tail (default 10)' },
         utterances: { type: 'string', description: 'your-recent utterance count (default 5)' },
+        since: {
+          type: 'string',
+          description:
+            'Delta-filter timestamp (ISO-8601 UTC, e.g. ' +
+            '2026-05-14T01:02:03.456Z). When set, `tail`, `your_recent`, ' +
+            'and `inbox_unread` only contain entries strictly newer than ' +
+            'this value (lexicographic compare on the `at` string). ' +
+            'Reduces token cost across a long session — pass the previous ' +
+            "boot's `last_activity` to get only what's new. The " +
+            '`status.inbox_unread` SCALAR reflects the true unread count ' +
+            '(not the filtered slice), so the counter stays truthful. ' +
+            '`last_activity` itself is NOT filtered so the next boot can ' +
+            'chain --since without a second read. Rejected with a "next: " ' +
+            'hint when the value is not strict ISO-8601 UTC.',
+        },
         'session-id': {
           type: 'string',
           description:
@@ -297,6 +312,14 @@ const VERBS: readonly VerbSchema[] = [
             'Names which input populated `session_id`: "flag" when ' +
             '--session-id was supplied on this invocation, "env" when ' +
             'GUILD_SESSION_ID was the source, null when neither.',
+        },
+        since: {
+          type: 'string',
+          description:
+            'Echoes the --since input value verbatim when a delta ' +
+            'filter was applied. Null when no filter; payload is the ' +
+            'full snapshot. Useful for an agent to confirm what cutoff ' +
+            'the substrate actually used before chaining the next boot.',
         },
         status: { type: 'object' },
         tail: { type: 'array' },

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -354,13 +354,21 @@ const SECTIONS: readonly Section[] = [
         tier: 'base',
         text:
           '  gate boot [--format json|text] [--tail <N>] [--utterances <N>]\n' +
+          '            [--since <ISO-ts>] [--session-id <id>]\n' +
           '                       Single-command session bootstrap for agents.\n' +
           '                       Returns identity + status + tail + your recent\n' +
           '                       utterances + inbox unread as one JSON payload.\n' +
           '                       GUILD_ACTOR optional (global view if unset).\n' +
           '                       Defaults: --tail 5 --utterances 5 (lean for\n' +
           '                       hot-path session start; pass higher N for deeper\n' +
-          '                       history).',
+          '                       history).\n' +
+          '                       --since <ISO-ts> trims tail / your_recent /\n' +
+          '                       inbox_unread to entries strictly newer than the\n' +
+          '                       cutoff (lexicographic). Token-cost lever for\n' +
+          '                       long sessions: pass the previous boot\'s\n' +
+          '                       `last_activity` to get only what changed.\n' +
+          '                       `status.inbox_unread` stays truthful (full\n' +
+          '                       count); only the surfaced entries are filtered.',
       },
       {
         tier: 'base',

--- a/src/interface/shared/explain.ts
+++ b/src/interface/shared/explain.ts
@@ -38,7 +38,7 @@ import type { ParsedArgs } from './parseArgs.js';
  * (`--help` does that).
  */
 export const EXPLAIN_MESSAGES: Readonly<Record<string, string>> = {
-  boot: 'session-start orientation; surfaces actor identity, recent wave activity, and the next verb to reach for.',
+  boot: 'session-start orientation; surfaces actor identity, recent wave activity, and the next verb to reach for. Pass --since <ISO-ts> (typically the prior boot\'s last_activity) for a delta-only payload.',
   next: 'one-call read-and-dispatch of the top actionable verb. Without --confirm prints the plan; with --confirm dispatches via subprocess. Auto-dispatch limited to verbs needing only --by.',
   list: 'lists requests filtered by --state/--from/--executors/--target; pair with `gate show <id>` for full body.',
   pending: 'lists requests in state=pending — the approval queue; subset of `gate list --state pending`.',

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -63,6 +63,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'role',
         'session_id',
         'session_id_source',
+        'since',
         'status',
         'suggested_next',
         'tail',

--- a/tests/interface/bootSince.test.ts
+++ b/tests/interface/bootSince.test.ts
@@ -1,0 +1,139 @@
+// gate boot --since <ISO-timestamp> — delta-filter contract.
+//
+// The token-cost lever: agents pass the previous boot's
+// `last_activity` to receive only new utterances + inbox messages.
+// This pins:
+//   1. valid ISO timestamps are accepted and echoed back
+//   2. malformed inputs are rejected with the "next: " hint
+//   3. tail / your_recent / inbox_unread filter strictly on `at > since`
+//   4. status.inbox_unread SCALAR stays truthful even when surface
+//      entries are filtered out (orientation accuracy)
+//   5. last_activity itself is NOT filtered (so the chain works)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-boot-since-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [human]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  writeFileSync(
+    join(root, 'members', 'bob.yaml'),
+    'name: bob\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status ?? -1 };
+}
+
+test('boot --since: omitted → since=null and full payload', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['fast-track', '--from', 'alice', '--action', 'a', '--reason', 'r']);
+    const { stdout, status } = runGate(root, ['boot'], { GUILD_ACTOR: 'alice' });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.since, null);
+    assert.ok(Array.isArray(payload.tail));
+    assert.ok(payload.tail.length >= 1, 'fast-track utterance should appear in tail');
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot --since: malformed ISO is rejected with "next: " hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stderr, status } = runGate(root, ['boot', '--since', 'yesterday'], { GUILD_ACTOR: 'alice' });
+    assert.notEqual(status, 0);
+    assert.match(stderr, /--since/);
+    assert.match(stderr, /ISO-8601/);
+    assert.match(stderr, /next:/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot --since: future ISO filters out all tail entries', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['fast-track', '--from', 'alice', '--action', 'a', '--reason', 'r']);
+    const future = '2099-01-01T00:00:00.000Z';
+    const { stdout, status } = runGate(root, ['boot', '--since', future], { GUILD_ACTOR: 'alice' });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.since, future);
+    assert.deepEqual(payload.tail, []);
+    assert.deepEqual(payload.your_recent, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot --since: past ISO keeps tail intact', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['fast-track', '--from', 'alice', '--action', 'a', '--reason', 'r']);
+    const past = '1970-01-01T00:00:00.000Z';
+    const { stdout, status } = runGate(root, ['boot', '--since', past], { GUILD_ACTOR: 'alice' });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.since, past);
+    assert.ok(payload.tail.length >= 1, 'past --since must not filter out historical entries');
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot --since: last_activity is NOT filtered (chain semantic)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['fast-track', '--from', 'alice', '--action', 'a', '--reason', 'r']);
+    const future = '2099-01-01T00:00:00.000Z';
+    const { stdout } = runGate(root, ['boot', '--since', future], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.notEqual(payload.last_activity, null,
+      'last_activity must survive --since so the next boot can chain --since=last_activity');
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot --since: status.inbox_unread scalar stays truthful when entries filter out', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    // bob sends alice a message — gives alice an unread entry to filter against.
+    runGate(root, ['message', '--from', 'bob', '--to', 'alice', '--text', 'hi']);
+    const future = '2099-01-01T00:00:00.000Z';
+    const { stdout, status } = runGate(root, ['boot', '--since', future], { GUILD_ACTOR: 'alice' });
+    assert.equal(status, 0);
+    const payload = JSON.parse(stdout);
+    // Scalar reflects truth (1 unread); surfaced entries filtered to none.
+    assert.equal(payload.status.inbox_unread, 1, 'scalar must NOT undercount due to --since');
+    assert.deepEqual(payload.inbox_unread, [], 'surfaced entries respect --since');
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- AI-agent-first delight cluster #2 — token-cost lever for long sessions
- `gate boot --since <ISO-timestamp>` filters `tail`, `your_recent`, and `inbox_unread` to entries strictly newer than the cutoff
- Strict ISO-8601 UTC validation; malformed input rejected with a `next:` hint pointing at the previous boot's `last_activity` as the canonical chain value

## Invariants preserved

- `status.inbox_unread` scalar reflects the TRUE unread count, not the filtered slice — the orientation counter never undercounts
- `last_activity` itself is NOT filtered so the next boot can chain `--since=$last_activity` without a second read

## Rubric placement

Tier-1: pure shape, no eris-specific content. Lands upstream cleanly.

## Test plan

- [x] 6 new tests under `tests/interface/bootSince.test.ts` cover happy/sad/edge cases
- [x] existing `boot.test.ts` top-level-keys pin updated to include `since`
- [x] full suite: 1691 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)