### PR TITLE
feat(voice): ornamental-voice plugin infrastructure (#345 cluster #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1165,6 +1165,33 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   Text-mode boot adds a `past selves left these cliffs:` section that
   renders only when entries exist (principle 13 voice budget). (#37x)
 
+- **Voice plugin infrastructure: ornamental-voice surface as the
+  second dogfood validation of principle 15.** Introduces a third
+  plugin kind (`plugins.voices`) alongside the existing verb/hook
+  plugins. A voice plugin attaches OPTIONAL personality narration to
+  write-verb JSON envelopes via a new `_meta.voice` field, distinct
+  from the doctrinal voice held in handlers (principle 08 — that
+  voice is intentionally NOT pluggable). Two-layer model preserved
+  by construction: doctrinal voice carries lore in `message` /
+  `suggested_next.reason` / schema descriptions; ornamental voice
+  carries personality and CANNOT replace doctrinal prose. Stripping
+  `_meta.voice` from a pipeline loses zero information — that
+  invariant is what keeps the two layers honest. Activation:
+  `GUILD_VOICE=<name>` env picks one loaded plugin by name; unset or
+  no match → no `_meta` field emitted (silent miss, never error).
+  Plugin shape: `{name, verbs: {<verb>: [{when, template}, ...]}}`
+  with `when ∈ {default, cliff_present, cliff_absent}` and
+  `{id} / {action} / {by} / {cliff}` template variables sourced from
+  the substrate (voice cannot invent facts). v1 scope: `gate
+  complete` fires voice on wave-terminal completion only; slice-only
+  closes do not emit voice (narrating a slice as "completed" would
+  be a false claim). Trust model: shares `plugins.trusted: true`
+  consent gate with verb/hook plugins. Doctor surfaces voice plugin
+  load failures as `area: 'plugin'` findings, same channel as the
+  other plugin kinds. Text-mode renders ornamental voice on stderr
+  (`(voice: …)` line) so JSON-piped consumers stay clean. (#37x —
+  cluster #1)
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/application/plugin/VoicePlugin.ts
+++ b/src/application/plugin/VoicePlugin.ts
@@ -1,0 +1,87 @@
+// Voice plugin contract (#345 — second dogfood validation of
+// principle 15 plugins-default-extension, surface: ornamental-voice
+// layer).
+//
+// Voice plugin lets a deployment attach an OPTIONAL ornamental
+// narration to write-verb response envelopes — separate from the
+// DOCTRINAL voice held in handlers (principle 08, "voice is held in
+// handlers, not in plugins"). The two layers coexist:
+//
+//   Doctrinal voice  — suggested_next.reason / schema descriptions /
+//                      finding messages. Lives in src/interface/**.
+//                      Carries lore. Untouchable by plugins.
+//
+//   Ornamental voice — _meta.voice field on the JSON envelope. Lives
+//                      in deployment-local YAML / .mjs files. Carries
+//                      personality. Augments the structured payload,
+//                      never replaces it.
+//
+// The plugin's default export carries per-verb template arrays. Each
+// entry has a `when` predicate (substrate state) and a `template`
+// string with `{var}` interpolation. First matching entry wins.
+//
+// v1 scope: terminal write verbs only (complete). fail/deny/etc.
+// follow in a sibling PR once the plumbing proves out.
+
+/**
+ * Predicate keys evaluated against the post-mutation Request. v1 set
+ * is small + explicit so the contract is auditable; new keys are
+ * additive within 0.x per `docs/POLICY.md` § "Plugin stability".
+ *
+ *   default          — always matches; intended as the last entry in
+ *                      a verb's array.
+ *   cliff_present    — terminal status_log entry has a non-empty cliff
+ *                      (i.e. the closer left a forward-pointing hint).
+ *   cliff_absent     — terminal status_log entry has no cliff.
+ */
+export type VoiceWhen = 'default' | 'cliff_present' | 'cliff_absent';
+
+/**
+ * One narration template, gated by its `when` predicate.
+ *
+ * `template` supports `{var}` interpolation; v1 variables:
+ *   {id}       — req.id.value
+ *   {action}   — req.action
+ *   {by}       — terminal status_log entry's `by` (closing actor)
+ *   {cliff}    — terminal cliff prose; empty string when absent
+ *
+ * Variables that are not in the supported set render as the literal
+ * `{varname}` text so a typo in the voice file fails loudly at the
+ * surface rather than silently producing empty output.
+ */
+export interface VoiceTemplate {
+  readonly when: VoiceWhen;
+  readonly template: string;
+}
+
+/**
+ * Plugin module's default export.
+ *
+ * `verbs` is a sparse map: only verbs the voice cares about appear.
+ * v1 honours `complete` only; entries for other keys are tolerated
+ * (forward-compatible) but unused.
+ */
+export interface VoicePlugin {
+  readonly name: string;
+  readonly verbs: Readonly<Record<string, readonly VoiceTemplate[]>>;
+}
+
+/**
+ * One per failed plugin path. Surfaced via `gate doctor` so the
+ * operator sees broken voice plugins instead of silently losing the
+ * narration. Mirrors VerbPluginLoadError shape.
+ */
+export interface VoicePluginLoadError {
+  readonly path: string;
+  readonly reason: string;
+}
+
+/**
+ * Result of a single load pass. Plugins and errors are disjoint —
+ * a path either contributes to `plugins` or to `errors`, never both.
+ */
+export interface VoicePluginLoadResult {
+  readonly plugins: readonly VoicePlugin[];
+  readonly errors: readonly VoicePluginLoadError[];
+  readonly pluginsLoaded: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
+}

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -137,6 +137,16 @@ export interface GuildConfigProps {
    * for the full event list and contract.
    */
   hookPluginPaths: readonly string[];
+  /**
+   * Absolute paths of voice plugins to load at CLI startup (#345 —
+   * second dogfood validation of principle 15 plugins-default-extension,
+   * ornamental-voice surface). Same `plugins.trusted: true` consent
+   * gate as verb/hook plugins. Each plugin attaches optional
+   * personality narration to write-verb JSON envelopes via the
+   * `_meta.voice` field, distinct from the doctrinal voice held in
+   * handlers (principle 08).
+   */
+  voicePluginPaths: readonly string[];
   profile: GuildProfile;
   features: GuildFeatures;
   gate: GateConfig;
@@ -161,6 +171,7 @@ export class GuildConfig implements GuildConfigProps {
     readonly doctorPlugins: readonly string[],
     readonly verbPluginPaths: readonly string[],
     readonly hookPluginPaths: readonly string[],
+    readonly voicePluginPaths: readonly string[],
     readonly profile: GuildProfile,
     readonly features: GuildFeatures,
     readonly gate: GateConfig,
@@ -264,6 +275,25 @@ export class GuildConfig implements GuildConfigProps {
           'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
       );
     }
+    // Voice plugins (#345 — ornamental-voice surface). Shares the
+    // `plugins.trusted` consent gate with verb/hook plugins. Voice
+    // plugins attach optional personality narration via `_meta.voice`
+    // on write envelopes; they cannot mutate substrate state and
+    // cannot veto transitions, but they run as full Node code in
+    // process — same trust model as verb/hook (the YAML alone is not
+    // consent).
+    const voicePluginPaths = Array.isArray(pluginsRaw.voices) && verbPluginsTrusted
+      ? pluginsRaw.voices
+          .filter((x: unknown): x is string => typeof x === 'string')
+          .map((x: string) => resolveUnder(root, x))
+      : [];
+    if (Array.isArray(pluginsRaw.voices) && pluginsRaw.voices.length > 0 && !verbPluginsTrusted) {
+      onMalformed(
+        configPath,
+        'plugins.voices present but plugins.trusted is not true — voice plugins will NOT be loaded. ' +
+          'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
+      );
+    }
     // Profile + features (#231). The two interact: `profile: swarm`
     // flips the default of `features.worktree_required_for_parallel`
     // to true, but an explicit `features:` block always wins so a
@@ -332,7 +362,7 @@ export class GuildConfig implements GuildConfigProps {
       }
     }
     const gate: GateConfig = { strictLenses };
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, profile, features, gate, onMalformed, configPath);
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, voicePluginPaths, profile, features, gate, onMalformed, configPath);
   }
 
   static default(
@@ -352,6 +382,7 @@ export class GuildConfig implements GuildConfigProps {
       },
       [...DEFAULT_HOSTS],
       [...DEFAULT_LENSES],
+      [],
       [],
       [],
       [],

--- a/src/infrastructure/plugin/VoicePluginLoader.ts
+++ b/src/infrastructure/plugin/VoicePluginLoader.ts
@@ -1,0 +1,139 @@
+// Voice plugin loader (#345 second dogfood validation of principle 15).
+//
+// Reads paths from `guild.config.yaml`'s `plugins.voices` (trust-gated
+// by GuildConfig — `plugins.trusted: true`) and dynamically imports
+// each as an ES module. Validates the export shape; one broken plugin
+// never takes the rest of the loader down. Mirrors the shape +
+// invariants of VerbPluginLoader so doctor reporting + trust model
+// stay uniform across plugin kinds.
+
+import { pathToFileURL } from 'node:url';
+import {
+  VoicePlugin,
+  VoicePluginLoadError,
+  VoicePluginLoadResult,
+  VoiceTemplate,
+  VoiceWhen,
+} from '../../application/plugin/VoicePlugin.js';
+
+const VALID_WHEN: ReadonlySet<VoiceWhen> = new Set([
+  'default',
+  'cliff_present',
+  'cliff_absent',
+]);
+
+function validateTemplates(raw: unknown): { ok: true; templates: VoiceTemplate[] } | { ok: false; reason: string } {
+  if (!Array.isArray(raw)) {
+    return { ok: false, reason: 'verb entry must be an array of {when, template} objects' };
+  }
+  const out: VoiceTemplate[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const e = raw[i];
+    if (e === null || typeof e !== 'object') {
+      return { ok: false, reason: `entry[${i}] is not an object` };
+    }
+    const obj = e as Record<string, unknown>;
+    if (typeof obj['when'] !== 'string' || !VALID_WHEN.has(obj['when'] as VoiceWhen)) {
+      return {
+        ok: false,
+        reason:
+          `entry[${i}].when must be one of ${[...VALID_WHEN].join(' | ')}, got ${JSON.stringify(obj['when'])}`,
+      };
+    }
+    if (typeof obj['template'] !== 'string' || obj['template'].length === 0) {
+      return { ok: false, reason: `entry[${i}].template must be a non-empty string` };
+    }
+    out.push({ when: obj['when'] as VoiceWhen, template: obj['template'] });
+  }
+  return { ok: true, templates: out };
+}
+
+/**
+ * Validate a freshly-imported module's default export against the
+ * VoicePlugin shape. Pure — no I/O — so the loader's error branch
+ * stays linear.
+ */
+function validatePluginShape(raw: unknown): { ok: true; plugin: VoicePlugin } | { ok: false; reason: string } {
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, reason: 'default export is not an object' };
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj['name'] !== 'string' || obj['name'].length === 0) {
+    return { ok: false, reason: 'name must be a non-empty string' };
+  }
+  // Same name regex as VerbPlugin — `GUILD_VOICE=<name>` lookups are
+  // case-sensitive and the name lands in shell env, so restrict to
+  // shell-friendly characters.
+  if (!/^[a-z][a-z0-9-]*$/.test(obj['name'])) {
+    return {
+      ok: false,
+      reason: `name "${obj['name']}" is not valid (lowercase, digits, hyphens; must start with a letter)`,
+    };
+  }
+  if (obj['verbs'] === null || typeof obj['verbs'] !== 'object') {
+    return { ok: false, reason: 'verbs must be an object keyed by verb name' };
+  }
+  const verbsObj = obj['verbs'] as Record<string, unknown>;
+  const verbs: Record<string, VoiceTemplate[]> = {};
+  for (const [verbName, entries] of Object.entries(verbsObj)) {
+    const r = validateTemplates(entries);
+    if (!r.ok) {
+      return { ok: false, reason: `verbs.${verbName}: ${r.reason}` };
+    }
+    verbs[verbName] = r.templates;
+  }
+  return {
+    ok: true,
+    plugin: { name: obj['name'] as string, verbs },
+  };
+}
+
+/**
+ * Load every path in `pluginPaths` as a voice plugin. Two plugins
+ * claiming the same `name` in the same load pass: first wins,
+ * the rest are rejected (mirrors VerbPluginLoader's collision rule).
+ *
+ * Order is the order of `plugins.voices` in `guild.config.yaml`.
+ */
+export async function loadVoicePlugins(
+  pluginPaths: readonly string[],
+): Promise<VoicePluginLoadResult> {
+  const plugins: VoicePlugin[] = [];
+  const errors: VoicePluginLoadError[] = [];
+  const pluginsLoaded: Array<{ path: string; status: 'loaded' | 'error' }> = [];
+  const seenNames = new Set<string>();
+
+  for (const pluginPath of pluginPaths) {
+    let mod: { default?: unknown } & Record<string, unknown>;
+    try {
+      mod = await import(pathToFileURL(pluginPath).href);
+    } catch (e) {
+      errors.push({
+        path: pluginPath,
+        reason: `import failed: ${e instanceof Error ? e.message : String(e)}`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    const exportRoot = mod.default ?? mod;
+    const result = validatePluginShape(exportRoot);
+    if (!result.ok) {
+      errors.push({ path: pluginPath, reason: result.reason });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    const plugin = result.plugin;
+    if (seenNames.has(plugin.name)) {
+      errors.push({
+        path: pluginPath,
+        reason: `voice "${plugin.name}" is already registered by an earlier plugin in this load pass`,
+      });
+      pluginsLoaded.push({ path: pluginPath, status: 'error' });
+      continue;
+    }
+    seenNames.add(plugin.name);
+    plugins.push(plugin);
+    pluginsLoaded.push({ path: pluginPath, status: 'loaded' });
+  }
+  return { plugins, errors, pluginsLoaded };
+}

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -32,6 +32,7 @@ import {
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
 import { RecoverableError } from '../../shared/errorEnvelope.js';
+import { renderVoice } from '../../shared/voiceRender.js';
 
 const APPROVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -436,7 +437,12 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
     emitSliceClose(r, by, 'complete', c.config, parseFormat(args), extraLines);
     return 0;
   }
-  emitWriteResponse(parseFormat(args), r, `✓ completed: ${id}`, c.config, extraLines);
+  // Ornamental voice (#345): fires only on wave-terminal completion,
+  // never on slice-only. Slice-only is a multi-executor intermediate
+  // state — narrating it as "completed" would be a false claim about
+  // wave state (principle 08's voice-must-stay-honest invariant).
+  const voice = renderVoice(c.voicePlugins, 'complete', r);
+  emitWriteResponse(parseFormat(args), r, `✓ completed: ${id}`, c.config, extraLines, { voice });
   return 0;
 }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -127,6 +127,31 @@ const writeResponseSchema: JsonSchema = {
         'orchestrators, not a directive. null when the lifecycle has no obvious next step.',
       ...suggestedNextSchema,
     },
+    _meta: {
+      type: 'object',
+      description:
+        'Optional metadata block carrying surface-level annotations that ' +
+        'augment but never replace the structured payload. Consumers may ' +
+        'ignore `_meta` entirely; nothing in it carries facts the rest ' +
+        "of the envelope doesn't already carry.",
+      properties: {
+        voice: {
+          type: 'string',
+          description:
+            'Ornamental-voice narration string (#345 — second dogfood ' +
+            'validation of principle 15). Present only when a voice ' +
+            'plugin is loaded, `GUILD_VOICE=<name>` picks it, and a ' +
+            'template matched the current request snapshot. Distinct ' +
+            'from the doctrinal voice held in `message` and ' +
+            '`suggested_next.reason` (principle 08, voice-as-doctrine ' +
+            '— that voice is intentionally NOT pluggable). Ornamental ' +
+            'voice is the second layer: deployment-local personality ' +
+            'that augments envelopes without claiming new facts. ' +
+            'Stripping `_meta.voice` from a pipeline loses no ' +
+            'information.',
+        },
+      },
+    },
   },
   required: ['ok', 'id', 'state', 'message', 'suggested_next'],
 };

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -41,6 +41,21 @@ export interface WriteResponse {
   state: string;
   message: string;
   suggested_next: SuggestedNext | null;
+  /**
+   * Ornamental-voice metadata (#345 — second dogfood validation of
+   * principle 15). Optional. Present only when a voice plugin is
+   * loaded, `GUILD_VOICE=<name>` picks it, and a template matched
+   * the current request snapshot. Carries ornamental narration
+   * separate from the doctrinal voice held in `message` and
+   * `suggested_next.reason` (principle 08, voice-as-doctrine).
+   *
+   * Consumers may ignore `_meta` entirely; it never carries facts
+   * the structured payload doesn't already carry. Voice can be
+   * stripped from a pipeline without information loss.
+   */
+  _meta?: {
+    voice?: string;
+  };
 }
 
 export interface SuggestedNext {
@@ -235,15 +250,20 @@ export function buildWriteResponse(
   req: Request,
   message: string,
   config: GuildConfig,
+  opts?: { voice?: string | null },
 ): WriteResponse {
   const envActor = resolveGuildActor() ?? null;
-  return {
+  const out: WriteResponse = {
     ok: true,
     id: req.id.value,
     state: req.state,
     message,
     suggested_next: deriveSuggestedNext(req, config, envActor),
   };
+  if (opts?.voice !== undefined && opts.voice !== null) {
+    out._meta = { voice: opts.voice };
+  }
+  return out;
 }
 
 /**
@@ -259,12 +279,20 @@ export function emitWriteResponse(
   message: string,
   config: GuildConfig,
   textLines: readonly string[] = [],
+  opts?: { voice?: string | null },
 ): void {
   if (format === 'json') {
-    const payload = buildWriteResponse(req, message, config);
+    const payload = buildWriteResponse(req, message, config, opts);
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
     return;
   }
   process.stdout.write(message + '\n');
   for (const line of textLines) process.stdout.write(line + '\n');
+  // Ornamental voice in text mode: a single stderr line below the
+  // structured output. stderr (not stdout) so JSON-piped consumers
+  // who also enable text-mode rendering by accident don't see voice
+  // mingle with parseable payload. Suppressed when null.
+  if (opts?.voice !== undefined && opts.voice !== null) {
+    process.stderr.write(`(voice: ${opts.voice})\n`);
+  }
 }

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -2,6 +2,7 @@ import { buildContainer } from '../shared/container.js';
 import { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
 import { loadVerbPlugins } from '../../infrastructure/plugin/VerbPluginLoader.js';
 import { loadHookPlugins } from '../../infrastructure/plugin/HookPluginLoader.js';
+import { loadVoicePlugins } from '../../infrastructure/plugin/VoicePluginLoader.js';
 import { parseArgs, optionalOption, HelpRequested } from '../shared/parseArgs.js';
 import { renderVerbHelp } from '../shared/verbHelp.js';
 import { nearestCommand } from '../shared/nearestCommand.js';
@@ -146,6 +147,11 @@ export async function main(argv: readonly string[]): Promise<number> {
   // resulting subscription map and load errors to handlers and
   // doctor respectively.
   const hookPluginLoad = await loadHookPlugins(config.hookPluginPaths);
+  // Voice plugins (#345 — second dogfood validation of principle 15).
+  // Loaded with the other plugin kinds; the container exposes them
+  // so handlers can call `renderVoice()` at write-verb fire points
+  // without re-discovering plugins per request.
+  const voicePluginLoad = await loadVoicePlugins(config.voicePluginPaths);
   const c = buildContainer({
     verbPlugins: verbPluginLoad.plugins,
     verbPluginErrors: verbPluginLoad.errors,
@@ -153,6 +159,9 @@ export async function main(argv: readonly string[]): Promise<number> {
     hookSubscriptions: hookPluginLoad.subscriptions,
     hookPluginErrors: hookPluginLoad.errors,
     hookPluginsLoaded: hookPluginLoad.pluginsLoaded,
+    voicePlugins: voicePluginLoad.plugins,
+    voicePluginErrors: voicePluginLoad.errors,
+    voicePluginsLoaded: voicePluginLoad.pluginsLoaded,
   });
   try {
     // #200: <write-verb> --help must not block on the lock. Help is

--- a/src/interface/shared/container.ts
+++ b/src/interface/shared/container.ts
@@ -38,6 +38,10 @@ import {
 } from '../../application/plugin/VerbPlugin.js';
 import type { HookSubscriptions } from '../../application/plugin/HookBus.js';
 import type { HookPluginLoadError } from '../../application/plugin/HookPlugin.js';
+import type {
+  VoicePlugin,
+  VoicePluginLoadError,
+} from '../../application/plugin/VoicePlugin.js';
 
 export interface Container {
   config: GuildConfig;
@@ -111,6 +115,20 @@ export interface Container {
    * `area: 'plugin'` findings, same channel as verb plugin errors.
    */
   hookPluginErrors: readonly HookPluginLoadError[];
+  /**
+   * Voice plugins (#345 — second dogfood validation of principle 15).
+   * Empty array when no plugins are listed under `plugins.voices` or
+   * `plugins.trusted: true` is absent. The active voice is picked at
+   * runtime via `GUILD_VOICE=<name>` env; the container only holds
+   * what was loaded, not which is active. Render via
+   * `interface/shared/voiceRender.ts` at write-verb fire points.
+   */
+  voicePlugins: readonly VoicePlugin[];
+  /**
+   * Per-path voice plugin load errors. Surfaced via `gate doctor` as
+   * `area: 'plugin'` findings, same channel as verb/hook plugin errors.
+   */
+  voicePluginErrors: readonly VoicePluginLoadError[];
 }
 
 export interface BuildContainerOpts {
@@ -156,6 +174,15 @@ export interface BuildContainerOpts {
    * loader. Mirrors `verbPluginsLoaded`.
    */
   hookPluginsLoaded?: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
+  /**
+   * Pre-loaded voice plugins (#345). main() loads via
+   * `loadVoicePlugins`. Defaults to `[]`.
+   */
+  voicePlugins?: readonly VoicePlugin[];
+  /** Per-path voice plugin load errors. Defaults to `[]`. */
+  voicePluginErrors?: readonly VoicePluginLoadError[];
+  /** Per-path voice plugin load outcome (loaded | error). Defaults to `[]`. */
+  voicePluginsLoaded?: ReadonlyArray<{ path: string; status: 'loaded' | 'error' }>;
 }
 
 export function buildContainer(opts: BuildContainerOpts = {}): Container {
@@ -214,6 +241,7 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
         pluginsLoaded: [
           ...(opts.verbPluginsLoaded ?? []),
           ...(opts.hookPluginsLoaded ?? []),
+          ...(opts.voicePluginsLoaded ?? []),
         ],
         errors: [
           ...(opts.verbPluginErrors ?? []).map((e) => ({
@@ -223,6 +251,10 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
           ...(opts.hookPluginErrors ?? []).map((e) => ({
             path: e.path,
             reason: `hook plugin: ${e.reason}`,
+          })),
+          ...(opts.voicePluginErrors ?? []).map((e) => ({
+            path: e.path,
+            reason: `voice plugin: ${e.reason}`,
           })),
         ],
       },
@@ -247,5 +279,7 @@ export function buildContainer(opts: BuildContainerOpts = {}): Container {
     verbPluginErrors: opts.verbPluginErrors ?? [],
     hookSubscriptions: opts.hookSubscriptions ?? new Map(),
     hookPluginErrors: opts.hookPluginErrors ?? [],
+    voicePlugins: opts.voicePlugins ?? [],
+    voicePluginErrors: opts.voicePluginErrors ?? [],
   };
 }

--- a/src/interface/shared/voiceRender.ts
+++ b/src/interface/shared/voiceRender.ts
@@ -1,0 +1,111 @@
+// Ornamental-voice rendering (#345 — second dogfood validation of
+// principle 15 plugins-default-extension).
+//
+// Two-layer model:
+//   Doctrinal voice  — handler-held prose, carries lore (principle 08).
+//   Ornamental voice — plugin-attached personality, augments envelopes.
+//
+// This module is the ornamental side. It evaluates a VoicePlugin's
+// per-verb template array against a Request post-mutation snapshot,
+// returns the first matching string, or null when nothing applies.
+//
+// Activation: `GUILD_VOICE=<name>` env var picks one loaded plugin by
+// name. Unset → null. Set but no matching plugin → null. Set and the
+// plugin has no entry for the verb → null. First matching `when` in
+// the array wins.
+//
+// Pure synchronous — no I/O — so handlers can call inline before
+// emitWriteResponse without growing the await surface.
+
+import type { Request } from '../../domain/request/Request.js';
+import type { VoicePlugin, VoiceWhen } from '../../application/plugin/VoicePlugin.js';
+
+/**
+ * Resolve the active voice plugin from env + loaded set. Public so
+ * the handler can short-circuit when no voice is active (avoid
+ * touching the Request just to ask "is voice on?").
+ */
+export function resolveActiveVoice(
+  voicePlugins: ReadonlyArray<VoicePlugin>,
+  env: NodeJS.ProcessEnv = process.env,
+): VoicePlugin | null {
+  const name = env['GUILD_VOICE'];
+  if (typeof name !== 'string' || name.length === 0) return null;
+  for (const p of voicePlugins) {
+    if (p.name === name) return p;
+  }
+  return null;
+}
+
+/**
+ * Variables an ornamental template may interpolate. Sourced from the
+ * post-mutation Request snapshot — never from caller imagination.
+ * Voice cannot invent facts; that's the principle 08 invariant the
+ * two-layer model preserves.
+ */
+interface VoiceVars {
+  readonly id: string;
+  readonly action: string;
+  readonly by: string;
+  readonly cliff: string;
+}
+
+function deriveVars(req: Request): VoiceVars {
+  const last = req.statusLog[req.statusLog.length - 1];
+  return {
+    id: req.id.value,
+    action: req.action,
+    by: last?.by ?? '',
+    cliff: last?.cliff ?? '',
+  };
+}
+
+function matchWhen(when: VoiceWhen, vars: VoiceVars): boolean {
+  switch (when) {
+    case 'default':
+      return true;
+    case 'cliff_present':
+      return vars.cliff.length > 0;
+    case 'cliff_absent':
+      return vars.cliff.length === 0;
+  }
+}
+
+const VAR_RE = /\{([a-z_]+)\}/g;
+
+function interpolate(template: string, vars: VoiceVars): string {
+  return template.replace(VAR_RE, (_, key: string) => {
+    if (key === 'id' || key === 'action' || key === 'by' || key === 'cliff') {
+      return vars[key];
+    }
+    // Unknown var renders as the literal `{name}` so a typo in the
+    // voice file fails loudly at the surface rather than silently
+    // emitting empty output. Matches the "voice cannot invent facts"
+    // invariant: a typo IS a missing fact, and the rendering
+    // surfaces that instead of papering over it.
+    return `{${key}}`;
+  });
+}
+
+/**
+ * Pick the first matching template for `verb` and render it. Returns
+ * null when no voice is active, no entry exists for the verb, or no
+ * `when` predicate matched. Callers attach the result to the JSON
+ * envelope's `_meta.voice` field — null suppresses the field entirely.
+ */
+export function renderVoice(
+  voicePlugins: ReadonlyArray<VoicePlugin>,
+  verb: string,
+  req: Request,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const plugin = resolveActiveVoice(voicePlugins, env);
+  if (plugin === null) return null;
+  const templates = plugin.verbs[verb];
+  if (!templates || templates.length === 0) return null;
+  const vars = deriveVars(req);
+  for (const t of templates) {
+    if (matchWhen(t.when, vars)) return interpolate(t.template, vars);
+  }
+  return null;
+}

--- a/tests/interface/voicePlugin.test.ts
+++ b/tests/interface/voicePlugin.test.ts
@@ -1,0 +1,205 @@
+// Voice plugin end-to-end contract (#345 — second dogfood validation of
+// principle 15, ornamental-voice surface).
+//
+// Pins:
+//   1. no GUILD_VOICE / no plugin → no `_meta` on envelope
+//   2. GUILD_VOICE set + plugin loaded + matching template → `_meta.voice`
+//      string interpolated from request snapshot
+//   3. `when: cliff_present` matches only when cliff is present;
+//      `cliff_absent` matches only when cliff is absent
+//   4. doctrinal voice (message / suggested_next.reason) is UNCHANGED
+//      when ornamental voice fires — augment-not-replace invariant
+//   5. text-mode renders ornamental voice on stderr (a single line)
+//      so JSON-piped consumers stay clean
+//   6. `plugins.trusted: true` is required — without it, plugin path
+//      is dropped with an onMalformed notice
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+interface Bootstrap {
+  root: string;
+  cleanup: () => void;
+}
+
+function bootstrap(opts?: { trusted?: boolean }): Bootstrap {
+  const trusted = opts?.trusted ?? true;
+  const root = makeTempRoot('guild-voice-');
+  const trustLine = trusted ? '  trusted: true\n' : '';
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\n' +
+      'host_names: [human]\n' +
+      'plugins:\n' +
+      trustLine +
+      '  voices:\n' +
+      '    - plugins/voices/test-voice.mjs\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins', 'voices'), { recursive: true });
+  writeFileSync(
+    join(root, 'plugins', 'voices', 'test-voice.mjs'),
+    `export default {
+  name: 'test',
+  verbs: {
+    complete: [
+      { when: 'cliff_present', template: '{action} :: cliff = {cliff}' },
+      { when: 'default', template: '{action} :: done' },
+    ],
+  },
+};
+`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status ?? -1 };
+}
+
+function buildAndComplete(root: string, opts?: { cliff?: string }): string {
+  const r1 = runGate(root, ['request', '--from', 'alice', '--action', 'do X', '--reason', 'r', '--executors', 'alice']);
+  const m = r1.stdout.match(/created: (\S+)/);
+  assert.ok(m, `parse id: ${r1.stdout}`);
+  const id = m![1]!;
+  runGate(root, ['approve', id, '--by', 'alice']);
+  runGate(root, ['execute', id, '--by', 'alice']);
+  return id;
+}
+
+test('voice: no GUILD_VOICE → no _meta on envelope', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root, ['complete', id, '--by', 'alice', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta, undefined, 'no GUILD_VOICE should suppress _meta');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: GUILD_VOICE picks plugin, cliff_present template fires with interpolation', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root,
+      ['complete', id, '--by', 'alice', '--cliff', 'verify with bob', '--format', 'json'],
+      { GUILD_VOICE: 'test' });
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    assert.ok(p._meta, '_meta should be present when voice is active and matched');
+    assert.equal(p._meta.voice, 'do X :: cliff = verify with bob');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: cliff_absent path falls to `default` when no cliff', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root,
+      ['complete', id, '--by', 'alice', '--format', 'json'],
+      { GUILD_VOICE: 'test' });
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta.voice, 'do X :: done');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: GUILD_VOICE referencing unknown plugin → no _meta (silent miss, not error)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root,
+      ['complete', id, '--by', 'alice', '--format', 'json'],
+      { GUILD_VOICE: 'nonexistent' });
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta, undefined, 'unknown voice name should not error, just suppress _meta');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: doctrinal voice (message + suggested_next) unchanged when ornamental voice fires', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const without = runGate(root,
+      ['complete', id, '--by', 'alice', '--format', 'json']);
+
+    // Second wave for the GUILD_VOICE case (the first wave is now closed)
+    const id2 = buildAndComplete(root);
+    const withVoice = runGate(root,
+      ['complete', id2, '--by', 'alice', '--format', 'json'],
+      { GUILD_VOICE: 'test' });
+
+    const p1 = JSON.parse(without.stdout);
+    const p2 = JSON.parse(withVoice.stdout);
+    // Strip the embedded ids before comparing — voice doesn't touch
+    // the message prose, but ids differ between the two waves.
+    const stripId = (s: string) => s.replace(/2026-\d{2}-\d{2}-\d{4}/g, 'ID');
+    assert.equal(stripId(p1.message), stripId(p2.message),
+      'augment-not-replace: doctrinal `message` shape must be byte-identical with/without voice');
+    // suggested_next.reason is doctrinal prose; voice does not touch it.
+    // Compare reason verbatim; verb/args may carry ids so check separately.
+    assert.equal(p1.suggested_next?.reason, p2.suggested_next?.reason,
+      'augment-not-replace: suggested_next.reason must be byte-identical');
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: text-mode renders voice on stderr (one line)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root,
+      ['complete', id, '--by', 'alice', '--cliff', 'pickup', '--format', 'text'],
+      { GUILD_VOICE: 'test' });
+    assert.equal(r.status, 0);
+    // stdout: doctrinal "✓ completed: <id>"; stderr: ornamental "(voice: ...)"
+    assert.match(r.stdout, /✓ completed:/);
+    assert.match(r.stderr, /\(voice: do X :: cliff = pickup\)/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('voice: `plugins.trusted: true` required — without it, plugin is dropped', () => {
+  const { root, cleanup } = bootstrap({ trusted: false });
+  try {
+    const id = buildAndComplete(root);
+    const r = runGate(root,
+      ['complete', id, '--by', 'alice', '--format', 'json'],
+      { GUILD_VOICE: 'test' });
+    // The plugin isn't loaded, so GUILD_VOICE=test resolves to nothing.
+    // No error — just silent miss + onMalformed notice on the load side.
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta, undefined,
+      'without plugins.trusted, voice plugin should not load');
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Second dogfood validation of principle 15 (plugins-default-extension), per the framing posted on #345. Introduces a third plugin kind (`plugins.voices`) for ornamental narration on write-verb JSON envelopes — distinct from the doctrinal voice held in handlers (principle 08, which is intentionally NOT pluggable).

## Two-layer model

| Layer | Where it lives | What it carries | Pluggable? |
|---|---|---|---|
| **Doctrinal voice** | `src/interface/**` handlers | lore (principle 08) | NO |
| **Ornamental voice** | deployment-local plugin `.mjs` | personality | YES |

Stripping `_meta.voice` from a pipeline loses zero information — that invariant is what keeps the two layers honest. Ornamental voice cannot replace doctrinal prose.

## Plugin shape

```js
// plugins/voices/<name>.mjs
export default {
  name: 'eris',
  verbs: {
    complete: [
      { when: 'cliff_present', template: '{action} closed。 ピックアップは {cliff} に渡した。' },
      { when: 'default', template: '{action} 完。' },
    ],
  },
};
```

- `when` ∈ `{default, cliff_present, cliff_absent}`
- Template variables ∈ `{id, action, by, cliff}` — substrate-sourced, never imagined
- First matching `when` wins per verb

## Activation

- `GUILD_VOICE=<name>` env picks one loaded plugin by name
- Unset / unknown name → no `_meta.voice` (silent miss, never error)
- `plugins.trusted: true` consent gate, same as verb/hook plugins

## Wired

- `GuildConfig.voicePluginPaths` (`plugins.voices: [...]`)
- `Container.voicePlugins` / `voicePluginErrors`
- `src/interface/shared/voiceRender.ts` — pure pick-and-interpolate
- `gate index.ts` loads at startup (parallel to verb/hook)
- `gate complete` fires voice on **wave-terminal only**; slice-only closes are skipped (narrating a slice as "completed" would be a false claim — principle 08's honesty invariant)
- `writeResponseSchema` declares optional `_meta.voice`
- Text mode prints `(voice: …)` on **stderr** below the doctrinal line so JSON-piped consumers stay clean

## v1 scope

`gate complete` only. `fail` / `deny` / `approve` / `review` follow in a sibling PR once the infra proves out.

## Test plan

- [x] 7 new tests under `tests/interface/voicePlugin.test.ts` cover: no-voice baseline, GUILD_VOICE picks plugin + interpolation, `cliff_present` / `cliff_absent` / `default` predicate, unknown-voice silent miss, doctrinal voice unchanged (augment-not-replace), text-mode stderr rendering, `plugins.trusted` gate
- [x] full suite: 1705 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)