### PR TITLE
feat(schema): `gate schema --voice <name>` overlay (#345 cluster #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1210,6 +1210,21 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   verb — the augment-not-replace invariant carries from PR 1
   unchanged. (#37x — cluster #1 continuation)
 
+- **`gate schema --voice <name>` voice-flavored description overlay.**
+  Voice plugin shape gains an optional `schema` section carrying
+  per-verb `summary` + per-flag `input.<flag>` description overrides;
+  `gate schema --voice <plugin-name>` overlays them onto the doctrinal
+  schema before emitting. Augment-only — any field a voice does NOT
+  override falls through verbatim, so principle 08 (voice-as-doctrine,
+  doctrinal voice held in handlers) is preserved as the substrate
+  floor. Unknown voice name → silent miss (no error, no overlay),
+  mirroring the `_meta.voice` semantic on write envelopes. Activation
+  is per-invocation (a flag, not env) so a reader can switch voices
+  without exporting `GUILD_VOICE` — useful for AI agents that want
+  to inspect what eris's schema reads like before committing to that
+  voice for the whole shell. (#37x — cluster #5, second half of the
+  voice-plugin landing pair)
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/application/plugin/VoicePlugin.ts
+++ b/src/application/plugin/VoicePlugin.ts
@@ -85,15 +85,39 @@ export interface VoiceTemplate {
 }
 
 /**
+ * Schema-description overrides keyed by verb name (#345 cluster #5).
+ * `gate schema --voice <name>` overlays these strings onto the base
+ * schema's `description` fields before emitting. Augment-not-replace:
+ * any field a voice does NOT override falls through to the doctrinal
+ * description held in handlers (principle 08 unchanged).
+ *
+ *   summary       — replaces the verb's top-level `summary` field
+ *   input.<flag>  — replaces the verb's input property `description`
+ *                   for the named flag (e.g. `cliff`, `note`, `by`)
+ *
+ * Both maps are sparse — only the keys the voice cares about appear.
+ * Missing entries cleanly fall through to upstream-neutral prose.
+ */
+export interface VoiceSchemaOverride {
+  readonly summary?: string;
+  readonly input?: Readonly<Record<string, string>>;
+}
+
+/**
  * Plugin module's default export.
  *
  * `verbs` is a sparse map: only verbs the voice cares about appear.
- * v1 honours `complete` only; entries for other keys are tolerated
- * (forward-compatible) but unused.
+ * `schema` (optional) carries voice-flavored description overrides
+ * surfaced by `gate schema --voice <name>` (#345 cluster #5). Both
+ * sections are independent — a plugin may carry only one, only the
+ * other, or both.
  */
 export interface VoicePlugin {
   readonly name: string;
   readonly verbs: Readonly<Record<string, readonly VoiceTemplate[]>>;
+  readonly schema?: {
+    readonly verbs?: Readonly<Record<string, VoiceSchemaOverride>>;
+  };
 }
 
 /**

--- a/src/infrastructure/plugin/VoicePluginLoader.ts
+++ b/src/infrastructure/plugin/VoicePluginLoader.ts
@@ -12,6 +12,7 @@ import {
   VoicePlugin,
   VoicePluginLoadError,
   VoicePluginLoadResult,
+  VoiceSchemaOverride,
   VoiceTemplate,
   VoiceWhen,
 } from '../../application/plugin/VoicePlugin.js';
@@ -87,9 +88,59 @@ function validatePluginShape(raw: unknown): { ok: true; plugin: VoicePlugin } | 
     }
     verbs[verbName] = r.templates;
   }
+  // schema overrides (#345 cluster #5) — optional, sparse, augment-only.
+  // Validated strictly here so a malformed `schema` block fails the
+  // whole plugin rather than silently dropping overrides at render time.
+  let schema: VoicePlugin['schema'] | undefined;
+  if (obj['schema'] !== undefined) {
+    if (obj['schema'] === null || typeof obj['schema'] !== 'object') {
+      return { ok: false, reason: 'schema must be an object when present' };
+    }
+    const schemaObj = obj['schema'] as Record<string, unknown>;
+    const schemaVerbsRaw = schemaObj['verbs'];
+    if (schemaVerbsRaw !== undefined) {
+      if (schemaVerbsRaw === null || typeof schemaVerbsRaw !== 'object') {
+        return { ok: false, reason: 'schema.verbs must be an object keyed by verb name' };
+      }
+      const schemaVerbs: Record<string, VoiceSchemaOverride> = {};
+      for (const [verbName, override] of Object.entries(schemaVerbsRaw)) {
+        if (override === null || typeof override !== 'object') {
+          return { ok: false, reason: `schema.verbs.${verbName} must be an object` };
+        }
+        const ov = override as Record<string, unknown>;
+        const out: { summary?: string; input?: Record<string, string> } = {};
+        if (ov['summary'] !== undefined) {
+          if (typeof ov['summary'] !== 'string') {
+            return { ok: false, reason: `schema.verbs.${verbName}.summary must be a string` };
+          }
+          out.summary = ov['summary'];
+        }
+        if (ov['input'] !== undefined) {
+          if (ov['input'] === null || typeof ov['input'] !== 'object') {
+            return { ok: false, reason: `schema.verbs.${verbName}.input must be an object` };
+          }
+          const inputRaw = ov['input'] as Record<string, unknown>;
+          const inputOut: Record<string, string> = {};
+          for (const [flag, desc] of Object.entries(inputRaw)) {
+            if (typeof desc !== 'string') {
+              return { ok: false, reason: `schema.verbs.${verbName}.input.${flag} must be a string` };
+            }
+            inputOut[flag] = desc;
+          }
+          out.input = inputOut;
+        }
+        schemaVerbs[verbName] = out;
+      }
+      schema = { verbs: schemaVerbs };
+    } else {
+      schema = {};
+    }
+  }
   return {
     ok: true,
-    plugin: { name: obj['name'] as string, verbs },
+    plugin: schema !== undefined
+      ? { name: obj['name'] as string, verbs, schema }
+      : { name: obj['name'] as string, verbs },
   };
 }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -5,7 +5,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 
-const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb']);
+const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb', 'voice']);
 
 /**
  * gate schema [--verb <name>] [--format json|text]
@@ -2000,7 +2000,25 @@ const VERBS: readonly VerbSchema[] = [
     name: 'schema',
     category: 'meta',
     summary: 'this introspection payload',
-    input: { type: 'object', properties: { verb: str, format: formatField } },
+    input: {
+      type: 'object',
+      properties: {
+        verb: str,
+        format: formatField,
+        voice: {
+          type: 'string',
+          description:
+            'Voice-flavored description overlay (#345 cluster #5). When set ' +
+            "to a loaded voice plugin's `name`, overlays the plugin's " +
+            '`schema.verbs.<verb>.summary` / `.input.<flag>` strings onto the ' +
+            'doctrinal descriptions before emitting. Augment-only: a field ' +
+            'not overridden falls through verbatim. Unknown name → silent ' +
+            'miss (no error, no overlay). Mirrors the write-envelope ' +
+            '`GUILD_VOICE` semantic but kept per-invocation so a reader can ' +
+            'switch voices without exporting an env var.',
+        },
+      },
+    },
     output: { type: 'object' },
   },
   {
@@ -2078,13 +2096,23 @@ export async function schemaCmd(c: C, args: ParsedArgs): Promise<number> {
   if (verbFilter && verbs.length === 0) {
     throw new Error(`unknown verb: ${verbFilter}`);
   }
+  // --voice <name> overlay (#345 cluster #5). Looks up the named voice
+  // plugin and applies its `schema.verbs.<verb>.summary` / `.input.<flag>`
+  // overrides onto each VerbSchema. Augment-not-replace: any field not
+  // overridden falls through to the doctrinal description held in
+  // handlers (principle 08 unchanged). Unknown voice name → no error,
+  // no overlay (silent miss, mirroring write-envelope --voice semantics).
+  const voiceName = optionalOption(args, 'voice');
+  const overlaidVerbs = voiceName
+    ? applyVoiceSchemaOverlay(verbs, voiceName, c.voicePlugins)
+    : verbs;
   const payload = {
     $schema: 'http://json-schema.org/draft-07/schema#',
     // semver so consumers can pin a major and tolerate additions.
     // Bump the major only for breaking changes to the schema payload
     // itself (not to individual verb schemas).
     version: '0.1.0',
-    verbs: verbs.map((v) => ({
+    verbs: overlaidVerbs.map((v) => ({
       name: v.name,
       category: v.category,
       // `source` defaults to 'core' when the VerbSchema entry omits
@@ -2103,7 +2131,7 @@ export async function schemaCmd(c: C, args: ParsedArgs): Promise<number> {
     process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
   } else {
     const lines: string[] = [];
-    for (const v of verbs) {
+    for (const v of overlaidVerbs) {
       const req = v.input.required?.join(', ') ?? '';
       // `source` is rendered only for plugin verbs — every built-in
       // verb is `core` and a `[core]` tag on every line would just
@@ -2120,3 +2148,56 @@ export async function schemaCmd(c: C, args: ParsedArgs): Promise<number> {
 }
 
 export { VERBS };
+
+/**
+ * Overlay voice-flavored description overrides from the named voice
+ * plugin onto the verb schemas (#345 cluster #5).
+ *
+ * Strict augment-only: a field NOT covered by an override falls
+ * through to the doctrinal description verbatim. Voice cannot delete
+ * doctrinal prose; it can only paint a flavored layer on top.
+ *
+ * Unknown voice name → returns the verbs array unchanged (silent
+ * miss, mirroring `_meta.voice` semantics on write envelopes).
+ *
+ * Pure synchronous; no I/O.
+ */
+function applyVoiceSchemaOverlay(
+  verbs: readonly VerbSchema[],
+  voiceName: string,
+  voicePlugins: ReadonlyArray<import('../../../application/plugin/VoicePlugin.js').VoicePlugin>,
+): VerbSchema[] {
+  const plugin = voicePlugins.find((p) => p.name === voiceName);
+  const overrides = plugin?.schema?.verbs;
+  if (!overrides) {
+    // Either plugin not loaded or it has no schema section — return
+    // the doctrinal verbs unchanged. Mirrors the write-envelope
+    // silent-miss contract: unknown voice never errors.
+    return verbs.map((v) => v);
+  }
+  return verbs.map((v) => {
+    const ov = overrides[v.name];
+    if (!ov) return v;
+    let next: VerbSchema = v;
+    if (ov.summary !== undefined) {
+      next = { ...next, summary: ov.summary };
+    }
+    if (ov.input !== undefined) {
+      // Walk the input schema's properties and replace descriptions
+      // where the override map has a matching key. Properties NOT in
+      // the override map keep their doctrinal description intact.
+      const baseProps = (v.input.properties ?? {}) as Record<string, JsonSchema>;
+      const nextProps: Record<string, JsonSchema> = {};
+      for (const [key, propSchema] of Object.entries(baseProps)) {
+        const newDesc = ov.input[key];
+        if (newDesc !== undefined && typeof propSchema === 'object' && propSchema !== null) {
+          nextProps[key] = { ...propSchema, description: newDesc };
+        } else {
+          nextProps[key] = propSchema;
+        }
+      }
+      next = { ...next, input: { ...next.input, properties: nextProps } };
+    }
+    return next;
+  });
+}

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -565,11 +565,17 @@ const SECTIONS: readonly Section[] = [
       {
         tier: 'base',
         text:
-          "  gate schema [--verb <name>] [--format json|text]\n" +
+          "  gate schema [--verb <name>] [--voice <name>] [--format json|text]\n" +
           "                       Introspection: JSON Schema for every verb's\n" +
           '                       inputs and outputs. Consumed by LLM tool layers.\n' +
           '                       Output is exhaustive regardless of profile or\n' +
-          '                       --all — orchestrators see every verb.',
+          '                       --all — orchestrators see every verb.\n' +
+          '                       --voice <name> overlays a loaded voice\n' +
+          "                       plugin's schema overrides (summary +\n" +
+          '                       per-flag descriptions) onto the doctrinal\n' +
+          "                       descriptions. Augment-only — unmatched fields\n" +
+          '                       fall through verbatim. Unknown name → no\n' +
+          '                       overlay, no error.',
       },
       {
         tier: 'base',

--- a/tests/interface/schemaVoice.test.ts
+++ b/tests/interface/schemaVoice.test.ts
@@ -1,0 +1,140 @@
+// gate schema --voice <name> — voice-flavored description overlay
+// (#345 cluster #5).
+//
+// Pins:
+//   1. no --voice → doctrinal descriptions verbatim
+//   2. --voice <plugin-name> → summary + per-flag overrides applied
+//   3. fields NOT overridden fall through (augment-not-replace)
+//   4. unknown voice name → silent miss (no error, no overlay)
+//   5. plugin without `schema` section → unchanged output
+//   6. text mode renders the overlaid summary
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(opts?: { withSchemaOverride?: boolean }): { root: string; cleanup: () => void } {
+  const withOverride = opts?.withSchemaOverride ?? true;
+  const root = makeTempRoot('guild-schema-voice-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\n' +
+      'host_names: [human]\n' +
+      'plugins:\n' +
+      '  trusted: true\n' +
+      '  voices:\n' +
+      '    - plugins/voices/eris.mjs\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins', 'voices'), { recursive: true });
+  const schemaSection = withOverride
+    ? `,
+  schema: {
+    verbs: {
+      complete: {
+        summary: 'flavored-complete-summary',
+        input: {
+          cliff: 'flavored-cliff-description',
+        },
+      },
+    },
+  }`
+    : '';
+  writeFileSync(
+    join(root, 'plugins', 'voices', 'eris.mjs'),
+    `export default {
+  name: 'eris',
+  verbs: {
+    complete: [ { when: 'default', template: 't' } ],
+  }${schemaSection},
+};
+`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(cwd: string, args: string[]): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, env: { ...process.env }, encoding: 'utf8' });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+test('schema (no --voice): doctrinal descriptions verbatim', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    const complete = p.verbs[0];
+    assert.equal(complete.summary, 'transition executing → completed');
+    // Doctrinal cliff description references "Forward-pointing hint"
+    assert.match(complete.input.properties.cliff.description, /Forward-pointing hint/);
+  } finally { cleanup(); }
+});
+
+test('schema --voice eris: summary + property overrides applied', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--voice', 'eris', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    const complete = p.verbs[0];
+    assert.equal(complete.summary, 'flavored-complete-summary');
+    assert.equal(complete.input.properties.cliff.description, 'flavored-cliff-description');
+  } finally { cleanup(); }
+});
+
+test('schema --voice eris: non-overridden fields fall through verbatim', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--voice', 'eris', '--format', 'json']);
+    const p = JSON.parse(r.stdout);
+    const complete = p.verbs[0];
+    // `note` is NOT in the override map → doctrinal description.
+    // The doctrinal complete schema declares `note: str` (just type),
+    // so description may be undefined — assert it is NOT the flavored
+    // string (the load-bearing contract).
+    assert.notEqual(complete.input.properties.note?.description, 'flavored-cliff-description');
+    // `by` is also not overridden → unchanged.
+    assert.notEqual(complete.input.properties.by?.description, 'flavored-cliff-description');
+  } finally { cleanup(); }
+});
+
+test('schema --voice unknown: silent miss, doctrinal descriptions returned', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--voice', 'nonexistent', '--format', 'json']);
+    assert.equal(r.status, 0, 'unknown voice name must not error');
+    const p = JSON.parse(r.stdout);
+    assert.equal(p.verbs[0].summary, 'transition executing → completed');
+  } finally { cleanup(); }
+});
+
+test('schema --voice <plugin-without-schema>: no overlay, plain pass-through', () => {
+  const { root, cleanup } = bootstrap({ withSchemaOverride: false });
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--voice', 'eris', '--format', 'json']);
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    assert.equal(p.verbs[0].summary, 'transition executing → completed');
+  } finally { cleanup(); }
+});
+
+test('schema --voice eris --format text: overlaid summary renders', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['schema', '--verb', 'complete', '--voice', 'eris', '--format', 'text']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /flavored-complete-summary/);
+  } finally { cleanup(); }
+});


### PR DESCRIPTION
## Summary

Closes the AI-agent-first delight cluster voice work. Stacked on **#378** (write-verb extension); this PR shows both commits in its diff until #378 merges, after which a rebase will leave only this commit. Merge order: #378 → this.

Voice plugin shape gains an optional \`schema\` section:

\`\`\`js
export default {
  name: 'eris',
  verbs: { ... },          // ornamental voice for write envelopes
  schema: {                 // NEW: schema description overlay
    verbs: {
      complete: {
        summary: '...',
        input: { cliff: '...' },
      },
    },
  },
};
\`\`\`

\`gate schema --voice <plugin-name>\` overlays:

- \`schema.verbs.<verb>.summary\` → replaces \`summary\`
- \`schema.verbs.<verb>.input.<flag>\` → replaces input property \`description\`

## Invariants

- **Augment-only**: any field a voice does NOT override falls through verbatim. Principle 08 (doctrinal voice held in handlers) is the substrate floor.
- **Unknown voice name → silent miss** (no error, no overlay), mirroring \`_meta.voice\` semantics on write envelopes.
- **Per-invocation flag, not env**: lets a reader inspect what eris's schema looks like without committing \`GUILD_VOICE\` shell-wide.

## Test plan

- [x] 6 new tests under \`tests/interface/schemaVoice.test.ts\`: no-voice baseline, summary + property override applied, non-overridden fall-through, unknown voice silent miss, plugin without schema section, text-mode rendering
- [x] full suite: 1719 pass / 0 fail

## Cluster status

Together with #377 (infrastructure) and #378 (write-verb extension), this completes the four-PR delight cluster initiated on #345:

| PR | role |
|----|------|
| #375 | \`gate boot --since\` (tier-1) |
| #376 | \`gate complete --cliff\` + boot \`past_cliffs\` (tier-1) |
| #377 | voice plugin infrastructure (tier-2 / #345 candidate validation #2) |
| #378 | voice plugin extension to all write verbs |
| **this** | \`gate schema --voice\` overlay |

🤖 Generated with [Claude Code](https://claude.com/claude-code)