### PR TITLE
feat(voice): `gate voice` mode-switch + 4-layer resolution (eris-first refinement PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,6 +1225,25 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   voice for the whole shell. (#37x — cluster #5, second half of the
   voice-plugin landing pair)
 
+- **`gate voice` mode-switch verb + 4-layer voice resolution.**
+  Lowers the burden of switching between voice plugins ("今この気分")
+  from "edit env / config" down to a one-keystroke verb. Resolution
+  order (least → most specific):
+  `config.voice.default < <content_root>/.guild-voice file <
+  GUILD_VOICE env < per-invocation --voice flag`. The new
+  `.guild-voice` file (single-line voice name) is the cwd-stable
+  middle tier — written by `gate voice <name>`, cleared by
+  `gate voice off`, inspected by bare `gate voice`. Introspect output
+  surfaces the active layer and emits a hint when a higher-priority
+  layer is masking the file ("$ unset GUILD_VOICE"). New optional
+  `voice.default: <name>` in `guild.config.yaml` provides the
+  deployment-baseline lowest tier. Set is permissive on whether the
+  named voice is currently loaded — mirrors the silent-miss contract
+  established by `_meta.voice` on write envelopes. Lock-exempt (the
+  marker file is config-shaped, not substrate-data-shaped, so the
+  content-root lock would be over-conservative). (#37x — eris-first
+  refinement, follow-up to the AI-agent-first delight cluster)
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -147,6 +147,15 @@ export interface GuildConfigProps {
    * handlers (principle 08).
    */
   voicePluginPaths: readonly string[];
+  /**
+   * Deployment-baseline default voice (#345 cluster #5 follow-up).
+   * Read from `voice.default: <name>` in `guild.config.yaml`. Used as
+   * the lowest-priority layer in the 4-layer voice resolution:
+   *   --voice flag > GUILD_VOICE env > .guild-voice file > config.voice.default
+   * Null when the config doesn't declare one — the resolver then
+   * returns null and ornamental voice stays off.
+   */
+  voiceDefault: string | null;
   profile: GuildProfile;
   features: GuildFeatures;
   gate: GateConfig;
@@ -172,6 +181,7 @@ export class GuildConfig implements GuildConfigProps {
     readonly verbPluginPaths: readonly string[],
     readonly hookPluginPaths: readonly string[],
     readonly voicePluginPaths: readonly string[],
+    readonly voiceDefault: string | null,
     readonly profile: GuildProfile,
     readonly features: GuildFeatures,
     readonly gate: GateConfig,
@@ -294,6 +304,21 @@ export class GuildConfig implements GuildConfigProps {
           'Add `trusted: true` under `plugins:` in guild.config.yaml to enable.',
       );
     }
+    // voice.default (#345 cluster mode-switch follow-up). Lowest-priority
+    // layer in the 4-layer voice resolution; gives a deployment a
+    // sensible baseline without forcing every shell to export
+    // GUILD_VOICE or every invocation to pass --voice.
+    const voiceRaw = raw.voice ?? {};
+    let voiceDefault: string | null = null;
+    if (typeof voiceRaw.default === 'string' && voiceRaw.default.length > 0) {
+      voiceDefault = voiceRaw.default;
+    } else if (voiceRaw.default !== undefined) {
+      onMalformed(
+        configPath,
+        `voice.default must be a non-empty string when present, got ${JSON.stringify(voiceRaw.default)}. ` +
+          'Ignoring; voice resolution falls through to GUILD_VOICE / .guild-voice / off.',
+      );
+    }
     // Profile + features (#231). The two interact: `profile: swarm`
     // flips the default of `features.worktree_required_for_parallel`
     // to true, but an explicit `features:` block always wins so a
@@ -362,7 +387,7 @@ export class GuildConfig implements GuildConfigProps {
       }
     }
     const gate: GateConfig = { strictLenses };
-    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, voicePluginPaths, profile, features, gate, onMalformed, configPath);
+    return new GuildConfig(root, contentRoot, paths, hostNames, lenses, doctorPlugins, verbPluginPaths, hookPluginPaths, voicePluginPaths, voiceDefault, profile, features, gate, onMalformed, configPath);
   }
 
   static default(
@@ -386,6 +411,7 @@ export class GuildConfig implements GuildConfigProps {
       [],
       [],
       [],
+      null,
       'standard',
       { worktreeRequiredForParallel: false, selfApprove: 'warn' },
       { strictLenses: false },

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -135,7 +135,7 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
     );
   }
   emitWriteResponse(parseFormat(args), r, `✓ approved: ${id}`, c.config, [], {
-    voice: renderVoice(c.voicePlugins, 'approve', r),
+    voice: renderVoice(c.voicePlugins, 'approve', r, c.config),
   });
   return 0;
 }
@@ -170,7 +170,7 @@ export async function reqDeny(c: C, args: ParsedArgs): Promise<number> {
   const r = await c.requestUC.deny(id, by, reason, invokedBy);
   await fireAfterHook(c.hookSubscriptions, 'deny', r, by);
   emitWriteResponse(parseFormat(args), r, `✓ denied: ${id}`, c.config, [], {
-    voice: renderVoice(c.voicePlugins, 'deny', r),
+    voice: renderVoice(c.voicePlugins, 'deny', r, c.config),
   });
   return 0;
 }
@@ -285,7 +285,7 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
     );
   }
   emitWriteResponse(parseFormat(args), r, `✓ executing: ${id}`, c.config, [], {
-    voice: renderVoice(c.voicePlugins, 'execute', r),
+    voice: renderVoice(c.voicePlugins, 'execute', r, c.config),
   });
   return 0;
 }
@@ -447,7 +447,7 @@ export async function reqComplete(c: C, args: ParsedArgs): Promise<number> {
   // never on slice-only. Slice-only is a multi-executor intermediate
   // state — narrating it as "completed" would be a false claim about
   // wave state (principle 08's voice-must-stay-honest invariant).
-  const voice = renderVoice(c.voicePlugins, 'complete', r);
+  const voice = renderVoice(c.voicePlugins, 'complete', r, c.config);
   emitWriteResponse(parseFormat(args), r, `✓ completed: ${id}`, c.config, extraLines, { voice });
   return 0;
 }
@@ -530,7 +530,7 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
   // Voice on fail: wave-terminal only — slice-only mirrors complete's
   // honesty rule (a slice failure does NOT mean the wave failed).
   emitWriteResponse(parseFormat(args), r, `✓ failed: ${id}`, c.config, [], {
-    voice: renderVoice(c.voicePlugins, 'fail', r),
+    voice: renderVoice(c.voicePlugins, 'fail', r, c.config),
   });
   return 0;
 }

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -228,7 +228,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     `✓ review recorded: ${id} [${displayLense}/${displayVerdict}]`,
     c.config,
     [],
-    { voice: renderVoice(c.voicePlugins, 'review', updated) },
+    { voice: renderVoice(c.voicePlugins, 'review', updated, c.config) },
   );
   return 0;
 }

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -596,6 +596,30 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'voice',
+    category: 'admin',
+    summary:
+      'mode-switch lever for the 4-layer voice resolution. set / read / clear the deployment-local voice mode marker (.guild-voice). per-invocation --voice flags layer on top; this verb writes the persistent middle tier so an operator can flip "今この気分" in one keystroke instead of re-exporting GUILD_VOICE.',
+    input: {
+      type: 'object',
+      properties: {
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      description:
+        'Three modes: (1) no positional → introspect ({active, source, file_path}); ' +
+        '(2) `gate voice <name>` → write .guild-voice to <content_root>; ' +
+        '(3) `gate voice off` → delete .guild-voice. Resolution priority ' +
+        '(low→high): config.voice.default < .guild-voice file < GUILD_VOICE ' +
+        'env < per-invocation --voice flag. Name validation matches the ' +
+        'plugin name regex; the verb is permissive on whether the named ' +
+        'voice is currently loaded (silent-miss contract carried over from ' +
+        'write-envelope ornamental voice).',
+    },
+  },
+  {
     name: 'suggest',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/voice.ts
+++ b/src/interface/gate/handlers/voice.ts
@@ -1,0 +1,145 @@
+// gate voice — set / read / clear the deployment-local voice mode.
+//
+// The mode-switch lever for the 4-layer voice resolution introduced
+// alongside the voice-plugin landing (#345 cluster). The single
+// short verb lets eris flip "今この気分" in one keystroke instead of
+// re-exporting `GUILD_VOICE` or editing `guild.config.yaml`.
+//
+// Surface:
+//   gate voice                  → introspect (which voice is active, from which layer)
+//   gate voice <name>           → write <content_root>/.guild-voice = <name>
+//   gate voice off              → delete <content_root>/.guild-voice
+//
+// Resolution (least → most specific):
+//   config.voice.default < .guild-voice file < GUILD_VOICE env < per-invocation --voice
+// Higher-precedence layers MASK lower ones in introspection output, so
+// `gate voice` reflects what an actual write verb would pick up. Per-
+// invocation flags aren't visible here — they live per command.
+//
+// Validation:
+//   <name> must match the same pattern as a plugin name
+//   (`[a-z][a-z0-9-]*`) so the env/file/config layers stay swappable.
+//   We do NOT verify the name corresponds to a LOADED plugin — an
+//   operator may set the mode for a plugin that will be installed
+//   later, or check what they previously asked for after removing
+//   the plugin. Silent miss on an unknown name is the established
+//   ornamental-voice contract; the verb stays consistent with it.
+
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { C } from './internal.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { maybeEmitExplain } from '../../shared/explain.js';
+import {
+  VOICE_MODE_FILE,
+  resolveActiveVoiceName,
+} from '../../shared/voiceRender.js';
+
+const VOICE_NAME_RE = /^[a-z][a-z0-9-]*$/;
+const VOICE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+export async function voiceCmd(c: C, args: ParsedArgs): Promise<number> {
+  rejectUnknownFlags(args, VOICE_KNOWN_FLAGS, 'voice');
+  maybeEmitExplain(args, 'voice');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'json' && format !== 'text') {
+    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+  }
+
+  const arg = args.positional[0];
+  const filePath = join(c.config.contentRoot, VOICE_MODE_FILE);
+
+  // === introspect: `gate voice` (no positional) ===
+  if (arg === undefined) {
+    const resolved = resolveActiveVoiceName(c.config);
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify({
+        active: resolved?.name ?? null,
+        source: resolved?.source ?? null,
+        file_path: filePath,
+      }, null, 2) + '\n');
+    } else if (resolved === null) {
+      process.stdout.write('voice: off\n');
+      process.stdout.write(`  next: gate voice <name>  (writes ${VOICE_MODE_FILE})\n`);
+    } else {
+      process.stdout.write(`voice: ${resolved.name} (source: ${resolved.source})\n`);
+      if (resolved.source !== 'file') {
+        // Surface the layer that's currently winning so the operator
+        // sees why `gate voice <other>` won't take effect until they
+        // unset the higher layer. Voice resolution is the load-bearing
+        // discoverability story here — without this hint, a confused
+        // user sets `.guild-voice` and wonders why GUILD_VOICE keeps
+        // overriding it.
+        process.stdout.write(
+          `  hint: higher-priority layer in effect; unset to let .guild-voice / config win.\n` +
+            (resolved.source === 'env'
+              ? '        $ unset GUILD_VOICE\n'
+              : '        # remove `voice.default:` from guild.config.yaml\n'),
+        );
+      }
+    }
+    return 0;
+  }
+
+  // === clear: `gate voice off` ===
+  if (arg === 'off') {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+      if (format === 'json') {
+        process.stdout.write(JSON.stringify({ ok: true, action: 'cleared', file_path: filePath }, null, 2) + '\n');
+      } else {
+        process.stdout.write(`voice: cleared (.guild-voice removed)\n`);
+      }
+    } else {
+      // Already off — idempotent. Surfacing this honestly rather than
+      // pretending we deleted something.
+      if (format === 'json') {
+        process.stdout.write(JSON.stringify({ ok: true, action: 'noop', file_path: filePath }, null, 2) + '\n');
+      } else {
+        process.stdout.write(`voice: already off (no ${VOICE_MODE_FILE})\n`);
+      }
+    }
+    return 0;
+  }
+
+  // === set: `gate voice <name>` ===
+  if (!VOICE_NAME_RE.test(arg)) {
+    throw new Error(
+      `voice name "${arg}" is not valid: must match [a-z][a-z0-9-]*.\n` +
+        '  next: use a name matching a voice plugin\'s `name` field (or any name you plan to install — set is permissive on intent).',
+    );
+  }
+  writeFileSync(filePath, arg + '\n', 'utf8');
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      action: 'set',
+      name: arg,
+      file_path: filePath,
+    }, null, 2) + '\n');
+  } else {
+    process.stdout.write(`voice: ${arg} (.guild-voice written)\n`);
+    // Heads-up if a higher-priority layer would still mask this.
+    const envOverride = process.env['GUILD_VOICE'];
+    if (typeof envOverride === 'string' && envOverride.length > 0 && envOverride !== arg) {
+      process.stdout.write(
+        `  notice: GUILD_VOICE=${envOverride} is set; it will mask .guild-voice until unset.\n`,
+      );
+    }
+    // Also surface if the named voice isn't currently loaded — a
+    // silent miss is the established contract but a one-line nudge
+    // here costs voice budget once and saves a "why isn't it working"
+    // troubleshoot.
+    const loaded = c.voicePlugins.some((p) => p.name === arg);
+    if (!loaded) {
+      process.stdout.write(
+        `  notice: voice "${arg}" is not currently loaded — set will take effect when the plugin is installed.\n`,
+      );
+    }
+  }
+  return 0;
+}

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -382,6 +382,19 @@ const SECTIONS: readonly Section[] = [
       {
         tier: 'base',
         text:
+          '  gate voice [<name> | off] [--format json|text]\n' +
+          '                       Mode-switch for the voice plugin layer.\n' +
+          '                       Bare `gate voice` shows the active voice +\n' +
+          '                       which layer resolved it. `gate voice <name>`\n' +
+          '                       writes <content_root>/.guild-voice so the\n' +
+          '                       deployment picks up <name> until you change\n' +
+          '                       it. `gate voice off` clears the marker.\n' +
+          '                       Resolution: --voice flag > GUILD_VOICE env\n' +
+          '                       > .guild-voice file > voice.default config.',
+      },
+      {
+        tier: 'base',
+        text:
           '  gate next [--confirm] [--format json|text]\n' +
           '                       One-call read-and-dispatch of the top actionable\n' +
           '                       verb. Without --confirm: prints the plan (verb /\n' +

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -34,6 +34,7 @@ import { doctorCmd } from './handlers/doctor.js';
 import { repairCmd } from './handlers/repair.js';
 import { bootCmd } from './handlers/boot.js';
 import { nextCmd } from './handlers/next.js';
+import { voiceCmd } from './handlers/voice.js';
 import { schemaCmd } from './handlers/schema.js';
 import { resumeCmd } from './handlers/resume.js';
 import { restCmd } from './handlers/rest.js';
@@ -295,6 +296,8 @@ async function dispatch(
       return await bootCmd(c, args);
     case 'next':
       return await nextCmd(c, args);
+    case 'voice':
+      return await voiceCmd(c, args);
     case 'suggest':
       return await suggestCmd(c, args);
     case 'flow-suggest':

--- a/src/interface/gate/verbs.ts
+++ b/src/interface/gate/verbs.ts
@@ -73,4 +73,10 @@ export const WRITE_VERBS: ReadonlySet<string> = new Set([
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set([
   'doctor',
   'repair',
+  // `voice` writes the .guild-voice mode marker (config-shaped, not
+  // substrate-data-shaped). It does not touch any persisted request /
+  // review / issue record, so taking the substrate lock would be
+  // over-conservative. Same maintenance-tier reasoning as doctor /
+  // repair — the verb is orthogonal to the lock's purpose.
+  'voice',
 ]);

--- a/src/interface/shared/explain.ts
+++ b/src/interface/shared/explain.ts
@@ -40,6 +40,7 @@ import type { ParsedArgs } from './parseArgs.js';
 export const EXPLAIN_MESSAGES: Readonly<Record<string, string>> = {
   boot: 'session-start orientation; surfaces actor identity, recent wave activity, and the next verb to reach for. Pass --since <ISO-ts> (typically the prior boot\'s last_activity) for a delta-only payload.',
   next: 'one-call read-and-dispatch of the top actionable verb. Without --confirm prints the plan; with --confirm dispatches via subprocess. Auto-dispatch limited to verbs needing only --by.',
+  voice: 'mode-switch for the voice plugin layer. Bare → introspect (which voice + which layer). With <name> → write .guild-voice. With `off` → clear. Per-invocation --voice flags override this layer.',
   list: 'lists requests filtered by --state/--from/--executors/--target; pair with `gate show <id>` for full body.',
   pending: 'lists requests in state=pending — the approval queue; subset of `gate list --state pending`.',
   show: 'reads one request (or other id) by id; use --fields for projection or --plain for shell-friendly output.',

--- a/src/interface/shared/voiceRender.ts
+++ b/src/interface/shared/voiceRender.ts
@@ -17,20 +17,107 @@
 // Pure synchronous — no I/O — so handlers can call inline before
 // emitWriteResponse without growing the await surface.
 
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Request } from '../../domain/request/Request.js';
 import type { VoicePlugin, VoiceWhen } from '../../application/plugin/VoicePlugin.js';
+import type { GuildConfig } from '../../infrastructure/config/GuildConfig.js';
 
 /**
- * Resolve the active voice plugin from env + loaded set. Public so
- * the handler can short-circuit when no voice is active (avoid
- * touching the Request just to ask "is voice on?").
+ * Filename of the per-deployment voice mode marker (#345 mode-switch
+ * cluster). Lives at `<content_root>/.guild-voice`. One-line file:
+ * the voice name to activate. Written by `gate voice <name>`, cleared
+ * by `gate voice off`. Trimmed before use; empty file is treated as
+ * "no mode set" (falls through to env / config / null).
+ *
+ * Centralised here so the verb handler + resolver agree on the path.
+ */
+export const VOICE_MODE_FILE = '.guild-voice';
+
+/**
+ * Source layer that resolved the active voice. Surfaced so callers
+ * (e.g. `gate voice` introspection) can explain WHERE the current
+ * mode came from. Mirrors `BootPayload.session_id_source`.
+ *
+ *   env    — GUILD_VOICE environment variable
+ *   file   — <content_root>/.guild-voice
+ *   config — voice.default in guild.config.yaml
+ *
+ * Per-invocation `--voice` flags (e.g. `gate schema --voice eris`)
+ * are resolved at the handler boundary, not here — so the source
+ * shown via this helper is the SESSION-level resolution.
+ */
+export type VoiceSource = 'env' | 'file' | 'config';
+
+export interface ResolvedVoiceName {
+  readonly name: string;
+  readonly source: VoiceSource;
+}
+
+/**
+ * Resolve the active voice NAME across the 4-layer priority order
+ * (most specific → least specific):
+ *   1. `--voice <name>` flag                 (per-invocation; resolved upstream)
+ *   2. GUILD_VOICE env                       — this function, source='env'
+ *   3. <content_root>/.guild-voice file      — source='file'
+ *   4. voice.default in guild.config.yaml    — source='config'
+ *
+ * Returns null when no layer carries a value. Pure-ish: reads env
+ * + filesystem but does not mutate. The file read is a hot path
+ * (every write verb fires voice), so we existsSync first to avoid
+ * raising ENOENT on the no-mode common case.
+ */
+export function resolveActiveVoiceName(
+  config: Pick<GuildConfig, 'contentRoot' | 'voiceDefault'>,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedVoiceName | null {
+  const fromEnv = env['GUILD_VOICE'];
+  if (typeof fromEnv === 'string' && fromEnv.length > 0) {
+    return { name: fromEnv, source: 'env' };
+  }
+  const filePath = join(config.contentRoot, VOICE_MODE_FILE);
+  if (existsSync(filePath)) {
+    try {
+      const raw = readFileSync(filePath, 'utf8').trim();
+      if (raw.length > 0) {
+        return { name: raw, source: 'file' };
+      }
+    } catch {
+      // Read failure is non-fatal — voice resolution falls through
+      // to the next layer. The verb handler will surface real read
+      // errors when explicitly invoked.
+    }
+  }
+  if (config.voiceDefault !== null && config.voiceDefault.length > 0) {
+    return { name: config.voiceDefault, source: 'config' };
+  }
+  return null;
+}
+
+/**
+ * Resolve the active voice plugin via the 4-layer name resolution +
+ * plugin lookup. Public so handlers can short-circuit when no voice
+ * is active (avoid touching the Request just to ask "is voice on?").
+ *
+ * Back-compat overload: when called with just `voicePlugins`, falls
+ * back to the legacy env-only resolution. The 2-arg form (plugins +
+ * config) honours the full 4-layer order. Existing call sites that
+ * only have plugins keep working; new sites pass config too.
  */
 export function resolveActiveVoice(
   voicePlugins: ReadonlyArray<VoicePlugin>,
+  config?: Pick<GuildConfig, 'contentRoot' | 'voiceDefault'>,
   env: NodeJS.ProcessEnv = process.env,
 ): VoicePlugin | null {
-  const name = env['GUILD_VOICE'];
-  if (typeof name !== 'string' || name.length === 0) return null;
+  let name: string | null = null;
+  if (config !== undefined) {
+    const resolved = resolveActiveVoiceName(config, env);
+    name = resolved?.name ?? null;
+  } else {
+    const fromEnv = env['GUILD_VOICE'];
+    if (typeof fromEnv === 'string' && fromEnv.length > 0) name = fromEnv;
+  }
+  if (name === null) return null;
   for (const p of voicePlugins) {
     if (p.name === name) return p;
   }
@@ -140,9 +227,10 @@ export function renderVoice(
   voicePlugins: ReadonlyArray<VoicePlugin>,
   verb: string,
   req: Request,
+  config?: Pick<GuildConfig, 'contentRoot' | 'voiceDefault'>,
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
-  const plugin = resolveActiveVoice(voicePlugins, env);
+  const plugin = resolveActiveVoice(voicePlugins, config, env);
   if (plugin === null) return null;
   const templates = plugin.verbs[verb];
   if (!templates || templates.length === 0) return null;

--- a/tests/interface/gateVoice.test.ts
+++ b/tests/interface/gateVoice.test.ts
@@ -1,0 +1,161 @@
+// gate voice — mode-switch lever for the 4-layer voice resolution.
+//
+// Pins:
+//   1. bare `gate voice` introspects + reports "off" when nothing set
+//   2. `gate voice <name>` writes .guild-voice; introspect reflects file source
+//   3. `gate voice off` clears the file idempotently
+//   4. 4-layer resolution: file is picked up by write-envelope render
+//   5. GUILD_VOICE env masks the file layer (introspect surfaces hint)
+//   6. config.voice.default is the lowest layer (used when env + file are off)
+//   7. invalid name → reject with `next:` hint
+//   8. unloaded voice name → permissive set + notice (silent-miss carry-over)
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(opts?: { configDefault?: string }): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-voice-mode-');
+  const cfg =
+    'content_root: .\n' +
+    'host_names: [human]\n' +
+    'plugins:\n' +
+    '  trusted: true\n' +
+    '  voices:\n' +
+    '    - plugins/voices/eris.mjs\n' +
+    (opts?.configDefault ? `voice:\n  default: ${opts.configDefault}\n` : '');
+  writeFileSync(join(root, 'guild.config.yaml'), cfg);
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins', 'voices'), { recursive: true });
+  writeFileSync(
+    join(root, 'plugins', 'voices', 'eris.mjs'),
+    `export default {
+  name: 'eris',
+  verbs: { complete: [ { when: 'default', template: 'V:{action}' } ] },
+};
+`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, env: { ...process.env, ...env }, encoding: 'utf8' });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+test('gate voice (bare): reports off when nothing set', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['voice'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /voice: off/);
+  } finally { cleanup(); }
+});
+
+test('gate voice <name>: writes .guild-voice; introspect reports source=file', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const set = runGate(root, ['voice', 'eris'], { GUILD_VOICE: '' });
+    assert.equal(set.status, 0);
+    assert.ok(existsSync(join(root, '.guild-voice')));
+    assert.equal(readFileSync(join(root, '.guild-voice'), 'utf8').trim(), 'eris');
+
+    const introspect = runGate(root, ['voice'], { GUILD_VOICE: '' });
+    assert.match(introspect.stdout, /voice: eris/);
+    assert.match(introspect.stdout, /source: file/);
+  } finally { cleanup(); }
+});
+
+test('gate voice <name>: write-envelope picks up file-layer voice', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['voice', 'eris'], { GUILD_VOICE: '' });
+    const cr = runGate(root, ['request', '--from', 'alice', '--action', 'X', '--reason', 'r', '--executors', 'alice'], { GUILD_VOICE: '' });
+    const m = cr.stdout.match(/created: (\S+)/);
+    assert.ok(m);
+    const id = m![1]!;
+    runGate(root, ['approve', id, '--by', 'alice'], { GUILD_VOICE: '' });
+    runGate(root, ['execute', id, '--by', 'alice'], { GUILD_VOICE: '' });
+    const r = runGate(root, ['complete', id, '--by', 'alice', '--format', 'json'], { GUILD_VOICE: '' });
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta.voice, 'V:X', 'file-layer voice must drive write-envelope ornamentation');
+  } finally { cleanup(); }
+});
+
+test('gate voice off: idempotent clear', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['voice', 'eris'], { GUILD_VOICE: '' });
+    assert.ok(existsSync(join(root, '.guild-voice')));
+    const r = runGate(root, ['voice', 'off'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0);
+    assert.ok(!existsSync(join(root, '.guild-voice')));
+    // Second call: already off, no error.
+    const r2 = runGate(root, ['voice', 'off'], { GUILD_VOICE: '' });
+    assert.equal(r2.status, 0);
+    assert.match(r2.stdout, /already off/);
+  } finally { cleanup(); }
+});
+
+test('gate voice: GUILD_VOICE env masks file layer (introspect surfaces hint)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['voice', 'eris']);
+    const r = runGate(root, ['voice'], { GUILD_VOICE: 'override-mode' });
+    assert.match(r.stdout, /voice: override-mode/);
+    assert.match(r.stdout, /source: env/);
+    assert.match(r.stdout, /higher-priority layer in effect/);
+    assert.match(r.stdout, /unset GUILD_VOICE/);
+  } finally { cleanup(); }
+});
+
+test('gate voice: config.voice.default is the lowest-priority layer', () => {
+  const { root, cleanup } = bootstrap({ configDefault: 'baseline' });
+  try {
+    const r = runGate(root, ['voice'], { GUILD_VOICE: '' });
+    assert.match(r.stdout, /voice: baseline/);
+    assert.match(r.stdout, /source: config/);
+  } finally { cleanup(); }
+});
+
+test('gate voice: invalid name → reject with next: hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['voice', 'Eris-CAPS'], { GUILD_VOICE: '' });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /is not valid/);
+    assert.match(r.stderr, /next:/);
+  } finally { cleanup(); }
+});
+
+test('gate voice: unloaded name → permissive set + notice', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['voice', 'not-installed-yet'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0, 'set is permissive on whether the plugin is loaded');
+    assert.match(r.stdout, /notice: voice "not-installed-yet" is not currently loaded/);
+  } finally { cleanup(); }
+});
+
+test('gate voice --format json: structured introspect output', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(root, ['voice', 'eris'], { GUILD_VOICE: '' });
+    const r = runGate(root, ['voice', '--format', 'json'], { GUILD_VOICE: '' });
+    const p = JSON.parse(r.stdout);
+    assert.equal(p.active, 'eris');
+    assert.equal(p.source, 'file');
+    assert.ok(p.file_path.endsWith('.guild-voice'));
+  } finally { cleanup(); }
+});

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -41,7 +41,7 @@ const GATE_ALL = [
   'complete', 'fail', 'review', 'claim', 'witness', 'unwitness',
   'thank', 'fast-track', 'issues',
   'message', 'broadcast', 'inbox', 'doctor', 'repair', 'status',
-  'boot', 'next', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
+  'boot', 'next', 'voice', 'suggest', 'flow-suggest', 'transcript', 'summarize', 'why', 'resume',
   'schema', 'unresponded', 'templates', 'lore', 'rest', 'wake', 'farewell',
   'wave-status', 'lense-stats', 'review-context',
   'decisions', 'self-pattern',


### PR DESCRIPTION
## Summary

eris-first refinement following the AI-agent-first delight cluster. The voice plugin layer shipped (#377-#379) but switching between voices was burdensome: edit env, edit config, or pass the flag every time. This PR introduces the **middle tier** — a one-keystroke mode-switch verb.

## Resolution order (least → most specific)

\`\`\`
config.voice.default                    # deployment baseline (guild.config.yaml)
< <content_root>/.guild-voice file       # cwd-stable, this PR's lever
< GUILD_VOICE env                        # session override
< per-invocation --voice flag            # one-shot override
\`\`\`

## The verb

\`\`\`
gate voice                  # introspect: active voice + layer
gate voice <name>           # write .guild-voice
gate voice off              # delete .guild-voice
\`\`\`

Introspect emits a hint when a higher-priority layer is masking the file (\`$ unset GUILD_VOICE\`).

## Eris-first delivery

Without this verb: \`export GUILD_VOICE=eris-devil\` then later \`export GUILD_VOICE=eris-soft\` ─ friction, and you forget. With this verb: \`gate voice devil\` to switch into review-mode before a critical pass; \`gate voice soft\` for late-night work. Tiny ritual, but the ritual *is* the cognitive switch.

## Invariants preserved

- **Silent-miss carry-over**: \`gate voice <name>\` is permissive on whether the named voice is currently loaded (matches \`_meta.voice\`'s "unknown name → no error" contract). A \`notice:\` line nudges when the operator points at an uninstalled plugin.
- **Lock-exempt**: \`.guild-voice\` is config-shaped, not substrate-data-shaped. Locking would be over-conservative.

## Test plan

- [x] 9 new tests under \`tests/interface/gateVoice.test.ts\` cover: bare introspect, set+inspect, write-envelope picks up file layer, idempotent off, env masks file, config baseline, name validation, unloaded-name notice, JSON output
- [x] full suite: 1728 pass / 0 fail

## Cluster

| PR | role |
|----|------|
| **this** | \`gate voice\` mode-switch lever (PR-A) |
| upcoming | Essentials section in voice plugin + \`gate --help --essentials\` (PR-D) |
| upcoming | \`past_cliffs\` voice re-rendering (PR-B) |
| upcoming | \`gate boot --since-last-mine\` sugar (PR-C) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)