### PR TITLE
feat(voice): dogfood polish bundle — 4-fix pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1290,6 +1290,40 @@ For day-to-day Unreleased churn, raw chronological append is fine.
   owns the resolution. (#37x — eris-first refinement PR-B + PR-C
   bundled)
 
+- **Voice polish bundle: dogfood-driven 4-fix pack.** Touch-feel pass
+  through the cluster shipped in #380-#382 surfaced four refinements;
+  bundled here so they ship together.
+
+  **P0** `gate voice` masking hint fires only when an env source is
+  winning. The pre-fix code emitted "higher-priority layer in effect"
+  on any non-file resolution including `config`, but `config` is the
+  BOTTOM layer — nothing was masking it, so the hint was misleading.
+  Hint now keyed to `source === 'env'` only.
+
+  **P1** `gate fast-track` fires ornamental voice on its `complete`
+  segment. v1 wired voice through `gate complete` direct only;
+  fast-track is the daily-use shortcut and was silent on the most
+  common write surface. Same template (`verbs.complete`) fires on
+  both paths now — eris's voice doesn't go quiet on the chained
+  flow.
+
+  **P2** text-mode voice marker changes from `(voice: …)` to
+  `⟶ …` (U+27F6). The parenthetical form read as a debug label
+  during dogfood; the arrow signals "voiced echo of what just
+  happened" without the hedge. stderr-only as before, so JSON-piped
+  consumers stay unaffected.
+
+  **P3** `gate --help --essentials --compact` renders one usage line
+  per verb instead of the full multi-line entry. Multi-line was
+  defensible for tier rendering (BASE/COORDINATION/EXTRA where the
+  audience is "everyone") but contradicted the essentials framing
+  ("the verbs I reach for, at a glance"). `--compact` is opt-in;
+  bare `--essentials` keeps the existing multi-line output, and
+  `--compact` without `--essentials` is a noop on the tier surface.
+
+  Existing voice envelope assertions updated for the new marker.
+  (#37x — eris-first refinement polish PR, dogfood-driven)
+
 ## [0.5.0] — 2026-05-06
 
 > **substrate self-improvement wave** (#207 / #208) closes the loop:

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -35,6 +35,7 @@ import {
   normalizeActor,
 } from './internal.js';
 import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { renderVoice } from '../../shared/voiceRender.js';
 
 // Known flags per write-verb. Silent-ignore of unknown flags (e.g.
 // `--executr noir` instead of `--executor noir`) would let a typo
@@ -594,12 +595,20 @@ export async function reqFastTrack(c: C, args: ParsedArgs): Promise<number> {
     extraLines.push(`→ auto-review pending for: ${reviewer}`);
     extraLines.push(`  ${tpl}`);
   }
+  // Ornamental voice on fast-track: dogfood-driven addition (#382
+  // follow-up). fast-track is the daily-use shortcut; with the v1
+  // wire-up only firing on `gate complete` direct invocation, the
+  // most common write surface was silent. Voice fires on the
+  // `complete` segment of the chain — same semantic as gate complete
+  // proper. (#37x — eris-first refinement polish PR-A1)
+  const voice = renderVoice(c.voicePlugins, 'complete', completed, c.config);
   emitWriteResponse(
     parseFormat(args),
     completed,
     `✓ fast-tracked: ${id} (pending→completed)`,
     c.config,
     extraLines,
+    { voice },
   );
   return 0;
 }

--- a/src/interface/gate/handlers/voice.ts
+++ b/src/interface/gate/handlers/voice.ts
@@ -67,18 +67,19 @@ export async function voiceCmd(c: C, args: ParsedArgs): Promise<number> {
       process.stdout.write(`  next: gate voice <name>  (writes ${VOICE_MODE_FILE})\n`);
     } else {
       process.stdout.write(`voice: ${resolved.name} (source: ${resolved.source})\n`);
-      if (resolved.source !== 'file') {
-        // Surface the layer that's currently winning so the operator
-        // sees why `gate voice <other>` won't take effect until they
-        // unset the higher layer. Voice resolution is the load-bearing
-        // discoverability story here — without this hint, a confused
-        // user sets `.guild-voice` and wonders why GUILD_VOICE keeps
-        // overriding it.
+      // Mask-detection: only fires when a HIGHER-priority layer is
+      // winning over a (potentially expected) lower layer. Source
+      // priority: env > file > config. So the hint applies ONLY when
+      // source === 'env' (env can mask file + config); source === 'file'
+      // can mask config but the operator just SET that file via this
+      // verb, so the hint is noise. source === 'config' is the bottom
+      // — nothing to mask. The pre-fix code fired the hint on every
+      // non-file source, which surfaced misleading "higher-priority
+      // layer" text on a config-only resolution.
+      if (resolved.source === 'env') {
         process.stdout.write(
-          `  hint: higher-priority layer in effect; unset to let .guild-voice / config win.\n` +
-            (resolved.source === 'env'
-              ? '        $ unset GUILD_VOICE\n'
-              : '        # remove `voice.default:` from guild.config.yaml\n'),
+          `  hint: GUILD_VOICE env is masking lower layers. unset to let .guild-voice / config win.\n` +
+            '        $ unset GUILD_VOICE\n',
         );
       }
     }

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -292,7 +292,15 @@ export function emitWriteResponse(
   // structured output. stderr (not stdout) so JSON-piped consumers
   // who also enable text-mode rendering by accident don't see voice
   // mingle with parseable payload. Suppressed when null.
+  //
+  // Marker design (#382 dogfood-driven, polish PR-A2): use `⟶ ` (U+27F6)
+  // as the voice line prefix instead of the v1 `(voice: …)` form.
+  // Dogfood reflection found `(voice: …)` reading as a debug label
+  // rather than a voice-line; the arrow marker signals "this is the
+  // voiced echo of what just happened" without the parenthetical
+  // hedge. Single character, monospace-safe, distinct from any
+  // existing gate stderr prefix.
   if (opts?.voice !== undefined && opts.voice !== null) {
-    process.stderr.write(`(voice: ${opts.voice})\n`);
+    process.stderr.write(`⟶ ${opts.voice}\n`);
   }
 }

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -651,6 +651,14 @@ export interface RenderHelpOptions {
     readonly verbs: readonly string[];
     readonly note?: string;
   } | null;
+  /**
+   * Render the essentials list as one line per verb instead of the
+   * full multi-line entry (#382 dogfood-driven, polish PR-A3).
+   * Trade-off: loses per-verb detail but gives a one-screen overview
+   * of "the verbs I reach for". Only meaningful under --essentials —
+   * a noop on the profile tier surface where multi-line is intended.
+   */
+  readonly compact?: boolean;
 }
 
 function tierVisible(tier: HelpTier, opts: RenderHelpOptions): boolean {
@@ -700,6 +708,7 @@ export function renderHelp(opts: RenderHelpOptions): string {
   lines.push('');
   lines.push(tierBanner(opts));
   lines.push('');
+  const wantCompact = opts.essentials !== null && opts.essentials !== undefined && opts.compact === true;
   for (const section of SECTIONS) {
     const visible = opts.essentials
       ? section.entries.filter((e) => essentialsVisible(e.text, opts.essentials!))
@@ -707,7 +716,20 @@ export function renderHelp(opts: RenderHelpOptions): string {
     if (visible.length === 0) continue;
     lines.push(section.heading);
     for (const e of visible) {
-      lines.push(e.text);
+      if (wantCompact) {
+        // 1-line-per-verb projection: take the first usage line of
+        // each entry (the line starting `  gate <verb>`) and emit
+        // just that. Multi-line entries collapse to their headline.
+        // The full description stays available via `gate schema
+        // --verb <name>` — essentials --compact is an overview, not
+        // a substitute for the detail.
+        const firstUsage = e.text
+          .split('\n')
+          .find((line) => /^ {2}gate [a-z]/.test(line));
+        lines.push(firstUsage ?? e.text);
+      } else {
+        lines.push(e.text);
+      }
     }
     lines.push('');
   }

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -121,6 +121,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   if (!cmd || cmd === '--help' || cmd === '-h') {
     const wantAll = rest.includes('--all');
     const wantEssentials = rest.includes('--essentials');
+    const wantCompact = rest.includes('--compact');
     let profile: 'standard' | 'swarm' = 'standard';
     let config: GuildConfig | null = null;
     try {
@@ -161,7 +162,7 @@ export async function main(argv: readonly string[]): Promise<number> {
         // Silent miss — fallback to profile tiering.
       }
     }
-    process.stdout.write(renderHelp({ profile, all: wantAll, essentials }));
+    process.stdout.write(renderHelp({ profile, all: wantAll, essentials, compact: wantCompact }));
     return 0;
   }
   const args = parseArgs(rest);

--- a/tests/interface/gateVoice.test.ts
+++ b/tests/interface/gateVoice.test.ts
@@ -115,7 +115,7 @@ test('gate voice: GUILD_VOICE env masks file layer (introspect surfaces hint)', 
     const r = runGate(root, ['voice'], { GUILD_VOICE: 'override-mode' });
     assert.match(r.stdout, /voice: override-mode/);
     assert.match(r.stdout, /source: env/);
-    assert.match(r.stdout, /higher-priority layer in effect/);
+    assert.match(r.stdout, /masking lower layers/);
     assert.match(r.stdout, /unset GUILD_VOICE/);
   } finally { cleanup(); }
 });

--- a/tests/interface/voicePlugin.test.ts
+++ b/tests/interface/voicePlugin.test.ts
@@ -179,9 +179,10 @@ test('voice: text-mode renders voice on stderr (one line)', () => {
       ['complete', id, '--by', 'alice', '--cliff', 'pickup', '--format', 'text'],
       { GUILD_VOICE: 'test' });
     assert.equal(r.status, 0);
-    // stdout: doctrinal "✓ completed: <id>"; stderr: ornamental "(voice: ...)"
+    // stdout: doctrinal "✓ completed: <id>"; stderr: ornamental "⟶ ..."
+    // (#382 polish: arrow marker replaces the v1 `(voice: …)` debug-style label)
     assert.match(r.stdout, /✓ completed:/);
-    assert.match(r.stderr, /\(voice: do X :: cliff = pickup\)/);
+    assert.match(r.stderr, /⟶ do X :: cliff = pickup/);
   } finally {
     cleanup();
   }

--- a/tests/interface/voicePolishBundle.test.ts
+++ b/tests/interface/voicePolishBundle.test.ts
@@ -1,0 +1,147 @@
+// Dogfood-driven polish bundle (#382 follow-up):
+//   P0  gate voice introspect hint only fires for env source
+//   P1  fast-track fires ornamental voice on its complete segment
+//   P3  gate --help --essentials --compact renders 1 line per verb
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(opts?: { configDefault?: string }): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-polish-');
+  const cfg =
+    'content_root: .\n' +
+    'host_names: [human]\n' +
+    'plugins:\n' +
+    '  trusted: true\n' +
+    '  voices:\n' +
+    '    - plugins/voices/test.mjs\n' +
+    (opts?.configDefault ? `voice:\n  default: ${opts.configDefault}\n` : '');
+  writeFileSync(join(root, 'guild.config.yaml'), cfg);
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  mkdirSync(join(root, 'plugins', 'voices'), { recursive: true });
+  writeFileSync(
+    join(root, 'plugins', 'voices', 'test.mjs'),
+    `export default {
+  name: 'test',
+  verbs: {
+    complete: [ { when: 'default', template: 'V:{action}' } ],
+  },
+  essentials: {
+    verbs: ['boot', 'fast-track', 'complete'],
+    note: 'three',
+  },
+};
+`,
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function runGate(cwd: string, args: string[], env: Record<string, string> = {}): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], { cwd, env: { ...process.env, ...env }, encoding: 'utf8' });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
+}
+
+test('P0: gate voice with config source does NOT emit a masking hint', () => {
+  const { root, cleanup } = bootstrap({ configDefault: 'test' });
+  try {
+    const r = runGate(root, ['voice'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /voice: test \(source: config\)/);
+    // The pre-fix code emitted "higher-priority layer in effect" on
+    // any non-file source, including config. Config is the BOTTOM
+    // layer — nothing masks it — so the hint was misleading.
+    assert.doesNotMatch(r.stdout, /higher-priority/);
+    assert.doesNotMatch(r.stdout, /masking lower layers/);
+  } finally { cleanup(); }
+});
+
+test('P0: gate voice with env source DOES emit the masking hint', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['voice'], { GUILD_VOICE: 'env-set' });
+    assert.match(r.stdout, /source: env/);
+    assert.match(r.stdout, /masking lower layers/);
+    assert.match(r.stdout, /unset GUILD_VOICE/);
+  } finally { cleanup(); }
+});
+
+test('P1: fast-track fires ornamental voice (cluster mid-step → complete)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root,
+      ['fast-track', '--from', 'alice', '--action', 'one-shot', '--reason', 'r', '--format', 'json'],
+      { GUILD_VOICE: 'test' });
+    assert.equal(r.status, 0);
+    const p = JSON.parse(r.stdout);
+    assert.ok(p._meta, 'fast-track must surface _meta.voice when active voice has a complete template');
+    assert.equal(p._meta.voice, 'V:one-shot',
+      'voice template fires on fast-track\'s complete segment');
+  } finally { cleanup(); }
+});
+
+test('P1: fast-track without active voice → no _meta (silent contract carries)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root,
+      ['fast-track', '--from', 'alice', '--action', 'X', '--reason', 'r', '--format', 'json'],
+      { GUILD_VOICE: '' });
+    const p = JSON.parse(r.stdout);
+    assert.equal(p._meta, undefined);
+  } finally { cleanup(); }
+});
+
+test('P3: --essentials --compact renders one line per verb', () => {
+  const { root, cleanup } = bootstrap({ configDefault: 'test' });
+  try {
+    const r = runGate(root, ['--help', '--essentials', '--compact'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0);
+    // The full --essentials renders multi-line entries; --compact
+    // collapses each entry to its first usage line. Count usage
+    // lines (lines starting "  gate <verb>") — they should match
+    // the count of curated verbs (modulo verbs with no help entry).
+    const usageLines = (r.stdout.match(/^ {2}gate [a-z]/gm) ?? []).length;
+    // The fixture curates 3 verbs (boot, fast-track, complete).
+    // All three have help entries → 3 usage lines.
+    assert.equal(usageLines, 3, `expected 3 usage lines in compact mode, got ${usageLines}`);
+    // Description lines (continuation lines under each entry) should
+    // be ABSENT in compact mode — that's the whole point of compact.
+    // Look for the "next-pointing hint" continuation that the
+    // multi-line render emits; if it's gone, compact is working.
+    assert.doesNotMatch(r.stdout, /Surfaced under/);
+    assert.doesNotMatch(r.stdout, /forward-pointing/);
+  } finally { cleanup(); }
+});
+
+test('P3: --essentials without --compact still renders multi-line (default)', () => {
+  const { root, cleanup } = bootstrap({ configDefault: 'test' });
+  try {
+    const r = runGate(root, ['--help', '--essentials'], { GUILD_VOICE: '' });
+    assert.equal(r.status, 0);
+    // Multi-line entries return — at least one continuation line
+    // referencing per-flag detail should appear.
+    assert.match(r.stdout, /next-step|forward-pointing|Surfaced under|Single-command/);
+  } finally { cleanup(); }
+});
+
+test('P3: --compact without --essentials is a noop (default tier rendering)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = runGate(root, ['--help', '--compact'], { GUILD_VOICE: '' });
+    // Standard profile BASE tier — multi-line entries are intended
+    // here; --compact only narrows the essentials projection.
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /showing: BASE/);
+  } finally { cleanup(); }
+});


### PR DESCRIPTION
## Summary

Touch-feel pass through the cluster shipped in #380-#382 surfaced four refinements; bundled here so they ship together.

## P0 — gate voice masking hint correctness

Pre-fix, \`gate voice\` emitted "higher-priority layer in effect" on any non-file source — including \`config\`. But \`config\` is the BOTTOM layer in the 4-layer resolution, nothing was masking it, so the hint was misleading. Hint now keyed to \`source === 'env'\` only.

## P1 — fast-track fires ornamental voice

v1 wired voice through \`gate complete\` direct only. \`gate fast-track\` is the daily-use shortcut and was silent on the most common write surface — \`_meta.voice: None\` even when GUILD_VOICE was active. Same \`verbs.complete\` template fires on both paths now. Eris's voice doesn't go quiet on the chained flow.

## P2 — text-mode voice marker

\`(voice: …)\` → \`⟶ …\` (U+27F6). The parenthetical form read as a debug label during dogfood; the arrow signals "voiced echo of what just happened" without the hedge. stderr-only as before — JSON-piped consumers unaffected.

\`\`\`
# before
✓ approved: 2026-05-14-0002
(voice: build feature Y 通した。)

# after
✓ approved: 2026-05-14-0002
⟶ build feature Y 通した。
\`\`\`

## P3 — gate --help --essentials --compact

Multi-line per verb was defensible for tier rendering (audience: everyone), but contradicted the essentials framing ("the verbs I reach for, at a glance"). \`--compact\` collapses each entry to its first usage line. Opt-in; bare \`--essentials\` keeps the multi-line output, and \`--compact\` without \`--essentials\` is a noop on the tier surface.

\`\`\`
# bare --essentials (default, multi-line, with description)
  gate complete <id> --by <m> [--note <s>] [--cliff <s>] [--dry-run]
                       --cliff "next agent should..." leaves a
                       forward-pointing hint for whoever picks up
                       ... [more lines]

# --essentials --compact (one line per verb)
  gate complete <id> --by <m> [--note <s>] [--cliff <s>] [--dry-run]
  gate review <id> --by <m> --lense <l> --verdict <v>
  gate fast-track --from <m> --action <a> --reason <r>
\`\`\`

## Test plan

- [x] 7 new tests under \`tests/interface/voicePolishBundle.test.ts\`
- [x] 2 existing voice tests updated for the new marker
- [x] full suite: 1751 pass / 0 fail

## Cluster status

| PR | role | status |
|----|------|--------|
| #380 | gate voice + 4-layer | merged |
| #381 | Essentials curation | merged |
| #382 | past_cliffs voice + --since-last-mine | open |
| **this** | dogfood polish 4-fix bundle | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)