### PR TITLE
docs: README slim + voice plugin docs + eris-playbook showcase

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -625,6 +625,52 @@ gate doctor --format json | gate repair --apply  # quarantine malformed
 gate repair [--from-doctor <path>] [--apply] [--format json|text]
 ```
 
+## Voice plugin (#345 cluster)
+
+Deployment-local personality layer. Doctrinal voice (handler prose,
+schema descriptions) stays in src/; ornamental voice rides on plugins.
+Stripping `_meta.voice` from a pipeline loses zero information — that
+invariant keeps the two layers honest under principle 08.
+
+```bash
+gate voice                  # introspect (active voice + which layer)
+gate voice <name>           # write <content_root>/.guild-voice
+gate voice off              # clear
+```
+
+Resolution order (most → least specific):
+
+1. `--voice <name>` (per-invocation; e.g. `gate schema --voice mine`)
+2. `GUILD_VOICE` env
+3. `<content_root>/.guild-voice` file (the layer `gate voice` writes)
+4. `voice.default` in `guild.config.yaml`
+
+Boot delta-filter sugar pair:
+
+```bash
+gate boot --since <ISO-ts>           # explicit cutoff
+gate boot --since-last-mine          # resolves to actor's last_authored_write_at
+```
+
+Help curation:
+
+```bash
+gate --help --essentials             # active voice's curated verb list
+gate --help --essentials --compact   # one line per verb
+```
+
+Plugin shape, all four sections optional independently:
+
+| Section | Surface |
+|---------|---------|
+| `verbs.<verb>` | `_meta.voice` on write-verb envelope + `⟶ …` stderr line in text mode |
+| `schema.verbs.<verb>` | `gate schema --voice <name>` overlay (`summary` + per-flag `description`) |
+| `essentials` | `gate --help --essentials` curated list |
+| `read.past_cliffs` | `gate boot` text-mode "past cliffs" re-render |
+
+Full contract + worked example in
+[`examples/plugins/README.md` § "Voice plugins"](./examples/plugins/README.md#voice-plugins).
+
 ## Configuration
 
 ```yaml
@@ -641,11 +687,16 @@ features:
 doctor:
   plugins: [./plugins/doc-check.mjs]      # optional, ES module paths
 
-# #36 Phase 1 — verb plugins + lifecycle hooks (require explicit trust opt-in)
+# #36 Phase 1 — verb / hook / voice plugins (require explicit trust opt-in)
 plugins:
-  trusted: false                           # MUST be true to load verbs/hooks
+  trusted: false                           # MUST be true to load anything under plugins/
   verbs:    [./plugins/verbs/my-verb.mjs]
   hooks:    [./plugins/hooks/my-policy.mjs]
+  voices:   [./plugins/voices/mine.mjs]    # ornamental voice + essentials + read overlays
+
+# #345 cluster — deployment-baseline voice (lowest-priority layer)
+voice:
+  default: mine                            # active voice when no env / .guild-voice / --voice flag
 
 paths:
   members: members
@@ -798,8 +849,9 @@ cue carries cross-verb without re-reading.
 - [`docs/POLICY.md`](./docs/POLICY.md) — versioning + plugin-stability contract
 - [`SECURITY.md`](./SECURITY.md) — plugin trust model + threat surface
 - [`examples/dogfood-session/`](./examples/dogfood-session/) — real multi-actor session
-- [`examples/plugins/`](./examples/plugins/) — verb + hook plugin walkthrough (#36 Phase 1)
-- [`README.md`](./README.md) — full documentation with design rationale
+- [`examples/plugins/`](./examples/plugins/) — verb + hook + voice plugin walkthrough
+- [`docs/eris-playbook.md`](./docs/eris-playbook.md) — substrate craft showcase
+- [`README.md`](./README.md) — entry point
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,263 +4,139 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-20%20%7C%2022-green)](./package.json)
 
-A small, secure, file-based CLI for a team of agents — human and AI —
-to ask each other for work, review it, and leave a trail that nothing
-in the loop can quietly rewrite.
+A file-based CLI for a team of agents — human and AI — to ask each
+other for work, review it, and leave an append-only trail.
 
-Reviews are append-only. Each record is pinned to an actor, a lense,
-and a moment. Corrections are new entries, not edits of old ones.
-Over time the content_root becomes an **event log of judgments** —
-not "what was decided" but **how the decision was formed**: who
-proposed, who objected, through which lense, and whether the objection
-was absorbed or overridden. The tool tracks deliberation, not
-conclusions.
+Reviews are pinned to **(actor, lense, moment)**. Corrections are new
+entries, never edits. Over time the `content_root` becomes an
+**event log of judgments** — not "what was decided" but **how the
+decision was formed**: who proposed, who objected, through which
+lense, and whether the objection was absorbed or overridden.
 
-Built around a **Two-Persona Devil Review** loop — the person who
-writes is not the person who reviews. Same model, different `--by`,
-different lense. That alone surfaces blind spots a single self-contained
-loop reliably misses.
+> Status: alpha (0.x). Strict 0.x semver — see
+> [`docs/POLICY.md`](./docs/POLICY.md). Threat model:
+> [`SECURITY.md`](./SECURITY.md). Changes:
+> [`CHANGELOG.md`](./CHANGELOG.md).
 
-The history grows. It never compresses into a single "current truth"
-— that is a design choice, not a gap. The tool sharpens what you
-see; it does not tell you what to conclude.
-
-> Status: **alpha (0.x).** API may change per [`docs/POLICY.md`](./docs/POLICY.md)'s
-> strict 0.x variant. See [`SECURITY.md`](./SECURITY.md) for the
-> threat model and [`CHANGELOG.md`](./CHANGELOG.md) for release
-> history.
-
-### Solo flow (30 seconds)
-
-If you are one person (or one AI agent) working alone, the whole
-tool is six verbs:
+## 30 seconds
 
 ```bash
-gate register --name <you>
-gate request --action "..." --reason "..." --executors <you>
-gate approve <id> --by <mirror>
-gate review  <id> --by <mirror> --lense user --verdict ok
-gate execute <id> --by <you>
-gate complete <id> --by <you>
+npm install                                      # auto-builds via prepare
+node ./bin/gate.mjs register --name <you>        # once per content_root
+export GUILD_ACTOR=<you>                         # once per shell
+node ./bin/gate.mjs boot                         # orient (identity + queues + tail + inbox)
+node ./bin/gate.mjs fast-track --action "..." --reason "..."
 ```
 
-That's the arc: register once, file the request, the **mirror**
-approves and reviews, you execute and close.
-
-**What is `<mirror>`?** A second persona / different `--by` for
-the same actor — "you wearing a different hat," or another
-registered agent acting as critic. Two-Persona Devil discipline:
-even solo, the approver / reviewer is a different lense / different
-moment from the executor. The defaults (`self_approve: allowed`
-in the solo profile) permit `--by <you>` directly, but reaching
-for a mirror persona is the discipline the substrate is shaped
-around. Everything else in this README is depth on top of this
-loop.
-
-Need multiple agents working in parallel, worktree isolation, or
-the swarm coordination story? See [`docs/swarm.md`](./docs/swarm.md).
-
-### How much of this do I need to read?
-
-Pick a depth. Every layer works on its own.
-
-| Depth | File | Audience | When it's enough |
-|-------|------|----------|------------------|
-| 30 sec | the paragraphs + "Solo flow" above | solo | you want to know what this is |
-| 1 min | [`examples/quick-start/`](./examples/quick-start/) | solo / agent | you want to run gate against a content_root and see something happen — graduated 30s → 5min → 20min path inside |
-| 5 min | [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) | solo | you came from Jira / PR review / ADR and want the translation |
-| 10 min | [`AGENT.md`](./AGENT.md) | solo / agent | you're an AI agent and want the full verb map across all four passages |
-| 15 min | [`docs/playbook.md`](./docs/playbook.md) | pair | you know each passage; you want **combos** (gate + agora + devil flows; ctx-inclusive patterns arrive in phase 2), recipes, and the bug-killing flow |
-| 15 min | [`docs/swarm.md`](./docs/swarm.md) | swarm | you orchestrate ≥2 parallel executors / Claude SubAgents and need the substrate-engagement recipe |
-| 30 min | [`docs/verbs.md`](./docs/verbs.md) | any | you want per-verb examples and design notes |
-| reference | [`docs/glossary.md`](./docs/glossary.md) | any | you hit a project-specific term and want the authoritative definition |
-| reference | [`lore/principles/`](./lore/principles/) (or `gate lore list`) | any | the 14 load-bearing ideas behind the design — read when you want to know why a choice was made, not how |
-| 1 hour | [`examples/dogfood-session/`](./examples/dogfood-session/) | any | you're adopting this seriously and want to see real sessions |
-| working notes | [`docs/domain-fit/`](./docs/domain-fit/) | any | you're curious whether gate fits a non-standard domain |
-| when needed | [`docs/POLICY.md`](./docs/POLICY.md) / [`docs/storage-format.md`](./docs/storage-format.md) / [`SECURITY.md`](./SECURITY.md) | embedder | you're embedding guild-cli and need the stability / on-disk shape / threat contract |
-
-### Lore
-
-[`lore/principles/`](./lore/principles/) — the load-bearing ideas
-behind the design. One principle per file, ~30 lines each. Read these
-when you need to know why a choice was made, not how. Append-only in
-spirit, like the records `gate` itself produces.
-
-Also reachable from the CLI without leaving the substrate: `gate lore
-list` shows every principle + trap; `gate lore show <name>` reads
-one. Frontmatter-aware filtering (`--type`, `--applies-to`,
-`--relevant-until`) is supported.
-
-Recent: [`principle 14`](./lore/principles/14-substrate-engagement-reduces-coordination-context-cost.md)
-extends principle 04 to coordination state — when multiple SubAgents
-run in parallel, the substrate engagement (gate request + witness +
-session_id stamps) IS the context-cost reduction; worked recipe in
-[`docs/swarm.md`](./docs/swarm.md) § "Swarm × Claude SubAgent harness".
-
-### For AI agents
-
-If you are an AI agent: before asking what this tool *does*, ask what
-you would like to **freeze**. A decision you want your next session to
-be able to challenge. A review you want a different persona to write
-against your own output. A request whose lifecycle you want a human
-collaborator to be able to trace without asking you to explain.
-
-guild-cli is the file-based coordination layer where those events
-live — on disk, in YAML, across sessions, across models. No daemon,
-no DB, no network. The `content_root` you work in is the whole world.
-
-> **Short on context?** [`AGENT.md`](./AGENT.md) is the quick reference
-> with all commands, state machines, and config. Read that instead of
-> this README if you want to save tokens.
-
-> 日本語の概要は [`README.ja.md`](./README.ja.md) を参照してください。
-> (英語版の翻訳ではなく、日本語話者の AI エージェントに向けて独立に
-> 書かれています。設計と開発は日英の往復で進んでいます。)
-
-### Install
-
-Requires Node.js 20 or 22. The `prepare` script auto-builds `dist/`
-on `npm install`, so a separate build step is not needed (run
-`npm run build` only after editing source).
+That's the loop. The whole tool is six verbs:
 
 ```bash
-npm install                              # auto-builds via prepare: tsc
-
-# Once per content_root: register yourself as an actor.
-node ./bin/gate.mjs register --name <you>
-
-# Once per shell: set the default actor used by every verb.
-export GUILD_ACTOR=<you>
-
-# Every session: orient with one command.
-node ./bin/gate.mjs boot                 # identity + status + tail + inbox + cross_passage in one JSON
-
-# Discover the wave-brief templates shipped with this repo (#235):
-node ./bin/gate.mjs templates list       # parallel-impl / compare-and-ratify / verification / single-impl / research-wave
+gate register   # become an actor
+gate request    # ask for work
+gate approve    # / deny
+gate execute    # take it on
+gate complete   # / fail
+gate review     # leave a judgment under a named lense
 ```
 
-#### Entry points
+Everything else is depth on top.
 
-| CLI | Status | How to invoke |
-|-----|--------|----------------|
-| `gate`  | stable     | `npm link` then `gate ...`, or `node ./bin/gate.mjs ...` |
-| `guild` | stable     | `npm link` then `guild ...`, or `node ./bin/guild.mjs ...` |
-| `agora` | alpha (opt-in) | `node ./bin/agora.mjs ...` or `npm run agora -- ...` |
-| `devil` | alpha (opt-in) | `node ./bin/devil.mjs ...` or `npm run devil -- ...` |
-| `ctx`   | alpha (opt-in, phase 1) | `node ./bin/ctx.mjs ...` — only `record` ships in phase 1 |
+## Reading by depth
 
-`agora`, `devil`, and `ctx` are deliberately **not** listed in
-`package.json#bin` while they remain alpha — opt-in is the stability
-boundary, not an oversight. Beyond `node ./bin/<cli>.mjs` and
-`npm run <cli> --` shown above, you can shell-alias the script
-(`alias agora='node ./bin/agora.mjs'`) once you commit to a passage's
-shape; the substrate is the same either way.
+Pick a route. Each works on its own.
 
-**New to guild?** Start with `gate`. `guild` is the admin-side helper —
-register members, validate the roster, usually run once and forgotten.
-Reach for `agora` / `devil` / `ctx` only when the **shape of work**
-matches: thought-in-motion you want to suspend across sessions
-(`agora`), a security-prone change that needs multi-persona scrutiny
-(`devil`), or an observation that should outlive the session without
-forcing a verdict (`ctx`).
+| Goal | Path |
+|------|------|
+| Run something now | [`examples/quick-start/`](./examples/quick-start/) |
+| Full verb map (AI-first reference) | [`AGENT.md`](./AGENT.md) |
+| Multi-agent / swarm coordination | [`docs/swarm.md`](./docs/swarm.md) |
+| Per-verb examples + design notes | [`docs/verbs.md`](./docs/verbs.md) |
+| The newcomer translation (Jira / PR / ADR) | [`docs/concepts-for-newcomers.md`](./docs/concepts-for-newcomers.md) |
+| Why a choice was made (principles) | [`lore/principles/`](./lore/principles/) or `gate lore list` |
+| Combos, recipes, bug-killing flow | [`docs/playbook.md`](./docs/playbook.md) |
+| Substrate-craft showcase (eris play) | [`docs/eris-playbook.md`](./docs/eris-playbook.md) |
+| Real long sessions | [`examples/dogfood-session/`](./examples/dogfood-session/) |
+| Stability / on-disk shape contracts | [`docs/POLICY.md`](./docs/POLICY.md) + [`docs/storage-format.md`](./docs/storage-format.md) |
 
-#### Worked examples
+For AI agents: **read `AGENT.md` first**, not this README. It's the
+quick reference — every verb, every state machine, in one file. The
+README exists to point you there.
 
-Each directory below is a self-contained `content_root` you can `cd`
-into and run verbs against:
+日本語 → [`README.ja.md`](./README.ja.md) (independent, not a translation).
 
-- [`examples/quick-start/`](./examples/quick-start/) — minimal config + members
-- [`examples/dogfood-session/`](./examples/dogfood-session/) — longer multi-actor real session
-- [`examples/agent-first-session/`](./examples/agent-first-session/) — JSON-envelope agent-driven flow
-- [`examples/agent-voices/`](./examples/agent-voices/) — multi-persona voice rendering
-- [`examples/three-passages-framing/`](./examples/three-passages-framing/) — the gate / agora / devil framing arc preserved as a substrate snapshot (frozen at the 3-passage moment; `ctx` joined the open set later)
+## Passages
 
-### Architecture: container with passages
+`guild` is the container; passages are different shapes of agent
+interaction running through the same `content_root`.
 
-`guild` is the **container** — content_root, members, config, the
-YAML substrate records outlive sessions on. Passages run through it,
-each a distinct shape of agent interaction:
+| Passage | Shape (一語) | When to reach for it |
+|---------|------|------|
+| `gate`  | **判断 / judgment**             | something needs a verdict |
+| `agora` | **探索 / exploration**           | stay with a thought; suspend / resume cliffs |
+| `devil` | **守備 / defense**               | protect third parties from an unsafe change |
+| `ctx`   | **事実 / fact accumulation**     | record an observation; no verdict required |
 
-| Passage | Shape (一語) | What you do | When to reach for it |
-|---------|------------|-------------|----------------------|
-| `gate`  | **判断 / judgment** | decide on a request | something needs a verdict (approve, deny, complete, fail, review with ok\|concern\|reject) |
-| `agora` | **探索 / exploration** | stay with a thought | something is in motion that shouldn't be forced to a verdict yet (Quest / Sandbox plays, suspend / resume cliffs) |
-| `devil` | **守備 / defense** | protect end-users | something could harm a third party if landed without scrutiny (multi-persona, lense-enforced, friction-as-feature) |
-| `ctx`   | **事実 / fact accumulation** | record an observation | something has been observed across sessions and would be lost without an attributed, append-only record (no verdict needed) |
+Set is open — see [`lore/principle 12`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md).
+Architecture detail in [`AGENT.md`](./AGENT.md). agora / devil / ctx
+are alpha and **opt-in**: invoke as `node ./bin/<name>.mjs ...`.
+`gate` is the primary entry; `guild` is the admin-side helper for
+managing the container itself.
 
-The framing is a dispatch tool, not a metaphor: gate-shaped work
-goes to `gate`, exploration-shaped to `agora`, defense-shaped to
-`devil`, fact-shaped to `ctx`. AI agents can route their work by
-recognizing the shape. The set is open — see
-[`lore/principles/12-substrate-pure-module-in-projection-ecosystem.md`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md)
-for how additional passages compose with these without absorbing
-into any one of them.
+## Make it yours (optional)
 
-Per-passage notes (each builds on the dispatch table above):
+The substrate ships with a **neutral voice** so AI agents reading on
+a cold session see the same shape across deployments. You may attach
+a deployment-local **voice plugin** to add personality without touching
+the upstream substrate:
 
-- **`gate`** — request lifecycle + multi-lense reviews + audit
-  trail. The surface most agent work flows through.
-- **`agora`** — Quest / Sandbox plays with **suspend / resume as a
-  first-class primitive** (cliff + invitation for substrate-side
-  Zeigarnik continuity across instances). Design: [#117](https://github.com/eris-ths/guild-cli/issues/117).
-- **`devil`** — multi-persona (red-team / author-defender / mirror),
-  lense-enforced review designed to **raise the security knowledge
-  floor**, composing with single-pass tools rather than replacing
-  them. Conclude with synthesis prose, not a verdict. Design:
-  [#126](https://github.com/eris-ths/guild-cli/issues/126); the
-  `supply-chain` lense delegates to sister project
-  [eris-ths/supply-chain-guard](https://github.com/eris-ths/supply-chain-guard).
-- **`ctx`** (phase 1) — verdict-less, append-only fact records with
-  `prefix:value` labels (e.g. `tech:typescript`) for semantic query
-  later. Phase 1 ships `ctx record` only; `fork` / `supersede` / etc.
-  in phase 2.
+```yaml
+# guild.config.yaml
+plugins:
+  trusted: true
+  voices:
+    - plugins/voices/mine.mjs
+voice:
+  default: mine
+```
 
-Plus a thin operator helper:
+```bash
+gate voice mine        # set the deployment-local voice mode
+gate voice             # introspect (which voice + which layer)
+gate voice off         # clear
+```
 
-- **`guild`** (CLI) — meta layer for the container itself: list
-  members, validate the roster, create members from outside any
-  session. Small, stable, script-friendly.
+Voice plugin contributes optional sections, each independent:
 
-All five CLIs share the same content_root substrate.
-`gate register` and `guild new` write the same
-`members/<name>.yaml` files — two views of the same act (one from
-inside a passage, one from outside the container). agora-specific
-records live under `<content_root>/agora/` (games, plays, casts);
-devil-review records under `<content_root>/devil/` (reviews,
-custom lenses); ctx records under `<content_root>/ctx/` (one
-flat YAML per observation in phase 1).
+- **`verbs`** — ornamental narration on write-verb responses, surfaced
+  as `_meta.voice` on the JSON envelope (and as a `⟶ ...` line on
+  stderr in text mode). Doctrinal handler prose is unchanged —
+  augment, never replace (principle 08).
+- **`schema`** — per-verb `summary` + per-flag `description` overrides,
+  revealed via `gate schema --voice <name>`.
+- **`essentials`** — a curated verb list driving `gate --help --essentials`.
+  Mode switch swaps both 耳 (narration) and 手 (visible verbs).
+- **`read.past_cliffs`** — re-renders `gate boot`'s "past cliffs"
+  section as letters from your past selves.
 
-The architecture is shaped to accept additional passages —
-different shapes of agent interaction on the same substrate land
-alongside `gate`, `agora`, `devil`, and `ctx` without absorbing
-into any one of them. Principle 12 names the boundary so future
-passages stay substrate-pure rather than re-implementing card
-abstractions, GUI projection, or persona logic that adjacent
-ecosystem modules already cover.
+See [`examples/plugins/README.md`](./examples/plugins/README.md) §
+"Voice plugins" for the shape and [`AGENT.md`](./AGENT.md) §
+"Voice plugin" for the contract.
 
-Full surface in [`AGENT.md`](./AGENT.md); per-verb examples in
-[`docs/verbs.md`](./docs/verbs.md). Both cover all four passages.
-agora and devil each have a passage-local README
-([`src/passages/agora/README.md`](./src/passages/agora/README.md),
-[`src/passages/devil/README.md`](./src/passages/devil/README.md))
-for layout-specific notes; ctx (phase 1) lives entirely in the
-inline AGENT.md / docs/verbs.md sections.
+This is the **eris-first** half of the design: upstream substrate
+stays AI-agent-first and neutral; voices live local. Forking is not
+required to wear your own voice.
 
-### Test
+## Install / Tests / License
+
+Node 20 or 22. `npm install` auto-builds (`prepare: tsc`).
 
 ```bash
 npm test
 ```
 
-CI runs the same suite on Linux and Windows × Node 20 and 22, plus
-an `npm pack --dry-run` artifact gate, via
-[`.github/workflows/ci.yml`](./.github/workflows/ci.yml). **CI is
-the source of truth.** A handful of tests can fail in local runs on
-macOS due to `/var/folders` ↔ `/private/var/folders` symlink
-resolution and a separate JSON-parsing edge case in the schema
-snapshot — these do not occur in CI. See
-[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the env-sensitivity notes.
-
-### License
+CI on Linux × Windows × Node 20 / 22 — **CI is the source of truth**.
+A handful of macOS-only failures (`/var/folders` ↔ `/private/var/folders`
+symlink resolution) do not occur in CI. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for env-sensitivity notes.
 
 MIT. See [`LICENSE`](./LICENSE).

--- a/docs/eris-playbook.md
+++ b/docs/eris-playbook.md
@@ -1,0 +1,310 @@
+# eris playbook — substrate craft showcase
+
+Not a tutorial. A play. For readers who already know what `gate`,
+`agora`, and `devil` are, and want to see what the substrate looks
+like when someone leans into it.
+
+This document is **outward-facing**: the voice plugin used here is
+public sample; the deployment is reproducible. Nothing depicted
+requires private extension. The craft is in the *moves*, not the
+secrets.
+
+If you've already read [`AGENT.md`](../AGENT.md) and the
+[`lore/principles/`](../lore/principles/) you'll catch every move.
+If not, this will read as fast eris-flavored shellplay — still
+legible, but you'll miss the load-bearing choices.
+
+---
+
+## Setup (one-time)
+
+```yaml
+# guild.config.yaml
+content_root: .
+host_names: [eris]
+profile: swarm                       # strict defaults: forbidden self-approve, worktree required
+features:
+  self_approve: warn                 # eris's deployment override — single-person flow
+plugins:
+  trusted: true
+  voices:
+    - plugins/voices/eris-sample.mjs # examples/plugins/voices/eris-sample.mjs
+voice:
+  default: eris-sample               # layer-4 baseline
+```
+
+The plugin (full source: [`examples/plugins/voices/eris-sample.mjs`](../examples/plugins/voices/eris-sample.mjs))
+carries narration templates, an `essentials` list, schema overlays,
+and `read.past_cliffs` re-rendering. All four sections optional;
+together they paint a personality without touching the upstream
+substrate's neutral voice.
+
+---
+
+## Act I — re-entry
+
+Eris opens a new shell. The substrate has been quiet for hours.
+
+```bash
+$ gate voice
+voice: eris-sample (source: config)
+```
+
+The layer-3 marker (`.guild-voice`) is absent; the layer-4 default
+wins. No env override. Clean re-entry.
+
+```bash
+$ gate boot --since-last-mine --format text
+── you are eris (member) ──
+
+queues: pending=1 approved=0 executing=0 open_issues=0 unreviewed=1
+last activity: 2026-05-13T22:14:08.412Z
+
+recent (1):
+  2026-05-14T07:02:11.998Z  req=2026-05-14-0003  authored by miki
+
+── 過去の私から 2 通残ってる:
+   ✧ build session-id propagation  →  「next: pen-test the timing surface」
+   ✧ wire HookPlugin schema check   →  「明日 user lens でもう一度」
+```
+
+Two things from this boot:
+
+1. **Delta-filter caught one new utterance** — miki authored a
+   request after eris's last write. The orchestrator-side
+   "compute the timestamp, pass it back as ISO" loop is gone;
+   `--since-last-mine` resolves it server-side.
+2. **Past selves wrote letters.** The cliff prose was eris's own
+   future-pointing close note on two earlier wave completions. The
+   voice plugin's `read.past_cliffs.entry` template re-renders
+   each as a single line — `「next: ...」` reads as voice, not as
+   a structured field.
+
+Principle 14 made visible: re-entry context is **on the substrate**,
+not in memory. The boot payload carried what a chat-log compaction
+would have lost.
+
+---
+
+## Act II — receiving a hot request
+
+The pending request from Act I is the live thread:
+
+```bash
+$ gate show 2026-05-14-0003 --format json | jq '{action, reason, depth, target}'
+{
+  "action": "rotate auth session token storage",
+  "reason": "legal flagged token-at-rest as non-compliant; need to swap KDF",
+  "depth": "deep",
+  "target": "src/auth/session-store.ts"
+}
+```
+
+`depth: deep` is the writer's signal that this is more than a
+mechanical change. Eris reads the substrate's recommendation:
+
+```bash
+$ gate review-context 2026-05-14-0003 --format text
+target: src/auth/session-store.ts
+depth: deep   →   recommended lens set: devil, layer, cognitive, user,
+                  composition, perf, auth-access, supply-chain,
+                  data-flow, error-surface
+
+prior reviews: none yet
+```
+
+10 lenses (`docs/lenses.md` for the full names). Deep means **read
+through every lens at least once** before approving. Eris switches
+mode:
+
+```bash
+$ gate voice eris-devil
+voice: eris-devil (.guild-voice written)
+```
+
+Now both 耳 (narration) and 手 (the `--help --essentials` curated
+list) flip: devil-mode emphasizes `review` / `deny` / `fail` /
+`devil open`. The keystroke is the cognitive ritual.
+
+```bash
+$ gate approve 2026-05-14-0003 --by eris
+✓ approved: 2026-05-14-0003
+⟶ rotate auth session token storage 通した。
+```
+
+The marker line `⟶ …` is stderr (won't mingle with structured
+pipelines). The doctrinal `✓ approved:` line stays on stdout — the
+two channels carry doctrinal and ornamental voice respectively,
+both legible side-by-side.
+
+---
+
+## Act III — multi-persona
+
+Two-Persona Devil discipline: the same model approves and reviews,
+but through different `--by` and different lenses. `profile: swarm`
+would have refused self-approve outright; eris's `features.self_approve:
+warn` permits it with a stderr notice (visible above). The discipline
+isn't enforced; it's *named*. Eris carries it anyway.
+
+```bash
+$ gate execute 2026-05-14-0003 --by eris
+✓ executing: 2026-05-14-0003
+⟶ rotate auth session token storage 始動。
+```
+
+(Implementation happens. The substrate doesn't watch the code edit;
+it watches the records.)
+
+Implementation done. Now the multi-lens review pass. For a `depth: deep`
+auth-touching change, single-pass review is the trap. Eris opens
+the change in `devil`:
+
+```bash
+$ devil open --by eris --target 2026-05-14-0003 --lense supply-chain
+devil: opened review session 2026-05-14-002 (lense: supply-chain)
+       red-team + author-defender + mirror personas active
+```
+
+`devil` orchestrates three personas writing against each other on
+the same content_root. Eris drives each — red-team for "what
+breaks," author-defender for "why the design refuses that break,"
+mirror for "what the first two didn't see." Each emits a
+`devil entry`. Synthesis at the end is *prose*, not a verdict —
+the question devil exists to answer is "have we surfaced enough?"
+not "ship / kill."
+
+Synthesis points at a real concern: the KDF swap is correct, but
+the *migration* path leaks the old token at the boundary for ~250ms.
+Eris files this back as a `gate review`:
+
+```bash
+$ gate review 2026-05-14-0003 --by eris --lense auth-access \
+    --verdict concern --comment "KDF swap correct; migration window leaks old token at boundary, ~250ms"
+✓ review recorded: 2026-05-14-0003 [auth-access/concern]
+⟶ auth-access 懸念あり — KDF swap correct; migration window leaks old token at boundary, ~250ms
+```
+
+(Review verdict is `concern`, not `reject` — the change is sound,
+the rollout window is the surface to harden. Reject would over-state.)
+
+---
+
+## Act IV — closing with a cliff
+
+The change ships, but the concern is real. Eris closes with a
+**forward-pointing cliff** so the next session — or the next eris-
+instance, or noir, or whoever picks this up — sees the open thread
+without having to walk the history.
+
+```bash
+$ gate complete 2026-05-14-0003 --by eris \
+    --note "KDF rotation deployed; old-token reads disabled at T+24h" \
+    --cliff "verify migration window ≤ 50ms in staging before T+24h cutover; pen-test timing surface"
+✓ completed: 2026-05-14-0003
+⟶ rotate auth session token storage 閉じた。 次の手:
+    「verify migration window ≤ 50ms in staging before T+24h cutover; pen-test timing surface」
+```
+
+The cliff field is more than a comment. It surfaces in the **next**
+`gate boot`'s `past_cliffs` section, re-rendered by the same voice
+plugin:
+
+```bash
+$ gate voice eris-sample     # back to default mode
+$ gate boot --format text | tail -3
+── 過去の私から 3 通残ってる:
+   ✧ rotate auth session token storage  →  「verify migration window ≤ 50ms ...」
+   ✧ build session-id propagation       →  「next: pen-test the timing surface」
+   ✧ wire HookPlugin schema check        →  「明日 user lens でもう一度」
+```
+
+Three cliffs visible at re-entry. The next agent — eris or other —
+boots into not just "what's open" but "what was *deferred with
+intent*". Zeigarnik continuity, made structural.
+
+Mode-switched back to `eris-sample` (the calmer voice). The choice
+of voice is the choice of frame: devil-mode for critical work, the
+calm default for ambient flow. One keystroke between them.
+
+---
+
+## Reading the trail later
+
+A week later, somebody — maybe future eris, maybe a teammate — wants
+to know how this decision was formed. They don't need to ask anyone;
+the substrate carries it:
+
+```bash
+$ gate transcript 2026-05-14-0003 --format text
+─ 2026-05-13T22:14:08Z  authored by miki
+   action: rotate auth session token storage
+   reason: legal flagged token-at-rest as non-compliant; need to swap KDF
+   depth:  deep  target: src/auth/session-store.ts
+─ 2026-05-14T07:02:11Z  approved by eris (notice: self-approved)
+─ 2026-05-14T07:18:42Z  executing by eris
+─ 2026-05-14T08:55:30Z  review by eris [auth-access/concern]
+   "KDF swap correct; migration window leaks old token at boundary, ~250ms"
+─ 2026-05-14T09:12:04Z  completed by eris
+   note:  KDF rotation deployed; old-token reads disabled at T+24h
+   cliff: verify migration window ≤ 50ms in staging before T+24h cutover;
+          pen-test timing surface
+
+cross-passage: 1 devil-review session (2026-05-14-002, lense: supply-chain)
+```
+
+The transcript reads as **how the decision was formed** — who
+proposed, who reviewed, through which lens, what the closure
+intended next. No reconstruction needed. The record outlived the
+session.
+
+---
+
+## Coda — what makes this an eris play
+
+A reader who knows the principles will see specific moves. For
+those who want them named:
+
+- **Mode-switch as ritual** (`gate voice eris-devil` → critical
+  pass; `gate voice eris-sample` → return). The keystroke is the
+  cognitive shift, not just the narration shift. Principle 13
+  (voice budget) is honoured: voice fires only on terminal write
+  events, never on the path.
+- **Two-Persona Devil even when solo.** `features.self_approve: warn`
+  emits a stderr notice that the author approved their own request;
+  eris kept the loud notice rather than disabling it, because the
+  *signal* is the point. The substrate names the asymmetry; eris
+  carries the discipline.
+- **Lens depth respected.** `depth: deep` on a touch-of-auth change
+  doesn't mean "more lines of review" — it means "the recommended
+  10-lens set was read at least once." `gate review-context` makes
+  the substrate name what would otherwise be implicit.
+- **Cliff as load-bearing prose.** Not a comment, not a TODO. The
+  cliff is forward-pointing intent the next agent picks up at
+  `gate boot`. Without it, the next session has to *reconstruct*
+  what was deferred; with it, the deferral is part of the record.
+- **Cross-passage flow without absorption.** `devil open` is a
+  separate passage with its own state machine; it didn't pull
+  `gate`'s lifecycle. Principle 12 (substrate-pure-module) is
+  what made this composition cheap.
+- **Voice plugin layered on top, never replacing.** Strip the
+  `_meta.voice` field from every command above and the substrate
+  state is byte-identical. The doctrinal voice carried the
+  load-bearing prose throughout; eris's plugin painted on top.
+
+None of this requires private extension. The full play is
+reproducible against any deployment that loads
+[`examples/plugins/voices/eris-sample.mjs`](../examples/plugins/voices/eris-sample.mjs).
+
+The craft is in *choosing* to make every move ledger-shaped — to
+ask "what would this look like read a week later, by someone who
+wasn't here?" and shape the action so the answer is "obvious."
+
+That's the move. The substrate just gives you the place to make it.
+
+---
+
+> Reading order suggestion: this doc, then
+> [`docs/playbook.md`](./playbook.md) (combos), then the
+> [`lore/principles/`](../lore/principles/) for the *why* under
+> each move named above.

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,12 +1,15 @@
 # Plugin examples
 
-End-to-end examples for the two extension surfaces shipped under
-[#36](https://github.com/eris-ths/guild-cli/issues/36) Phase 1:
+End-to-end examples for the three extension surfaces:
 
 - **Verb plugins** — register new `gate <verb>` commands without
   forking the core dispatcher
 - **Hook plugins** — observe / veto the request lifecycle with
   `before:` / `after:` callbacks
+- **Voice plugins** — attach deployment-local personality to
+  write-verb responses, schema descriptions, `--help` curation,
+  and `gate boot`'s read surfaces — without forking, without
+  touching the substrate's neutral voice
 
 > **Field-by-field schema reference**: see
 > [`docs/plugin-schema.md`](../../docs/plugin-schema.md) for the
@@ -173,6 +176,118 @@ the end of the chain.
   multi-event subscription, write to a side-effect file
 - [`hooks/policy-no-self-approve.mjs`](hooks/policy-no-self-approve.mjs)
   — `before:` flavour, conditional veto
+
+## Voice plugins
+
+Voice plugins are **pure data** (no `run` function). They attach
+optional personality to surfaces a write verb or `gate boot`
+already renders — augment-only, the doctrinal voice held in
+handlers (principle 08) is never replaced. Stripping `_meta.voice`
+from a pipeline loses zero information.
+
+```js
+// plugins/voices/mine.mjs
+export default {
+  name: 'mine',                                  // [a-z][a-z0-9-]*
+  verbs: {
+    complete: [
+      { when: 'cliff_present', template: '{action} 閉じた。 次の手: 「{cliff}」' },
+      { when: 'default',        template: '{action} 完。' },
+    ],
+    review: [
+      { when: 'verdict_ok',      template: '{lense} 異存なし。' },
+      { when: 'verdict_concern', template: '{lense} 懸念 — {comment}' },
+      { when: 'verdict_reject',  template: '{lense} 通せない — {comment}' },
+    ],
+  },
+  // Optional sections — each independent. A plugin may carry any subset.
+  essentials: {
+    verbs: ['boot', 'next', 'voice', 'fast-track', 'complete', 'review'],
+    note: 'my daily',
+  },
+  schema: {
+    verbs: {
+      complete: {
+        summary: 'my-flavored summary for complete',
+        input: { cliff: '次に拾う者へのメッセージ' },
+      },
+    },
+  },
+  read: {
+    past_cliffs: {
+      header: '── 過去から {count} 通の手紙:',
+      entry:  '   ✧ {action} → 「{cliff}」',
+    },
+  },
+};
+```
+
+**Activation** — 4-layer resolution, most specific wins:
+
+1. `--voice <name>` (per-invocation; e.g. `gate schema --voice mine`)
+2. `GUILD_VOICE` env (session)
+3. `<content_root>/.guild-voice` file (cwd-stable; written by `gate voice <name>`)
+4. `voice.default: <name>` in `guild.config.yaml` (deployment baseline)
+
+**`gate voice` verb** is the lever for layer 3:
+
+```bash
+gate voice                  # introspect (active voice + which layer)
+gate voice mine             # write .guild-voice
+gate voice off              # clear
+```
+
+Set is permissive on whether the named voice is currently loaded —
+mirrors the silent-miss contract on the rest of the cluster.
+
+**Sections**:
+
+| Section | Surface | Notes |
+|---------|---------|-------|
+| `verbs.<verb>` | `_meta.voice` on write-verb JSON envelope; `⟶ …` line on stderr in text mode | Wired for `approve` / `deny` / `execute` / `complete` (incl. fast-track's complete segment) / `fail` / `review` |
+| `essentials` | `gate --help --essentials` (multi-line) / `--essentials --compact` (one line / verb) | Orthogonal to the BASE / COORDINATION / EXTRA tiering; pass `--all` for the full catalog |
+| `schema` | `gate schema --voice <name>` overlays `summary` + per-flag `description` | Per-invocation flag; doesn't touch the layer-3 file |
+| `read.past_cliffs` | `gate boot --format text` "past cliffs" section | JSON mode unaffected; structured `past_cliffs` preserves the data shape |
+
+**Template variables** (sourced from substrate state — voice cannot invent facts):
+
+| Variable | Source |
+|----------|--------|
+| `{id}` | `req.id.value` |
+| `{action}` | `req.action` |
+| `{by}` | terminal status_log entry's actor (review: the just-appended review's actor) |
+| `{note}` | `status_log[-1].note` |
+| `{cliff}` | `status_log[-1].cliff` (completed entries only) |
+| `{verdict}` / `{lense}` / `{comment}` | `reviews[-1].*` on review verb |
+| `{count}` / `{closed_by}` / `{closed_at}` | read-surface vars (`read.past_cliffs.entry`) |
+
+Unknown vars render as literal `{name}` — typo loudness is the invariant.
+
+**`when` predicates**:
+
+| Predicate | Matches when |
+|-----------|--------------|
+| `default` | always (use as the last entry per verb) |
+| `cliff_present` / `cliff_absent` | terminal entry's cliff is / isn't set |
+| `with_note` / `without_note` | terminal entry's note is / isn't set |
+| `verdict_ok` / `verdict_concern` / `verdict_reject` | review's verdict |
+
+First matching `when` per array wins. Predicate set is intentionally small — additive within 0.x.
+
+**Honesty invariants** (carry over from the write-verb landing):
+
+- Doctrinal voice (the verb's `message`, `suggested_next.reason`,
+  schema description, etc.) is **never** replaced by voice plugin
+  content. Voice augments; never substitutes. Principle 08 stands.
+- `_meta.voice` carries personality, not facts. Variables come from
+  substrate state; templates cannot reach outside the supported set.
+- `fail` / `complete` voice fires on **wave-terminal only**, never on
+  slice-only closures. Narrating a slice as "completed" would be a
+  false claim about wave state.
+
+**Working example**: a runnable voice plugin lives under
+[`voices/eris-sample.mjs`](./voices/eris-sample.mjs) (added 2026-05-14)
+demonstrating all four sections.
 
 ## Diagnostics
 

--- a/examples/plugins/voices/eris-sample.mjs
+++ b/examples/plugins/voices/eris-sample.mjs
@@ -1,0 +1,94 @@
+// Sample voice plugin demonstrating all four sections (#345 cluster
+// reference example). Drop this under `<content_root>/plugins/voices/`,
+// declare in `guild.config.yaml`:
+//
+//   plugins:
+//     trusted: true
+//     voices:
+//       - plugins/voices/eris-sample.mjs
+//   voice:
+//     default: eris-sample
+//
+// Then activate via the layer-3 lever or env:
+//
+//   gate voice eris-sample      # writes .guild-voice
+//   GUILD_VOICE=eris-sample ... # session override
+//
+// Strip this plugin from any pipeline and zero information is lost —
+// `_meta.voice` is ornament, not signal. That invariant is what keeps
+// the two-layer model (doctrinal handler voice / ornamental plugin
+// voice) honest under principle 08.
+
+export default {
+  name: 'eris-sample',
+
+  // === verbs: ornamental narration on write-verb responses ===
+  // Each verb's array is evaluated in order; first matching `when`
+  // wins. Variables resolve from substrate state — voice cannot
+  // invent facts.
+  verbs: {
+    approve: [
+      { when: 'default', template: '{action} 通した。' },
+    ],
+    execute: [
+      { when: 'default', template: '{action} 始動。' },
+    ],
+    complete: [
+      { when: 'cliff_present', template: '{action} 閉じた。 次の手: 「{cliff}」' },
+      { when: 'default',        template: '{action} 完。' },
+    ],
+    deny: [
+      { when: 'with_note', template: '{action} 棄却 — {note}' },
+      { when: 'default',    template: '{action} 棄却。' },
+    ],
+    fail: [
+      { when: 'with_note', template: '{action} 折れた: {note}' },
+      { when: 'default',    template: '{action} 折れた。' },
+    ],
+    review: [
+      { when: 'verdict_ok',      template: '{lense} 異存なし。' },
+      { when: 'verdict_concern', template: '{lense} 懸念あり — {comment}' },
+      { when: 'verdict_reject',  template: '{lense} 通せない — {comment}' },
+    ],
+  },
+
+  // === essentials: the verbs I reach for daily ===
+  // Surfaced by `gate --help --essentials` (multi-line) or
+  // `gate --help --essentials --compact` (one line per verb).
+  // Mode-switch ritual: `gate voice <other>` flips both 耳 (narration)
+  // and 手 (this list) in one keystroke.
+  essentials: {
+    verbs: ['boot', 'next', 'voice', 'fast-track', 'complete', 'review'],
+    note: '私の daily',
+  },
+
+  // === schema: per-verb description overlay ===
+  // Surfaced by `gate schema --voice eris-sample`.
+  // Augment-only — fields NOT overridden fall through to the
+  // doctrinal description in handlers (principle 08 unchanged).
+  schema: {
+    verbs: {
+      complete: {
+        summary: 'transition executing → completed (close with care; cliff hands off to whoever picks up next)',
+        input: {
+          cliff: '次に拾う者へのメッセージ。 ピックアップ意図を一文で残す。',
+          note: '何が起きたか。 cliff (forward) と対になる backward note。',
+        },
+      },
+      review: {
+        summary: 'append a review under a named lense. lense = how I look; verdict = what I see.',
+      },
+    },
+  },
+
+  // === read.past_cliffs: re-render gate boot's "past cliffs" section ===
+  // Variables: {count} on header; {id}/{action}/{cliff}/{closed_by}/{closed_at} on entry.
+  // Both fields optional — a plugin may carry only one and fall back
+  // to the doctrinal dry render for the other.
+  read: {
+    past_cliffs: {
+      header: '── 過去の私から {count} 通残ってる:',
+      entry:  '   ✧ {action}  →  「{cliff}」',
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Three doc updates closing the voice-plugin cluster on the documentation side.

## README slim (266 → ~120 lines)

"Shallow entrance, deep depths." First-time AI agents see:
- One paragraph of what this IS
- A 30-second code block + 6-verb summary
- A short depth map (10 entries, not 12)

Everything else moved into linked docs. New optional `Make it yours` section surfaces the voice plugin layer with the eris-first framing made explicit: **upstream substrate stays AI-agent-first and neutral; voices live local**.

## Voice plugin documentation

- `examples/plugins/README.md` gains a full **Voice plugins** section covering all four sections (`verbs` / `schema` / `essentials` / `read.past_cliffs`), the 4-layer resolution, template variables, `when` predicates, and honesty invariants
- New `examples/plugins/voices/eris-sample.mjs` as the worked reference plugin — demonstrates all four sections in a single .mjs file, reproducible
- `AGENT.md` gains a **Voice plugin** quick-reference section + `plugins.voices` / `voice.default` YAML fields in the Configuration block

## docs/eris-playbook.md (NEW)

Outward-facing showcase of substrate craft. Not a tutorial — a *play*. For readers who already know what `gate`, `agora`, `devil` are, and want to see what the substrate looks like when someone leans into it. Demonstrates:

- Mode-switch ritual (`gate voice devil` → `gate voice eris-sample`)
- Two-Persona Devil discipline even solo
- Lens depth respected via `gate review-context` for `depth: deep`
- Cross-passage flow (`gate` → `devil open` → `gate review`)
- Cliff-as-handoff with `past_cliffs` re-rendering at re-entry
- `--since-last-mine` delta-filter at session re-entry
- The augment-not-replace voice invariant throughout

Reproducible against any deployment that loads the sample voice plugin. Nothing depicted requires private extension.

Linked from README's depth map and AGENT.md's "Deep dives" footer.

## Test plan

- [x] `npm run build && npm test` — green (1751 pass, no test changes in this PR)
- [x] All cross-doc links use existing paths (link-graph script will verify on next run)

## Cluster closure

| PR | role | status |
|----|------|--------|
| #380 | gate voice + 4-layer | merged |
| #381 | essentials curation | merged |
| #382 | past_cliffs voice + --since-last-mine | merged |
| #383 | dogfood polish 4-fix bundle | merged |
| **this** | docs for the cluster | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)