### PR TITLE
docs: fix lingering 'lens' → 'lense' singular-spelling drift

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -270,7 +270,7 @@ state instead of out-of-band prompt content:
   the wave was created without `--depth`)
 - `recommended_lenses`: derived from `depth`
   - `shallow` → `[Logic]` (point-check)
-  - `standard` → 6-lens default (`Logic, Pattern, Flow, Error, Test, Input`)
+  - `standard` → 6-lense default (`Logic, Pattern, Flow, Error, Test, Input`)
   - `deep` → all 10 + extras (`memory_mcp_trap_lookup`,
     `state_machine_trace`, `prior_review_cross_check`)
 - `prior_reviews` bundled in-payload — saves a second `gate show`

--- a/docs/eris-playbook.md
+++ b/docs/eris-playbook.md
@@ -65,7 +65,7 @@ recent (1):
 
 ── 過去の私から 2 通残ってる:
    ✧ build session-id propagation  →  「next: pen-test the timing surface」
-   ✧ wire HookPlugin schema check   →  「明日 user lens でもう一度」
+   ✧ wire HookPlugin schema check   →  「明日 user lense でもう一度」
 ```
 
 Two things from this boot:
@@ -106,7 +106,7 @@ mechanical change. Eris reads the substrate's recommendation:
 ```bash
 $ gate review-context 2026-05-14-0003 --format text
 target: src/auth/session-store.ts
-depth: deep   →   recommended lens set: devil, layer, cognitive, user,
+depth: deep   →   recommended lense set: devil, layer, cognitive, user,
                   composition, perf, auth-access, supply-chain,
                   data-flow, error-surface
 
@@ -114,7 +114,7 @@ prior reviews: none yet
 ```
 
 10 lenses (`docs/lenses.md` for the full names). Deep means **read
-through every lens at least once** before approving. Eris switches
+through every lense at least once** before approving. Eris switches
 mode:
 
 ```bash
@@ -156,7 +156,7 @@ $ gate execute 2026-05-14-0003 --by eris
 (Implementation happens. The substrate doesn't watch the code edit;
 it watches the records.)
 
-Implementation done. Now the multi-lens review pass. For a `depth: deep`
+Implementation done. Now the multi-lense review pass. For a `depth: deep`
 auth-touching change, single-pass review is the trap. Eris opens
 the change in `devil`:
 
@@ -216,7 +216,7 @@ $ gate boot --format text | tail -3
 ── 過去の私から 3 通残ってる:
    ✧ rotate auth session token storage  →  「verify migration window ≤ 50ms ...」
    ✧ build session-id propagation       →  「next: pen-test the timing surface」
-   ✧ wire HookPlugin schema check        →  「明日 user lens でもう一度」
+   ✧ wire HookPlugin schema check        →  「明日 user lense でもう一度」
 ```
 
 Three cliffs visible at re-entry. The next agent — eris or other —
@@ -254,7 +254,7 @@ cross-passage: 1 devil-review session (2026-05-14-002, lense: supply-chain)
 ```
 
 The transcript reads as **how the decision was formed** — who
-proposed, who reviewed, through which lens, what the closure
+proposed, who reviewed, through which lense, what the closure
 intended next. No reconstruction needed. The record outlived the
 session.
 
@@ -275,9 +275,9 @@ those who want them named:
   eris kept the loud notice rather than disabling it, because the
   *signal* is the point. The substrate names the asymmetry; eris
   carries the discipline.
-- **Lens depth respected.** `depth: deep` on a touch-of-auth change
+- **Lense depth respected.** `depth: deep` on a touch-of-auth change
   doesn't mean "more lines of review" — it means "the recommended
-  10-lens set was read at least once." `gate review-context` makes
+  10-lense set was read at least once." `gate review-context` makes
   the substrate name what would otherwise be implicit.
 - **Cliff as load-bearing prose.** Not a comment, not a TODO. The
   cliff is forward-pointing intent the next agent picks up at

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -38,7 +38,7 @@ If you are reading the codebase for the first time, the [`Quick vocabulary`](./c
 - **verdict** — review outcome: `ok` (landed cleanly), `concern` (lives with the decision but you want it named), `reject` (don't do this). The word is deliberately soft — `concern` is usable, not a veto.
 - **claim** — exclusive stake on a wave: "I'm working on this." `gate claim <id> --by <m>` is refused if another actor holds the claim. Auto-released on terminal transition. See #226.
 - **witness** — non-exclusive observation: "I'm watching this." Multiple actors can witness one wave. `gate witness <id> --by <m>` is idempotent (same-actor re-witness no-op unless note/session differs). See #244 / #246.
-- **depth** — reviewer-depth advisory on a wave: `shallow | standard | deep`. Stamped at `gate request --depth <v>`. Consumed by `gate review-context` (#310) to recommend a lens set. See #221.
+- **depth** — reviewer-depth advisory on a wave: `shallow | standard | deep`. Stamped at `gate request --depth <v>`. Consumed by `gate review-context` (#310) to recommend a lense set. See #221.
 - **strict_lenses** — opt-in `guild.config.yaml` setting that flips `gate review`'s allowed-lense set from the team-chosen `lenses:` list to the bundled devil catalog. Default `false`. See `docs/verbs.md` § "Strict lense vocabulary".
 
 ## Cross-passage / time

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1227,8 +1227,8 @@ A fresh witness on a 33-min-old wave no longer trips a false stale.
 #### `gate review-context <id>` (issue #310)
 
 Reviewer-facing bundle: action / reason / target / executors / depth
-advisory (`shallow | standard | deep`) / recommended lens set / prior
-reviews. Lets a reviewer agent drive lens selection from substrate
+advisory (`shallow | standard | deep`) / recommended lense set / prior
+reviews. Lets a reviewer agent drive lense selection from substrate
 state rather than out-of-band prompt content.
 
 ```bash
@@ -1241,7 +1241,7 @@ gate review-context 2026-05-11-0005 --format json
 # }
 ```
 
-Lens recommendation by depth: `shallow → [Logic]`, `standard → 6-lens
+Lense recommendation by depth: `shallow → [Logic]`, `standard → 6-lense
 default`, `deep → all 10 + memory MCP + state-machine + cross-check`.
 Advisory not directive (principle 02) — the reviewer is free to
 widen / narrow.

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -238,7 +238,7 @@ const SECTIONS: readonly Section[] = [
           '  gate review-context <id> [--format text|json]\n' +
           '                       Reviewer-facing bundle for a wave: action /\n' +
           '                       reason / target, executors, depth advisory,\n' +
-          '                       recommended lens set by depth, prior reviews.\n' +
+          '                       recommended lense set by depth, prior reviews.\n' +
           '                       Lets a reviewer agent drive behaviour from\n' +
           '                       substrate state instead of out-of-band prompt\n' +
           '                       content. depth=shallow→[Logic], standard→6\n' +

--- a/src/interface/gate/voices.ts
+++ b/src/interface/gate/voices.ts
@@ -252,7 +252,7 @@ export function collectUtterances(
     // Thank utterances: emitted for both the `by` actor (who gave)
     // and the `to` actor (who received) — either name-filter match
     // surfaces the record. Reviews are one-sided (only `by` speaks),
-    // so this is the one place the filter diverges. Lens/verdict
+    // so this is the one place the filter diverges. Lense/verdict
     // filters short-circuit the thanks loop entirely — thanks have
     // no lense/verdict, so a lense-scoped query should not carry them.
     const filteringReviewsOnly =


### PR DESCRIPTION
## Summary

Follow-up sweep after #333: the README slim + voice plugin batch
(#377-#384) added new prose (`docs/eris-playbook.md`, AGENT.md help
block) and live CLI help text that landed with the bare singular
`lens` instead of the project's deliberate `lense` (with trailing
`-e`, per `docs/concepts-for-newcomers.md:58`).

13 hits / 6 files:

- `src/interface/gate/help.ts` — `gate --help` text (user-visible)
- `src/interface/gate/voices.ts` — internal comment
- `AGENT.md` — review-context recipe
- `docs/glossary.md` — `depth` entry
- `docs/verbs.md` — `gate review-context` section (incl. "Lens recommendation by depth" heading)
- `docs/eris-playbook.md` — 8 hits in the long playbook prose

Skipped intentionally:

- `CHANGELOG.md` — append-only history
- `examples/agent-voices/`, `examples/dogfood-session/` — historical wave records
- `lore/principles/12-…md` "shared GUI lens (projector)" — separate optical/projector metaphor (preserved from #333)

JSON envelope field name `recommended_lenses` (plural) intentionally
unchanged.

## Test plan

- [x] `npm run build` clean
- [x] `node tests/run.mjs dist/tests` — 1751 pass / 0 fail
- [x] zero remaining singular `lens` hits via case-insensitive `git grep` (excluding the carve-outs above)

https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_