### PR TITLE
docs(domain): name 'ambient-by-design' on stamped-but-unread advisories (#344)

### DIFF
--- a/.changelog/next/changed-advisory-ambient-comments.md
+++ b/.changelog/next/changed-advisory-ambient-comments.md
@@ -1,0 +1,9 @@
+- **Advisory fields classified ambient-by-design now name that status at
+  the declaration site (#344 audit close-out).** Touched 4 fields per
+  the 2026-05-15 audit: `Issue.severity`, `Issue.area`,
+  `Request.sourceAgoraPlay`, `Request.template` (representing the
+  template / templateVersion / gateRequiredAcknowledged trio).
+  Each gets a one-paragraph comment naming the audit, its consumer
+  (display-only or cold-reader audit), and why no further consumer
+  is needed. `schema.ts` description for `from-agora` softened — it
+  previously promised `gate chain`-style navigation that did not ship.

--- a/src/domain/issue/Issue.ts
+++ b/src/domain/issue/Issue.ts
@@ -204,7 +204,24 @@ export interface IssueStateLogEntry {
 export interface IssueProps {
   id: IssueId;
   from: MemberName;
+  /**
+   * Advisory (principle 02) — ambient by design.
+   * Stamped on creation and displayed in `gate issues show`, but no
+   * verb reads the stored value to alter behavior. The behavior-side
+   * consumer is `gate flow-suggest --severity <s>`, which takes the
+   * value from the CLI flag (the invocation), not from the stored
+   * issue. The stored field is cold-reader audit material — a future
+   * reader can see "this issue was filed as high-severity" even if
+   * no runtime branch fires on it. Audited 2026-05-15 in #344.
+   */
   severity: IssueSeverity;
+  /**
+   * Advisory (principle 02) — ambient by design.
+   * Same shape as `severity` above: stamped on creation, displayed
+   * in `gate issues show`, behavior consumer (`gate flow-suggest
+   * --area <a>`) reads from the CLI flag, not the stored value.
+   * Cold-reader audit material. Audited 2026-05-15 in #344.
+   */
   area: string;
   text: string;
   state: IssueState;

--- a/src/domain/request/Request.ts
+++ b/src/domain/request/Request.ts
@@ -206,6 +206,14 @@ export interface RequestProps {
    * Same shape as `promotedFrom` (the issue→request equivalent). Issue
    * #232 — surfaces "this request came out of <play>" without forcing
    * the operator to remember to mention the id in prose.
+   *
+   * Advisory (principle 02) — ambient by design. Currently read only
+   * by `gate show` for display (`requestReads.ts`); the schema
+   * description previously promised `gate chain`-style navigation
+   * would lift this, but no consumer ships today. Audited
+   * 2026-05-15 in #344 and reframed as cold-reader audit material:
+   * the agora→gate bridge itself was the value, the back-reference
+   * is bonus.
    */
   sourceAgoraPlay?: string;
   /**
@@ -231,7 +239,15 @@ export interface RequestProps {
    * if you stamped a template, the version and gate-acknowledgement
    * round-trip with it). Pre-#235 records lack all three fields and
    * hydrate as undefined (template-less). Byte-stable round-trip for
-   * non-template records. */
+   * non-template records.
+   *
+   * Advisory (principle 02) — ambient by design (this field and the
+   * two below). Currently read only by `gate show` for the
+   * `(v<N>) [gate-ack]` badge in `requestReads.ts`. The value carries
+   * principle-04 audit weight (records-outlive-writers): a future
+   * reader can tell which template body the request was authored
+   * against even after the template skeleton drifts. No further
+   * runtime consumer needed. Audited 2026-05-15 in #344. */
   template?: string;
   /** Template version (#235). Currently always 1; bumps if a template's
    *  intended_use or skeleton meaningfully changes. Paired with

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -1537,10 +1537,11 @@ const VERBS: readonly VerbSchema[] = [
             '(#232). Lifts the play\'s most-recent suspension cliff into ' +
             '--reason and invitation into --action; either flag may still ' +
             'be passed explicitly to override the corresponding lift. ' +
-            'Stamps source_agora_play on the record so `gate chain`-style ' +
-            'walks see the agora→gate edge. Refuses on concluded plays ' +
-            'and on plays with no suspension on record (state=playing, ' +
-            'never suspended).',
+            'Stamps source_agora_play on the record as ambient ' +
+            'audit material (advisory per principle 02; #344 audit ' +
+            'confirmed cold-reader-only consumer in `gate show` today). ' +
+            'Refuses on concluded plays and on plays with no suspension ' +
+            'on record (state=playing, never suspended).',
         ),
         game: strOpt(
           'agora game slug; only meaningful with --from-agora (#232). ' +


### PR DESCRIPTION
Close-out for [#344](https://github.com/eris-ths/guild-cli/issues/344) (principle-02 followup inventory).

The [2026-05-15 audit](https://github.com/eris-ths/guild-cli/issues/344#issuecomment-4456587749) walked every advisory field in the candidate list and concluded:

- **7 consumed**: \`depth\`, \`requiresWorktreeIsolation\`, \`target\`, \`autoReview\`, \`with\`, \`Witness.note\`, \`session_id\`
- **0 deprecation candidates**
- **4 ambient-by-design**: \`Issue.severity\`, \`Issue.area\`, \`Request.sourceAgoraPlay\`, \`Request.template\` (representing the template / templateVersion / gateRequiredAcknowledged trio)

This PR makes the "ambient-by-design" status discoverable at the field declaration site so future PRs auditing \"should this field be consumed?\" find the answer in-place instead of re-deriving it.

## Changes

- \`src/domain/issue/Issue.ts\`: comment on \`severity\` and \`area\` props naming the audit, the cold-reader purpose, and the CLI-flag asymmetry with \`gate flow-suggest\`.
- \`src/domain/request/Request.ts\`: comment on \`sourceAgoraPlay\` reframing it as cold-reader audit (the promised \`gate chain\` navigation didn't ship); comment on \`template\` for the template/templateVersion/gateRequiredAcknowledged trio naming the principle-04 audit weight.
- \`src/interface/gate/handlers/schema.ts\`: softened the \`from-agora\` description — previously promised \`gate chain\`-style walks would lift the source_agora_play edge, but no consumer ships today. Now reads as \"ambient audit material.\"

## Why prose-only

The audit found **no field needs deprecation and no field needs a new consumer**. Stamping all four advisories carries cold-reader audit value the substrate would lose if writing stopped; per the issue body's option (c), \"keep as ambient record\" is the chosen fate.

## Test plan

- [x] \`npm run build\` clean
- [x] \`node tests/run.mjs\` — 1751/1751 pass, 111s
- [x] No code-path changes; declaration-site comments + one schema description text only.

After merge, #344 can close as \"audit complete.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)