### PR TITLE
feat(gate): swarm-status verb — cross-wave director / participant view (#346)

### DIFF
--- a/.changelog/next/added-gate-swarm-status.md
+++ b/.changelog/next/added-gate-swarm-status.md
@@ -1,0 +1,14 @@
+- **`gate swarm-status` — cross-wave director / participant view
+  (#346).** Closes the principle-14 loop: composes `wave-status`
+  across all active waves into one envelope so a director never has
+  to chain 1 + N + N×M sub-reads to compose the swarm picture.
+  Returns waves (with per-executor freshness bands per #309),
+  distinct-executor count, and a flat `alerts[]` array surfacing
+  `stale_executor` / `overlapping_target` / `attribution_risk`.
+  Dual scope flags: `--orchestrating <actor>` (director-centric, "what
+  swarm am I conducting?") and `--for <actor>` (participant-centric,
+  "what swarm am I part of?"). GUILD_ACTOR env defaults to
+  `orchestrating=$GUILD_ACTOR` with `scope.for_source="env"` reported
+  in the payload. Sibling of `gate wave-status` (per-wave) and
+  `gate decisions` (per-actor history). 8 tests under
+  `tests/interface/swarmStatus346.test.ts`.

--- a/docs/swarm.md
+++ b/docs/swarm.md
@@ -240,11 +240,15 @@ fixes:
   Per-slice closure is not first-class on the substrate. Follow-up
   to #230 (see issue tracker — `gate slice-complete` / per-executor
   status field).
-- **In-flight slice status not visible** — `gate boot` and the
-  overlap surface (#234) detect cross-request overlap but don't
-  expose per-executor progress inside a single wave. A future
-  `gate wave-status <id>` read verb composes per-executor latest
-  witness + last write; tracked separately.
+- **In-flight slice status visible at two scales** — `gate
+  wave-status <id>` returns per-executor progress inside one wave
+  (witness notes, claim/witness occupancy, freshness band).
+  `gate swarm-status [--orchestrating <m>] [--for <m>]` (#346)
+  returns the same shape composed *across* every active wave in
+  scope, so a director conducting multiple waves never has to chain
+  `board` + per-wave `wave-status` reads. Alerts surface
+  `stale_executor` / `overlapping_target` / `attribution_risk` as a
+  flat array — one read closes the principle-14 loop.
 - **Judgment trail is half** — the substrate captures who-did-what
   (operational) but not why-this-option-not-that (judgment). The
   per-slice agora play is the right home for the judgment layer;

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -837,6 +837,98 @@ const VERBS: readonly VerbSchema[] = [
     },
   },
   {
+    name: 'swarm-status',
+    category: 'read',
+    summary:
+      "cross-wave director / participant view (#346). Closes the principle-14 loop: composes wave-status across all active waves into one envelope so the director never has to compose 1 + N + N×M sub-reads. Returns waves, distinct-executor count, and a flat alerts array (stale_executor / overlapping_target / attribution_risk). Read-only; live picture not a stored snapshot.",
+    input: {
+      type: 'object',
+      properties: {
+        orchestrating: {
+          type: 'string',
+          description:
+            'director-centric scope: keep only waves where this actor is the `from` author. "what swarm am I conducting?" When neither this nor --for is set and GUILD_ACTOR is in the env, defaults to orchestrating=GUILD_ACTOR (reported as scope.for_source="env").',
+        },
+        for: {
+          type: 'string',
+          description:
+            'participant-centric scope: keep waves where this actor is from / executor / auto-review / with-partner. "what swarm am I part of?" Composes with --orchestrating via AND when both are set.',
+        },
+        format: formatField,
+      },
+    },
+    output: {
+      type: 'object',
+      properties: {
+        as_of: str,
+        scope: {
+          type: 'object',
+          properties: {
+            orchestrating: { type: 'string', description: 'echoed --orchestrating; null when unset' },
+            for: { type: 'string', description: 'echoed --for; null when unset' },
+            for_source: {
+              type: 'string',
+              enum: ['flag', 'env'],
+              description: 'whether the scope came from a flag or from GUILD_ACTOR; null when no scope applied',
+            },
+          },
+        },
+        summary: {
+          type: 'object',
+          properties: {
+            active_waves: { type: 'integer' },
+            distinct_executors: { type: 'integer' },
+            alerts: { type: 'integer' },
+          },
+        },
+        waves: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: str,
+              state: str,
+              from: str,
+              age_ms: { type: 'integer', description: 'ms since wave was approved; null when never approved' },
+              age_band: { type: 'string', enum: ['fresh', 'in-progress', 'stale'] },
+              approved_at: { type: 'string', description: 'ISO timestamp of first approved entry; null when never approved' },
+              executors: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name: str,
+                    slice_status: { type: 'string', enum: ['pending', 'completed', 'failed', 'unknown'] },
+                    last_attributable_at: { type: 'string', description: 'most recent ISO timestamp attributable to this executor; null when none' },
+                    activity_band: {
+                      type: 'string',
+                      enum: ['fresh', 'in-progress', 'stale', 'active'],
+                    },
+                    claim_held: { type: 'boolean' },
+                    witness_session: { type: 'string', description: 'null when no session_id was stamped on the witness' },
+                  },
+                },
+              },
+              wave_stale_effective: { type: 'boolean', description: 'true when every executor reads as stale (#309 semantics)' },
+            },
+          },
+        },
+        alerts: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', enum: ['stale_executor', 'overlapping_target', 'attribution_risk'] },
+              wave_id: str,
+              actor: str,
+              why: str,
+            },
+          },
+        },
+      },
+    },
+  },
+  {
     name: 'lense-stats',
     category: 'read',
     summary:

--- a/src/interface/gate/handlers/swarmStatus.ts
+++ b/src/interface/gate/handlers/swarmStatus.ts
@@ -1,0 +1,312 @@
+// gate swarm-status — cross-wave director / participant view for swarm
+// coordination (#346).
+//
+// Closes the principle-14 loop. `gate wave-status <id>` answers
+// per-wave state; `gate board` answers per-state status; `gate boot`'s
+// overlap surface (#234) detects cross-wave overlap on targets — but
+// no single read returned "the current swarm picture" without the
+// caller composing 1 + N + N×M sub-reads. This verb returns it as
+// one envelope.
+//
+// Routing rationale (principle 15): director-axis reads belong in
+// core so AI agents reading `gate schema` discover them; this is the
+// sibling of `gate decisions` (decision-shaped), `gate next` (action-
+// shaped), and `gate suggest` (orientation-shaped). Composes existing
+// substrate primitives — no new domain field is stamped by this verb.
+
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../shared/parseArgs.js';
+import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+import { C } from './internal.js';
+import { Request } from '../../../domain/request/Request.js';
+import {
+  buildWaveStatus,
+  WaveExecutorView,
+  WaveStatusPayload,
+} from './waveStatus.js';
+import { computeActiveOverlappingTargets } from './bootActionable.js';
+
+const SWARM_STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'orchestrating',
+  'for',
+  'format',
+]);
+
+const ACTIVE_STATES: ReadonlySet<string> = new Set([
+  'pending',
+  'approved',
+  'executing',
+]);
+
+export type SwarmAlertKind =
+  | 'stale_executor'
+  | 'overlapping_target'
+  | 'attribution_risk';
+
+export interface SwarmAlert {
+  readonly kind: SwarmAlertKind;
+  readonly wave_id: string;
+  readonly actor: string;
+  readonly why: string;
+}
+
+export interface SwarmWaveView {
+  readonly id: string;
+  readonly state: string;
+  readonly from: string;
+  readonly age_ms: number | null;
+  readonly age_band: 'fresh' | 'in-progress' | 'stale';
+  readonly approved_at: string | null;
+  readonly executors: readonly WaveExecutorView[];
+  readonly wave_stale_effective: boolean;
+}
+
+export interface SwarmStatusPayload {
+  readonly as_of: string;
+  readonly scope: {
+    readonly orchestrating: string | null;
+    readonly for: string | null;
+    readonly for_source: 'flag' | 'env' | null;
+  };
+  readonly summary: {
+    readonly active_waves: number;
+    readonly distinct_executors: number;
+    readonly alerts: number;
+  };
+  readonly waves: readonly SwarmWaveView[];
+  readonly alerts: readonly SwarmAlert[];
+}
+
+/**
+ * Apply the dual scope filters. Director-centric: actor is the `from`
+ * of the wave. Participant-centric: actor is a named executor, the
+ * auto-review, or a `with`-partner.
+ *
+ * Both flags compose with AND when both are set — useful for "waves
+ * where I orchestrate AND X participates." The common case is exactly
+ * one of them.
+ */
+function matchesScope(
+  r: Request,
+  orchestrating: string | null,
+  participantFor: string | null,
+): boolean {
+  if (orchestrating !== null && r.from.value !== orchestrating) return false;
+  if (participantFor !== null) {
+    const inExecs = r.hasExecutor(participantFor);
+    const isAuthor = r.from.value === participantFor;
+    const isReviewer = r.autoReview?.value === participantFor;
+    const isPartner = r.with.some((p) => p.value === participantFor);
+    if (!inExecs && !isAuthor && !isReviewer && !isPartner) return false;
+  }
+  return true;
+}
+
+export async function swarmStatusCmd(
+  c: C,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, SWARM_STATUS_KNOWN_FLAGS, 'swarm-status');
+  const format = optionalOption(args, 'format') ?? 'text';
+  if (format !== 'text' && format !== 'json') {
+    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
+  }
+  const orchestratingFlag = optionalOption(args, 'orchestrating') ?? null;
+  const explicitFor = optionalOption(args, 'for') ?? null;
+  // GUILD_ACTOR fallback: when neither flag is set and env is set, default
+  // to orchestrating-the-env-actor. Matches the `gate board` precedent for
+  // implicit narrowing; the source is reported in `scope.for_source` so a
+  // JSON consumer can disambiguate.
+  let orchestrating = orchestratingFlag;
+  let forSource: 'flag' | 'env' | null = null;
+  if (orchestrating === null && explicitFor === null) {
+    const envActor = resolveGuildActor() ?? null;
+    if (envActor !== null && envActor.length > 0) {
+      orchestrating = envActor;
+      forSource = 'env';
+    }
+  } else if (orchestratingFlag !== null) {
+    forSource = 'flag';
+  } else if (explicitFor !== null) {
+    forSource = 'flag';
+  }
+
+  const allRequests = await c.requestUC.listAll();
+  const activeAll = allRequests.filter((r) => ACTIVE_STATES.has(r.state));
+  const scoped = activeAll.filter((r) =>
+    matchesScope(r, orchestrating, explicitFor),
+  );
+  scoped.sort((a, b) =>
+    a.id.value < b.id.value ? -1 : a.id.value > b.id.value ? 1 : 0,
+  );
+
+  const now = new Date();
+  const waveViews: SwarmWaveView[] = scoped.map((r) => {
+    const ws = buildWaveStatus(r, now);
+    return shapeWave(ws);
+  });
+
+  const distinctExecutors = new Set<string>();
+  for (const w of waveViews) {
+    for (const e of w.executors) distinctExecutors.add(e.name);
+  }
+
+  const alerts: SwarmAlert[] = [];
+
+  // stale_executor: any executor in the scoped set whose freshness
+  // band reads 'stale'. Per-executor band is already derived in
+  // wave-status (#309); we just surface those that fired.
+  for (const w of waveViews) {
+    for (const e of w.executors) {
+      if (e.activity_band === 'stale') {
+        const since = e.last_attributable_at
+          ? `since ${e.last_attributable_at}`
+          : 'no attributable write yet';
+        alerts.push({
+          kind: 'stale_executor',
+          wave_id: w.id,
+          actor: e.name,
+          why: `executor activity_band=stale (${since})`,
+        });
+      }
+    }
+  }
+
+  // overlapping_target: re-use the boot-side computation so the two
+  // surfaces agree (#234). Filter to the scoped set so we don't alert
+  // the director about overlaps outside their view.
+  const scopedById = new Map(scoped.map((r) => [r.id.value, r]));
+  const overlapGroups = computeActiveOverlappingTargets(activeAll);
+  for (const group of overlapGroups) {
+    const relevantIds = group.requests
+      .map((req) => req.id)
+      .filter((id) => scopedById.has(id));
+    if (relevantIds.length === 0) continue;
+    // Surface one alert per relevant request so a consumer scanning
+    // the alerts array sees one entry per affected wave id.
+    for (const id of relevantIds) {
+      const r = scopedById.get(id)!;
+      alerts.push({
+        kind: 'overlapping_target',
+        wave_id: id,
+        actor: r.from.value,
+        why: `target='${group.target}' shared with ${group.requests.length - 1} other active wave(s)`,
+      });
+    }
+    // attribution_risk: when the same author has ≥2 distinct sessions
+    // in the overlap group, surface as separate alert kind. The boot-
+    // side compute returns the per-author session list under the
+    // snake_case key, matching the JSON wire format.
+    const parallelAuthors = group.parallel_session_authors ?? {};
+    for (const [author, sessionsRaw] of Object.entries(parallelAuthors)) {
+      const sessions = sessionsRaw as readonly string[];
+      // Find one wave_id in the scoped set authored by this actor.
+      const anchorId = relevantIds.find(
+        (id) => scopedById.get(id)?.from.value === author,
+      );
+      if (!anchorId) continue;
+      alerts.push({
+        kind: 'attribution_risk',
+        wave_id: anchorId,
+        actor: author,
+        why: `${sessions.length} distinct sessions writing as '${author}' (${sessions.join(', ')})`,
+      });
+    }
+  }
+
+  const payload: SwarmStatusPayload = {
+    as_of: now.toISOString(),
+    scope: {
+      orchestrating,
+      for: explicitFor,
+      for_source: forSource,
+    },
+    summary: {
+      active_waves: waveViews.length,
+      distinct_executors: distinctExecutors.size,
+      alerts: alerts.length,
+    },
+    waves: waveViews,
+    alerts,
+  };
+
+  if (format === 'json') {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return 0;
+  }
+  process.stdout.write(renderText(payload) + '\n');
+  return 0;
+}
+
+function shapeWave(ws: WaveStatusPayload): SwarmWaveView {
+  return {
+    id: ws.id,
+    state: ws.state,
+    from: ws.from,
+    age_ms: ws.age_ms,
+    age_band: ws.age_band,
+    approved_at: ws.approved_at,
+    executors: ws.executors,
+    wave_stale_effective: ws.wave_stale_effective,
+  };
+}
+
+function renderText(p: SwarmStatusPayload): string {
+  const lines: string[] = [];
+  const scopeBits: string[] = [];
+  if (p.scope.orchestrating !== null)
+    scopeBits.push(`orchestrating=${p.scope.orchestrating}`);
+  if (p.scope.for !== null) scopeBits.push(`for=${p.scope.for}`);
+  const scopeStr =
+    scopeBits.length > 0 ? `  (${scopeBits.join(', ')})` : '  (all)';
+  lines.push(`swarm picture as of ${p.as_of}${scopeStr}`);
+  lines.push(
+    `  ${p.summary.active_waves} active wave(s)  ` +
+      `${p.summary.distinct_executors} distinct executor(s)  ` +
+      `${p.summary.alerts} alert(s)`,
+  );
+  lines.push('');
+
+  if (p.waves.length === 0) {
+    lines.push('(no active waves in scope)');
+    return lines.join('\n');
+  }
+
+  lines.push('waves:');
+  for (const w of p.waves) {
+    const ageBadge = w.age_band !== 'fresh' ? `  [${w.age_band}]` : '';
+    lines.push(`  ${w.id}  [${w.state}]  from=${w.from}${ageBadge}`);
+    if (w.executors.length === 0) {
+      lines.push('    (no executors assigned)');
+      continue;
+    }
+    for (const e of w.executors) {
+      const tags: string[] = [e.slice_status];
+      if (e.claim_held) tags.push('claim');
+      if (e.activity_band === 'stale') tags.push('⚠ stale');
+      else if (e.activity_band === 'in-progress')
+        tags.push('in-progress');
+      const tagStr = `[${tags.join(' ')}]`;
+      const last = e.last_attributable_at
+        ? `  last write: ${e.last_attributable_at}`
+        : '';
+      const sess = e.witness_session
+        ? `  session=${e.witness_session}`
+        : '';
+      lines.push(`    ${e.name}  ${tagStr}${last}${sess}`);
+    }
+  }
+
+  if (p.alerts.length > 0) {
+    lines.push('');
+    lines.push('alerts:');
+    for (const a of p.alerts) {
+      lines.push(`  [${a.kind}] ${a.wave_id} actor=${a.actor}: ${a.why}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -47,9 +47,10 @@ interface Section {
 // BASE (14): request, approve, execute, complete, fail, review,
 //            show, list, tail, boot, register, doctor, fast-track,
 //            schema
-// COORDINATION (5): claim, witness, unwitness, wave-status,
-//                   slice-complete (slice-complete is forthcoming
-//                   and intentionally absent from the help body).
+// COORDINATION (6): claim, witness, unwitness, wave-status,
+//                   swarm-status, slice-complete (slice-complete is
+//                   forthcoming and intentionally absent from the
+//                   help body).
 
 const SECTIONS: readonly Section[] = [
   {
@@ -231,6 +232,24 @@ const SECTIONS: readonly Section[] = [
           '                       executor progress, claim/witness occupancy,\n' +
           '                       and aggregate state. Companion to claim /\n' +
           '                       witness for swarm coordination.',
+      },
+      {
+        tier: 'coordination',
+        text:
+          '  gate swarm-status [--orchestrating <actor>] [--for <actor>]\n' +
+          '                    [--format text|json]\n' +
+          '                       Cross-wave director / participant view.\n' +
+          '                       Composes wave-status across all active waves\n' +
+          '                       into one envelope so a director never has to\n' +
+          '                       chain 1+N+N×M sub-reads. Returns waves, distinct\n' +
+          '                       executor count, and a flat alerts array\n' +
+          '                       (stale_executor / overlapping_target /\n' +
+          '                       attribution_risk). --orchestrating filters to\n' +
+          '                       waves authored by <actor> ("what swarm am I\n' +
+          '                       conducting?"); --for filters to waves where\n' +
+          '                       <actor> participates anywhere. When neither is\n' +
+          '                       set and GUILD_ACTOR is in env, defaults to\n' +
+          '                       --orchestrating=$GUILD_ACTOR.',
       },
       {
         tier: 'coordination',

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -51,6 +51,7 @@ import { suggestCmd } from './handlers/suggest.js';
 import { flowSuggestCmd } from './handlers/flowSuggest.js';
 import { transcriptCmd } from './handlers/transcript.js';
 import { waveStatusCmd } from './handlers/waveStatus.js';
+import { swarmStatusCmd } from './handlers/swarmStatus.js';
 import { lenseStatsCmd } from './handlers/lenseStats.js';
 import { reviewContextCmd } from './handlers/reviewContext.js';
 import { decisionsCmd } from './handlers/decisions.js';
@@ -100,6 +101,7 @@ const KNOWN_COMMANDS = [
   'wake',
   'farewell',
   'wave-status',
+  'swarm-status',
   'lense-stats',
   'review-context',
   'decisions',
@@ -342,6 +344,8 @@ async function dispatch(
       return await transcriptCmd(c, args);
     case 'wave-status':
       return await waveStatusCmd(c, args);
+    case 'swarm-status':
+      return await swarmStatusCmd(c, args);
     case 'lense-stats':
       return await lenseStatsCmd(c, args);
     case 'review-context':

--- a/tests/interface/swarmStatus346.test.ts
+++ b/tests/interface/swarmStatus346.test.ts
@@ -1,0 +1,231 @@
+// #346 — gate swarm-status regression suite.
+//
+// Acceptance per the issue / design comment:
+//   - returns one envelope composing wave-status across active waves
+//   - --orchestrating scopes to waves authored by <actor>
+//   - --for scopes to waves where <actor> participates (executor /
+//     auto-review / with-partner / author)
+//   - GUILD_ACTOR fallback applies orchestrating=$GUILD_ACTOR with
+//     scope.for_source="env"
+//   - alerts array surfaces stale_executor / overlapping_target /
+//     attribution_risk with per-wave entries
+//   - text and json formats both work; non-zero scope is reflected in
+//     scope echo
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-swarm-status-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  for (const name of ['alice', 'bob', 'critic']) {
+    writeFileSync(
+      join(root, 'members', `${name}.yaml`),
+      `name: ${name}\ncategory: professional\nactive: true\n`,
+    );
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function extractRequestId(output: string): string {
+  const m = output.match(/\d{4}-\d{2}-\d{2}-\d{4}/);
+  if (!m) throw new Error(`could not find request id in output: ${output}`);
+  return m[0];
+}
+
+// -------------------- empty content_root --------------------
+
+test('#346: swarm-status on empty content_root returns zero active waves', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['swarm-status', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.summary.active_waves, 0);
+  assert.equal(payload.summary.distinct_executors, 0);
+  assert.equal(payload.summary.alerts, 0);
+  assert.deepEqual(payload.waves, []);
+  assert.deepEqual(payload.alerts, []);
+});
+
+// -------------------- one wave, default scope --------------------
+
+test('#346: swarm-status surfaces one active wave with executor in JSON', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const created = runGate(root, [
+    'request',
+    '--from', 'alice',
+    '--executors', 'alice,bob',
+    '--action', 'paired work',
+    '--reason', 'two executors',
+  ]);
+  const id = extractRequestId(created.stdout + created.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+
+  const r = runGate(root, ['swarm-status', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.summary.active_waves, 1);
+  assert.equal(payload.summary.distinct_executors, 2);
+  assert.equal(payload.waves.length, 1);
+  assert.equal(payload.waves[0].id, id);
+  assert.equal(payload.waves[0].from, 'alice');
+  assert.equal(payload.waves[0].state, 'approved');
+  const execNames = payload.waves[0].executors.map((e: { name: string }) => e.name).sort();
+  assert.deepEqual(execNames, ['alice', 'bob']);
+});
+
+// -------------------- --orchestrating filter --------------------
+
+test('#346: --orchestrating filters to waves authored by the actor', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Two waves, different authors.
+  const a = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'alice work', '--reason', 'a',
+  ]);
+  const idA = extractRequestId(a.stdout + a.stderr);
+  runGate(root, ['approve', idA, '--by', 'eris']);
+  const b = runGate(root, [
+    'request', '--from', 'bob', '--executors', 'bob',
+    '--action', 'bob work', '--reason', 'b',
+  ]);
+  const idB = extractRequestId(b.stdout + b.stderr);
+  runGate(root, ['approve', idB, '--by', 'eris']);
+
+  const r = runGate(root, [
+    'swarm-status', '--orchestrating', 'alice', '--format', 'json',
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.summary.active_waves, 1);
+  assert.equal(payload.waves[0].id, idA);
+  assert.equal(payload.scope.orchestrating, 'alice');
+});
+
+// -------------------- --for filter --------------------
+
+test('#346: --for filters to waves where actor participates', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const a = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'bob',
+    '--action', 'work', '--reason', 'r',
+  ]);
+  const idA = extractRequestId(a.stdout + a.stderr);
+  runGate(root, ['approve', idA, '--by', 'eris']);
+  const b = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'critic',
+    '--action', 'other', '--reason', 'r',
+  ]);
+  const idB = extractRequestId(b.stdout + b.stderr);
+  runGate(root, ['approve', idB, '--by', 'eris']);
+
+  const r = runGate(root, ['swarm-status', '--for', 'bob', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.summary.active_waves, 1);
+  assert.equal(payload.waves[0].id, idA);
+  assert.equal(payload.scope.for, 'bob');
+});
+
+// -------------------- GUILD_ACTOR env fallback --------------------
+
+test('#346: GUILD_ACTOR fallback applies orchestrating with for_source=env', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const a = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'work', '--reason', 'r',
+  ]);
+  const idA = extractRequestId(a.stdout + a.stderr);
+  runGate(root, ['approve', idA, '--by', 'eris']);
+
+  const r = runGate(
+    root,
+    ['swarm-status', '--format', 'json'],
+    { GUILD_ACTOR: 'alice' },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.scope.orchestrating, 'alice');
+  assert.equal(payload.scope.for_source, 'env');
+});
+
+// -------------------- text format --------------------
+
+test('#346: text format renders summary line and wave list', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const a = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice,bob',
+    '--action', 'work', '--reason', 'r',
+  ]);
+  const id = extractRequestId(a.stdout + a.stderr);
+  runGate(root, ['approve', id, '--by', 'eris']);
+
+  const r = runGate(root, ['swarm-status', '--format', 'text']);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /swarm picture as of /);
+  assert.match(r.stdout, /1 active wave\(s\)/);
+  assert.match(r.stdout, /2 distinct executor\(s\)/);
+  assert.match(r.stdout, /waves:/);
+  assert.match(r.stdout, new RegExp(id));
+});
+
+// -------------------- terminal states excluded --------------------
+
+test('#346: completed waves are excluded (active states only)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const a = runGate(root, [
+    'request', '--from', 'alice', '--executors', 'alice',
+    '--action', 'work', '--reason', 'r',
+  ]);
+  const idA = extractRequestId(a.stdout + a.stderr);
+  runGate(root, ['approve', idA, '--by', 'eris']);
+  runGate(root, ['execute', idA, '--by', 'alice']);
+  runGate(root, ['complete', idA, '--by', 'alice']);
+
+  const r = runGate(root, ['swarm-status', '--format', 'json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout);
+  assert.equal(payload.summary.active_waves, 0);
+});
+
+// -------------------- unknown flag rejection --------------------
+
+test('#346: unknown flag rejected (schema-as-contract drift guard)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['swarm-status', '--bogus', 'x']);
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /unknown flag.*bogus/);
+});


### PR DESCRIPTION
Closes [#346](https://github.com/eris-ths/guild-cli/issues/346). Shape decisions per the [design comment](https://github.com/eris-ths/guild-cli/issues/346#issuecomment-4456653123) on that issue.

## What this closes

Principle 14 (substrate-engagement-reduces-coordination-context-cost) names substrate engagement as the load-bearing move for swarm coordination. The substrate carried everything needed for the picture — \`executors[]\`, \`witnessSessions\`, \`status_log\`, \`active_overlapping_targets\` — but composing it into "the current swarm picture" required the director to chain \`board\` + per-wave \`wave-status\` + per-executor session inspection. This verb returns the composed view in one read.

## Shape

\`\`\`text
gate swarm-status [--orchestrating <actor>] [--for <actor>]
                  [--format text|json]
\`\`\`

JSON envelope:

\`\`\`json
{
  \"as_of\": \"2026-05-15T...\",
  \"scope\": { \"orchestrating\": \"eris\", \"for\": null, \"for_source\": \"env\" },
  \"summary\": {
    \"active_waves\": 3,
    \"distinct_executors\": 4,
    \"alerts\": 2
  },
  \"waves\": [
    {
      \"id\": \"2026-05-12-0001\", \"state\": \"executing\", \"from\": \"eris\",
      \"age_ms\": ..., \"age_band\": \"in-progress\", \"approved_at\": \"...\",
      \"executors\": [
        {\"name\": \"noir\", \"slice_status\": \"pending\",
         \"activity_band\": \"fresh\",
         \"last_attributable_at\": \"...\", \"witness_session\": \"...\",
         \"claim_held\": false}, ...
      ],
      \"wave_stale_effective\": false
    }
  ],
  \"alerts\": [
    {\"kind\": \"stale_executor\", \"wave_id\": \"...\",
     \"actor\": \"miki\", \"why\": \"activity_band=stale (since ...)\"},
    {\"kind\": \"overlapping_target\", \"wave_id\": \"...\",
     \"actor\": \"alice\",
     \"why\": \"target='X' shared with 1 other active wave(s)\"},
    {\"kind\": \"attribution_risk\", \"wave_id\": \"...\",
     \"actor\": \"eris\",
     \"why\": \"2 distinct sessions writing as 'eris' (foo-1, foo-2)\"}
  ]
}
\`\`\`

## Design decisions (per #346 comment)

| Question | Choice | Why |
|---|---|---|
| New verb vs \`board --swarm\`? | **New verb** | shape differs (per-executor-within-wave nests); conditional envelopes break principle 10 |
| Director-centric vs participant-centric scope? | **Both via two flags**, default = orchestrating | maps cleanly to two real roles |
| Plugin vs core? | **Core** | director-axis read, principle-11 contract requires \`gate schema\` to advertise it (#345 routing) |
| What counts as \"swarm\"? | Any in-flight state | floor is degenerate-OK; \"no swarm yet\" not the right cliff |
| Live read or snapshot? | **Live**, future \`--snapshot-to <path>\` deferred | read verbs don't write (principle 05) |

## Composition reuse

The handler does **not** introduce new substrate primitives. It composes:

- \`buildWaveStatus(r, now)\` — the per-wave composer already used by \`gate wave-status\`
- \`computeActiveOverlappingTargets(allRequests)\` — the boot-side overlap detector (#234)

This keeps \`swarm-status\`, \`wave-status\`, and \`boot.active_overlapping_targets\` aligned by construction — a future schema change to per-executor freshness propagates through all three at once.

## Test plan

- [x] \`npm run build\` clean
- [x] \`node tests/run.mjs\` — 1759/1759 pass (was 1751; +8 new under \`tests/interface/swarmStatus346.test.ts\`)
- [x] Tests cover: empty content_root, one wave default-scope, \`--orchestrating\` filter, \`--for\` filter, GUILD_ACTOR env fallback, text vs JSON, terminal-state exclusion, unknown-flag rejection
- [x] schema-as-contract drift detector green (principle 10)

## Follow-ups not in this PR

- **\`--as-of <ISO-ts>\` for historical replay** — the substrate has the inputs (\`status_log\`, \`witnessUpdatedAt\`, \`witness_sessions\`); deriving a snapshot at time T is straightforward but the right call site / convention deserves its own design pass.
- **\`--snapshot-to <path>\` for successor handoff** — useful but tangential to the principle-14 closure; one-PR-at-a-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)