### PR TITLE
feat(config): GUILD_CONFIG env override + Claude Code activity bridge (#308 Layer A)

### DIFF
--- a/.changelog/next/added-guild-config-env-and-claude-code-wiring.md
+++ b/.changelog/next/added-guild-config-env-and-claude-code-wiring.md
@@ -1,0 +1,20 @@
+- **`GUILD_CONFIG` env var override for cross-tree substrate access
+  (#308 Layer A).** When set to an absolute path, `gate` skips the
+  cwd walk-up and uses the named `guild.config.yaml` directly.
+  Unblocks the "worktree at <path-A>, substrate at <path-B>" case
+  where the orchestrator's substrate is not in the worktree's git
+  ancestry — most notably Claude Code SubAgents running in
+  `.claude/worktrees/agent-X/` against a parent substrate that
+  lives outside the repo tree. Resolution priority:
+  `GUILD_CONFIG` env > `findConfig(cwd)` walk-up > cwd fallback.
+  A nonexistent path errors loudly rather than silently falling
+  back (silent fallback here would let a SubAgent write to a
+  stale substrate without realising).
+
+- **Claude Code `PostToolUse` → `gate witness` example wiring**
+  shipped under `examples/plugins/harness-wirings/claude-code/`.
+  Surfaces SubAgent tool-use as throttled witness updates on the
+  parent wave so `gate wave-status` / `gate swarm-status` show
+  fresh activity without polling. Source 3 of the #308 Layer A
+  bundle (per principle 15 routing: harness-specific wirings live
+  in `examples/`, not in core).

--- a/docs/swarm.md
+++ b/docs/swarm.md
@@ -264,30 +264,50 @@ fixes:
 ### Worktree-ledger blindspot
 
 When SubAgent isolation uses a Claude Code worktree
-(`.claude/worktrees/agent-*`), the SubAgent's `gate witness` /
-`gate complete` against the parent wave id **fails silently or with
-not-found**: the ledger lives in the parent session's substrate, not
-in the worktree's git tree.
+(`.claude/worktrees/agent-*`), the SubAgent's cwd is outside the
+parent session's substrate tree. By default `gate` walks up from cwd
+to find `guild.config.yaml`; if the parent substrate lives at a
+different filesystem path, the walk-up may find the wrong config (or
+none) and the SubAgent's writes never reach the ledger.
 
-Two consequences:
+**The bridge (#308 Layer A): `GUILD_CONFIG` env override.** When set
+to an absolute path, `gate` skips the cwd walk-up and uses that
+config directly. The orchestrator exports it before spawning the
+SubAgent; every `gate` invocation in the SubAgent's shell writes to
+the parent substrate without per-call boilerplate.
 
-1. Per-slice progress witness from inside the worktree is not
-   possible. The SubAgent should report progress in its final
-   report; the parent stamps `gate witness` / `gate complete` on
-   return.
-2. The SubAgent brief MUST surface this. Otherwise each SubAgent
-   individually discovers it ("ledger not visible — can't stamp")
-   and the same friction recurs every wave.
-
-Recommended brief snippet:
+```bash
+# Orchestrator side, before launching the SubAgent
+export GUILD_CONFIG=/abs/path/to/parent/guild.config.yaml
+export GUILD_WAVE_ID=2026-05-15-0001     # the wave the SubAgent owns
+export GUILD_ACTOR=noir                  # the SubAgent's name
+# launch SubAgent (it inherits these env vars)
+```
 
 ```
-Note: the gate wave record lives in the PARENT session's
-substrate, not in this worktree. `gate witness` / `gate complete`
-against the wave id WILL NOT reach the ledger from here. Do not
-attempt; report progress in your final result message and the
-parent will stamp on your behalf.
+# SubAgent brief snippet
+The parent wave substrate is reachable via:
+  - GUILD_CONFIG = $GUILD_CONFIG
+  - GUILD_WAVE_ID = $GUILD_WAVE_ID
+  - GUILD_ACTOR = $GUILD_ACTOR
+Call `gate witness $GUILD_WAVE_ID --by $GUILD_ACTOR --note "..."` at
+slice boundaries (start, midpoint, end) so the orchestrator sees
+your progress without polling.
 ```
+
+**Automated activity surfacing.** For SubAgents under Claude Code,
+`examples/plugins/harness-wirings/claude-code/` carries a `PostToolUse`
+hook that calls `gate witness` automatically on every tool call
+(throttled to one call per 30s, dedup-safe per #246). Install
+opt-in via `.claude/settings.json`; the script no-ops when
+`GUILD_WAVE_ID` is unset so global installation is safe.
+
+For harnesses other than Claude Code, an explicit `gate witness`
+call inside the SubAgent's prompt at slice boundaries is the
+portable equivalent. Cross-harness automation is the second-harness
+threshold per [principle 15](../lore/principles/15-plugins-as-default-extension.md):
+when two harnesses ship convergent wirings, the bus moves into
+core.
 
 ### Failure mode: worktree-only ("ceremony swarm")
 

--- a/examples/plugins/harness-wirings/claude-code/README.md
+++ b/examples/plugins/harness-wirings/claude-code/README.md
@@ -1,0 +1,136 @@
+# Claude Code → guild-cli activity bridge
+
+A worked example of bridging Claude Code's `PostToolUse` hook to
+`gate witness`, so a SubAgent running in worktree isolation surfaces
+its in-flight activity to the orchestrator's `gate wave-status` /
+`gate swarm-status` views.
+
+This is **Source 3** in the [#308](https://github.com/eris-ths/guild-cli/issues/308)
+Layer A bundle: harness-specific wiring lives in `examples/`, not in
+core. Each harness that wants the equivalent contributes its own
+wiring file alongside this one.
+
+## When you need this
+
+You're running a SubAgent (under Claude Code's Agent tool) that does
+real implementation work in worktree isolation. The orchestrator's
+`gate wave-status <id>` shows `(in progress — no recent attributable
+write)` for the SubAgent because guild-cli's substrate sees no
+`gate witness` calls from inside the worktree.
+
+This wiring fires `gate witness` automatically on every Claude Code
+tool call, so the orchestrator's view shows fresh activity without
+the SubAgent's prompt needing explicit `gate witness` boilerplate.
+
+## What this does NOT do
+
+- Does not intercept agent decisions — `PostToolUse` is after-the-
+  fact, observational only.
+- Does not replace explicit `gate witness` calls — the hook surfaces
+  *tool activity*, not *progress narrative*. The SubAgent should
+  still emit a meaningful witness note at slice boundaries (start,
+  midpoint, end) so the substrate carries the story, not just the
+  heartbeat.
+- Does not work cross-harness — if your SubAgent runs under Codex,
+  Gemini CLI, or a custom orchestrator, you need a parallel wiring
+  for that harness. See `../` for siblings (currently empty; pull
+  requests welcome).
+
+## Setup
+
+### 1. The hook script
+
+`post-tool-use.sh` is the shell script Claude Code invokes on every
+tool call. It reads three env vars (set by the orchestrator before
+spawning the SubAgent), rate-limits to avoid write storms, and calls
+`gate witness` on the parent substrate.
+
+Required env vars:
+
+```
+GUILD_CONFIG=<abs path to parent guild.config.yaml>
+                             # without this, gate walks up from the
+                             # worktree and may find the wrong substrate
+GUILD_WAVE_ID=<YYYY-MM-DD-NNNN>
+                             # the wave the SubAgent is executing
+GUILD_ACTOR=<sub-agent name> # the SubAgent's registered actor name
+```
+
+### 2. Wire it into Claude Code
+
+In your project's `.claude/settings.json` (or `~/.claude/settings.json`
+for global):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/guild-cli/examples/plugins/harness-wirings/claude-code/post-tool-use.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Claude Code fires this script after every tool call. The script
+short-circuits to a no-op when `GUILD_WAVE_ID` is unset (so it's safe
+to install globally — only fires when an orchestrator has explicitly
+opted in by setting the env).
+
+### 3. Orchestrator-side setup
+
+Before launching the SubAgent, the orchestrator:
+
+```bash
+export GUILD_CONFIG=/abs/path/to/parent/guild.config.yaml
+export GUILD_WAVE_ID=2026-05-15-0001
+export GUILD_ACTOR=noir
+# launch SubAgent (it inherits these env vars)
+```
+
+The orchestrator continues to call `gate witness` / `gate complete`
+on its own behalf as usual; this wiring just ensures the SubAgent's
+heartbeat is also visible.
+
+## Rate limiting
+
+The hook script throttles to one `gate witness` call per
+`$GUILD_WITNESS_THROTTLE_SEC` (default 30s). Without throttling, a
+busy SubAgent firing PostToolUse 50+ times in a slice would produce
+a write storm. The throttle state lives in `$XDG_RUNTIME_DIR` (or
+`/tmp` as fallback) keyed by wave id + actor, so concurrent
+SubAgents on different waves don't interfere.
+
+`gate witness` is already idempotent on identical note text (#246),
+so the throttle is belt-and-suspenders: the substrate would dedupe
+even without it, but the throttle avoids the round-trip.
+
+## Failure modes named explicitly
+
+- `GUILD_CONFIG` unset → hook walks up from cwd, may find wrong
+  substrate (or none). Script logs to stderr and continues — the
+  PostToolUse hook is not load-bearing for the SubAgent's actual
+  work.
+- Parent substrate moved / deleted → `gate witness` errors; script
+  logs and continues.
+- Network filesystem latency → throttle is permissive; lost
+  heartbeats are recoverable on the next tool call.
+- SubAgent crash mid-slice → last `witness_updated_at` timestamp
+  pinpoints where work stopped; orchestrator decides recovery.
+
+## See also
+
+- [`docs/swarm.md`](../../../../docs/swarm.md) § "Worktree-ledger
+  blindspot" — the gap this bridge closes.
+- [`#308`](https://github.com/eris-ths/guild-cli/issues/308) Layer A
+  bundle — the design conversation that led here.
+- [`lore/principles/15-plugins-as-default-extension.md`](../../../../lore/principles/15-plugins-as-default-extension.md)
+  — the routing rule that puts this wiring in `examples/` rather than
+  guild-cli core.

--- a/examples/plugins/harness-wirings/claude-code/post-tool-use.sh
+++ b/examples/plugins/harness-wirings/claude-code/post-tool-use.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse → gate witness bridge (#308 Layer A, Source 3).
+#
+# Reads Claude Code's JSON hook payload on stdin (we ignore its
+# specifics here — the mere fact of invocation is the activity
+# signal), throttles, and calls `gate witness` on the parent
+# substrate.
+#
+# Designed to fail open: when GUILD_WAVE_ID is unset the script
+# exits 0 immediately so this hook is safe to install globally.
+
+set -u   # NOT -e — a single failed witness must not block the agent.
+
+# Required to fire. Without GUILD_WAVE_ID we have no wave to witness
+# against; silent no-op is the right shape (the global hook installs
+# safely without configuring every project).
+: "${GUILD_WAVE_ID:=}"
+if [ -z "$GUILD_WAVE_ID" ]; then
+  exit 0
+fi
+
+# Actor identity. The SubAgent's registered guild member name.
+: "${GUILD_ACTOR:=}"
+if [ -z "$GUILD_ACTOR" ]; then
+  echo "post-tool-use.sh: GUILD_ACTOR unset; skipping witness" >&2
+  exit 0
+fi
+
+# Parent substrate location. When unset, gate walks up from cwd and
+# may find the wrong substrate (or none). We do not error here so
+# the hook fails open — but emit a one-line stderr nudge.
+: "${GUILD_CONFIG:=}"
+if [ -z "$GUILD_CONFIG" ]; then
+  echo "post-tool-use.sh: GUILD_CONFIG unset; relying on cwd walk-up (may be wrong substrate)" >&2
+fi
+
+# Throttle: at most one witness call per THROTTLE_SEC per (wave, actor).
+# Keyed in a runtime directory so concurrent SubAgents on different
+# waves don't interfere. We use sub-second mtime granularity because
+# Linux tmpfs is millisecond-resolution; macOS HFS is second-resolution
+# and that's fine (the throttle has 30s defaults).
+THROTTLE_SEC="${GUILD_WITNESS_THROTTLE_SEC:-30}"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}/guild-cli-witness"
+mkdir -p "$RUNTIME_DIR" 2>/dev/null || true
+# Sanitize the key to filesystem-safe chars (alphanumeric + dash).
+KEY=$(printf '%s_%s' "$GUILD_WAVE_ID" "$GUILD_ACTOR" | tr -c 'A-Za-z0-9_-' '_')
+THROTTLE_FILE="$RUNTIME_DIR/$KEY"
+
+now=$(date +%s)
+if [ -f "$THROTTLE_FILE" ]; then
+  last=$(stat -f %m "$THROTTLE_FILE" 2>/dev/null || stat -c %Y "$THROTTLE_FILE" 2>/dev/null || echo 0)
+  delta=$((now - last))
+  if [ "$delta" -lt "$THROTTLE_SEC" ]; then
+    exit 0
+  fi
+fi
+
+# Coarse note: surfaces "this actor is alive and doing work."
+# Specifics (which tool, which file) are deliberately omitted —
+# `gate witness` dedupes identical notes (#246), so a coarse note
+# also gives us free dedupe.
+NOTE="${GUILD_WITNESS_NOTE:-tool-use heartbeat}"
+
+# Resolve `gate` from PATH; respect GUILD_CLI_BIN override for
+# environments without `gate` on PATH (the SubAgent's worktree
+# might not have it installed globally).
+GATE_BIN="${GUILD_CLI_BIN:-gate}"
+
+# Fire and forget. We deliberately do NOT capture exit codes —
+# the agent's actual work proceeds regardless. Errors land on stderr
+# (preserved because we did not redirect).
+"$GATE_BIN" witness "$GUILD_WAVE_ID" --by "$GUILD_ACTOR" --note "$NOTE" >/dev/null 2>>"$RUNTIME_DIR/witness.err" \
+  && touch "$THROTTLE_FILE" \
+  || true
+
+exit 0

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -200,7 +200,40 @@ export class GuildConfig implements GuildConfigProps {
     cwd: string = process.cwd(),
     onMalformed: OnMalformed = defaultOnMalformed,
   ): GuildConfig {
-    const configPath = findConfig(cwd);
+    // GUILD_CONFIG env var override (#308 Layer A bridge). When set,
+    // skip the cwd walk-up and use the named guild.config.yaml directly.
+    // This unblocks the "worktree at <path-A>, substrate at <path-B>"
+    // case where the orchestrator's substrate is not in the worktree's
+    // git ancestry — most notably Claude Code SubAgents running in
+    // `.claude/worktrees/agent-X/` against a parent substrate that
+    // lives outside the repo tree. The orchestrator exports
+    // GUILD_CONFIG=<abs path> before spawning the SubAgent; every
+    // `gate` invocation in that shell writes to the parent substrate
+    // without a flag boilerplate at every call site.
+    //
+    // Resolution priority: GUILD_CONFIG env > findConfig(cwd) walk-up
+    //   > GuildConfig.default(cwd) fallback.
+    //
+    // Validation: the path must exist and be a regular file. A missing
+    // or unreadable GUILD_CONFIG throws rather than silently falling
+    // back to walk-up — silent fallback here would be a worse failure
+    // mode (the SubAgent writes to a stale substrate without realising).
+    const envConfig = process.env['GUILD_CONFIG'];
+    let configPath: string | null;
+    if (envConfig !== undefined && envConfig.length > 0) {
+      const resolvedEnv = resolve(envConfig);
+      if (!existsSync(resolvedEnv)) {
+        throw new DomainError(
+          `GUILD_CONFIG="${envConfig}" does not exist (resolved: ${resolvedEnv}).\n` +
+            `  next: export GUILD_CONFIG=<absolute path to guild.config.yaml>, ` +
+            `or unset to fall back to cwd walk-up.`,
+          'GUILD_CONFIG',
+        );
+      }
+      configPath = resolvedEnv;
+    } else {
+      configPath = findConfig(cwd);
+    }
     if (!configPath) {
       // Default: treat cwd as guild root
       return GuildConfig.default(cwd, onMalformed);

--- a/tests/infrastructure/guildConfigDiscovery.test.ts
+++ b/tests/infrastructure/guildConfigDiscovery.test.ts
@@ -95,3 +95,70 @@ test('GuildConfig.load: walks up parents to find .gate-sessions/ from a nested c
     cleanup();
   }
 });
+
+// -------------------- GUILD_CONFIG env override (#308 Layer A) --------------------
+
+test('GuildConfig.load: GUILD_CONFIG env overrides cwd walk-up', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    // Substrate at <dir>/parent — what the orchestrator owns.
+    const parent = join(dir, 'parent');
+    mkdirSync(parent);
+    writeFileSync(
+      join(parent, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [eris]\n',
+    );
+    // Worktree at <dir>/elsewhere — no walk-up reaches the parent.
+    const worktree = join(dir, 'elsewhere');
+    mkdirSync(worktree);
+    const prev = process.env['GUILD_CONFIG'];
+    process.env['GUILD_CONFIG'] = join(parent, 'guild.config.yaml');
+    try {
+      const cfg = GuildConfig.load(worktree);
+      assert.equal(cfg.configFile, join(parent, 'guild.config.yaml'));
+      assert.equal(cfg.contentRoot, parent);
+      assert.deepEqual(cfg.hostNames, ['eris']);
+    } finally {
+      if (prev === undefined) delete process.env['GUILD_CONFIG'];
+      else process.env['GUILD_CONFIG'] = prev;
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('GuildConfig.load: GUILD_CONFIG with nonexistent path throws DomainError', () => {
+  const prev = process.env['GUILD_CONFIG'];
+  process.env['GUILD_CONFIG'] = '/nonexistent/guild.config.yaml';
+  try {
+    assert.throws(
+      () => GuildConfig.load(),
+      /GUILD_CONFIG="\/nonexistent\/guild.config.yaml" does not exist/,
+    );
+  } finally {
+    if (prev === undefined) delete process.env['GUILD_CONFIG'];
+    else process.env['GUILD_CONFIG'] = prev;
+  }
+});
+
+test('GuildConfig.load: empty GUILD_CONFIG falls back to walk-up (treated as unset)', () => {
+  const { dir, cleanup } = setupRepo();
+  try {
+    writeFileSync(
+      join(dir, 'guild.config.yaml'),
+      'content_root: .\nhost_names: [nao]\n',
+    );
+    const prev = process.env['GUILD_CONFIG'];
+    process.env['GUILD_CONFIG'] = '';
+    try {
+      const cfg = GuildConfig.load(dir);
+      // empty string is treated as unset; walk-up finds the local config
+      assert.equal(cfg.configFile, join(dir, 'guild.config.yaml'));
+    } finally {
+      if (prev === undefined) delete process.env['GUILD_CONFIG'];
+      else process.env['GUILD_CONFIG'] = prev;
+    }
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closes the worktree-ledger blindspot named in [#308](https://github.com/eris-ths/guild-cli/issues/308) Layer A. Solves the trigger scenario (Noir-in-worktree producing edits invisible to parent \`gate wave-status\`) with a tight bundle rather than the proposal's full daemon + namespace expansion.

The eris-first analysis on [#308](https://github.com/eris-ths/guild-cli/issues/308#issuecomment-4456818652) is the rationale for the scope cut: Layer B (\`agent.activity.*\` namespace, file-watching daemon, three-source architecture) is principled-but-premature; only Layer A is felt today.

## What ships

### 1. \`GUILD_CONFIG\` env override (\`src/infrastructure/config/GuildConfig.ts\`)

When set to an absolute path, \`gate\` skips the cwd walk-up and uses the named \`guild.config.yaml\` directly. Unblocks the case where worktree and parent substrate live at unrelated filesystem locations.

\`\`\`bash
# Orchestrator side, before launching the SubAgent
export GUILD_CONFIG=/abs/path/to/parent/guild.config.yaml
# every \`gate\` call in the SubAgent's shell now writes to the parent substrate
\`\`\`

Resolution priority: \`GUILD_CONFIG\` env > \`findConfig(cwd)\` walk-up > cwd fallback. Nonexistent path **errors loudly** — silent fallback here would let a SubAgent write to a stale substrate without realising.

### 2. Claude Code PostToolUse → \`gate witness\` example wiring

Under \`examples/plugins/harness-wirings/claude-code/\`:
- \`post-tool-use.sh\` — ~80-line shell hook that throttles (default 30s) and calls \`gate witness\` on every Claude Code tool call. No-ops when \`GUILD_WAVE_ID\` is unset (safe for global install).
- \`README.md\` — setup, env-var contract, failure modes named explicitly.

Per principle 15 routing: harness-specific wirings live in \`examples/\`, not in core.

### 3. \`docs/swarm.md\` worktree-ledger blindspot refresh

Replaces the previous "report progress in your final result message" workaround with the env-var bridge + brief snippet + wiring path. Cross-references principle 15 for the second-harness threshold.

## What this does NOT ship

- **No \`gate notify\` verb**. \`gate witness\` is sufficient (per-actor, optional note, session_id stamp, dedupe on identical note per #246).
- **No \`agent.activity.*\` hook namespace**. Premature until a second harness implementation presses on the surface.
- **No \`gate progress-watch\` daemon**. Long-running lifecycle is the current plugin gap; introducing it for one feature is wrong order. Per principle 15, when criterion (c) fires (two convergent plugin implementations), this can re-open.

## End-to-end smoke test (manual)

1. Created temp substrate at \`/tmp/<rand>\` with eris/noir registered
2. Created wave with noir as executor, approved
3. Fired the PostToolUse hook with \`GUILD_CONFIG\` / \`GUILD_WAVE_ID\` / \`GUILD_ACTOR\` set
4. \`gate wave-status <id>\` shows:
   \`\`\`
   executor: noir  [pending]
     witness: tool-use heartbeat
     last write: 2026-05-15T04:16:51.339Z
   \`\`\`

Without the bridge, that block reads \`(in progress — no recent attributable write)\` — the original trigger.

## Test plan

- [x] \`npm run build\` clean
- [x] \`node tests/run.mjs\` — 1754/1754 pass (was 1751; +3 new)
- [x] New tests under \`tests/infrastructure/guildConfigDiscovery.test.ts\`:
  - \`GUILD_CONFIG\` env wins over walk-up
  - nonexistent path throws \`DomainError\`
  - empty string treated as unset (falls back to walk-up)
- [x] End-to-end smoke test confirms hook → wave-status visibility

## Follow-ups deferred

- **Hook wirings for other harnesses** (Codex, Gemini CLI, custom orchestrators). Each contributes its own under \`examples/plugins/harness-wirings/<harness>/\`. When two of them ship convergent shapes, principle 15 criterion (c) for promotion to core fires.
- **Cross-harness event bus** (Layer B in #308). Held until the second-harness threshold materialises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)