### PR TITLE
chore: post-2026-05-15-touch-feel polish (4 papercuts)

### DIFF
--- a/.changelog/next/changed-post-touch-feel-polish.md
+++ b/.changelog/next/changed-post-touch-feel-polish.md
@@ -1,0 +1,29 @@
+- **Four post-2026-05-15-touch-feel polish fixes.** None blocked any
+  current workflow; each closes a small papercut surfaced during the
+  end-of-day dogfood pass.
+
+  1. **`bin/_lib/checkDistFreshness.mjs`** — stale-dist warning now
+     names *"after switching worktrees on this repo"* alongside the
+     existing *"after a `git pull`"* cause. Worktree exit followed by
+     `./bin/gate.mjs` in the parent is a regular trigger and the
+     prior hint missed it.
+
+  2. **`GuildConfig.load()`** — `GUILD_CONFIG=""` (set-but-empty) now
+     emits a one-line stderr nudge before falling back to walk-up.
+     The previous behavior silently treated empty as unset, which is
+     the footgun mode where the caller thinks they're clearing the
+     override but is in fact letting walk-up decide the substrate.
+
+  3. **`gate swarm-status` text rendering** — waves with no executors
+     render on a single line (`<id> [state] from=<from> (no executors)`)
+     rather than emitting a separate indented `(no executors assigned)`
+     sub-line. Substrates dominated by pre-#230 records (or freshly-
+     filed pending waves) no longer present visually heavy two-line
+     blocks per wave.
+
+  4. **`gate swarm-status` summary hint** — when `active_waves > 0` but
+     `distinct_executors == 0`, a one-line hint surfaces
+     `(no executor-stamped activity — likely pre-#230 records or
+     freshly-filed pending)`. The previous summary line read as
+     "swarm picture" at face value, misleading the reader for the
+     legacy-substrate case.

--- a/bin/_lib/checkDistFreshness.mjs
+++ b/bin/_lib/checkDistFreshness.mjs
@@ -62,7 +62,10 @@ export function checkDistFreshness(srcDir, distDir) {
     process.stderr.write(
       'guild-cli: dist/ is stale relative to src/ (some src files modified after the last build).\n' +
         '  Run: npm run build  (rebuild before re-running)\n' +
-        '  Hint: this commonly fires after a `git pull`. The current run will continue against the stale dist.\n',
+        '  Hint: this commonly fires after a `git pull`, after switching\n' +
+        '        worktrees on this repo, or after a branch checkout that\n' +
+        '        touched src/. The current run will continue against the\n' +
+        '        stale dist.\n',
     );
   }
 }

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -232,6 +232,17 @@ export class GuildConfig implements GuildConfigProps {
       }
       configPath = resolvedEnv;
     } else {
+      // Empty string is treated as unset (caller did `GUILD_CONFIG=`
+      // to clear the override). Emit a one-line stderr nudge —
+      // silent fallback to cwd walk-up here is the footgun mode
+      // where the caller thinks they're clearing the override but
+      // is actually letting walk-up decide the substrate.
+      if (envConfig === '') {
+        process.stderr.write(
+          'guild-cli: GUILD_CONFIG is set but empty — treating as unset, falling back to cwd walk-up.\n' +
+            '  Hint: `unset GUILD_CONFIG` to clear cleanly, or set to an absolute path to a guild.config.yaml.\n',
+        );
+      }
       configPath = findConfig(cwd);
     }
     if (!configPath) {

--- a/src/interface/gate/handlers/swarmStatus.ts
+++ b/src/interface/gate/handlers/swarmStatus.ts
@@ -268,6 +268,16 @@ function renderText(p: SwarmStatusPayload): string {
       `${p.summary.distinct_executors} distinct executor(s)  ` +
       `${p.summary.alerts} alert(s)`,
   );
+  // Eris-axis nuance: "active waves" without any executor-stamped
+  // activity is the legacy / pre-#230 shape — the surface should
+  // not advertise "swarm picture" at face value for that case. Add
+  // a one-line hint so a reader scanning the summary knows what
+  // they're looking at before walking the per-wave list.
+  if (p.summary.active_waves > 0 && p.summary.distinct_executors === 0) {
+    lines.push(
+      '  (no executor-stamped activity — likely pre-#230 records or freshly-filed pending)',
+    );
+  }
   lines.push('');
 
   if (p.waves.length === 0) {
@@ -278,11 +288,17 @@ function renderText(p: SwarmStatusPayload): string {
   lines.push('waves:');
   for (const w of p.waves) {
     const ageBadge = w.age_band !== 'fresh' ? `  [${w.age_band}]` : '';
-    lines.push(`  ${w.id}  [${w.state}]  from=${w.from}${ageBadge}`);
+    // No-executors waves render on ONE line — the previous shape
+    // emitted a separate `    (no executors assigned)` indented line
+    // per wave, which produced visually heavy blocks for substrates
+    // dominated by pre-#230 records. Inline tag is tighter and
+    // doesn't fight for attention with executor-bearing waves
+    // (which need their own per-executor block).
     if (w.executors.length === 0) {
-      lines.push('    (no executors assigned)');
+      lines.push(`  ${w.id}  [${w.state}]  from=${w.from}${ageBadge}  (no executors)`);
       continue;
     }
+    lines.push(`  ${w.id}  [${w.state}]  from=${w.from}${ageBadge}`);
     for (const e of w.executors) {
       const tags: string[] = [e.slice_status];
       if (e.claim_held) tags.push('claim');

--- a/tests/infrastructure/guildConfigDiscovery.test.ts
+++ b/tests/infrastructure/guildConfigDiscovery.test.ts
@@ -142,6 +142,15 @@ test('GuildConfig.load: GUILD_CONFIG with nonexistent path throws DomainError', 
 });
 
 test('GuildConfig.load: empty GUILD_CONFIG falls back to walk-up (treated as unset)', () => {
+  // Behavior-only verification: empty string is treated as unset and
+  // walk-up resolves the local config. The stderr nudge that fires
+  // alongside this fallback is verified by a CLI subprocess test
+  // (see tests/interface/guildConfigEmpty.test.ts) — capturing it
+  // here via `process.stderr.write` monkey-patch interacted with the
+  // test runner's worker stdio on Windows + Node 20 and produced
+  // CI hangs. The split keeps the unit test cheap and cross-platform-
+  // safe while preserving the message-wording assertion at a layer
+  // that owns its own process boundary.
   const { dir, cleanup } = setupRepo();
   try {
     writeFileSync(
@@ -150,23 +159,10 @@ test('GuildConfig.load: empty GUILD_CONFIG falls back to walk-up (treated as uns
     );
     const prev = process.env['GUILD_CONFIG'];
     process.env['GUILD_CONFIG'] = '';
-    // Capture stderr to verify the footgun-nudge fires.
-    const origStderr = process.stderr.write.bind(process.stderr);
-    let captured = '';
-    process.stderr.write = ((s: string | Uint8Array) => {
-      captured += typeof s === 'string' ? s : Buffer.from(s).toString();
-      return true;
-    }) as typeof process.stderr.write;
     try {
       const cfg = GuildConfig.load(dir);
-      // empty string is treated as unset; walk-up finds the local config
       assert.equal(cfg.configFile, join(dir, 'guild.config.yaml'));
-      // ...AND a one-line nudge surfaces the footgun (caller likely
-      // wanted to clear the override but used `=` instead of `unset`).
-      assert.match(captured, /GUILD_CONFIG is set but empty/);
-      assert.match(captured, /unset GUILD_CONFIG/);
     } finally {
-      process.stderr.write = origStderr;
       if (prev === undefined) delete process.env['GUILD_CONFIG'];
       else process.env['GUILD_CONFIG'] = prev;
     }

--- a/tests/infrastructure/guildConfigDiscovery.test.ts
+++ b/tests/infrastructure/guildConfigDiscovery.test.ts
@@ -150,11 +150,23 @@ test('GuildConfig.load: empty GUILD_CONFIG falls back to walk-up (treated as uns
     );
     const prev = process.env['GUILD_CONFIG'];
     process.env['GUILD_CONFIG'] = '';
+    // Capture stderr to verify the footgun-nudge fires.
+    const origStderr = process.stderr.write.bind(process.stderr);
+    let captured = '';
+    process.stderr.write = ((s: string | Uint8Array) => {
+      captured += typeof s === 'string' ? s : Buffer.from(s).toString();
+      return true;
+    }) as typeof process.stderr.write;
     try {
       const cfg = GuildConfig.load(dir);
       // empty string is treated as unset; walk-up finds the local config
       assert.equal(cfg.configFile, join(dir, 'guild.config.yaml'));
+      // ...AND a one-line nudge surfaces the footgun (caller likely
+      // wanted to clear the override but used `=` instead of `unset`).
+      assert.match(captured, /GUILD_CONFIG is set but empty/);
+      assert.match(captured, /unset GUILD_CONFIG/);
     } finally {
+      process.stderr.write = origStderr;
       if (prev === undefined) delete process.env['GUILD_CONFIG'];
       else process.env['GUILD_CONFIG'] = prev;
     }

--- a/tests/interface/guildConfigEmpty.test.ts
+++ b/tests/interface/guildConfigEmpty.test.ts
@@ -1,0 +1,78 @@
+// `GUILD_CONFIG=""` footgun-nudge verification via CLI subprocess.
+//
+// Split from tests/infrastructure/guildConfigDiscovery.test.ts: the
+// in-process variant monkey-patched `process.stderr.write` to capture
+// the nudge text, which interacted with the node:test runner's worker
+// stdio on Windows + Node 20 and produced CI hangs. The CLI here owns
+// its own process boundary, so stderr capture is clean.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function runGate(
+  cwd: string,
+  args: readonly string[],
+  env: Record<string, string>,
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-config-empty-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('GUILD_CONFIG="" emits the empty-but-set stderr nudge before walking up', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['doctor', '--summary'], { GUILD_CONFIG: '' });
+  // Exit succeeds because empty is treated as unset, walk-up finds
+  // the local config, doctor reports clean.
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+  // The nudge fires on stderr.
+  assert.match(r.stderr, /GUILD_CONFIG is set but empty/);
+  assert.match(r.stderr, /unset GUILD_CONFIG/);
+});
+
+test('GUILD_CONFIG unset (env var absent) emits no nudge', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Explicitly omit GUILD_CONFIG from the child env. The runGate
+  // helper merges over process.env, so we have to overwrite-as-empty
+  // and rely on the env-isolation strategy used by other tests. The
+  // simplest portable form: pass a sentinel and check the nudge does
+  // NOT fire (Node treats undefined entries in the env object as
+  // omitted from the child).
+  const r = spawnSync(process.execPath, [GATE, 'doctor', '--summary'], {
+    cwd: root,
+    encoding: 'utf8',
+    env: (() => {
+      const copy: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (k === 'GUILD_CONFIG') continue;
+        if (typeof v === 'string') copy[k] = v;
+      }
+      return copy;
+    })(),
+  });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+  assert.doesNotMatch(r.stderr ?? '', /GUILD_CONFIG is set but empty/);
+});

--- a/tests/interface/swarmStatus346.test.ts
+++ b/tests/interface/swarmStatus346.test.ts
@@ -229,3 +229,26 @@ test('#346: unknown flag rejected (schema-as-contract drift guard)', (t) => {
   assert.notEqual(r.status, 0);
   assert.match(r.stderr, /unknown flag.*bogus/);
 });
+
+// -------------------- legacy / no-executor rendering --------------------
+
+test('#346: waves with no executors render on a single line + summary hint fires', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  // Two pending waves, both without executors (the pre-#230 / freshly-
+  // filed-pending shape).
+  for (let i = 0; i < 2; i += 1) {
+    runGate(root, [
+      'request', '--from', 'alice',
+      '--action', `work ${i}`, '--reason', 'r',
+    ]);
+  }
+  const r = runGate(root, ['swarm-status', '--format', 'text']);
+  assert.equal(r.status, 0, r.stderr);
+  // Summary-line hint surfaces the "this looks like swarm but isn't" case.
+  assert.match(r.stdout, /no executor-stamped activity/);
+  // Single-line rendering: each wave line ends with "(no executors)" and
+  // there is no separate indented "(no executors assigned)" sub-line.
+  assert.match(r.stdout, /\(no executors\)/);
+  assert.doesNotMatch(r.stdout, /\(no executors assigned\)/);
+});


### PR DESCRIPTION
Four small fixes surfaced during the end-of-day dogfood pass against the just-shipped surfaces (#387, #391, #392, #393). None blocked any current workflow; each closes a papercut named in the touch-feel report.

## Changes

### 1. \`bin/_lib/checkDistFreshness.mjs\` — stale-dist hint adds worktree cause

The warning fires correctly when \`dist/\` is older than \`src/\`. The hint named only \`git pull\` as the trigger; **worktree exit → parent \`./bin/gate.mjs\`** is the same shape and was missed. Added to the hint.

\`\`\`
Hint: this commonly fires after a `git pull`, after switching
      worktrees on this repo, or after a branch checkout that
      touched src/. The current run will continue against the
      stale dist.
\`\`\`

### 2. \`GuildConfig.load()\` — \`GUILD_CONFIG=\"\"\` no longer silent

\`GUILD_CONFIG=\"\"\` (set-but-empty, the result of \`GUILD_CONFIG=\` in shell) previously fell back to walk-up silently. That is the footgun mode: the caller intended to clear the override but \`unset GUILD_CONFIG\` is what they needed. Now emits:

\`\`\`
guild-cli: GUILD_CONFIG is set but empty — treating as unset, falling back to cwd walk-up.
  Hint: `unset GUILD_CONFIG` to clear cleanly, or set to an absolute path to a guild.config.yaml.
\`\`\`

New test pins the nudge text.

### 3. \`gate swarm-status\` text — no-executors waves on one line

Pre-#230 records (and freshly-filed pending) have no \`executors[]\`. The renderer used to emit:

\`\`\`
  2026-04-23-0001  [pending]  from=author
    (no executors assigned)
\`\`\`

For substrates dominated by such records (yori-code's 5 pending shown above), this was visually heavy. Now:

\`\`\`
  2026-04-23-0001  [pending]  from=author  (no executors)
\`\`\`

### 4. \`gate swarm-status\` summary — hint when no swarm activity

When the substrate has \`active_waves > 0\` but \`distinct_executors == 0\` (the legacy-pending shape), the summary line previously read as a real swarm picture. Added one-line hint:

\`\`\`
swarm picture as of ...
  5 active wave(s)  0 distinct executor(s)  0 alert(s)
  (no executor-stamped activity — likely pre-#230 records or freshly-filed pending)
\`\`\`

## Touch-feel context

Running the just-shipped surfaces against the yori-code substrate via \`GUILD_CONFIG\` produced the rendering observed and the friction list. All four fixes are direct responses to that.

## Test plan

- [x] \`npm run build\` clean
- [x] \`node tests/run.mjs\` — 1763/1763 pass (was 1759)
- [x] Manual verify against yori-code substrate (\`GUILD_CONFIG=…/yori-code/.gate-sessions/…\`) shows new rendering
- [x] \`GUILD_CONFIG=\"\"\` smoke test emits the nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)