### PR TITLE
fix(bin): clean error envelope on pre-dispatch throws + GUILD_CONFIG="" nudge dedup

### DIFF
--- a/.changelog/next/fixed-bin-catch-and-nudge-dedup.md
+++ b/.changelog/next/fixed-bin-catch-and-nudge-dedup.md
@@ -1,0 +1,19 @@
+- **`bin/*.mjs` entries now catch unhandled errors and render them in
+  the standard `error: <msg>` envelope instead of raw Node stack
+  traces.** Surfaced by `GUILD_CONFIG=/nonexistent` printing an
+  `at file:///…/bin/gate.mjs:54:1 { field: 'GUILD_CONFIG' }` stack
+  with a `Node.js v23.6.1` footer — unprofessional for what is user
+  error. The shared helper `bin/_lib/handleMainError.mjs` detects
+  DomainError-shaped throws (presence of `.field` property) and
+  prints clean `error: <msg>` + exit 1; unexpected internal throws
+  still surface their stack with a `<bin>: internal error (please
+  file an issue …)` preamble. Fired from gate / guild / agora /
+  devil / ctx — all five entry-points.
+
+- **`GUILD_CONFIG=""` stderr nudge now fires exactly once per
+  process** instead of twice. `GuildConfig.load()` is called
+  multiple times in one invocation (top-level + at least one
+  plugin loader); the prior implementation re-emitted on each.
+  Module-private one-shot guard `emptyGuildConfigNudgeFired`
+  preserves per-process emission semantics so a fresh shell still
+  gets the warning, but a single CLI run no longer doubles it.

--- a/bin/_lib/handleMainError.mjs
+++ b/bin/_lib/handleMainError.mjs
@@ -1,0 +1,50 @@
+// Shared `.catch` handler for the five `bin/*.mjs` entry-points
+// (gate / guild / agora / devil / ctx).
+//
+// Why this exists: each `main()` from the dist/ entry has its own
+// try/catch around verb dispatch, but `GuildConfig.load()` and other
+// pre-dispatch setup throw BEFORE that try block. Without a catch
+// at the bin level, those throws surface as raw Node "Unhandled
+// promise rejection" stack traces — unprofessional for what is
+// usually user error (bad env var, missing config).
+//
+// Lives in `bin/_lib/` as plain .mjs (not in dist/) so it doesn't
+// participate in the dist-missing failure mode. This is the same
+// pattern the partial-staleness check uses; see the lead comment
+// on each `bin/<passage>.mjs` for the duplication-vs-share
+// trade-off.
+
+/**
+ * Promise rejection handler for `main(...)`. Detects DomainError-
+ * shaped errors (clean user-error message) and renders the rest
+ * with a stack trace as suspected internal bugs.
+ *
+ * @param {string} prefix - one of 'gate' / 'guild' / 'agora' /
+ *                          'devil' / 'ctx', used in the
+ *                          internal-error preamble.
+ * @returns {(err: unknown) => never} - rejection handler
+ */
+export function handleMainError(prefix) {
+  return (err) => {
+    // DomainError is identified structurally rather than via
+    // `instanceof` so we don't have to import from dist/ at the bin
+    // layer (which would re-introduce the dist-missing trap this
+    // file was carefully placed outside of). DomainError ships with
+    // a `field` property and a string `message`; nothing else
+    // in the codebase shares that exact shape.
+    const isDomainError =
+      err !== null &&
+      typeof err === 'object' &&
+      'field' in err &&
+      typeof err.message === 'string';
+    if (isDomainError) {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exit(1);
+    }
+    process.stderr.write(
+      `${prefix}: internal error (please file an issue with the stack below)\n` +
+        `${err?.stack ?? err}\n`,
+    );
+    process.exit(1);
+  };
+}

--- a/bin/agora.mjs
+++ b/bin/agora.mjs
@@ -8,6 +8,7 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+import { handleMainError } from './_lib/handleMainError.mjs';
 // Match the bin/gate.mjs setBlocking comment — same rationale.
 process.stdout._handle?.setBlocking?.(true);
 process.stderr._handle?.setBlocking?.(true);
@@ -38,4 +39,6 @@ try {
   }
   throw err;
 }
-main(process.argv.slice(2)).then((code) => process.exit(code));
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch(handleMainError('agora'));

--- a/bin/ctx.mjs
+++ b/bin/ctx.mjs
@@ -8,6 +8,7 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+import { handleMainError } from './_lib/handleMainError.mjs';
 // Match the bin/gate.mjs setBlocking comment — same rationale.
 process.stdout._handle?.setBlocking?.(true);
 process.stderr._handle?.setBlocking?.(true);
@@ -38,4 +39,6 @@ try {
   }
   throw err;
 }
-main(process.argv.slice(2)).then((code) => process.exit(code));
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch(handleMainError('ctx'));

--- a/bin/devil.mjs
+++ b/bin/devil.mjs
@@ -8,6 +8,7 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+import { handleMainError } from './_lib/handleMainError.mjs';
 // Match the bin/gate.mjs setBlocking comment — same rationale.
 process.stdout._handle?.setBlocking?.(true);
 process.stderr._handle?.setBlocking?.(true);
@@ -38,4 +39,6 @@ try {
   }
   throw err;
 }
-main(process.argv.slice(2)).then((code) => process.exit(code));
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch(handleMainError('devil'));

--- a/bin/gate.mjs
+++ b/bin/gate.mjs
@@ -10,6 +10,7 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+import { handleMainError } from './_lib/handleMainError.mjs';
 // Make stdout/stderr blocking so large payloads (e.g. `gate schema --format
 // json`, `gate boot` on busy substrates) drain before the trailing
 // `process.exit` truncates them. Pipe writes are async by default; on
@@ -51,4 +52,6 @@ try {
   }
   throw err;
 }
-main(process.argv.slice(2)).then((code) => process.exit(code));
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch(handleMainError('gate'));

--- a/bin/guild.mjs
+++ b/bin/guild.mjs
@@ -8,6 +8,7 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { checkDistFreshness } from './_lib/checkDistFreshness.mjs';
+import { handleMainError } from './_lib/handleMainError.mjs';
 // Match the bin/gate.mjs setBlocking comment — same rationale.
 process.stdout._handle?.setBlocking?.(true);
 process.stderr._handle?.setBlocking?.(true);
@@ -38,4 +39,6 @@ try {
   }
   throw err;
 }
-main(process.argv.slice(2)).then((code) => process.exit(code));
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch(handleMainError('guild'));

--- a/src/infrastructure/config/GuildConfig.ts
+++ b/src/infrastructure/config/GuildConfig.ts
@@ -165,6 +165,14 @@ export interface GuildConfigProps {
 const DEFAULT_HOSTS = ['eris', 'nao'] as const;
 
 /**
+ * Module-private one-shot guard for the `GUILD_CONFIG=""` empty-but-
+ * set stderr nudge. Set on first emission; subsequent loads in the
+ * same process skip the emit. See the comment at the call site in
+ * `GuildConfig.load()` for the per-process semantics rationale.
+ */
+let emptyGuildConfigNudgeFired = false;
+
+/**
  * GuildConfig — file-based config with path safety.
  *
  * All resolved paths must live under `contentRoot`. This is the single
@@ -237,11 +245,18 @@ export class GuildConfig implements GuildConfigProps {
       // silent fallback to cwd walk-up here is the footgun mode
       // where the caller thinks they're clearing the override but
       // is actually letting walk-up decide the substrate.
-      if (envConfig === '') {
+      //
+      // Deduped at module scope per Node process: `GuildConfig.load()`
+      // fires multiple times in one invocation (top-level + at least
+      // one plugin loader). Without dedup the nudge surfaces twice
+      // and looks noisy. A new process re-emits the nudge because
+      // the operator may have changed shells / scripts between.
+      if (envConfig === '' && !emptyGuildConfigNudgeFired) {
         process.stderr.write(
           'guild-cli: GUILD_CONFIG is set but empty — treating as unset, falling back to cwd walk-up.\n' +
             '  Hint: `unset GUILD_CONFIG` to clear cleanly, or set to an absolute path to a guild.config.yaml.\n',
         );
+        emptyGuildConfigNudgeFired = true;
       }
       configPath = findConfig(cwd);
     }

--- a/tests/interface/guildConfigEmpty.test.ts
+++ b/tests/interface/guildConfigEmpty.test.ts
@@ -76,3 +76,39 @@ test('GUILD_CONFIG unset (env var absent) emits no nudge', (t) => {
   assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
   assert.doesNotMatch(r.stderr ?? '', /GUILD_CONFIG is set but empty/);
 });
+
+// -------------------- bogus path → clean error envelope (no stack trace) --------------------
+
+test('GUILD_CONFIG=/nonexistent prints clean error: line, no Node stack trace', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['voices'], { GUILD_CONFIG: '/nonexistent/guild.config.yaml' });
+  assert.notEqual(r.status, 0, 'bogus path must exit non-zero');
+  // Clean error envelope: starts with `error: ` and carries the
+  // DomainError message verbatim.
+  assert.match(r.stderr, /^error: GUILD_CONFIG=/m);
+  assert.match(r.stderr, /does not exist/);
+  // Must NOT surface as a raw Node "Unhandled promise rejection"
+  // stack trace — that's the regression the bin-level catch
+  // handler closes (handleMainError in bin/_lib/).
+  assert.doesNotMatch(r.stderr, /at file:\/\/.*bin\/gate\.mjs/);
+  assert.doesNotMatch(r.stderr, /Node\.js v\d+/);
+});
+
+// -------------------- nudge dedup --------------------
+
+test('GUILD_CONFIG="" emits the nudge exactly once per process (dedup)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const r = runGate(root, ['voices'], { GUILD_CONFIG: '' });
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stderr}`);
+  // GuildConfig.load() fires multiple times per invocation (top-
+  // level + plugin loaders). The module-private flag ensures the
+  // stderr nudge surfaces exactly once.
+  const matches = r.stderr.match(/GUILD_CONFIG is set but empty/g);
+  assert.equal(
+    matches === null ? 0 : matches.length,
+    1,
+    `expected nudge to fire exactly once, got ${matches === null ? 0 : matches.length}`,
+  );
+});


### PR DESCRIPTION
Two papercuts surfaced during the second round of touch-feel after #395 merged.

## (A) Raw Node stack trace on pre-dispatch throws

\`GUILD_CONFIG=/nonexistent gate voices\` previously produced:

\`\`\`
DomainError: GUILD_CONFIG=\"/nonexistent\" does not exist...
    at file:///.../bin/gate.mjs:54:1 {
  field: 'GUILD_CONFIG'
}
Node.js v23.6.1
\`\`\`

Because \`GuildConfig.load()\` runs at the top of \`main()\`, BEFORE the verb-dispatch try/catch wraps anything. The DomainError message was there but rendered as an unhandled promise rejection — unprofessional for what is user error.

After: a clean envelope matching the rest of the CLI.

\`\`\`
error: GUILD_CONFIG=\"/nonexistent\" does not exist (resolved: /nonexistent).
  next: export GUILD_CONFIG=<absolute path to guild.config.yaml>, or unset to fall back to cwd walk-up.
\`\`\`

## (B) \`GUILD_CONFIG=\"\"\` nudge double-fires

\`GuildConfig.load()\` runs multiple times in one CLI invocation (top-level entry + at least one plugin loader). The set-but-empty nudge from #395 had no dedup; the warning surfaced twice per process. Cosmetic but noisy.

After: exactly one emission per process, fresh shells still get the warning.

## Implementation

- **\`bin/_lib/handleMainError.mjs\`** (new) — shared \`.catch\` handler for all five entry-points (gate / guild / agora / devil / ctx). DomainError-shaped throws (structural: presence of \`.field\` + string \`.message\`) render as \`error: <msg>\` + exit 1. Anything else surfaces with a \`<bin>: internal error (please file an issue …)\` preamble + stack — those represent actual bugs worth investigating.
- Lives in \`bin/_lib/\` (same precedent as \`checkDistFreshness.mjs\`) to stay outside the dist-missing trap. Detection is structural, not \`instanceof DomainError\`, because importing from dist/ at the bin layer re-introduces the failure mode the placement was designed to avoid.
- **\`src/infrastructure/config/GuildConfig.ts\`** — module-private one-shot guard \`emptyGuildConfigNudgeFired\` for the nudge. Flips on first emission within a process; new process re-emits.
- All five \`bin/*.mjs\` entries wire \`handleMainError(<prefix>)\` into the existing \`main(...).then(...)\` chain.

## Tests

\`tests/interface/guildConfigEmpty.test.ts\` gets two more cases:

- \`GUILD_CONFIG=/nonexistent\` produces clean \`error:\` line and **no** Node stack trace markers (no \`at file://.../bin/gate.mjs\`, no \`Node.js v…\` footer)
- \`GUILD_CONFIG=\"\"\` emits the nudge exactly once per invocation

1767/1767 tests pass (was 1765; +2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)