### PR TITLE
refactor(interface): shared --format validator + 2 eris-first polish items

### DIFF
--- a/.changelog/next/changed-parsefor-and-notice-and-prefix.md
+++ b/.changelog/next/changed-parsefor-and-notice-and-prefix.md
@@ -1,0 +1,33 @@
+- **Shared `--format` validator (`src/interface/shared/parseFormat.ts`)
+  replaces 55 inline `if format !== json && format !== text` blocks
+  across gate / agora / devil / ctx handlers.** Drift surface
+  collapses to a single source of truth; the validation message
+  ("`--format must be 'json' or 'text', got: <raw>`") is now uniform
+  across passages (previously several handlers had the reversed-order
+  "text or json" variant). Helper throws `DomainError(field='format')`
+  so JSON-mode callers now receive the structured envelope
+  (`{"ok":false,"error":{"field":"format","code":"validation_error",…}}`)
+  instead of plain text — consistent with how every OTHER error in
+  the same handler renders. Single-format verbs (`gate boot`,
+  `gate schema`, `gate status`, etc.) pass `'json'` as the default
+  via `parseFormat(args, 'json')`. Net: −134 LOC across 55 files.
+
+- **`notice: wrote <path>` stderr line is suppressed in JSON mode
+  for `agora new`, `agora play`, `devil open`.** The path and
+  config-file are already in the stdout JSON envelope
+  (`where_written` + `config_file`); re-emitting them on stderr was
+  pure context pollution for AI consumers — every successful create
+  burned two extra lines of tool-result context for information the
+  caller already had structured. Text-mode readers still get the
+  disclosure (the stdout `✓ created` line does not carry the path).
+  `ctx record` already had the notice correctly gated inside its
+  text-mode `else` branch.
+
+- **Error prefix unified to `error: <msg>` across `gate next`,
+  `gate self-pattern`, `gate decisions`.** Three handlers used a
+  passage-verb-named prefix (`gate next: GUILD_ACTOR is not set…`),
+  which on the `throw new Error` path produced the doubled prologue
+  `error: gate self-pattern: …` once the outer-catch added its own
+  `error:` envelope. Machine consumers that grep for `^error:` now
+  match every error from every verb; prose hints retain the
+  `next: <command>` recovery line below for the human reader.

--- a/src/interface/gate/handlers/board.ts
+++ b/src/interface/gate/handlers/board.ts
@@ -8,6 +8,7 @@ import { C } from './internal.js';
 
 const BOARD_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for', 'format']);
 import { Request } from '../../../domain/request/Request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   computeReviewMarkerWidth,
   formatReviewMarkers,
@@ -45,10 +46,7 @@ const BOARD_STATES = ['pending', 'approved', 'executing'] as const;
 
 export async function boardCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, BOARD_KNOWN_FLAGS, 'board');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const explicitFor = optionalOption(args, 'for');
   const envActor =

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -43,6 +43,7 @@ import {
   computeLastAuthoredWriteAt,
 } from './bootActionable.js';
 import { collectCrossPassage, renderBootText } from './bootRender.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 // Re-exports for external consumers (suggest.ts + tests/boot.test.ts).
 // The split moved these out of this file; the re-exports keep the
@@ -90,10 +91,7 @@ const ISO_TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
 export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, BOOT_KNOWN_FLAGS, 'boot');
   maybeEmitExplain(args, 'boot');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args, 'json');
   // Default tail=5 (was 10) to keep `gate boot` lean — agents call
   // boot at every session start, so the orientation payload is on the
   // hot path. 5 covers "what just happened" without flooding the JSON

--- a/src/interface/gate/handlers/decisions.ts
+++ b/src/interface/gate/handlers/decisions.ts
@@ -27,6 +27,7 @@ import {
 import { C, parseOptionalIntOption } from './internal.js';
 import { parseDuration } from './lenseStats.js';
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 // limit: sibling gate-voices accepts --limit; aligning here removes a
 // cross-verb inconsistency. Applied post-sort so the most-recent N survive.
@@ -81,15 +82,12 @@ export async function decisionsCmd(c: C, args: ParsedArgs): Promise<number> {
   const forActor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
   if (!forActor) {
     throw new Error(
-      'gate decisions: --for <actor> is required when GUILD_ACTOR is not set.' +
+      '--for <actor> is required when GUILD_ACTOR is not set.' +
         '\n  next: pass --for <name>, or `export GUILD_ACTOR=<you>` once per shell.',
     );
   }
   const sinceRaw = optionalOption(args, 'since') ?? '7d';
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const now = new Date();
   const sinceMs = parseDuration(sinceRaw);

--- a/src/interface/gate/handlers/doctor.ts
+++ b/src/interface/gate/handlers/doctor.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { join, basename } from 'node:path';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -82,11 +83,7 @@ export async function doctorCmd(c: C, args: ParsedArgs): Promise<number> {
     return await sweepTrapsCmd(c, args);
   }
   rejectUnknownFlags(args, DOCTOR_KNOWN_FLAGS, 'doctor');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
   const report = await c.diagnosticUC.run();
   const summaryOnly =
     args.options['summary'] === true || args.positional[0] === 'summary';
@@ -243,13 +240,7 @@ async function sweepTrapsCmd(c: C, args: ParsedArgs): Promise<number> {
 
   const apply = args.options['apply'] === true;
   const revive = optionalOption(args, 'revive');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(
-      `error: --format must be 'json' or 'text', got: ${format}\n`,
-    );
-    return 1;
-  }
+  const format = parseFormat(args);
   if (apply && revive !== undefined) {
     process.stderr.write(
       'error: --apply and --revive are mutually exclusive.\n' +

--- a/src/interface/gate/handlers/flowSuggest.ts
+++ b/src/interface/gate/handlers/flowSuggest.ts
@@ -4,6 +4,7 @@ import {
   requireOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { C } from './internal.js';
 import {
   suggestFlow,
@@ -44,11 +45,8 @@ export async function flowSuggestCmd(
   const severityRaw = requireOption(args, 'severity', '<low|med|high>');
   const area = requireOption(args, 'area', '<copy|doc|style|bug|auth|...>');
   const scope = optionalOption(args, 'scope');
-  const format = optionalOption(args, 'format') ?? 'json';
+  const format = parseFormat(args, 'json');
 
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
   if (!SEVERITIES.has(severityRaw)) {
     // The check fires AFTER format validation so a `--format xml` typo
     // still surfaces the format error first (more likely the operator

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -7,6 +7,7 @@ import {
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { resolveGuildSessionId } from '../../shared/resolveGuildSessionId.js';
 import { parseExecutorsList } from './request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   C,
   readStdin,
@@ -147,10 +148,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
   if (sub === 'list') {
     rejectUnknownFlags(args, ISSUES_LIST_KNOWN_FLAGS, 'issues list');
     const stateRaw = optionalOption(args, 'state');
-    const format = optionalOption(args, 'format') ?? 'text';
-    if (format !== 'text' && format !== 'json') {
-      throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-    }
+    const format = parseFormat(args);
 
     // `--state all` is sugar for "every state, no filter". Implemented
     // here rather than in IssueUseCases because the use case is
@@ -225,10 +223,7 @@ export async function issuesCmd(c: C, args: ParsedArgs): Promise<number> {
         'Usage: gate issues show <id> [--format text|json]',
       );
     }
-    const format = optionalOption(args, 'format') ?? 'text';
-    if (format !== 'text' && format !== 'json') {
-      throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-    }
+    const format = parseFormat(args);
     const issue = await c.issueUC.find(id);
     if (!issue) {
       process.stderr.write(notFoundMessage('issue', id));

--- a/src/interface/gate/handlers/lenseStats.ts
+++ b/src/interface/gate/handlers/lenseStats.ts
@@ -34,6 +34,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { YamlDevilReviewRepository } from '../../../passages/devil/infrastructure/YamlDevilReviewRepository.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const LENSE_STATS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'for',
@@ -79,10 +80,7 @@ export async function lenseStatsCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, LENSE_STATS_KNOWN_FLAGS, 'lense-stats');
   const forActor = optionalOption(args, 'for') ?? null;
   const sinceRaw = optionalOption(args, 'since') ?? '7d';
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const now = new Date();
   const sinceMs = parseDuration(sinceRaw);

--- a/src/interface/gate/handlers/lore.ts
+++ b/src/interface/gate/handlers/lore.ts
@@ -22,6 +22,7 @@ import {
 import { maybeEmitExplain } from '../../shared/explain.js';
 import { LoreType } from '../../../infrastructure/lore/LoreRepository.js';
 import { C, truncateCodePoints } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const LORE_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'type',
@@ -67,10 +68,7 @@ function loreList(c: C, args: ParsedArgs): number {
   const typeRaw = optionalOption(args, 'type');
   const appliesTo = optionalOption(args, 'applies-to');
   const relevantUntilRaw = optionalOption(args, 'relevant-until');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   let type: LoreType | undefined;
   if (typeRaw !== undefined) {
     if (typeRaw !== 'principle' && typeRaw !== 'trap') {
@@ -147,10 +145,7 @@ function loreShow(c: C, args: ParsedArgs): number {
       'Usage: gate lore show <name> [--format text|json]',
     );
   }
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const entry = c.loreUC.find(name);
   if (!entry) {
     // Custom not-found message — `notFoundMessage` ships with a typed

--- a/src/interface/gate/handlers/messages.ts
+++ b/src/interface/gate/handlers/messages.ts
@@ -13,6 +13,7 @@ import {
   normalizeActor,
 } from './internal.js';
 import { InboxMessage } from '../../../application/ports/NotificationPort.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 /**
  * Serialise an InboxMessage for `gate inbox --format json`. snake_case
@@ -174,10 +175,7 @@ export async function msgInbox(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, INBOX_KNOWN_FLAGS, 'inbox');
   const forName = requireOption(args, 'for', '<m>', 'GUILD_ACTOR');
   const unreadOnly = args.options['unread'] === true;
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const messages = await c.messageUC.inbox(forName);
   const filtered = unreadOnly
     ? messages.filter((m) => !m.read)

--- a/src/interface/gate/handlers/next.ts
+++ b/src/interface/gate/handlers/next.ts
@@ -43,6 +43,7 @@ import {
 // re-exports today; import directly from the derivation module so
 // `gate next` reads the same actionable ladder bootCmd assembles.
 import { deriveVerbsAvailableNow } from './bootActionable.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const NEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'confirm',
@@ -87,10 +88,7 @@ interface Plan {
 export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, NEXT_KNOWN_FLAGS, 'next');
   maybeEmitExplain(args, 'next');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const confirm = args.options['confirm'] === true;
 
   const envActor = resolveGuildActor();
@@ -100,7 +98,7 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
     // but `next` is specifically about actor-scoped actionable work.
     // Refuse rather than auto-dispatch a meaningless suggestion.
     process.stderr.write(
-      'gate next: GUILD_ACTOR is not set. ' +
+      'error: GUILD_ACTOR is not set. ' +
         'Set it before asking gate next what to do — the actionable ' +
         'ladder is actor-scoped.\n' +
         '  next: export GUILD_ACTOR=<your-name>\n',
@@ -122,7 +120,7 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
       : 'unknown';
   if (role === 'unknown') {
     process.stderr.write(
-      `gate next: GUILD_ACTOR=${actor} is not a registered member or host. ` +
+      `error: GUILD_ACTOR=${actor} is not a registered member or host. ` +
         `gate boot would suggest registering — run that first.\n` +
         `  next: gate register --name ${actor}\n`,
     );
@@ -190,7 +188,7 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
   if (!canAuto) {
     emitPlan(plan, format, true);
     process.stderr.write(
-      `gate next: '${top.verb}' needs caller-supplied args and won't be ` +
+      `error: '${top.verb}' needs caller-supplied args and won't be ` +
         `auto-dispatched. Run the command shown above with your inputs filled in.\n`,
     );
     return 1;

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -13,6 +13,7 @@ import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
 import { compareSequenceIds } from '../../../domain/shared/compareSequenceIds.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   collectUtterances,
   renderUtterance,
@@ -58,10 +59,7 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
     // the discovery question (trap_silent_fallback_loses_signal). We
     // count per-actor utterances across the substrate so a cold reader
     // can pick a name from the list directly.
-    const format = optionalOption(args, 'format') ?? 'text';
-    if (format !== 'text' && format !== 'json') {
-      throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-    }
+    const format = parseFormat(args);
     return emitVoicesIndex(c, format);
   }
 
@@ -72,10 +70,7 @@ export async function reqVoices(c: C, args: ParsedArgs): Promise<number> {
   const verdictFilter =
     verdictFilterRaw !== undefined ? parseVerdict(verdictFilterRaw) : undefined;
   const limit = parseOptionalIntOption(args, 'limit');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args, 'json');
 
   const allJson = await loadAllRequestsAsJson(c);
 
@@ -324,10 +319,7 @@ export async function reqTail(c: C, args: ParsedArgs): Promise<number> {
   }
   const limit = n ?? 20;
 
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const allJson = await loadAllRequestsAsJson(c);
   const utterances = collectUtterances(allJson, {
@@ -380,10 +372,7 @@ export async function reqWhoami(c: C, args: ParsedArgs): Promise<number> {
   // line. JSON path emits the same data with snake_case fields so
   // orchestrators can reflect on identity / role / actor_source /
   // recent utterances without parsing prose.
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const resolved = resolveGuildActorWithSource();
   if (!resolved) {
     if (format === 'json') {
@@ -505,10 +494,7 @@ const CHAIN_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, CHAIN_KNOWN_FLAGS, 'chain');
   maybeEmitExplain(args, 'chain');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const rootId = args.positional[0];
   if (!rootId) {
     throw new Error('Usage: gate chain <request-id | issue-id>');

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -8,6 +8,7 @@ import {
 import { C } from './internal.js';
 import { MemberName } from '../../../domain/member/MemberName.js';
 import { parseMemberCategory } from '../../../domain/member/MemberCategory.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const REGISTER_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'name',
@@ -53,10 +54,7 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
   const category = optionalOption(args, 'category') ?? 'professional';
   const displayName = optionalOption(args, 'display-name');
   const dryRun = args.options['dry-run'] === true || args.options['dry-run'] === '';
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   // Host assignment is intentionally a guild.config.yaml concern,
   // not a CLI-drive-by. Block it here with an explicit message

--- a/src/interface/gate/handlers/requestReads.ts
+++ b/src/interface/gate/handlers/requestReads.ts
@@ -23,6 +23,7 @@ import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import { C, truncateCodePoints } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 // `gate list` and `gate pending` share `reqList`. pending only takes
 // `--for`; list adds the four narrowing filters. The list set is the
@@ -110,10 +111,7 @@ export async function reqList(
   // the state being listed (informational for both list and pending) and
   // any active filter so a JSON consumer sees what the stderr notice
   // shows to humans.
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   // The "filtered by GUILD_ACTOR=..." stderr notice exists so a *human*
   // reading text output knows why their result set is implicitly
@@ -202,7 +200,7 @@ export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
   const plain = args.options['plain'] === true;
   const format = optionalOption(args, 'format') ?? (plain ? 'plain' : 'json');
   if (format !== 'json' && format !== 'text' && format !== 'plain') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
+    throw new Error(`--format must be 'json', 'text', or 'plain', got: ${format}`);
   }
   const r = await c.requestUC.show(id);
   if (!r) {

--- a/src/interface/gate/handlers/resume.ts
+++ b/src/interface/gate/handlers/resume.ts
@@ -22,6 +22,7 @@ import {
   DiagnosticFinding,
 } from '../../../domain/diagnostic/DiagnosticReport.js';
 import { RepairResult } from '../../../application/repair/RepairUseCases.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 /**
  * #306 — `--with-doctor` augments the resume payload with a
@@ -177,10 +178,7 @@ interface ResumePayload {
 
 export async function resumeCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, RESUME_KNOWN_FLAGS, 'resume');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args, 'json');
   const withDoctor = args.options['with-doctor'] === true;
   const autoRepair = args.options['auto-repair'] === true;
   if (autoRepair && !withDoctor) {

--- a/src/interface/gate/handlers/reviewContext.ts
+++ b/src/interface/gate/handlers/reviewContext.ts
@@ -22,6 +22,7 @@ import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
 import { RequestDepth } from '../../../domain/request/RequestDepth.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const REVIEW_CONTEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -112,10 +113,7 @@ export async function reviewContextCmd(c: C, args: ParsedArgs): Promise<number> 
   if (!id) {
     throw new Error('Usage: gate review-context <id> [--format text|json]');
   }
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
     process.stderr.write(notFoundMessage('request', id));

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -4,6 +4,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb', 'voice']);
 
@@ -2227,10 +2228,7 @@ const VERBS: readonly VerbSchema[] = [
 
 export async function schemaCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SCHEMA_KNOWN_FLAGS, 'schema');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args, 'json');
   const verbFilter = optionalOption(args, 'verb');
   // Plugin verbs (#36 Phase 1 step 4) are spliced into the schema
   // payload as siblings of built-ins. They carry `source: 'plugin'`

--- a/src/interface/gate/handlers/selfPattern.ts
+++ b/src/interface/gate/handlers/selfPattern.ts
@@ -27,6 +27,7 @@ import {
 import { C } from './internal.js';
 import { parseDuration } from './lenseStats.js';
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const SELF_PATTERN_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'for',
@@ -70,15 +71,12 @@ export async function selfPatternCmd(c: C, args: ParsedArgs): Promise<number> {
   const forActor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
   if (!forActor) {
     throw new Error(
-      'gate self-pattern: --for <actor> is required when GUILD_ACTOR is not set.' +
+      '--for <actor> is required when GUILD_ACTOR is not set.' +
         '\n  next: pass --for <name>, or `export GUILD_ACTOR=<you>` once per shell.',
     );
   }
   const sinceRaw = optionalOption(args, 'since') ?? '7d';
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const now = new Date();
   const sinceMs = parseDuration(sinceRaw);

--- a/src/interface/gate/handlers/status.ts
+++ b/src/interface/gate/handlers/status.ts
@@ -6,6 +6,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { Request } from '../../../domain/request/Request.js';
 import { C, warnIfMisconfiguredCwd } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set(['for', 'format']);
 
@@ -173,11 +174,7 @@ function renderStatusText(s: StatusSummary): string {
 export async function statusCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, STATUS_KNOWN_FLAGS, 'status');
   const actor = optionalOption(args, 'for') ?? resolveGuildActor() ?? null;
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args, 'json');
 
   const all = await c.requestUC.listAll();
   const summary = collectStatus(all, actor);

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -6,6 +6,7 @@ import {
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
 import { deriveBootSuggestedNext, BootSuggestedNext } from './boot.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -37,10 +38,7 @@ interface SuggestPayload {
 
 export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SUGGEST_KNOWN_FLAGS, 'suggest');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args, 'json');
 
   const envActor = resolveGuildActor();
   const actor = envActor && envActor.length > 0 ? envActor : null;

--- a/src/interface/gate/handlers/summarize.ts
+++ b/src/interface/gate/handlers/summarize.ts
@@ -6,6 +6,7 @@ import {
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const SUMMARIZE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -42,10 +43,7 @@ export async function summarizeCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SUMMARIZE_KNOWN_FLAGS, 'summarize');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate summarize <id> [--format text|json]');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
     process.stderr.write(notFoundMessage('request', id));

--- a/src/interface/gate/handlers/swarmStatus.ts
+++ b/src/interface/gate/handlers/swarmStatus.ts
@@ -28,6 +28,7 @@ import {
   WaveStatusPayload,
 } from './waveStatus.js';
 import { computeActiveOverlappingTargets } from './bootActionable.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const SWARM_STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'orchestrating',
@@ -110,10 +111,7 @@ export async function swarmStatusCmd(
   args: ParsedArgs,
 ): Promise<number> {
   rejectUnknownFlags(args, SWARM_STATUS_KNOWN_FLAGS, 'swarm-status');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const orchestratingFlag = optionalOption(args, 'orchestrating') ?? null;
   const explicitFor = optionalOption(args, 'for') ?? null;
   // GUILD_ACTOR fallback: when neither flag is set and env is set, default

--- a/src/interface/gate/handlers/templates.ts
+++ b/src/interface/gate/handlers/templates.ts
@@ -14,6 +14,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const TEMPLATES_LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 const TEMPLATES_SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
@@ -51,10 +52,7 @@ function shiftPositional(args: ParsedArgs): ParsedArgs {
 
 async function templatesList(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, TEMPLATES_LIST_KNOWN_FLAGS, 'templates list');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const items = c.templateUC.list();
   const exists = c.templateUC.registryExists();
   const dir = c.templateUC.registryDir();
@@ -125,10 +123,7 @@ async function templatesShow(c: C, args: ParsedArgs): Promise<number> {
       'Usage: gate templates show <name> [--format json|text]',
     );
   }
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const t = c.templateUC.show(name);
   if (!t) {
     const available = c.templateUC.list().map((s) => s.name);

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -6,6 +6,7 @@ import {
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const TRANSCRIPT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -59,10 +60,7 @@ export async function transcriptCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, TRANSCRIPT_KNOWN_FLAGS, 'transcript');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate transcript <id> [--format text|json]');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
     process.stderr.write(notFoundMessage('request', id));

--- a/src/interface/gate/handlers/unresponded.ts
+++ b/src/interface/gate/handlers/unresponded.ts
@@ -5,6 +5,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C, parseOptionalIntOption } from './internal.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   DEFAULT_MAX_AGE_DAYS,
   UnrespondedConcernsEntry,
@@ -59,10 +60,7 @@ export async function unrespondedCmd(
   // silently falling back to the 30-day default would be the
   // exact fail-open shape this guard exists to prevent.
   rejectUnknownFlags(args, UNRESPONDED_KNOWN_FLAGS, 'unresponded');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const explicit = optionalOption(args, 'for');
   const envActor = resolveGuildActor();

--- a/src/interface/gate/handlers/voice.ts
+++ b/src/interface/gate/handlers/voice.ts
@@ -34,6 +34,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { maybeEmitExplain } from '../../shared/explain.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   VOICE_MODE_FILE,
   resolveActiveVoiceName,
@@ -45,10 +46,7 @@ const VOICE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 export async function voiceCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, VOICE_KNOWN_FLAGS, 'voice');
   maybeEmitExplain(args, 'voice');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${format}`);
-  }
+  const format = parseFormat(args);
 
   const arg = args.positional[0];
   const filePath = join(c.config.contentRoot, VOICE_MODE_FILE);

--- a/src/interface/gate/handlers/waveStatus.ts
+++ b/src/interface/gate/handlers/waveStatus.ts
@@ -32,6 +32,7 @@ import {
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const WAVE_STATUS_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -129,10 +130,7 @@ export async function waveStatusCmd(c: C, args: ParsedArgs): Promise<number> {
   if (!id) {
     throw new Error('Usage: gate wave-status <id> [--format text|json]');
   }
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
     process.stderr.write(notFoundMessage('request', id));

--- a/src/interface/gate/handlers/why.ts
+++ b/src/interface/gate/handlers/why.ts
@@ -6,6 +6,7 @@ import {
 import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const WHY_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -55,10 +56,7 @@ export async function whyCmd(c: C, args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, WHY_KNOWN_FLAGS, 'why');
   const id = args.positional[0];
   if (!id) throw new Error('Usage: gate why <id> [--format text|json]');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'text' && format !== 'json') {
-    throw new Error(`--format must be 'text' or 'json', got: ${format}`);
-  }
+  const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
     process.stderr.write(notFoundMessage('request', id));

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -1,19 +1,19 @@
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import { Request } from '../../../domain/request/Request.js';
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
-import { ParsedArgs, optionalOption } from '../../shared/parseArgs.js';
+import { ParsedArgs } from '../../shared/parseArgs.js';
+import { parseFormat as parseFormatShared } from '../../shared/parseFormat.js';
 
 /**
- * Shared `--format <json|text>` parser so every write handler validates
- * the value identically. Text is the default to keep the `✓ ...`
- * muscle memory intact for humans; agents opt into json explicitly.
+ * Re-export of the shared `--format` parser. Kept as a named export
+ * here for backwards-compatibility with the many gate write-handlers
+ * that import it from this module; new code should pull from
+ * `interface/shared/parseFormat.js` directly. Text is the default to
+ * keep the `✓ ...` muscle memory intact for humans; agents opt into
+ * json explicitly.
  */
 export function parseFormat(args: ParsedArgs): 'json' | 'text' {
-  const raw = optionalOption(args, 'format') ?? 'text';
-  if (raw !== 'json' && raw !== 'text') {
-    throw new Error(`--format must be 'json' or 'text', got: ${raw}`);
-  }
-  return raw;
+  return parseFormatShared(args);
 }
 
 /**

--- a/src/interface/shared/parseFormat.ts
+++ b/src/interface/shared/parseFormat.ts
@@ -1,0 +1,57 @@
+// parseFormat — shared `--format <json|text>` parser.
+//
+// Before this helper: 40+ handlers across gate / agora / devil / ctx
+// each inlined the same 4-line validation:
+//
+//   const format = optionalOption(args, 'format') ?? 'text';
+//   if (format !== 'json' && format !== 'text') {
+//     process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
+//     return 1;
+//   }
+//
+// Two issues with the inline form:
+//   1. Drift surface — 40+ places to keep aligned. Changing the
+//      message (e.g. adding a yaml mode later) is a 40-file edit.
+//   2. The inline `stderr.write + return 1` shape bypasses the
+//      passage's outer-catch which already routes through
+//      `emitErrorEnvelope`. JSON-mode callers got plain text back
+//      from the validation while every OTHER error in the same
+//      handler returned a structured envelope. Inconsistency.
+//
+// This helper collapses the call site to one line:
+//
+//   const format = parseFormat(args);   // or parseFormat(args, 'json') for json-default verbs
+//
+// The throw path goes through the passage's outer-catch and produces
+// the same structured envelope as any other DomainError — JSON
+// consumers now get `{"ok":false,"error":{"message":"...","field":"format","code":"validation_error"}}`
+// for free.
+
+import { ParsedArgs, optionalOption } from './parseArgs.js';
+import { DomainError } from '../../domain/shared/DomainError.js';
+
+export type Format = 'json' | 'text';
+
+/**
+ * Parse and validate `--format` from CLI args.
+ *
+ * Throws `DomainError(field='format')` on invalid input — caught by
+ * the passage's outer error envelope (no per-handler try/catch
+ * required).
+ *
+ * @param args            parsed argv
+ * @param defaultFormat   format to use when `--format` is omitted
+ *                        (most read/list verbs default to 'text';
+ *                        agent-loop verbs like `gate boot` /
+ *                        `gate schema` / `gate status` default to
+ *                        'json' so the agent's first call gets a
+ *                        machine-parseable response without an
+ *                        extra flag).
+ */
+export function parseFormat(args: ParsedArgs, defaultFormat: Format = 'text'): Format {
+  const raw = optionalOption(args, 'format') ?? defaultFormat;
+  if (raw !== 'json' && raw !== 'text') {
+    throw new DomainError(`--format must be 'json' or 'text', got: ${raw}`, 'format');
+  }
+  return raw;
+}

--- a/src/passages/agora/interface/handlers/cliff.ts
+++ b/src/passages/agora/interface/handlers/cliff.ts
@@ -8,6 +8,7 @@ import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
 import { parsePlayId } from '../../domain/Play.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const CLIFF_KNOWN_FLAGS: ReadonlySet<string> = new Set(['game', 'format']);
 
@@ -61,11 +62,7 @@ export async function cliffOf(deps: CliffDeps, args: ParsedArgs): Promise<number
   const playId = parsePlayId(positional);
 
   const gameFilter = optionalOption(args, 'game');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   // resolvePlayForVerb throws PlayIdAmbiguous on cross-game collision
   // (#205); the entry-point's outer catch surfaces it through

--- a/src/passages/agora/interface/handlers/conclude.ts
+++ b/src/passages/agora/interface/handlers/conclude.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const CONCLUDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'note',
@@ -59,11 +60,7 @@ export async function concludePlay(
   }
   const note = optionalOption(args, 'note');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const gameFilter = optionalOption(args, 'game');
   const play = await resolvePlayForVerb(deps.plays, playId, gameFilter);

--- a/src/passages/agora/interface/handlers/last.ts
+++ b/src/passages/agora/interface/handlers/last.ts
@@ -7,6 +7,7 @@ import {
   requireOption,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const LAST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -74,11 +75,7 @@ export async function lastPlay(deps: LastDeps, args: ParsedArgs): Promise<number
   }
 
   const includeConcluded = args.options['include-concluded'] === true;
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   let plays: Play[] = await deps.plays.listAll();
   // started_by is the canonical "whose play is this" field.

--- a/src/passages/agora/interface/handlers/list.ts
+++ b/src/passages/agora/interface/handlers/list.ts
@@ -8,6 +8,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'game',
@@ -55,11 +56,7 @@ export async function listAgora(deps: ListDeps, args: ParsedArgs): Promise<numbe
     );
     return 1;
   }
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   // Games: omitted when --game is set (narrowed to a single game's
   // plays; the games list would be one row, not useful).

--- a/src/passages/agora/interface/handlers/move.ts
+++ b/src/passages/agora/interface/handlers/move.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const MOVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
@@ -51,11 +52,7 @@ export async function moveOnPlay(deps: MoveDeps, args: ParsedArgs): Promise<numb
   }
   const text = requireOption(args, 'text', '"..."');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const gameFilter = optionalOption(args, 'game');
   const play = await resolvePlayForVerb(deps.plays, playId, gameFilter);

--- a/src/passages/agora/interface/handlers/new.ts
+++ b/src/passages/agora/interface/handlers/new.ts
@@ -4,6 +4,7 @@ import { ParsedArgs, optionalOption, requireOption, rejectUnknownFlags } from '.
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { sanitizeError } from '../../../../interface/shared/sanitizeError.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const NEW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'slug',
@@ -48,11 +49,7 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
   const title = optionalOption(args, 'title') ?? slug;
   const description = optionalOption(args, 'description');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   let game: Game;
   try {
@@ -127,13 +124,19 @@ export async function newGame(deps: NewGameDeps, args: ParsedArgs): Promise<numb
         `  next: agora play --slug ${game.slug}  (or agora list to see all games)\n`,
     );
   }
-  // Stderr notice mirrors gate register's path-disclosure line shape
-  // (principle 09): one canonical line surface across all create-style
-  // verbs in any passage.
-  const configSegment =
-    deps.config.configFile === null
-      ? 'config: none — cwd used as fallback root'
-      : `config: ${deps.config.configFile}`;
-  process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  // Stderr notice mirrors the path-disclosure line shape used across
+  // create-style verbs in agora / devil / ctx (principle 09). Suppressed
+  // in JSON mode because `where_written` and `config_file` are already
+  // emitted in the stdout envelope above — re-printing them on stderr
+  // is pure context pollution for the AI consumer. Text-mode readers
+  // still get the disclosure since the stdout `✓ created` line doesn't
+  // carry the path.
+  if (format !== 'json') {
+    const configSegment =
+      deps.config.configFile === null
+        ? 'config: none — cwd used as fallback root'
+        : `config: ${deps.config.configFile}`;
+    process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  }
   return 0;
 }

--- a/src/passages/agora/interface/handlers/play.ts
+++ b/src/passages/agora/interface/handlers/play.ts
@@ -8,6 +8,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const PLAY_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'slug',
@@ -44,11 +45,7 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
 
   const slug = requireOption(args, 'slug', '<game-slug>');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const game = await deps.games.findBySlug(slug);
   if (!game) {
@@ -103,10 +100,15 @@ export async function startPlay(deps: PlayDeps, args: ParsedArgs): Promise<numbe
         `        or agora suspend ${play.id} --game ${play.game} --cliff "..." --invitation "..."  (leave a cliff)\n`,
     );
   }
-  const configSegment =
-    deps.config.configFile === null
-      ? 'config: none — cwd used as fallback root'
-      : `config: ${deps.config.configFile}`;
-  process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  // path-disclosure line: text-mode only. JSON consumers already have
+  // `where_written` / `config_file` in the stdout envelope, so re-emitting
+  // them on stderr is pure context pollution.
+  if (format !== 'json') {
+    const configSegment =
+      deps.config.configFile === null
+        ? 'config: none — cwd used as fallback root'
+        : `config: ${deps.config.configFile}`;
+    process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  }
   return 0;
 }

--- a/src/passages/agora/interface/handlers/resume.ts
+++ b/src/passages/agora/interface/handlers/resume.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'note',
@@ -56,11 +57,7 @@ export async function resumePlay(deps: ResumeDeps, args: ParsedArgs): Promise<nu
   }
   const note = optionalOption(args, 'note');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const gameFilter = optionalOption(args, 'game');
   const play = await resolvePlayForVerb(deps.plays, playId, gameFilter);

--- a/src/passages/agora/interface/handlers/schema.ts
+++ b/src/passages/agora/interface/handlers/schema.ts
@@ -4,6 +4,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb']);
 
@@ -437,11 +438,7 @@ const VERBS: readonly VerbSchema[] = [
 export async function schemaCmd(args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SCHEMA_KNOWN_FLAGS, 'schema');
   const verbFilter = optionalOption(args, 'verb');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args, 'json');
   const verbs = verbFilter ? VERBS.filter((v) => v.name === verbFilter) : VERBS;
   if (verbFilter && verbs.length === 0) {
     // Throw rather than write+return so the entry-point envelope

--- a/src/passages/agora/interface/handlers/show.ts
+++ b/src/passages/agora/interface/handlers/show.ts
@@ -10,6 +10,7 @@ import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'game',
@@ -57,11 +58,7 @@ export async function showAgora(deps: ShowDeps, args: ParsedArgs): Promise<numbe
     return 1;
   }
   const gameFilter = optionalOption(args, 'game');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   if (PLAY_ID_PATTERN.test(arg)) {
     return await showPlay(deps, arg, gameFilter, format);

--- a/src/passages/agora/interface/handlers/suspend.ts
+++ b/src/passages/agora/interface/handlers/suspend.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { resolvePlayForVerb } from './resolvePlay.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SUSPEND_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'cliff',
@@ -62,11 +63,7 @@ export async function suspendPlay(
   const cliff = requireOption(args, 'cliff', '"<what just happened>"');
   const invitation = requireOption(args, 'invitation', '"<next opener\'s move>"');
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const gameFilter = optionalOption(args, 'game');
   const play = await resolvePlayForVerb(deps.plays, playId, gameFilter);

--- a/src/passages/ctx/interface/handlers/record.ts
+++ b/src/passages/ctx/interface/handlers/record.ts
@@ -1,5 +1,6 @@
 import { CtxUseCases } from '../../application/CtxUseCases.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 import {
   ParsedArgs,
   optionalOption,
@@ -53,11 +54,7 @@ export async function recordCtx(
   const fact = requireOption(args, 'fact', '"..."');
   const tags = parseTagList(optionalOption(args, 'tag'));
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const ctx = await deps.uc.record({ by, fact, tags });
 

--- a/src/passages/devil/interface/handlers/conclude.ts
+++ b/src/passages/devil/interface/handlers/conclude.ts
@@ -15,6 +15,7 @@ import {
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const CONCLUDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'synthesis',
@@ -90,11 +91,7 @@ export async function concludeReview(
     : [];
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/src/passages/devil/interface/handlers/dismiss.ts
+++ b/src/passages/devil/interface/handlers/dismiss.ts
@@ -19,6 +19,7 @@ import {
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const DISMISS_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'reason',
@@ -83,11 +84,7 @@ export async function dismissEntry(
   const note = optionalOption(args, 'note');
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/src/passages/devil/interface/handlers/entry.ts
+++ b/src/passages/devil/interface/handlers/entry.ts
@@ -28,6 +28,7 @@ import {
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const ENTRY_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'persona',
@@ -109,11 +110,7 @@ export async function entryOnReview(
   const text = requireOption(args, 'text', '"..."');
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   // Catalog resolution. Throw structured errors so the dispatcher
   // surfaces them as named failures rather than generic message text.

--- a/src/passages/devil/interface/handlers/ingest.ts
+++ b/src/passages/devil/interface/handlers/ingest.ts
@@ -27,6 +27,7 @@ import {
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const INGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'from',
@@ -195,11 +196,7 @@ export async function ingestSource(
   }
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   // Read + parse input.
   let raw: unknown;

--- a/src/passages/devil/interface/handlers/list.ts
+++ b/src/passages/devil/interface/handlers/list.ts
@@ -6,6 +6,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'state',
@@ -53,11 +54,7 @@ export async function listReviews(deps: ListDeps, args: ParsedArgs): Promise<num
     targetTypeFilter = parseTargetType(typeRaw);
   }
 
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const all = await deps.reviews.listAll();
   const filtered = all.filter(

--- a/src/passages/devil/interface/handlers/open.ts
+++ b/src/passages/devil/interface/handlers/open.ts
@@ -7,6 +7,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const OPEN_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'type',
@@ -64,11 +65,7 @@ export async function openReview(deps: OpenDeps, args: ParsedArgs): Promise<numb
   const type = parseTargetType(typeRaw);
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   // Allocate sequence: rev-YYYY-MM-DD-NNN. The dateKey comes from the
   // runtime clock — same source pattern as agora play and gate
@@ -119,10 +116,14 @@ export async function openReview(deps: OpenDeps, args: ParsedArgs): Promise<numb
         `        or devil ingest ${review.id} --from <ultrareview|claude-security|scg> <input>\n`,
     );
   }
-  const configSegment =
-    deps.config.configFile === null
-      ? 'config: none — cwd used as fallback root'
-      : `config: ${deps.config.configFile}`;
-  process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  // path-disclosure line: text-mode only. JSON consumers already have
+  // `where_written` / `config_file` in the stdout envelope.
+  if (format !== 'json') {
+    const configSegment =
+      deps.config.configFile === null
+        ? 'config: none — cwd used as fallback root'
+        : `config: ${deps.config.configFile}`;
+    process.stderr.write(`notice: wrote ${where_written} (${configSegment})\n`);
+  }
   return 0;
 }

--- a/src/passages/devil/interface/handlers/resolve.ts
+++ b/src/passages/devil/interface/handlers/resolve.ts
@@ -14,6 +14,7 @@ import {
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { emitErrorEnvelope } from '../../../../interface/shared/errorEnvelope.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const RESOLVE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'commit',
@@ -75,11 +76,7 @@ export async function resolveEntry(
   }
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/src/passages/devil/interface/handlers/resume.ts
+++ b/src/passages/devil/interface/handlers/resume.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const RESUME_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'note',
@@ -69,11 +70,7 @@ export async function resumeReview(
   const note = optionalOption(args, 'note');
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/src/passages/devil/interface/handlers/schema.ts
+++ b/src/passages/devil/interface/handlers/schema.ts
@@ -4,6 +4,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SCHEMA_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format', 'verb']);
 
@@ -512,11 +513,7 @@ const VERBS: readonly VerbSchema[] = [
 export async function schemaCmd(args: ParsedArgs): Promise<number> {
   rejectUnknownFlags(args, SCHEMA_KNOWN_FLAGS, 'schema');
   const verbFilter = optionalOption(args, 'verb');
-  const format = optionalOption(args, 'format') ?? 'json';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args, 'json');
   const verbs = verbFilter ? VERBS.filter((v) => v.name === verbFilter) : VERBS;
   if (verbFilter && verbs.length === 0) {
     // Throw rather than write+return so the entry-point envelope

--- a/src/passages/devil/interface/handlers/show.ts
+++ b/src/passages/devil/interface/handlers/show.ts
@@ -7,6 +7,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
@@ -39,11 +40,7 @@ export async function showReview(deps: ShowDeps, args: ParsedArgs): Promise<numb
   }
   parseReviewId(reviewId); // domain format check (throws DomainError)
 
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/src/passages/devil/interface/handlers/suspend.ts
+++ b/src/passages/devil/interface/handlers/suspend.ts
@@ -12,6 +12,7 @@ import {
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
 import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
 
 const SUSPEND_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'cliff',
@@ -73,11 +74,7 @@ export async function suspendReview(
   const invitation = requireOption(args, 'invitation', '"<next opener\'s move>"');
 
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
-  const format = optionalOption(args, 'format') ?? 'text';
-  if (format !== 'json' && format !== 'text') {
-    process.stderr.write(`error: --format must be 'json' or 'text', got: ${format}\n`);
-    return 1;
-  }
+  const format = parseFormat(args);
 
   const review = await deps.reviews.findById(reviewId);
   if (!review) throw new DevilReviewNotFound(reviewId);

--- a/tests/interface/chainFormatAndCrossPassage.test.ts
+++ b/tests/interface/chainFormatAndCrossPassage.test.ts
@@ -132,7 +132,7 @@ test('gate chain --format unknown is rejected with a clear error', (t) => {
   const reqId = seedGateRequestMentioning(root, playId);
   const r = runBin(GATE, root, ['chain', reqId, '--format', 'yaml']);
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
 });
 
 test('agora play id present in multiple games surfaces every match', (t) => {

--- a/tests/interface/issuesListSurface.test.ts
+++ b/tests/interface/issuesListSurface.test.ts
@@ -234,5 +234,5 @@ test('gate issues list --format bogus errors', (t) => {
     { GUILD_ACTOR: 'alice' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
 });

--- a/tests/interface/messageSurface.test.ts
+++ b/tests/interface/messageSurface.test.ts
@@ -261,5 +261,5 @@ test('gate inbox --format bogus errors with format validation', (t) => {
     { GUILD_ACTOR: 'alice' },
   );
   assert.notEqual(r.status, 0);
-  assert.match(r.stderr, /--format must be 'text' or 'json'/);
+  assert.match(r.stderr, /--format must be 'json' or 'text'/);
 });

--- a/tests/passages/agora/new.test.ts
+++ b/tests/passages/agora/new.test.ts
@@ -136,9 +136,12 @@ test('agora new: JSON mode emits snake_case envelope with where_written + config
   for (const key of Object.keys(payload)) {
     assert.ok(!/[A-Z]/.test(key), `envelope key "${key}" must be snake_case`);
   }
-  // Stderr notice fires in JSON mode too — humans reading stderr see
-  // the path even when stdout is machine-bound. Same shape as text.
-  assert.match(r.stderr, /^notice: wrote /);
+  // JSON mode: stderr notice is suppressed because the path
+  // (`where_written`) and config file (`config_file`) are already in
+  // the structured stdout envelope; re-emitting them on stderr is pure
+  // context pollution for AI consumers. Text-mode callers still get
+  // the disclosure (verified by the prior test).
+  assert.doesNotMatch(r.stderr, /^notice: wrote /m);
 });
 
 test('agora new: --description optional; omitted when empty; preserved when provided', (t) => {


### PR DESCRIPTION
## Summary

Three eris-first / context-pollution polish items surfaced during a
gate/agora audit (post-#396):

1. **Shared `parseFormat` helper** — `src/interface/shared/parseFormat.ts`
   replaces **55 inline `if format !== json && format !== text` blocks**
   across gate / agora / devil / ctx. Helper throws
   `DomainError(field='format')` so JSON-mode callers get the
   structured envelope, matching every other error in the same
   handler. **Net −134 LOC**; drift surface collapses to one.

2. **`notice: wrote <path>` suppressed in JSON mode** for `agora new`,
   `agora play`, `devil open`. The path was already in the stdout
   envelope (`where_written` + `config_file`); re-emitting on stderr
   burned tool-result context for AI consumers without adding any
   info. Text-mode readers still get the disclosure. `ctx record`
   was already gated correctly inside its `else` branch.

3. **Error prefix unified to `error: <msg>`** across `gate next`,
   `gate self-pattern`, `gate decisions`. Removes the doubled prologue
   `error: gate <verb>: …` that surfaced when handler-thrown errors
   passed through the outer-catch envelope. `^error:` is now a
   reliable machine-grep across all verbs; `next:` recovery hints
   remain for humans.

Eris-first framing: items 2 and 3 are pure context-pollution wins
(fewer stderr lines / cleaner prefix for AI consumers); item 1 is a
drift-surface collapse + parity win (JSON envelope on format errors
where previously only plain text was emitted).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1765/1765 pass
- [x] `node bin/gate.mjs boot --format=bogus` → `error: --format must be 'json' or 'text', got: bogus`, exit 1
- [x] `node bin/gate.mjs boot --format=json` → valid JSON to stdout
- [x] `node bin/agora.mjs list --format=bogus` → same `error:` envelope (uniform across passages)
- [x] `node bin/gate.mjs self-pattern` (no GUILD_ACTOR) → `error: --for <actor> is required…`, single prefix
- [ ] Manual: `agora new --format=json` does not emit `notice: wrote` on stderr

## Files touched

- new: `src/interface/shared/parseFormat.ts` (~60 LOC, mostly doc)
- modified: 55 handler files (mostly 4-line block → 1-line call)
- modified: 4 test files (assertion message order + JSON-mode notice expectation)
- new: `.changelog/next/changed-parsefor-and-notice-and-prefix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)