### PR TITLE
chore(interface): remove writeFormat.ts parseFormat shim

### DIFF
--- a/.changelog/next/changed-writeformat-shim-removal.md
+++ b/.changelog/next/changed-writeformat-shim-removal.md
@@ -1,0 +1,8 @@
+- **`writeFormat.ts:parseFormat` re-export shim removed.** PR #397
+  introduced `src/interface/shared/parseFormat.ts` as the canonical
+  parser and left a single-line re-export in `writeFormat.ts` so the
+  9 write-side handlers that pull `parseFormat` from there didn't
+  need touching in the same PR. This PR finishes the move: those 9
+  handlers now import from `../../shared/parseFormat.js` directly,
+  the shim is gone. Single import path for one symbol — no
+  divergence risk if either side changes signature.

--- a/src/interface/gate/handlers/claim.ts
+++ b/src/interface/gate/handlers/claim.ts
@@ -5,7 +5,8 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C, isDryRun, emitDryRunPreview } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { resolveGuildSessionId } from '../../shared/resolveGuildSessionId.js';
 
 // Issue #226 phase 1 — cross-session stake claim.

--- a/src/interface/gate/handlers/farewell.ts
+++ b/src/interface/gate/handlers/farewell.ts
@@ -5,7 +5,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
-import { parseFormat } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   fireBeforeSessionHook,
   fireAfterSessionHook,

--- a/src/interface/gate/handlers/request.ts
+++ b/src/interface/gate/handlers/request.ts
@@ -34,7 +34,8 @@ import {
   resolveInvokedBy,
   normalizeActor,
 } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { renderVoice } from '../../shared/voiceRender.js';
 
 // Known flags per write-verb. Silent-ignore of unknown flags (e.g.

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -30,7 +30,8 @@ import {
   emitDryRunPreview,
   normalizeActor,
 } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { RecoverableError } from '../../shared/errorEnvelope.js';
 import { renderVoice } from '../../shared/voiceRender.js';
 

--- a/src/interface/gate/handlers/rest.ts
+++ b/src/interface/gate/handlers/rest.ts
@@ -5,7 +5,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
-import { parseFormat } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   fireBeforeSessionHook,
   fireAfterSessionHook,

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -13,7 +13,8 @@ import {
   emitDryRunPreview,
   normalizeActor,
 } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { renderVoice } from '../../shared/voiceRender.js';
 import {
   fireBeforeHook,

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -12,7 +12,8 @@ import {
   emitDryRunPreview,
   normalizeActor,
 } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 
 const THANK_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'for',

--- a/src/interface/gate/handlers/wake.ts
+++ b/src/interface/gate/handlers/wake.ts
@@ -5,7 +5,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
-import { parseFormat } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import {
   fireBeforeSessionHook,
   fireAfterSessionHook,

--- a/src/interface/gate/handlers/witness.ts
+++ b/src/interface/gate/handlers/witness.ts
@@ -5,7 +5,8 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C, isDryRun, emitDryRunPreview } from './internal.js';
-import { emitWriteResponse, parseFormat } from './writeFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
+import { parseFormat } from '../../shared/parseFormat.js';
 import { resolveGuildSessionId } from '../../shared/resolveGuildSessionId.js';
 
 // Issue #244 (#226 phase 2) — non-exclusive cross-session observer.

--- a/src/interface/gate/handlers/writeFormat.ts
+++ b/src/interface/gate/handlers/writeFormat.ts
@@ -1,20 +1,6 @@
 import { resolveGuildActor } from '../../shared/resolveGuildActor.js';
 import { Request } from '../../../domain/request/Request.js';
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
-import { ParsedArgs } from '../../shared/parseArgs.js';
-import { parseFormat as parseFormatShared } from '../../shared/parseFormat.js';
-
-/**
- * Re-export of the shared `--format` parser. Kept as a named export
- * here for backwards-compatibility with the many gate write-handlers
- * that import it from this module; new code should pull from
- * `interface/shared/parseFormat.js` directly. Text is the default to
- * keep the `✓ ...` muscle memory intact for humans; agents opt into
- * json explicitly.
- */
-export function parseFormat(args: ParsedArgs): 'json' | 'text' {
-  return parseFormatShared(args);
-}
 
 /**
  * Structured write-side response for agent-first consumers.


### PR DESCRIPTION
## Summary

Follow-up to #397. The re-export shim
`writeFormat.ts:parseFormat → shared/parseFormat.ts:parseFormat`
existed only to spare 9 write-handlers from same-PR churn. This
sweep removes it:

- 9 handlers (wake, thank, claim, requestLifecycle, rest, witness,
  review, request, farewell) now import \`parseFormat\` from
  \`'../../shared/parseFormat.js'\` directly
- 1-line shim in \`writeFormat.ts\` deleted (along with its unused
  \`ParsedArgs\` / \`parseFormatShared\` imports)

One symbol, one import path. Drift surface gone.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1759/1759 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)