### PR TITLE
polish(stderr): gate success-path notices in JSON mode (audit follow-up)

### DIFF
--- a/.changelog/next/changed-stderr-notice-json-gating.md
+++ b/.changelog/next/changed-stderr-notice-json-gating.md
@@ -1,0 +1,36 @@
+- **Success-path stderr notices now suppressed in JSON mode** for
+  `gate approve`, `gate execute`, `gate review`, `gate thank`. The
+  notices (self-approve / executor-assignment mismatch / self-review
+  / `--comment` deprecation hint / self-thank) carry information that
+  JSON consumers can already detect structurally from the envelope
+  (`by` / `from` / `executors[].name` fields), so re-emitting prose
+  on stderr was pure context pollution for AI consumers. Text-mode
+  readers still get the disclosure unchanged.
+  - `gate approve --by X` where `X == request.from`, profile-feature
+    `selfApprove: warn` → notice (text only)
+  - `gate execute --by X` where `X` is not in the assigned executors
+    list → notice (text only); message updated from
+    `--executor records intent` to `--executors records intent`
+    (singular flag was removed in #398)
+  - `gate review --by X` where `X == request.from` → ⚠ self-review
+    (text only)
+  - `gate review --comment <s>` → deprecation hint (text only)
+  - `gate thank X --to X` → self-thank notice (text only)
+
+  Audit follow-up to #397 (which handled `notice: wrote <path>` in
+  agora new/play, devil open). Same eris-first principle: stderr on
+  success paths should not carry prose that's already in the JSON
+  envelope.
+
+  Out of scope (kept as-is):
+  - `gate message` self-message / inactive-recipient notices: this
+    verb has no JSON output mode at all, so stderr is the only
+    signal channel.
+  - `gate next` setup-failure notices: those are error paths, not
+    success-path notices; they need a separate parity refactor
+    (route through `emitErrorEnvelope` for JSON consumers) covered
+    by a future PR.
+  - `errorEnvelope.ts` JSON-on-stderr write: that's the contract
+    (JSON consumers parse stderr for the envelope), not pollution.
+  - `(explain: ...)`: opt-in via `--explain`, caller asked for it.
+  - `⟶ <voice>`: text-mode-only ornament by design (#382).

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -127,15 +127,22 @@ export async function reqApprove(c: C, args: ParsedArgs): Promise<number> {
   // Self-approval notice. Suppressed under `allowed` (deployments that
   // actively rely on self-approve and don't want the audit line).
   // Preserved under `warn` — the historical default — so the
-  // no-second-pair-of-eyes case never happens silently.
-  if (by === r.from.value && c.config.features.selfApprove === 'warn') {
+  // no-second-pair-of-eyes case never happens silently. Text mode
+  // only: JSON consumers have `by` and `from` in the envelope and can
+  // detect the self-edge structurally without 3 lines of prose.
+  const format = parseFormat(args);
+  if (
+    by === r.from.value &&
+    c.config.features.selfApprove === 'warn' &&
+    format !== 'json'
+  ) {
     process.stderr.write(
       `notice: ${by} approved their own request ${id} ` +
         `(no second reviewer; for a single-step self-flow use ` +
         `'gate fast-track').\n`,
     );
   }
-  emitWriteResponse(parseFormat(args), r, `✓ approved: ${id}`, c.config, [], {
+  emitWriteResponse(format, r, `✓ approved: ${id}`, c.config, [], {
     voice: renderVoice(c.voicePlugins, 'approve', r, c.config),
   });
   return 0;
@@ -277,15 +284,16 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   // contradicts the actual record. Membership check resolves both
   // false-positives and silent drops.
   const assigned = r.executors;
-  if (assigned.length > 0 && !r.hasExecutor(by)) {
+  const execFormat = parseFormat(args);
+  if (assigned.length > 0 && !r.hasExecutor(by) && execFormat !== 'json') {
     const assignedList = assigned.map((m) => m.value).join(', ');
     const noun = assigned.length === 1 ? 'assigned to' : 'assigned to one of';
     process.stderr.write(
       `notice: ${by} executed request ${id} (${noun} ` +
-        `${assignedList}); --executor records intent, not access.\n`,
+        `${assignedList}); --executors records intent, not access.\n`,
     );
   }
-  emitWriteResponse(parseFormat(args), r, `✓ executing: ${id}`, c.config, [], {
+  emitWriteResponse(execFormat, r, `✓ executing: ${id}`, c.config, [], {
     voice: renderVoice(c.voicePlugins, 'execute', r, c.config),
   });
   return 0;

--- a/src/interface/gate/handlers/review.ts
+++ b/src/interface/gate/handlers/review.ts
@@ -101,6 +101,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   // as --executor / --executors in `gate request`.
   const noteOpt = optionalOption(args, 'note');
   const commentOpt = optionalOption(args, 'comment');
+  const format = parseFormat(args);
   if (noteOpt !== undefined && commentOpt !== undefined) {
     throw new Error(
       'review: --note and --comment are mutually exclusive (got both). ' +
@@ -108,10 +109,10 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     );
   }
   // Surface a one-line deprecation hint when the legacy alias is used,
-  // so the migration path is visible in session transcripts. The hint
-  // goes to stderr (not stdout) so JSON callers stay clean — same
-  // discipline as the self-approve / self-review notices.
-  if (commentOpt !== undefined) {
+  // so the migration path is visible in session transcripts. Text mode
+  // only — JSON consumers don't need the prose hint clogging their
+  // context window; the flag still works either way.
+  if (commentOpt !== undefined && format !== 'json') {
     process.stderr.write(
       'notice: --comment is a deprecated alias of --note; please migrate ' +
         '(both will continue to work for now).\n',
@@ -175,7 +176,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
     });
     // Review doesn't transition state — omit would_transition, let
     // the preview payload carry the new review entry in `reviews`.
-    emitDryRunPreview({ verb: 'review', id, by, after: updated, format: parseFormat(args) });
+    emitDryRunPreview({ verb: 'review', id, by, after: updated, format });
     return 0;
   }
   // Lifecycle hook fire point (#36 Phase 1 step 5). `before:review`
@@ -201,9 +202,10 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   // undermined when the critic is the author. We surface a stderr
   // marker rather than reject — history may need self-annotations
   // (e.g. "I want to flag this myself") and the caller's own
-  // judgement wins. The warning exists so the choice is visible in
-  // the session transcript and not silently laundered into YAML.
-  if (updated.from.value === by) {
+  // judgement wins. Text mode only — JSON consumers can detect the
+  // self-edge structurally from the `by` and `from` fields in the
+  // envelope without 3 lines of prose.
+  if (updated.from.value === by && format !== 'json') {
     process.stderr.write(
       `⚠ self-review: ${by} reviewed their own request ${id}. ` +
         `The Two-Persona Devil frame expects a different voice — ` +
@@ -224,7 +226,7 @@ export async function reqReview(c: C, args: ParsedArgs): Promise<number> {
   const displayLense = stored?.lense ?? lense;
   const displayVerdict = stored?.verdict ?? verdict;
   emitWriteResponse(
-    parseFormat(args),
+    format,
     updated,
     `✓ review recorded: ${id} [${displayLense}/${displayVerdict}]`,
     c.config,

--- a/src/interface/gate/handlers/thank.ts
+++ b/src/interface/gate/handlers/thank.ts
@@ -76,8 +76,11 @@ export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
   const updated = await c.requestUC.thank(ucInput);
 
   // Self-thank: not an error, just surface it so the log reads
-  // honestly. Mirrors the self-review / self-approval notices.
-  if (by === to) {
+  // honestly. Mirrors the self-review / self-approval notices. Text
+  // mode only — JSON consumers have the by/to fields in the envelope
+  // and can detect the self-edge structurally without prose noise.
+  const format = parseFormat(args);
+  if (by === to && format !== 'json') {
     process.stderr.write(
       `notice: self-thank — ${by} thanked themselves on ${id}. ` +
         `thanks is usually a cross-actor primitive; if that's intentional ` +
@@ -86,7 +89,7 @@ export async function reqThank(c: C, args: ParsedArgs): Promise<number> {
   }
 
   emitWriteResponse(
-    parseFormat(args),
+    format,
     updated,
     `✓ thanked: ${to} on ${id}`,
     c.config,

--- a/tests/interface/executorMismatchNotice.test.ts
+++ b/tests/interface/executorMismatchNotice.test.ts
@@ -67,7 +67,7 @@ test('gate execute: notice fires when --executor was set and actor differs', (t)
   assert.match(r.stdout, /✓ executing/);
   assert.match(
     r.stderr,
-    /notice: alice executed request .* \(assigned to bob\); --executor records intent, not access\./,
+    /notice: alice executed request .* \(assigned to bob\); --executors records intent, not access\./,
   );
 });
 


### PR DESCRIPTION
## Summary

stderr context-pollution audit follow-up to #397. Five success-path
notices on `gate approve / execute / review / thank` were firing on
stderr regardless of `--format`, even though JSON consumers can
detect the underlying conditions structurally from the envelope
(`by` / `from` / `executors[].name`). The prose was pure context
pollution for AI agents.

This PR gates them behind `format !== 'json'`:

| Site | Condition | Lines saved per call |
|------|-----------|----------------------|
| \`gate approve\` | self-approve + \`selfApprove: warn\` | 3 |
| \`gate execute\` | actor not in assigned executors | 2 |
| \`gate review\` | self-review (\`--by == from\`) | 3 |
| \`gate review --comment\` | deprecation hint | 2 |
| \`gate thank\` | self-thank (\`--by == --to\`) | 3 |

Bonus: \`gate execute\` mismatch notice still said \`--executor records intent\`
— updated to \`--executors records intent\` post-#398 (singular flag was removed).

## Out of scope (with rationale)

The audit also flagged these but they're staying as-is:

- **\`gate message\`** self-message / inactive-recipient notices: this verb has no JSON output mode at all, so stderr is the only signal channel.
- **\`gate next\`** setup-failure errors: those are error paths, not success-path notices. They need a separate parity refactor (route through \`emitErrorEnvelope\` so JSON consumers get a structured envelope instead of plain \`error: ...\` text). Different scope.
- **errorEnvelope.ts** JSON-on-stderr write: that's the contract — JSON consumers parse stderr for the envelope.
- **\`(explain: ...)\`**: opt-in via \`--explain\`, caller asked for it.
- **\`⟶ <voice>\`**: text-mode-only ornament by design (#382).

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1759/1759 pass
- [x] Smoke: \`gate approve <id> --by alice\` (self) text mode → notice fires
- [x] Smoke: \`gate approve <id> --by alice --format json\` (self) → notice suppressed, JSON envelope clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)