### PR TITLE
polish(gate next): route setup errors through emitErrorEnvelope (JSON parity)

### DIFF
--- a/.changelog/next/changed-gate-next-error-envelope-parity.md
+++ b/.changelog/next/changed-gate-next-error-envelope-parity.md
@@ -1,0 +1,20 @@
+- **`gate next` setup-failure errors now flow through the structured
+  JSON error envelope** instead of plain-text `error: <msg>` on
+  stderr. Three sites (GUILD_ACTOR not set / actor not registered /
+  --confirm but verb needs extra args) used to write
+  `process.stderr.write('error: ...')` + `return 1`, bypassing the
+  outer-catch's `emitErrorEnvelope` helper. JSON consumers got plain
+  text where every other gate verb gives them
+  `{"ok":false,"error":{"message":"...","field":"...","code":"..."}}`.
+  After this PR, the first two throw `DomainError(field='GUILD_ACTOR')`
+  and route through the standard envelope; the third (post-plan-emit
+  failure) emits the plan with `dispatched: false` and confines the
+  prose hint to text mode.
+
+- **`gate next --confirm` on a verb-needing-args now emits `dispatched: false`**
+  in the plan envelope (was `dispatched: true` — misleading, since
+  nothing was dispatched). Consumers branching on `dispatched` to
+  decide retry semantics were getting false positives.
+
+  Follow-up to #400's success-path notice gating: same eris-first
+  cleanup applied to error paths.

--- a/src/interface/gate/handlers/next.ts
+++ b/src/interface/gate/handlers/next.ts
@@ -44,6 +44,7 @@ import {
 // `gate next` reads the same actionable ladder bootCmd assembles.
 import { deriveVerbsAvailableNow } from './bootActionable.js';
 import { parseFormat } from '../../shared/parseFormat.js';
+import { DomainError } from '../../../domain/shared/DomainError.js';
 
 const NEXT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'confirm',
@@ -96,14 +97,16 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
   if (actor === null) {
     // No GUILD_ACTOR — boot would suggest `export GUILD_ACTOR=...`,
     // but `next` is specifically about actor-scoped actionable work.
-    // Refuse rather than auto-dispatch a meaningless suggestion.
-    process.stderr.write(
-      'error: GUILD_ACTOR is not set. ' +
+    // Throw DomainError so the outer catch routes through
+    // emitErrorEnvelope; JSON callers get the structured envelope
+    // (field='GUILD_ACTOR'), text callers get the prose `error:` line.
+    throw new DomainError(
+      'GUILD_ACTOR is not set. ' +
         'Set it before asking gate next what to do — the actionable ' +
         'ladder is actor-scoped.\n' +
-        '  next: export GUILD_ACTOR=<your-name>\n',
+        '  next: export GUILD_ACTOR=<your-name>',
+      'GUILD_ACTOR',
     );
-    return 1;
   }
 
   // Reuse boot's derivation modules so the actionable ladder gate
@@ -119,12 +122,12 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
       ? 'host'
       : 'unknown';
   if (role === 'unknown') {
-    process.stderr.write(
-      `error: GUILD_ACTOR=${actor} is not a registered member or host. ` +
+    throw new DomainError(
+      `GUILD_ACTOR=${actor} is not a registered member or host. ` +
         `gate boot would suggest registering — run that first.\n` +
-        `  next: gate register --name ${actor}\n`,
+        `  next: gate register --name ${actor}`,
+      'GUILD_ACTOR',
     );
-    return 1;
   }
 
   const allRequests = await c.requestUC.listAll();
@@ -186,11 +189,18 @@ export async function nextCmd(c: C, args: ParsedArgs): Promise<number> {
   }
 
   if (!canAuto) {
-    emitPlan(plan, format, true);
-    process.stderr.write(
-      `error: '${top.verb}' needs caller-supplied args and won't be ` +
-        `auto-dispatched. Run the command shown above with your inputs filled in.\n`,
-    );
+    // Caller asked --confirm but the verb needs extra args we don't
+    // know — emit the plan with `dispatched: false` (truth) and exit
+    // non-zero. JSON consumers read `can_auto_dispatch: false +
+    // dispatched: false` and know to fill in args; text callers get
+    // the prose hint on stderr alongside the human plan render.
+    emitPlan(plan, format, false);
+    if (format !== 'json') {
+      process.stderr.write(
+        `error: '${top.verb}' needs caller-supplied args and won't be ` +
+          `auto-dispatched. Run the command shown above with your inputs filled in.\n`,
+      );
+    }
     return 1;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #400. The stderr audit flagged \`gate next\`'s three
setup-failure sites as not yet routing through the structured JSON
error envelope — JSON callers got plain text where every other gate
verb gives them \`{"ok":false,"error":{"message":"...","field":"...","code":"..."}}\`.

### Changes

| Site | Before | After |
|------|--------|-------|
| GUILD_ACTOR not set | \`stderr.write('error: ...') + return 1\` | \`throw new DomainError(msg, 'GUILD_ACTOR')\` |
| Actor not registered | same | same |
| --confirm but verb needs args | \`emitPlan(plan, format, true)\` + plain stderr | \`emitPlan(plan, format, false)\` + format-gated stderr |

### Bonus bug

The third site emitted \`{plan, dispatched: true}\` even though no
dispatch happened — consumers branching on \`dispatched\` to decide
retry semantics were getting false positives. Now correctly \`false\`.

## Smoke check

\`\`\`text
$ gate next --format json   # no GUILD_ACTOR
{"ok":false,"error":{"message":"GUILD_ACTOR is not set. …","field":"GUILD_ACTOR","code":"validation_error"}}
error: GUILD_ACTOR is not set. …
exit 1
\`\`\`

JSON consumers now get the structured envelope; text consumers get the
prose unchanged.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1759/1759 pass
- [x] Smoke: \`gate next\` (no env) text mode → plain \`error:\` line
- [x] Smoke: \`gate next --format json\` → structured JSON envelope with field/code

🤖 Generated with [Claude Code](https://claude.com/claude-code)