### PR TITLE
polish: asteria dogfood + eris touch-feel bundle (9 fixes)

### DIFF
--- a/.changelog/next/changed-asteria-eris-dogfood-polish-bundle.md
+++ b/.changelog/next/changed-asteria-eris-dogfood-polish-bundle.md
@@ -1,0 +1,84 @@
+- **`gate decisions` no longer mis-attributes slice-fail/complete
+  reasons to the `executing` row.** Issue surfaced by asteria's
+  dogfood run (2026-05-16, finding D1): running `gate fail <id>
+  --by X --reason "msg"` produced a `decisions` payload where the
+  fail row carried the cascade auto-note (`wave failed (any-fail-
+  wave-fail)`) while the **execute** row carried the actor's
+  `--reason` text. Root cause: per-#294 slice-closure writes a
+  second `executing` status_log stamp (with the slice note) that
+  the dedupe walk collapsed into the execute row via "later wins".
+  Fix: detect slice-close stamps (executing entry whose `at`
+  matches the executor record's `completed_at`) and re-kind them
+  to fail/complete; skip wave-cascade entries whose auto-notes
+  match the domain-emitted patterns from `Request.ts:1060`.
+
+- **`gate transcript` prose reads naturally on slice-closure
+  waves.** Same root cause as the decisions fix (eris touch-feel
+  2026-05-16 finding 4.4). Before:
+  `Asteria moved it to executing (90ms later). Asteria moved it
+  to executing (87ms later) (note: "slice done"). Asteria moved
+  it to completed (0ms later) (note: "wave completed (all slices
+  closed)").`
+  After:
+  `Asteria moved it to executing (90ms later). Asteria closed
+  their slice as completed (87ms later) (note: "slice done").
+  The wave completed (all slices closed) (0ms later).`
+  Cold readers see one judgement per executor, plus the wave-level
+  consequence as subject-less prose (no actor credited with
+  writing the auto-text).
+
+- **`gate fail` on an approved wave now surfaces the `gate execute`
+  bridge.** asteria finding B1: pending → fail returned a
+  RecoverableError with a `gate deny` recovery hint and the JSON
+  envelope's `error.recovery` field; approved → fail returned the
+  domain layer's raw `Illegal state transition: approved → failed`
+  with no recovery shape at all. Same prose + structured-recovery
+  discipline now applies — JSON consumers can dispatch the
+  `execute` move without pattern-matching on state-machine prose.
+
+- **`gate help` is now a sugar alias for `gate --help`.** The bare
+  `help` was previously rejected as `unknown command`, costing one
+  tool-call round-trip for the universal "what does this CLI do?"
+  reflex (asteria finding A1). Aligns with `gate --help` / `-h`.
+
+- **`boot.session_id_source: "unset"` replaces `null`.** Enum is
+  now `['flag', 'env', 'unset']`. asteria finding A2 — null
+  required readers to know whether it meant "not present yet" or
+  "error". The explicit `"unset"` token is principle 10 (schema-
+  as-contract / output specificity) applied at the value layer.
+  Schema enum updated; tests adjusted.
+
+- **`gate lore show <number>` resolves to the slug.** Numeric input
+  (`gate lore show 11`) now matches the unique principle/trap with
+  that number prefix (`11-ai-first-human-as-projection`). Cold
+  readers reach for the number first; the slug-only requirement
+  cost a round-trip (eris touch-feel finding 4.6). Ambiguous or
+  non-numeric input falls through to the previous "not found"
+  hint unchanged.
+
+- **`--note` / `--reason` / `--action` / stake-note fields now
+  declare `maxLength` in `gate schema`.** Free-form text fields
+  (`MAX_TEXT = 4096`) and stake fields (`MAX_STAKE_NOTE = 80`)
+  ship their domain caps via the schema envelope so AI consumers
+  pre-validate before composing long payloads. asteria finding F1
+  ("`--note` cap not advertised → silent truncate risk on long
+  handoff messages"). Applied to gate's primary write verbs
+  (approve, deny, execute, complete, fail, claim, witness);
+  others inherit the same caps but advertise them less
+  prominently — sweep-out is a follow-up.
+
+- **`gate review` help example uses `--note` (the canonical flag)
+  instead of `--comment` (the deprecated alias).** Drift surfaced
+  by eris touch-feel finding 4.5: the same verb runs a deprecation
+  notice when `--comment` is used, but the canonical example still
+  showed it as the first surface. Aligned.
+
+- **Lore broken citations removed.** Principle 12 cited
+  `substrate/agora/plays/whole-repo-review/2026-05-04-001.yaml`
+  (dir doesn't exist in repo); principle 04 cited
+  `alexandria/orientation/PHILOSOPHY.md` (dir doesn't exist).
+  Both were dangling references — the irony of principle 04
+  (records-outlive-writers) carrying a citation that didn't
+  outlive its writer was not lost. Principle 12 kept the
+  three-voice framing but removed the file pin; principle 04 lost
+  the alexandria bullet entirely (asteria findings 1 & 2).

--- a/lore/principles/04-records-outlive-writers.md
+++ b/lore/principles/04-records-outlive-writers.md
@@ -64,5 +64,3 @@ preserves the trail of thinking, not just the latest conclusion.
 - `principles/03-legibility-costs.md` — legibility is what makes
   records-outliving-writers work; this principle names *why* we
   pay legibility's costs.
-- `alexandria/orientation/PHILOSOPHY.md` — same-agent-over-time
-  coordination is this principle at a different layer.

--- a/lore/principles/12-substrate-pure-module-in-projection-ecosystem.md
+++ b/lore/principles/12-substrate-pure-module-in-projection-ecosystem.md
@@ -110,8 +110,9 @@ This principle was written aware of its own gravity — once a
 record exists in `lore/principles/`, it is read later as
 inheritance. Readers who arrive at this file because grep
 surfaced it are asked to read this section before treating the
-content above as binding. The substrate ledger inside
-`substrate/agora/plays/whole-repo-review/2026-05-04-001.yaml`
-holds the three-voice conversation (eris / noir / asteria) from
-which this writing emerged; it is the trace of a specific reading
-on a specific date, not a universal claim.
+content above as binding. The writing emerged from a three-voice
+conversation (eris / noir / asteria) reading the May-2026 repo
+shape against the (then private) `yori-code` substrate; the trace
+of that reading is held in the authors' working substrate, not
+shipped here. Treat the content above as the trace of a specific
+reading on a specific date, not a universal claim.

--- a/src/application/lore/LoreUseCases.ts
+++ b/src/application/lore/LoreUseCases.ts
@@ -42,9 +42,23 @@ export class LoreUseCases {
     return all.filter((e) => matchesFilter(e, filter));
   }
 
-  /** Lookup by exact name. Returns null when missing. */
+  /**
+   * Lookup by exact name (canonical slug, e.g. `11-ai-first-human-as-projection`)
+   * with a numeric-prefix fallback (e.g. `11` resolves to that file).
+   * Numeric fallback matches when the input is purely digits and
+   * exactly one entry starts with `<digits>-`. Disambiguates only the
+   * common "I remember the number, not the slug" cold-read case;
+   * ambiguous matches (multiple hits, or non-digit input) fall through
+   * to null so the caller's `next: gate lore list` hint stays
+   * meaningful (eris touch-feel 2026-05-16 finding 4.6).
+   */
   find(name: string): LoreEntry | null {
-    return this.repo.find(name);
+    const exact = this.repo.find(name);
+    if (exact !== null) return exact;
+    if (!/^\d+$/.test(name)) return null;
+    const prefix = `${name}-`;
+    const candidates = this.repo.listAll().filter((e) => e.name.startsWith(prefix));
+    return candidates.length === 1 ? candidates[0]! : null;
   }
 }
 

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -160,7 +160,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
 
   const sessionIdFlag = optionalOption(args, 'session-id');
   let sessionId: string | null = null;
-  let sessionIdSource: 'flag' | 'env' | null = null;
+  let sessionIdSource: 'flag' | 'env' | 'unset' = 'unset';
   if (sessionIdFlag !== undefined && sessionIdFlag.length > 0) {
     if (!SESSION_ID_RE.test(sessionIdFlag)) {
       throw new Error(

--- a/src/interface/gate/handlers/bootTypes.ts
+++ b/src/interface/gate/handlers/bootTypes.ts
@@ -175,7 +175,7 @@ export interface BootPayload {
   actor: string | null;
   role: 'member' | 'host' | 'unknown' | null;
   session_id: string | null;
-  session_id_source: 'flag' | 'env' | null;
+  session_id_source: 'flag' | 'env' | 'unset';
   /**
    * Delta-filter timestamp (--since). When set, `tail`, `your_recent`,
    * and `inbox_unread` only contain entries whose `at` is strictly

--- a/src/interface/gate/handlers/decisions.ts
+++ b/src/interface/gate/handlers/decisions.ts
@@ -103,11 +103,47 @@ export async function decisionsCmd(c: C, args: ParsedArgs): Promise<number> {
   // is "how many distinct decisions did I make?", not "how many
   // status_log entries did I write?". Keep the latest entry per
   // tuple (later note wins; later `at` wins ties).
+  //
+  // Slice-closure re-kinding (asteria dogfood 2026-05-16 finding D1):
+  // The slice-close stamp is `state: executing` on disk because the
+  // wave is still mid-flight when the slice closes (other executors
+  // may still be running). From the actor's POV, however, that
+  // stamp IS their `fail`/`complete` decision — the slice-fail reason
+  // they passed via `--reason X` lives on this stamp, not on the
+  // later wave-cascade `failed`/`completed` entry (which carries an
+  // auto-derived "wave ..." note). Re-kind the slice-close entry to
+  // the executor's terminal status so the note lands where the actor
+  // wrote it. Mirror move: skip the wave-cascade entry when its note
+  // matches the domain-emitted pattern (Request.ts:1060), because
+  // that entry is the wave's consequence, not the actor's decision.
+  const CASCADE_NOTE_RE =
+    /^wave failed \(any-fail-wave-fail\)$|^wave completed \(all slices closed\)$/;
   const dedup = new Map<string, DecisionRow>();
   for (const r of requests) {
     const j = r.toJSON() as Record<string, unknown>;
     const id = String(j['id']);
     const log = Array.isArray(j['status_log']) ? j['status_log'] : [];
+    // Per-actor executor record lookup. When the calling actor
+    // appears in executors[] with a terminal status, the slice-close
+    // stamp (executing entry whose `at` matches `completed_at`) is
+    // really their fail/complete decision.
+    const execEntries = Array.isArray(j['executors']) ? j['executors'] : [];
+    let actorExec: { status: string; completedAt: string; note: string | null } | null = null;
+    for (const ex of execEntries) {
+      if (typeof ex !== 'object' || ex === null) continue;
+      const exRec = ex as Record<string, unknown>;
+      const name = typeof exRec['name'] === 'string' ? exRec['name'] : null;
+      const status = typeof exRec['status'] === 'string' ? exRec['status'] : null;
+      const completedAt = typeof exRec['completed_at'] === 'string' ? exRec['completed_at'] : null;
+      if (name === forActor && status !== null && completedAt !== null) {
+        actorExec = {
+          status,
+          completedAt,
+          note: typeof exRec['note'] === 'string' ? exRec['note'] : null,
+        };
+        break;
+      }
+    }
     for (const e of log) {
       if (typeof e !== 'object' || e === null) continue;
       const rec = e as Record<string, unknown>;
@@ -117,13 +153,39 @@ export async function decisionsCmd(c: C, args: ParsedArgs): Promise<number> {
       if (at === null || by === null || state === null) continue;
       if (by !== forActor) continue;
       if (at < cutoffIso) continue;
-      const kind = STATE_TO_KIND[state];
-      if (!kind) continue;
       const note = typeof rec['note'] === 'string' ? (rec['note'] as string) : null;
+      // Slice-close re-kinding: `state: executing` whose `at` matches
+      // the actor's `executors[].completed_at` IS their slice fail /
+      // complete decision (not a redundant execute stamp).
+      let kind = STATE_TO_KIND[state];
+      let effectiveNote = note;
+      if (
+        state === 'executing' &&
+        actorExec !== null &&
+        at === actorExec.completedAt &&
+        (actorExec.status === 'failed' || actorExec.status === 'completed')
+      ) {
+        kind = actorExec.status === 'failed' ? 'fail' : 'complete';
+        // The slice-close stamp's note IS the actor's terminal reason;
+        // prefer it. Fall back to executor.note if for some reason the
+        // stamp lacks one (defensive).
+        effectiveNote = note ?? actorExec.note;
+      }
+      // Skip wave-cascade entries: their notes are domain-auto and
+      // would otherwise overwrite the actor's slice-close note via the
+      // "later wins" dedup rule (slice-close and cascade differ by 1 ms).
+      if (
+        (state === 'failed' || state === 'completed') &&
+        note !== null &&
+        CASCADE_NOTE_RE.test(note)
+      ) {
+        continue;
+      }
+      if (!kind) continue;
       const key = `${id}|${kind}`;
       const cur = dedup.get(key);
       if (cur === undefined || at >= cur.at) {
-        dedup.set(key, { at, request_id: id, transition: kind, note });
+        dedup.set(key, { at, request_id: id, transition: kind, note: effectiveNote });
       }
     }
   }

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -507,6 +507,29 @@ export async function reqFail(c: C, args: ParsedArgs): Promise<number> {
         },
       );
     }
+    // approved → fail mirrors pending → fail: the domain layer would
+    // throw "Illegal state transition: approved → failed" without a
+    // recovery hint, leaving the cold-session caller to deduce that
+    // `gate execute` is the bridge. Surface the verb directly — same
+    // structured `recovery` slot + prose discipline as the pending
+    // branch, so JSON consumers can dispatch the next move without
+    // pattern-matching on state-machine prose (asteria dogfood
+    // 2026-05-16 finding B1).
+    if (priorFail.state === 'approved') {
+      throw new RecoverableError(
+        `Request ${id} is approved — fail is reachable only from executing.\n` +
+          `  Transition to executing first, then fail:\n` +
+          `    gate execute ${id} --by <m>\n` +
+          `    gate fail ${id} --by <m> --reason <s>`,
+        {
+          verb: 'execute',
+          args: { id },
+          reason:
+            `${id} is approved; fail is reachable only from executing — ` +
+            `execute is the bridge step before failing.`,
+        },
+      );
+    }
     // See reqComplete: issue #294 / miki concern #1 — refuse fail
     // when wave has executors and `by` is not one of them. Same
     // typo-safety rationale as complete: a misspelt `--by` would

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -37,6 +37,15 @@ export type JsonSchema = {
   description?: string;
   items?: JsonSchema;
   oneOf?: JsonSchema[];
+  /**
+   * Hard ceiling on string length for free-form text fields. Surfaced
+   * here so AI consumers can pre-validate payload length without
+   * having to compose, submit, and recover from a domain-side
+   * DomainError (asteria dogfood 2026-05-16 finding F1).
+   * Domain caps: MAX_TEXT=4096 (action/reason/note/comment/text);
+   * MAX_STAKE_NOTE=80 (witness/claim stake notes).
+   */
+  maxLength?: number;
 };
 
 export interface VerbSchema {
@@ -60,6 +69,21 @@ export interface VerbSchema {
 const str: JsonSchema = { type: 'string' };
 const strOpt = (description?: string): JsonSchema =>
   description ? { type: 'string', description } : { type: 'string' };
+// Domain-side caps for free-form text fields (action / reason / note /
+// review comment / message text). Surfaced here so AI consumers know
+// the ceiling without having to guess or hit a domain error after
+// composing a long payload (asteria dogfood 2026-05-16 finding F1).
+// Keep in sync with `MAX_TEXT` / `MAX_STAKE_NOTE` in Request.ts.
+const TEXT_MAX = 4096;
+const STAKE_NOTE_MAX = 80;
+const textField = (description?: string): JsonSchema =>
+  description
+    ? { type: 'string', maxLength: TEXT_MAX, description }
+    : { type: 'string', maxLength: TEXT_MAX };
+const stakeNoteField = (description?: string): JsonSchema =>
+  description
+    ? { type: 'string', maxLength: STAKE_NOTE_MAX, description }
+    : { type: 'string', maxLength: STAKE_NOTE_MAX };
 const idStr: JsonSchema = {
   type: 'string',
   description:
@@ -365,11 +389,12 @@ const VERBS: readonly VerbSchema[] = [
         },
         session_id_source: {
           type: 'string',
-          enum: ['flag', 'env'],
+          enum: ['flag', 'env', 'unset'],
           description:
             'Names which input populated `session_id`: "flag" when ' +
             '--session-id was supplied on this invocation, "env" when ' +
-            'GUILD_SESSION_ID was the source, null when neither.',
+            'GUILD_SESSION_ID was the source, "unset" when neither ' +
+            '(session_id is null in that case).',
         },
         since: {
           type: 'string',
@@ -1734,7 +1759,7 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: strOpt('approver (defaults to $GUILD_ACTOR)'),
-        note: str,
+        note: textField(),
         format: formatField,
         'dry-run': dryRunField,
       },
@@ -1751,8 +1776,8 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: str,
-        reason: strOpt('alias for --note'),
-        note: strOpt('closure note; falls back to positional arg'),
+        reason: textField('alias for --note'),
+        note: textField('closure note; falls back to positional arg'),
         format: formatField,
         'dry-run': dryRunField,
       },
@@ -1769,7 +1794,7 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: str,
-        note: str,
+        note: textField(),
         cwd: {
           type: 'string',
           description:
@@ -1791,7 +1816,7 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: str,
-        note: str,
+        note: textField(),
         cliff: {
           type: 'string',
           description:
@@ -1822,8 +1847,8 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: str,
-        reason: str,
-        note: str,
+        reason: textField(),
+        note: textField(),
         format: formatField,
         'dry-run': dryRunField,
       },
@@ -1870,7 +1895,7 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: strOpt('claimant (defaults to $GUILD_ACTOR)'),
-        note: strOpt(
+        note: stakeNoteField(
           'optional stake metadata (issue #246). Single short string ' +
             '≤ 80 chars — metadata for THIS stake event, not commentary. ' +
             'Cross-actor discussion belongs in agora plays; the note is ' +
@@ -1900,7 +1925,7 @@ const VERBS: readonly VerbSchema[] = [
       properties: {
         id: idStr,
         by: strOpt('observer (defaults to $GUILD_ACTOR)'),
-        note: strOpt(
+        note: stakeNoteField(
           'optional per-witness metadata (issue #246). Single short string ' +
             '≤ 80 chars — metadata for THIS stake event, not commentary. ' +
             'Cross-actor discussion belongs in agora plays. Same-actor ' +

--- a/src/interface/gate/handlers/transcript.ts
+++ b/src/interface/gate/handlers/transcript.ts
@@ -92,6 +92,29 @@ function buildTranscript(r: Request): TranscriptPayload {
   const log = Array.isArray(j['status_log'])
     ? (j['status_log'] as Array<Record<string, unknown>>)
     : [];
+  // Slice-close map: executor name → { status, completed_at, note }.
+  // Used to re-phrase the second `executing` stamp (the slice-close
+  // append from #294's per-executor closure) as "closed her slice"
+  // rather than yet another "moved it to executing" sentence. Same
+  // re-kinding logic as `gate decisions` (eris touch-feel 2026-05-16
+  // finding 4.4 / asteria dogfood finding D1).
+  const execRecords = Array.isArray(j['executors']) ? (j['executors'] as Array<Record<string, unknown>>) : [];
+  const sliceCloseByAt = new Map<string, { status: 'completed' | 'failed'; by: string; note: string | null }>();
+  for (const ex of execRecords) {
+    if (typeof ex !== 'object' || ex === null) continue;
+    const name = typeof ex['name'] === 'string' ? ex['name'] : null;
+    const status = typeof ex['status'] === 'string' ? ex['status'] : null;
+    const completedAt = typeof ex['completed_at'] === 'string' ? ex['completed_at'] : null;
+    if (name === null || completedAt === null) continue;
+    if (status !== 'completed' && status !== 'failed') continue;
+    sliceCloseByAt.set(completedAt, {
+      status: status as 'completed' | 'failed',
+      by: name,
+      note: typeof ex['note'] === 'string' ? ex['note'] : null,
+    });
+  }
+  const CASCADE_NOTE_RE =
+    /^wave failed \(any-fail-wave-fail\)$|^wave completed \(all slices closed\)$/;
   const reviews = Array.isArray(j['reviews'])
     ? (j['reviews'] as Array<Record<string, unknown>>)
     : [];
@@ -127,7 +150,7 @@ function buildTranscript(r: Request): TranscriptPayload {
     const state = String(entry['state'] ?? '');
     const by = String(entry['by'] ?? '');
     const at = String(entry['at'] ?? '');
-    const note = entry['note'] ? ` (note: "${entry['note']}")` : '';
+    const rawNote = typeof entry['note'] === 'string' ? (entry['note'] as string) : null;
     const invokedBy = entry['invoked_by']
       ? ` [invoked by ${entry['invoked_by']}]`
       : '';
@@ -137,6 +160,38 @@ function buildTranscript(r: Request): TranscriptPayload {
       continue;
     }
     const delta = prevAt ? ` (${humanDelta(prevAt, at)} later)` : '';
+    // Slice-close re-phrase: an `executing` stamp whose `at` matches
+    // an executor's `completed_at` is that executor's terminal slice
+    // closure, not a second "moved it to executing" event. Surface as
+    // "closed her slice as completed/failed" so the cold reader sees
+    // one judgment, not two.
+    const sliceClose = state === 'executing' ? sliceCloseByAt.get(at) : undefined;
+    if (sliceClose !== undefined && sliceClose.by === by) {
+      const closeNote = sliceClose.note !== null ? ` (note: "${sliceClose.note}")` : '';
+      lifecycle.push(
+        `${capitalise(by)} closed their slice as ${sliceClose.status}${delta}${invokedBy}${closeNote}`,
+      );
+      prevAt = at;
+      continue;
+    }
+    // Wave-cascade re-phrase: the terminal `failed`/`completed` entry
+    // with the domain-auto note (Request.ts:1060) is the wave's
+    // consequence, not an authored decision. Lift it to subject-less
+    // prose so the actor isn't credited with writing the auto-text.
+    if (
+      (state === 'failed' || state === 'completed') &&
+      rawNote !== null &&
+      CASCADE_NOTE_RE.test(rawNote)
+    ) {
+      const phrase =
+        state === 'completed'
+          ? 'The wave completed (all slices closed)'
+          : 'The wave failed (any-fail-wave-fail)';
+      lifecycle.push(`${phrase}${delta}`);
+      prevAt = at;
+      continue;
+    }
+    const note = rawNote !== null ? ` (note: "${rawNote}")` : '';
     lifecycle.push(
       `${capitalise(by)} moved it to ${state}${delta}${invokedBy}${note}`,
     );

--- a/src/interface/gate/index.ts
+++ b/src/interface/gate/index.ts
@@ -120,7 +120,12 @@ export async function main(argv: readonly string[]): Promise<number> {
   // back to a standard-profile view so `gate --help` keeps working
   // even on a misconfigured root (the help payload is purely
   // informational and must never block diagnosis).
-  if (!cmd || cmd === '--help' || cmd === '-h') {
+  // `gate help` is accepted as a sugar alias for `gate --help` because
+  // the reflex "what does this CLI do? — gate help" is universal across
+  // tools (asteria dogfood 2026-05-16: AI agents hit this first). The
+  // bare `help` was previously rejected with `unknown command`, which
+  // wasted a tool-call round. Aligns with `gate --help` / `-h`.
+  if (!cmd || cmd === '--help' || cmd === '-h' || cmd === 'help') {
     const wantAll = rest.includes('--all');
     const wantEssentials = rest.includes('--essentials');
     const wantCompact = rest.includes('--compact');

--- a/src/interface/shared/verbExamples.ts
+++ b/src/interface/shared/verbExamples.ts
@@ -22,7 +22,7 @@ export const VERB_EXAMPLES: Record<string, Record<string, string>> = {
     complete: 'complete <id>',
     fail: 'fail <id> --reason "<why>"',
     'fast-track': 'fast-track --action "<what>" --reason "<why>"',
-    review: 'review <id> --lense layer --verdict ok --comment "<note>"',
+    review: 'review <id> --lense layer --verdict ok --note "<comment>"',
     thank: 'thank <to> --for <id>',
     message: 'message --to <m> --text "<body>"',
     broadcast: 'broadcast --text "<body>"',

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -1165,7 +1165,12 @@ test('transcript: narrative prose names filer, action, executor, reviews', () =>
     assert.match(stdout, /Alice filed/);
     assert.match(stdout, /refactor parser/);
     assert.match(stdout, /bob as executor/);
-    assert.match(stdout, /Bob moved it to completed/);
+    // Slice-close re-phrase (#400-era polish + eris touch-feel
+    // 2026-05-16 finding 4.4): single-executor `complete` shows up
+    // as the slice closure, not as "moved it to executing" + "moved
+    // it to completed". Cold reader sees the actor's terminal
+    // judgement directly.
+    assert.match(stdout, /Bob closed their slice as completed/);
     assert.match(stdout, /devil lense/);
     assert.match(stdout, /verdict of ok/);
     assert.match(stdout, /LGTM/);

--- a/tests/interface/sessionIdStamping.test.ts
+++ b/tests/interface/sessionIdStamping.test.ts
@@ -248,7 +248,7 @@ test('gate boot: actor set + no session → hints.session_id_unset=true', (t) =>
   assert.equal(r.status, 0);
   const j = JSON.parse(r.stdout) as Record<string, unknown>;
   assert.equal(j['session_id'], null);
-  assert.equal(j['session_id_source'], null);
+  assert.equal(j['session_id_source'], 'unset');
   const hints = j['hints'] as Record<string, unknown>;
   assert.equal(hints['session_id_unset'], true);
 });


### PR DESCRIPTION
## Summary

9 fixes from two parallel real-world touch-feel runs (2026-05-16):

- **asteria SubAgent dogfood** (via the Agent tool, given a lore-audit task + instructed to run on a real gate wave; surfaced 8 findings)
- **eris touch-feel report** (in \`_nao/inbox/\`, separate eris instance read all 15 principles + 8 traps + ran one sandbox cycle; surfaced 6 frictions)

The overlap between the two reports validates a couple of root causes (slice-closure status_log shape leaks into both \`gate decisions\` and \`gate transcript\` prose). Bundling because the changes share testing surface and ship cleanly together.

## Findings × fixes

| ID | Finding | Surface | Severity |
|----|---------|---------|----------|
| asteria D1 | \`gate decisions\` mis-attributes fail-reason to execute row | decisions handler | high (bug) |
| asteria B1 | \`gate fail\` on approved gives raw error, no recovery | requestLifecycle | med |
| eris 4.4 | transcript prose shows "moved to executing" twice on slice-close | transcript handler | med |
| asteria A1 | \`gate help\` is rejected as unknown | gate index dispatcher | low |
| asteria A2 | \`session_id_source: null\` is ambiguous to AI readers | bootTypes + schema | low |
| eris 4.6 | \`gate lore show 11\` requires full slug | LoreUseCases.find | low |
| asteria F1 | \`--note\` cap not advertised in schema | schema (textField helper) | low |
| eris 4.5 | \`gate review\` help example uses deprecated \`--comment\` | verbExamples | low |
| asteria 1+2 | principle 04 + 12 cite non-existent paths | lore/principles | docs |

## Out of scope

- **eris 4.1**: \`devil entry --kind assumption/synthesis\` requiring \`--lense\` — separate semantic question (kind ↔ lense coupling)
- **eris 4.2**: 12-lense floor cargo-cult risk — structural trade-off, not directly fixable
- **eris 4.3**: \`agora move <play-id> --game <slug>\` double-spec — storage shape trade-off

These are noted but need their own design rounds.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1759/1759 pass
- [x] Smoke: \`gate decisions --format json\` after slice-fail wave → fail row carries actor reason, execute row note is null
- [x] Smoke: \`gate fail <id> --by X --reason Y\` on approved → JSON envelope carries \`error.recovery.verb: "execute"\`
- [x] Smoke: \`gate transcript\` reads "X closed their slice as completed" + "The wave completed"
- [x] Smoke: \`gate help\` works (was: unknown command)
- [x] Smoke: \`gate lore show 11\` returns principle 11 body

🤖 Generated with [Claude Code](https://claude.com/claude-code)