### PR TITLE
polish: suggested_next_reason + register host-collision touch-feel

### DIFF
--- a/.changelog/next/changed-suggest-null-reason-and-register-host-hint.md
+++ b/.changelog/next/changed-suggest-null-reason-and-register-host-hint.md
@@ -1,0 +1,18 @@
+- **`gate boot` / `gate suggest`: new `suggested_next_reason` field.**
+  When `suggested_next` is `null` but the substrate has open
+  (`pending` / `approved` / `executing`) requests that don't name the
+  caller as executor, the field carries a one-line explanation —
+  closing the asteria-dogfood gap where `status.pending.total: 1`
+  next to `suggested_next: null` read as a substrate bug for a host
+  who approves from `gate list --state pending` rather than through
+  the suggest ladder. Field is `null` when silence is genuine. Text
+  mode renders the reason inline as `(nothing urgent — <reason>)` /
+  `→ (no suggestion — <reason>)`.
+- **`gate register --name <n>`: host-collision error front-loads the
+  fix.** The "pick a different `--name`" path is now the lead
+  recovery hint; "remove from `host_names:`" is parenthetical. Lines
+  up with the asteria observation that a first-time user hitting
+  `nao` (a default `host_names` reservation) was reading the longer
+  guidance first. README `30 seconds` block also picks up a
+  one-liner: `<you>` should be distinct from `host_names:` (default
+  reservations: `eris`, `nao`).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ gate fast-track --action "..." --reason "..."
 > form — `node ./bin/gate.mjs <verb>` works too if you'd rather not
 > rely on PATH.
 
+> Pick `<you>` to be a name distinct from `host_names:` in
+> `guild.config.yaml` (default reservations: `eris`, `nao`). Hosts and
+> members are different roles, so `register --name eris` is rejected
+> with a one-line hint to pick a different name.
+
 That's the loop. The whole tool is six verbs:
 
 ```bash

--- a/src/interface/gate/handlers/boot.ts
+++ b/src/interface/gate/handlers/boot.ts
@@ -37,6 +37,7 @@ import { collectUtterances } from '../voices.js';
 import type { BootPayload, BootSuggestedNextOrPendingResponse } from './bootTypes.js';
 import {
   deriveBootSuggestedNext,
+  deriveSuggestedNextNullReason,
   derivePendingBroadcastResponse,
   deriveVerbsAvailableNow,
   computeActiveOverlappingTargets,
@@ -53,6 +54,7 @@ import { parseFormat } from '../../shared/parseFormat.js';
 // for any third-party plugin reading them via the package surface).
 export {
   deriveBootSuggestedNext,
+  deriveSuggestedNextNullReason,
   computeLastAuthoredWriteAt,
 } from './bootActionable.js';
 export type { BootSuggestedNext } from './bootTypes.js';
@@ -398,6 +400,13 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     baseSuggestedNext !== null
       ? baseSuggestedNext
       : derivePendingBroadcastResponse(inboxUnread);
+  // Sibling field: when both halves of the suggest ladder above end
+  // up null AND the caller has an identity, explain why if the
+  // substrate still has open state. See deriveSuggestedNextNullReason.
+  const suggestedNextReason: string | null =
+    suggestedNext === null && actor !== null
+      ? deriveSuggestedNextNullReason(actor, allRequests)
+      : null;
   const verbsAvailableNow = deriveVerbsAvailableNow(
     actor,
     role,
@@ -507,6 +516,7 @@ export async function bootCmd(c: C, args: ParsedArgs): Promise<number> {
     cross_passage: crossPassage,
     active_overlapping_targets: activeOverlappingTargets,
     suggested_next: suggestedNext,
+    suggested_next_reason: suggestedNextReason,
     past_cliffs: pastCliffs,
     verbs_available_now: verbsAvailableNow,
     lore_stats: loreStats,

--- a/src/interface/gate/handlers/bootActionable.ts
+++ b/src/interface/gate/handlers/bootActionable.ts
@@ -134,6 +134,47 @@ export function deriveBootSuggestedNext(
 }
 
 /**
+ * Explain why `deriveBootSuggestedNext` returned null when the
+ * substrate still has open work. Most common cause: the caller is a
+ * host (or an author who delegated execution) and `pending` /
+ * `approved` / `executing` requests exist but name a different
+ * executor, so `actionableTransitions` finds nothing for them.
+ *
+ * Returns `null` when the substrate is genuinely empty for this actor
+ * (true silence is fine) — only emit text when there is open state
+ * the caller might otherwise wonder about. Mirrors the project's
+ * "no silent gaps" convention (#228 friction bundle): if `gate
+ * suggest` is null but `gate status` shows pending, the reader gets
+ * one line that links the two.
+ */
+export function deriveSuggestedNextNullReason(
+  actor: string,
+  allRequests: ReadonlyArray<Request>,
+): string | null {
+  const lower = actor.toLowerCase();
+  let pendingNotMine = 0;
+  let approvedNotMine = 0;
+  let executingNotMine = 0;
+  for (const r of allRequests) {
+    if (r.hasExecutor(lower)) continue;
+    if (r.state === 'pending') pendingNotMine += 1;
+    else if (r.state === 'approved') approvedNotMine += 1;
+    else if (r.state === 'executing') executingNotMine += 1;
+  }
+  if (pendingNotMine + approvedNotMine + executingNotMine === 0) return null;
+  const parts: string[] = [];
+  if (pendingNotMine > 0) parts.push(`${pendingNotMine} pending`);
+  if (approvedNotMine > 0) parts.push(`${approvedNotMine} approved`);
+  if (executingNotMine > 0) parts.push(`${executingNotMine} executing`);
+  return (
+    `${parts.join(', ')} open request(s) on substrate, but none names you ` +
+    'as executor — use `gate list --state pending` (or --state approved / ' +
+    'executing) to read them. Hosts approve from this list rather than ' +
+    'through `gate suggest`.'
+  );
+}
+
+/**
  * Lowest-priority hint: pick the oldest unread broadcast whose sender
  * stamped `expects_response: true`. Returns null when no such entry
  * exists, when expectsResponse was never opted in, or when every

--- a/src/interface/gate/handlers/bootRender.ts
+++ b/src/interface/gate/handlers/bootRender.ts
@@ -364,6 +364,12 @@ export function renderBootText(
       lines.push(`→ or:   gate ${a.verb} ${a.id}`);
       lines.push(`        (${a.reason})`);
     }
+  } else if (p.suggested_next_reason !== null) {
+    // suggested_next is null but the substrate has open work. Surface
+    // the reason here so the reader doesn't have to cross-check the
+    // status block manually.
+    lines.push('');
+    lines.push(`→ (no suggestion — ${p.suggested_next_reason})`);
   }
   return lines.join('\n') + '\n';
 }

--- a/src/interface/gate/handlers/bootTypes.ts
+++ b/src/interface/gate/handlers/bootTypes.ts
@@ -230,6 +230,17 @@ export interface BootPayload {
   };
   suggested_next: BootSuggestedNextOrPendingResponse | null;
   /**
+   * Short explanation set when `suggested_next` is `null` but the
+   * substrate still has open work the caller might wonder about
+   * (e.g. host with `pending` waves that name other executors).
+   * `null` when the silence is genuine — no open work, no gap to
+   * explain. Mirrors the friction-fix in #404 follow-up: a null
+   * suggestion is fine, but a null suggestion sitting next to a
+   * non-zero pending count reads as a substrate bug; this field
+   * closes the loop.
+   */
+  suggested_next_reason: string | null;
+  /**
    * Forward-pointing cliffs left on completed requests the actor
    * authored or executed (#37x). Most-recent-terminal-first, capped at
    * 5. Each entry surfaces the request id, the closing actor's cliff

--- a/src/interface/gate/handlers/register.ts
+++ b/src/interface/gate/handlers/register.ts
@@ -79,9 +79,10 @@ export async function reqRegister(c: C, args: ParsedArgs): Promise<number> {
   if (c.config.hostNames.includes(parsedName.value)) {
     throw new Error(
       `"${parsedName.value}" is already declared as a host in guild.config.yaml.\n` +
-        `  Hosts and members are different roles; a single name cannot be both.\n` +
-        `  Either pick a different --name, or remove "${parsedName.value}" from ` +
-        `host_names: in guild.config.yaml before registering as a member.`,
+        `  Pick a different --name (hosts and members are different roles; ` +
+        `a single name cannot be both).\n` +
+        `  (Or, if you really want this name as a member, remove ` +
+        `"${parsedName.value}" from host_names: in guild.config.yaml first.)`,
     );
   }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -536,6 +536,15 @@ const VERBS: readonly VerbSchema[] = [
             },
           },
         },
+        suggested_next_reason: {
+          type: 'string',
+          description:
+            'Short explanation when `suggested_next` is null but open ' +
+            'work exists. Closes the gap a host sees as "status.pending ≥ 1, ' +
+            'but suggested_next is null" — names which open requests ' +
+            'exist and where to read them. Emitted as JSON null when ' +
+            'silence is genuine (no open work, or actor is unresolved).',
+        },
         past_cliffs: {
           type: 'array',
           description:
@@ -704,6 +713,14 @@ const VERBS: readonly VerbSchema[] = [
           // was added). Keeps `actor_resolved` and any future field
           // visible to schema-aware consumers without a second edit.
           properties: suggestedNextProperties,
+        },
+        suggested_next_reason: {
+          type: 'string',
+          description:
+            'Short explanation when `suggested_next` is null but open ' +
+            'work exists on substrate (e.g. host with pending waves ' +
+            'that name other executors). Emitted as JSON null when ' +
+            'silence is genuine. Mirrors the sibling field on `gate boot`.',
         },
       },
     },

--- a/src/interface/gate/handlers/suggest.ts
+++ b/src/interface/gate/handlers/suggest.ts
@@ -5,7 +5,11 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { C } from './internal.js';
-import { deriveBootSuggestedNext, BootSuggestedNext } from './boot.js';
+import {
+  deriveBootSuggestedNext,
+  deriveSuggestedNextNullReason,
+  BootSuggestedNext,
+} from './boot.js';
 import { parseFormat } from '../../shared/parseFormat.js';
 
 const SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
@@ -34,6 +38,15 @@ const SUGGEST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
 
 interface SuggestPayload {
   suggested_next: BootSuggestedNext | null;
+  /**
+   * Short explanation set when `suggested_next` is `null` but the
+   * substrate still has open work the caller might wonder about
+   * (host with pending waves that name other executors, author who
+   * delegated execution, …). `null` when the silence is genuine.
+   * Matches the sibling field on `gate boot` — two surfaces, one
+   * contract.
+   */
+  suggested_next_reason: string | null;
 }
 
 export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
@@ -57,14 +70,25 @@ export async function suggestCmd(c: C, args: ParsedArgs): Promise<number> {
 
   const allRequests = await c.requestUC.listAll();
   const suggestion = deriveBootSuggestedNext(actor, role, members, allRequests);
+  const reason =
+    suggestion === null && actor !== null
+      ? deriveSuggestedNextNullReason(actor, allRequests)
+      : null;
 
-  const payload: SuggestPayload = { suggested_next: suggestion };
+  const payload: SuggestPayload = {
+    suggested_next: suggestion,
+    suggested_next_reason: reason,
+  };
 
   if (format === 'json') {
     process.stdout.write(JSON.stringify(payload) + '\n');
   } else {
     if (suggestion === null) {
-      process.stdout.write('(nothing urgent)\n');
+      if (reason !== null) {
+        process.stdout.write(`(nothing urgent — ${reason})\n`);
+      } else {
+        process.stdout.write('(nothing urgent)\n');
+      }
     } else {
       // Compact text form: one line for verb + args, one for reason,
       // one trailing advisory footer. The footer goes to stderr so

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -311,6 +311,77 @@ test('suggest: null when registered actor has nothing to do', () => {
     const { stdout } = runGate(root, ['suggest'], { GUILD_ACTOR: 'alice' });
     const payload = JSON.parse(stdout);
     assert.equal(payload.suggested_next, null);
+    // Genuine silence — no open work, no reason to surface.
+    assert.equal(payload.suggested_next_reason, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test('suggest: null with substrate open-work surfaces suggested_next_reason', () => {
+  // Asteria dogfood 2026-05-17: host saw status.pending.total: 1 but
+  // suggested_next: null. The substrate's silence read as a bug. Fix:
+  // a sibling `suggested_next_reason` names which open requests exist
+  // when the suggestion ladder is empty but the substrate isn't.
+  const { root, cleanup } = bootstrap();
+  try {
+    // Alice authors a request naming bob as executor. Host has no
+    // role in the executor list, so actionableTransitions is empty
+    // for the host — but `status.pending.total: 1` would still show.
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executors', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['suggest'], { GUILD_ACTOR: 'human' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next, null);
+    assert.ok(
+      typeof payload.suggested_next_reason === 'string' &&
+        payload.suggested_next_reason.includes('1 pending'),
+      `expected reason to mention 1 pending, got: ${payload.suggested_next_reason}`,
+    );
+    assert.match(payload.suggested_next_reason, /none names you as executor/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('suggest --format text: null + reason → (nothing urgent — <reason>)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executors', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(
+      root,
+      ['suggest', '--format', 'text'],
+      { GUILD_ACTOR: 'human' },
+    );
+    assert.match(stdout, /^\(nothing urgent — /);
+    assert.match(stdout, /1 pending/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('boot: suggested_next_reason field is null when suggested_next is non-null', () => {
+  // When the suggest ladder picks a hint, the hint's own `reason`
+  // field carries the explanation — the sibling field stays null
+  // to avoid duplicate prose at the surface.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'x', '--reason', 'r', '--executors', 'bob'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['boot'], { GUILD_ACTOR: 'bob' });
+    const payload = JSON.parse(stdout);
+    assert.ok(payload.suggested_next !== null);
+    assert.equal(payload.suggested_next_reason, null);
   } finally {
     cleanup();
   }

--- a/tests/interface/boot.test.ts
+++ b/tests/interface/boot.test.ts
@@ -67,6 +67,7 @@ test('gate boot: JSON top-level keys are stable', () => {
         'since',
         'status',
         'suggested_next',
+        'suggested_next_reason',
         'tail',
         'verbs_available_now',
         'warnings',


### PR DESCRIPTION
## Summary

Two touch-feel papercuts from the asteria 30-minute dogfood review:

### 1. `gate boot` / `gate suggest`: sibling `suggested_next_reason`

Closes the gap a host saw as **"status.pending.total: 1 but
`suggested_next: null`"** — the substrate had open work, just none
that named the caller as executor. The new field names the open
counts (pending/approved/executing) and points at `gate list --state
pending`. `null` when silence is genuine.

- Text mode rendering: `(nothing urgent — <reason>)` for suggest,
  `→ (no suggestion — <reason>)` for boot.
- JSON envelope: sibling field, **not nested** in `suggested_next`,
  so hot-loop consumers reading the verb/args/reason triple don't
  have to branch on shape.
- Boot top-level key set picks up `suggested_next_reason` (key-
  stability pin updated).

### 2. `gate register --name`: host-collision error front-loads the fix

Previously the recovery hint led with **"remove from `host_names:`
in `guild.config.yaml`"**, which is the deeper operator action.
First-time users hitting `nao` (a `DEFAULT_HOSTS` reservation) were
reading the longer path first.

- New lead line: **"Pick a different `--name`"**.
- Removal path moves to parenthetical.
- README `30 seconds` block gains a one-liner naming `eris` / `nao`
  as default reservations so the trap surfaces before the user
  types it.

## Files

- `src/interface/gate/handlers/bootActionable.ts` — new
  `deriveSuggestedNextNullReason()` helper.
- `src/interface/gate/handlers/{boot,bootRender,bootTypes,suggest,schema}.ts`
  — wire-through + text rendering + JSON-schema declaration.
- `src/interface/gate/handlers/register.ts` — error message reorder.
- `README.md` — host-name caveat in the 30-second block.
- `tests/interface/ax.test.ts` — 4 new tests pinning the contract.
- `tests/interface/boot.test.ts` — top-level-keys pin updated.
- `.changelog/next/...` — release-note fragment.

## Test plan

- [x] `npm run build` clean
- [x] `node tests/run.mjs dist/tests` — only the pre-existing 8
  failures remain (`executorSingularDeprecation239.test` stale
  after #398 removed `--executor` singular; `loreScope.test`
  shell-script unrelated). No new failures from this PR.
- [x] Targeted: `boot.test` + `ax.test` + `register.test` → 113/113 pass

https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMMEmovcT24rYDfCukvWuN)_