### PR TITLE
fix(members): identity resolution chain — empty file + name divergence (#407)

### DIFF
--- a/.changelog/next/fixed-identity-trust-407.md
+++ b/.changelog/next/fixed-identity-trust-407.md
@@ -1,0 +1,26 @@
+- **`members/`: identity resolution chain hardened (#407).** Two
+  related gaps in the `members/` actor identity boundary, surfaced
+  by a first-impression dogfood:
+  - An empty (0-byte) or malformed `members/<name>.yaml` no longer
+    promotes `<name>` to a registered actor. Previously `exists()`
+    was filename-only, so `touch members/ghost.yaml` was enough for
+    `gate fast-track --from ghost ...` to slip past `assertActor`
+    while `whoami` already classified `ghost` as `unknown` — write
+    verbs and the read-side identity surface disagreed. Both
+    surfaces now follow the same parse + hydrate contract.
+  - The internal `name:` field of `members/<filename>.yaml`, if
+    present, must match the filename stem. A divergence (e.g.
+    `members/alice.yaml` containing `name: leysia`) is now flagged
+    as malformed by `hydrate` and the record is rejected — neither
+    `alice` nor `leysia` resolves to member status from such a file.
+    Previously yaml.name silently won, letting a write-access
+    adversary (or careless operator) promote arbitrary names to
+    `member` by editing the yaml internals without renaming the file.
+  - `SECURITY.md` "Invariants enforced in code" gains an "Identity
+    resolution chain" entry documenting the `GUILD_ACTOR` env /
+    filename / yaml.name resolution rules now enforced.
+  - Three new tests under
+    `tests/infrastructure/hydrateErrorSurface.test.ts` cover the
+    empty-file path, the divergence path, and the regression guard
+    that properly-registered actors (with or without an explicit
+    yaml.name) continue to work transparently.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -133,6 +133,24 @@ For full details: `src/passages/devil/README.md`,
   per issue), inbox messages (500 per member).
 - **YAML safety** — parsing goes through `yaml` lib's default schema
   which refuses custom tags.
+- **Identity resolution chain** (#407) — actor identity goes through
+  three distinct steps that must all agree:
+  - `GUILD_ACTOR` env var is the actor claim (also the trail-author
+    value recorded into request `from`/`by`/`executors` fields).
+  - `members/<name>.yaml` must exist, parse as a YAML mapping, and
+    successfully `hydrate` to count as a registered member. An empty
+    or malformed file does NOT promote `<name>` to actor status —
+    `assertActor` consults `findByName` (parse + hydrate), not bare
+    file existence. (Pre-#407 this was filename-only, so
+    `touch members/ghost.yaml` was enough to slip past `--by` /
+    `--from` / `--executors` validation while `whoami` already
+    classified the same actor as `unknown`.)
+  - The `name:` field inside `members/<name>.yaml`, if present, must
+    equal the filename stem. A divergence (e.g. `members/alice.yaml`
+    containing `name: leysia`) is treated as malformed by `hydrate`
+    and the record is rejected — neither `alice` nor `leysia` is
+    promoted to member status from such a file. The operator must
+    either rename the file or fix the field.
 
 ## Trust assumptions (v0.3.0)
 

--- a/src/infrastructure/persistence/YamlMemberRepository.ts
+++ b/src/infrastructure/persistence/YamlMemberRepository.ts
@@ -52,7 +52,13 @@ export class YamlMemberRepository implements MemberRepository {
   }
 
   async exists(name: MemberName): Promise<boolean> {
-    return existsSafe(this.config.paths.members, `${name.value}.yaml`);
+    // Membership is gated by successful parse + hydrate, not by mere
+    // file existence. A 0-byte or malformed members/<name>.yaml must
+    // NOT promote the name to "registered actor" — `assertActor`
+    // calls this for every write verb's --by/--from/--executor, and
+    // a silent yes there leads to trail entries authored by an
+    // identity the substrate cannot actually describe (issue #407).
+    return (await this.findByName(name)) !== null;
   }
 
   async listAll(): Promise<Member[]> {
@@ -131,6 +137,18 @@ function hydrate(
     return null;
   }
   const obj = data as Record<string, unknown>;
+  // If yaml.name is set, it must match the filename stem. A divergence
+  // (e.g. members/alice.yaml containing `name: leysia`) would otherwise
+  // silently promote an unregistered name to "member" status — see #407.
+  // Treat as malformed and reject the record entirely; the operator
+  // must either rename the file or fix the field.
+  if (typeof obj['name'] === 'string' && obj['name'] !== fallbackName) {
+    onMalformed(
+      source,
+      `yaml.name=${JSON.stringify(obj['name'])} does not match filename stem "${fallbackName}"; rename the file or fix the field; skipping`,
+    );
+    return null;
+  }
   const name =
     typeof obj['name'] === 'string' ? (obj['name'] as string) : fallbackName;
   const category =

--- a/tests/infrastructure/hydrateErrorSurface.test.ts
+++ b/tests/infrastructure/hydrateErrorSurface.test.ts
@@ -435,3 +435,91 @@ test('YamlIssueRepository.findById: unparseable YAML returns null without throwi
     cleanup();
   }
 });
+
+// --- #407: identity trust boundary -------------------------------------
+// Three tests covering H-1 (empty-file actor) and H-2 (yaml.name vs
+// filename divergence). These close the trail-author asymmetry where
+// whoami warns "unknown" but write verbs silently accept the same
+// actor — see issue #407 for the full PoC trace.
+
+test('YamlMemberRepository: empty members/<name>.yaml does not promote to actor (#407 H-1)', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // 0-byte file — the situation an attacker (or a careless operator
+    // with write access to content_root) produces by `touch
+    // members/ghost.yaml`. Pre-#407 this passed `exists()` and any
+    // write verb would silently file a trail entry as `authored ghost`
+    // while `whoami` already classified ghost as `unknown`.
+    writeFileSync(join(root, 'members', 'ghost.yaml'), '');
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (_s, msg) => warnings.push(msg));
+    const repo = new YamlMemberRepository(config);
+
+    const exists = await repo.exists(MemberName.of('ghost'));
+    assert.equal(exists, false, 'empty file must NOT count as registered actor');
+    assert.ok(
+      warnings.some((w) => /top-level YAML is not a mapping/.test(w)),
+      `expected malformed warning, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlMemberRepository: yaml.name diverging from filename is rejected (#407 H-2)', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // `alice.yaml` whose internal `name:` is `leysia`. Pre-#407 hydrate
+    // silently let yaml.name win, so `GUILD_ACTOR=leysia` would
+    // resolve to member status even though no `leysia.yaml` exists.
+    writeFileSync(
+      join(root, 'members', 'alice.yaml'),
+      'name: leysia\ncategory: professional\nactive: true\n',
+    );
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (_s, msg) => warnings.push(msg));
+    const repo = new YamlMemberRepository(config);
+
+    // The unregistered name `leysia` must NOT be promoted to member
+    // status just because some other file says so internally.
+    const leysiaExists = await repo.exists(MemberName.of('leysia'));
+    assert.equal(leysiaExists, false, 'unregistered name must not be promoted via foreign yaml.name');
+
+    // The actual filename owner is also rejected because the file is
+    // malformed — both halves of the spoof path are closed.
+    const aliceExists = await repo.exists(MemberName.of('alice'));
+    assert.equal(aliceExists, false, 'malformed file must not pass exists()');
+
+    assert.ok(
+      warnings.some((w) => /yaml\.name=.*does not match filename stem/.test(w)),
+      `expected divergence warning, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('YamlMemberRepository: properly-registered actor with matching yaml.name still works', async () => {
+  const { root, cleanup } = makeRoot();
+  try {
+    // Regression guard: the most common case (yaml.name omitted, or
+    // yaml.name matches filename) must continue to work transparently.
+    writeFileSync(
+      join(root, 'members', 'bob.yaml'),
+      'name: bob\ncategory: professional\nactive: true\n',
+    );
+    writeFileSync(
+      join(root, 'members', 'carol.yaml'),
+      'category: professional\nactive: true\n', // no yaml.name — falls back to filename
+    );
+    const warnings: string[] = [];
+    const config = GuildConfig.load(root, (_s, msg) => warnings.push(msg));
+    const repo = new YamlMemberRepository(config);
+
+    assert.equal(await repo.exists(MemberName.of('bob')), true, 'matching yaml.name OK');
+    assert.equal(await repo.exists(MemberName.of('carol')), true, 'omitted yaml.name OK');
+    assert.deepEqual(warnings, [], 'happy paths must not warn');
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closes #407.

## What

Two related gaps in the `members/` actor identity boundary, surfaced by a first-impression dogfood (R19) and verified by hand-PoC on a fresh `content_root` (R20a):

### H-1 — empty file slips past write verbs
`members.exists()` was filename-only. `touch members/ghost.yaml` was enough for `gate fast-track --from ghost ...` to file a trail entry as `authored ghost`, while `whoami` already classified the same actor as `unknown`. The two surfaces disagreed.

**Fix**: `exists()` now goes through `findByName()` (parse + hydrate). Both surfaces follow the same contract.

### H-2 — yaml.name silently wins
`hydrate()` let `obj['name']` override the filename stem with no agreement check. `members/alice.yaml` containing `name: leysia` would promote `leysia` to `member` status though no `leysia.yaml` was registered.

**Fix**: `hydrate()` rejects yaml.name ↔ filename divergence as malformed. Operator must rename the file or fix the field.

## Verification

Hand-PoC on `/tmp/guild-407-verify/` post-fix:

```
$ touch members/ghost.yaml
$ GUILD_ACTOR=ghost gate fast-track --action "..." --reason "..."
warn: ... ghost.yaml: top-level YAML is not a mapping; skipping
error: Invalid --from: "ghost" — no such member or host.    ← rejected ✓

$ echo "name: leysia" > members/alice.yaml
$ GUILD_ACTOR=alice gate fast-track --action "..." --reason "..."
warn: ... alice.yaml: yaml.name="leysia" does not match filename stem "alice"; ...
error: Invalid --from: "alice" — no such member or host.    ← rejected ✓
```

## Tests

Three new tests in `tests/infrastructure/hydrateErrorSurface.test.ts`:
- empty file → `exists()` returns false + malformed warning surfaces
- name divergence → both names rejected + divergence warning surfaces
- regression guard: properly-registered actors (with or without explicit yaml.name) still work silently

`npm test`: 1766 pass / 2 fail (unrelated — `loreScope.sh` count not updated for principle 16 added in c0e2e4d).

## Docs

- `SECURITY.md` "Invariants enforced in code" gains an "Identity resolution chain" subsection documenting `GUILD_ACTOR` / filename / yaml.name contract
- `.changelog/next/fixed-identity-trust-407.md` added

## Context

Threat-model-wise: write access to `content_root` is still out of scope. What this PR fixes is the **internal contract asymmetry** — the substrate previously told one surface ("unknown") and another surface ("ok") about the same actor. After this PR they agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)