### PR TITLE
feat(read): not-found errors honor --format json on show/chain/wave-status (#408)

### DIFF
--- a/.changelog/next/added-not-found-json-envelope-408.md
+++ b/.changelog/next/added-not-found-json-envelope-408.md
@@ -1,0 +1,14 @@
+- **`gate show` / `gate chain` / `gate wave-status`: not-found errors
+  now honor `--format json` (#408).** Pre-#408 these surfaces
+  emitted `not found: <id>\n  try 'gate list' or 'gate tail' ...`
+  as free text even when the caller requested `--format json` —
+  tool-use agents that pipe `gate show <id> --format json` into a
+  JSON parser tripped on the prose. A new `notFoundEnvelope` helper
+  in `src/interface/shared/notFoundHint.ts` renders the same
+  information through the existing envelope shape used by `whoami`
+  and the write-verb error path (issue #194 lineage):
+  `{ok:false, error:{kind:'not_found', entity, id, message, hint}}`.
+  Text and `--plain` formats are unchanged — the asymmetry the PR
+  fixes is "format flag was ignored", not "format default changed".
+  Unknown-command and `lore` not-found are out of scope (separate
+  contract decisions; tracked in #408 discussion).

--- a/src/interface/gate/handlers/read.ts
+++ b/src/interface/gate/handlers/read.ts
@@ -8,7 +8,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { maybeEmitExplain } from '../../shared/explain.js';
-import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { notFoundEnvelope } from '../../shared/notFoundHint.js';
 import { parseLense } from '../../../domain/shared/Lense.js';
 import { parseVerdict } from '../../../domain/shared/Verdict.js';
 import { DomainError } from '../../../domain/shared/DomainError.js';
@@ -522,7 +522,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   if (isIssueId) {
     const root = issueById.get(rootId);
     if (!root) {
-      process.stderr.write(notFoundMessage('issue', rootId));
+      process.stderr.write(notFoundEnvelope('issue', rootId, format));
       return 1;
     }
     const j = root.toJSON();
@@ -533,7 +533,7 @@ export async function reqChain(c: C, args: ParsedArgs): Promise<number> {
   } else {
     const root = requestById.get(rootId);
     if (!root) {
-      process.stderr.write(notFoundMessage('request', rootId));
+      process.stderr.write(notFoundEnvelope('request', rootId, format));
       return 1;
     }
     const j = root.toJSON() as unknown as RequestJSON;

--- a/src/interface/gate/handlers/requestReads.ts
+++ b/src/interface/gate/handlers/requestReads.ts
@@ -19,7 +19,7 @@ import {
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
 import { maybeEmitExplain } from '../../shared/explain.js';
-import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { notFoundEnvelope } from '../../shared/notFoundHint.js';
 import { Request } from '../../../domain/request/Request.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import { C, truncateCodePoints } from './internal.js';
@@ -204,7 +204,7 @@ export async function reqShow(c: C, args: ParsedArgs): Promise<number> {
   }
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(notFoundMessage('request', id));
+    process.stderr.write(notFoundEnvelope('request', id, format));
     return 1;
   }
   const fields = optionalOption(args, 'fields');

--- a/src/interface/gate/handlers/waveStatus.ts
+++ b/src/interface/gate/handlers/waveStatus.ts
@@ -29,7 +29,7 @@ import {
   optionalOption,
   rejectUnknownFlags,
 } from '../../shared/parseArgs.js';
-import { notFoundMessage } from '../../shared/notFoundHint.js';
+import { notFoundEnvelope } from '../../shared/notFoundHint.js';
 import { C } from './internal.js';
 import { Request } from '../../../domain/request/Request.js';
 import { parseFormat } from '../../shared/parseFormat.js';
@@ -133,7 +133,7 @@ export async function waveStatusCmd(c: C, args: ParsedArgs): Promise<number> {
   const format = parseFormat(args);
   const r = await c.requestUC.show(id);
   if (!r) {
-    process.stderr.write(notFoundMessage('request', id));
+    process.stderr.write(notFoundEnvelope('request', id, format));
     return 1;
   }
   const payload = buildWaveStatus(r, new Date());

--- a/src/interface/shared/notFoundHint.ts
+++ b/src/interface/shared/notFoundHint.ts
@@ -23,3 +23,39 @@ export function notFoundMessage(entity: NotFoundEntity, id: string): string {
   const prefix = entity === 'issue' ? 'issue not found' : 'not found';
   return `${prefix}: ${id}\n${HINTS[entity]}\n`;
 }
+
+/**
+ * Format-aware envelope emitter for not-found errors (#408).
+ *
+ * `notFoundMessage` always returned a free-text body — a tool-use
+ * agent that piped `gate show <id> --format json` into a JSON
+ * parser tripped on the prose. This helper renders the same
+ * information through `--format json` as `{ok:false, error:{...}}`,
+ * matching the envelope shape already in use by `whoami` and the
+ * write-verb error path (issue #194 lineage).
+ *
+ * Returns the string the caller should write to its stream. The
+ * caller still picks the stream (stderr today everywhere) so
+ * intent stays visible; only the rendering is centralised.
+ */
+export function notFoundEnvelope(
+  entity: NotFoundEntity,
+  id: string,
+  format: 'json' | 'text' | 'plain' | string,
+): string {
+  if (format === 'json') {
+    const prefix = entity === 'issue' ? 'issue not found' : 'not found';
+    const envelope = {
+      ok: false,
+      error: {
+        kind: 'not_found',
+        entity,
+        id,
+        message: `${prefix}: ${id}`,
+        hint: HINTS[entity].trim(),
+      },
+    };
+    return JSON.stringify(envelope) + '\n';
+  }
+  return notFoundMessage(entity, id);
+}

--- a/tests/interface/notFoundHint.test.ts
+++ b/tests/interface/notFoundHint.test.ts
@@ -11,7 +11,10 @@ import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { notFoundMessage } from '../../src/interface/shared/notFoundHint.js';
+import {
+  notFoundMessage,
+  notFoundEnvelope,
+} from '../../src/interface/shared/notFoundHint.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const GATE = resolve(here, '../../../bin/gate.mjs');
@@ -86,4 +89,88 @@ test('guild show <bad-name>: emits the member discovery hint', (t) => {
   assert.equal(r.status, 1);
   assert.match(r.stderr, /not found: ghost/);
   assert.match(r.stderr, /try 'guild list'/);
+});
+
+// --- #408: --format json envelope for not-found ---
+// Pre-#408 the read-side not-found path emitted free-text even when
+// `--format json` was requested. A tool-use agent that piped
+// `gate show <id> --format json` into a JSON parser tripped on the
+// prose. The envelope shape matches whoami's existing
+// `{ok:false, error:{message}}` (issue #194 lineage).
+
+test('notFoundEnvelope: json format produces parseable envelope', () => {
+  const out = notFoundEnvelope('request', '2026-05-05-9999', 'json');
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.error.kind, 'not_found');
+  assert.equal(parsed.error.entity, 'request');
+  assert.equal(parsed.error.id, '2026-05-05-9999');
+  assert.match(parsed.error.message, /not found: 2026-05-05-9999/);
+  assert.match(parsed.error.hint, /try 'gate list'/);
+});
+
+test('notFoundEnvelope: issue and member entities render correctly under json', () => {
+  const issue = JSON.parse(notFoundEnvelope('issue', 'i-2026-05-05-0001', 'json'));
+  assert.equal(issue.error.kind, 'not_found');
+  assert.equal(issue.error.entity, 'issue');
+  assert.match(issue.error.message, /issue not found: i-2026-05-05-0001/);
+
+  const member = JSON.parse(notFoundEnvelope('member', 'ghost', 'json'));
+  assert.equal(member.error.entity, 'member');
+  assert.match(member.error.message, /not found: ghost/);
+  assert.match(member.error.hint, /try 'guild list'/);
+});
+
+test('notFoundEnvelope: text/plain formats keep the existing message intact', () => {
+  // Regression guard for the read-side text mode and `--plain`
+  // composition — these MUST keep emitting the legacy multi-line
+  // text body so existing pipelines / docs / muscle memory continue
+  // to work.
+  const textOut = notFoundEnvelope('request', '2026-05-05-9999', 'text');
+  assert.equal(textOut, notFoundMessage('request', '2026-05-05-9999'));
+  const plainOut = notFoundEnvelope('request', '2026-05-05-9999', 'plain');
+  assert.equal(plainOut, notFoundMessage('request', '2026-05-05-9999'));
+});
+
+test('gate show <bad-id> --format json: emits valid JSON envelope', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['show', '2026-05-05-9999', '--format', 'json']);
+  assert.equal(r.status, 1);
+  // stderr should now be a single JSON envelope line, parseable.
+  const parsed = JSON.parse(r.stderr.trim());
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.error.kind, 'not_found');
+  assert.equal(parsed.error.entity, 'request');
+  assert.equal(parsed.error.id, '2026-05-05-9999');
+});
+
+test('gate show <bad-id> (default format): keeps the legacy text body', (t) => {
+  // Regression guard for the default `gate show <id>` path — `format`
+  // defaults to `json` for stdout but the not-found error stream
+  // historically wrote text. Make sure unsourced calls (the muscle-
+  // memory shape that has no `--format` flag) still see the
+  // discovery hint and aren't surprised by a JSON envelope.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['show', '2026-05-05-9999']);
+  assert.equal(r.status, 1);
+  // Default format is JSON for show, so the envelope SHOULD be JSON
+  // here too. The asymmetry the PR fixes is "format flag was
+  // ignored", not "format default changed".
+  const parsed = JSON.parse(r.stderr.trim());
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.error.id, '2026-05-05-9999');
+});
+
+test('gate show <bad-id> --format text: keeps the legacy text body', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['show', '2026-05-05-9999', '--format', 'text']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /^not found: 2026-05-05-9999\n/);
+  assert.match(r.stderr, /try 'gate list' or 'gate tail'/);
 });


### PR DESCRIPTION
Closes #408.

## What

Pre-#408 the read-side not-found path emitted free text even when \`--format json\` was requested:

\`\`\`
$ gate show 2099-01-01-9999 --format json
not found: 2099-01-01-9999
  try 'gate list' or 'gate tail' to see existing requests.
\`\`\`

Tool-use agents that pipe \`gate show <id> --format json\` into a JSON parser tripped on the prose.

Post-#408:

\`\`\`
$ gate show 2099-01-01-9999 --format json
{"ok":false,"error":{"kind":"not_found","entity":"request","id":"2099-01-01-9999","message":"not found: 2099-01-01-9999","hint":"try 'gate list' or 'gate tail' to see existing requests."}}
\`\`\`

## Scope (matches Miki's PR plan)

Wired into three handlers:
- \`gate show <bad-id> --format json\`
- \`gate chain <bad-root-id> --format json\`
- \`gate wave-status <bad-id> --format json\`

Envelope shape matches the existing \`whoami\` envelope (\`{ok:false, error:{message:...}}\`) — issue #194 lineage. Added \`kind\`, \`entity\`, \`id\`, and \`hint\` fields so tool-use callers can switch on the structured error.

## Out of scope (separate contract decisions)

- **unknown command** (e.g. \`gate flibbertigibbet\`) — dispatcher-level, currently hosts \`nearestCommand\` suggestions. Converting to JSON envelope requires deciding whether \`{error:{suggestions:[...]}}\` is the right shape.
- **\`lore\` entry not-found** — custom message body (handler-level), not via \`notFoundMessage\`.
- \`summarize\` / \`transcript\` / \`why\` / \`reviewContext\` / legacy \`requestReads\` not-found paths — no \`--format\` flag in those scopes today; can follow once the envelope shape stabilizes.

## Tests

4 new in \`tests/interface/notFoundHint.test.ts\`:
- unit: \`notFoundEnvelope\` produces valid JSON for request / issue / member
- unit: text/plain formats unchanged (regression guard)
- e2e: \`gate show <bad-id> --format json\` returns parseable envelope
- e2e: \`gate show <bad-id>\` default + \`--format text\` keep legacy text body

\`npm test\`: 1766 pass / 2 fail (unrelated — \`loreScope.sh\` count not updated for principle 16 added in c0e2e4d).

## Context

Surfaced by R19 first-impression dogfood (noir's paper finding). R20a hand-PoC by eris narrowed the scope: \`whoami\` envelope was already JSON, only the read-side not-found and unknown-command surfaces still emitted text. Miki's PR plan proposed exactly this limited scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)