### PR TITLE
docs: README install entry (3 styles) + AGENT.md humans-welcome preface (R19 dogfood)

### DIFF
--- a/.changelog/next/changed-readme-30-seconds-install-styles.md
+++ b/.changelog/next/changed-readme-30-seconds-install-styles.md
@@ -1,0 +1,27 @@
+- **README `30 seconds`: install entry now 3-tier + shell-portable
+  GUILD_ACTOR.** R19 first-impression dogfood (yuki / asteria /
+  miki) surfaced two doc papercuts that the prior block left to the
+  reader:
+  - The leading `npm install` looked clone-first by default, with
+    `npx gate` / `npm i -g` buried in a blockquote — newcomers
+    repeatedly missed the "use inside an existing repo" path. The
+    block now presents three explicit install styles (A clone, B
+    drop-in dev-dep, C one-off npx) so the reader picks before
+    running anything.
+  - The `export GUILD_ACTOR=` line was bash-shaped only; fish and
+    PowerShell readers had to mentally re-translate. The exports
+    for all three shells now sit inline as comments under the
+    POSIX form.
+- **README config warning: "no `guild.config.yaml`? no problem" is
+  now leading prose, not the overcautious "pick a name distinct
+  from `host_names:`" warning the dogfood read as gatekeeping.**
+  The substrate already handles the config-less path with a clear
+  `notice: config: none — cwd used as fallback root` line; the
+  README now says that *before* getting into the host-name
+  collision detail, which is now framed as "if you do add a
+  config" rather than "before you start".
+- **`AGENT.md`: explicit "humans welcome" preface.** R19 dogfood
+  (yuki) found the "AI-agent-first" framing read as a membership
+  tier to first-time human readers. The preface now reframes it as
+  "documentation density choice, not membership tier" — humans and
+  AI share a content_root, share a trail, share the same verbs.

--- a/AGENT.md
+++ b/AGENT.md
@@ -12,8 +12,17 @@
 > mirror / synergy / axis / lore / etc.), see
 > [`docs/glossary.md`](./docs/glossary.md).
 
-File-based coordination for AI agents. No daemon, no DB, no network.
-State lives in YAML files under a `content_root`. Git gives you history.
+> **Humans welcome.** This file is the short-form for AI agents
+> because it densifies — verbs, state machine, JSON envelope — into
+> something an agent can consume cold. Humans reading the same file
+> get the same information without the prose padding. The substrate
+> doesn't distinguish: human and AI actors share a content_root,
+> share a trail, share the same verbs. AI-agent-first is a
+> documentation density choice, not a membership tier.
+
+File-based coordination for human and AI agents. No daemon, no DB, no
+network. State lives in YAML files under a `content_root`. Git gives
+you history.
 
 ## Solo flow
 

--- a/README.md
+++ b/README.md
@@ -22,22 +22,41 @@ lense, and whether the objection was absorbed or overridden.
 
 ## 30 seconds
 
+Pick the install style that fits — every step after `register` is the
+same.
+
 ```bash
-npm install                              # auto-builds via prepare
+# A. Use it standalone (most common):
+git clone https://github.com/eris-ths/guild-cli && cd guild-cli && npm install
+
+# B. Use it inside an existing repo:
+npm install --save-dev eris-ths/guild-cli            # then `npx gate <verb>`
+# (or `npm i -g eris-ths/guild-cli` for a system-wide `gate` command)
+
+# C. One-off try without installing:
+npx -y github:eris-ths/guild-cli gate <verb>
+
+# Then, in whatever directory you want as the content_root:
 gate register --name <you>               # once per content_root
-export GUILD_ACTOR=<you>                 # once per shell
+export GUILD_ACTOR=<you>                 # once per shell (POSIX)
+                                          #   fish: set -x GUILD_ACTOR <you>
+                                          #   powershell: $env:GUILD_ACTOR = "<you>"
 gate boot                                # orient (identity + queues + tail + inbox)
 gate fast-track --action "..." --reason "..."
 ```
 
-> `gate` resolves to `./bin/gate.mjs` after install (or `npx gate`,
-> or `npm i -g`). Throughout this README `gate <verb>` is the canonical
-> form — `node ./bin/gate.mjs <verb>` works too if you'd rather not
-> rely on PATH.
+> Throughout this README `gate <verb>` is the canonical form. After
+> install A or B, `gate` resolves to `./bin/gate.mjs`. If you'd rather
+> spell it out, `node ./bin/gate.mjs <verb>` works too.
 
-> Pick `<you>` to be a name distinct from `host_names:` in
-> `guild.config.yaml` (default reservations: `eris`, `nao`). Hosts and
-> members are different roles, so `register --name eris` is rejected
+> **No `guild.config.yaml`? No problem.** `gate register` works in any
+> empty directory — the cwd becomes the `content_root` and you'll see
+> a `notice: config: none — cwd used as fallback root` line so you know
+> nothing is being silently inferred elsewhere. Drop in a
+> `guild.config.yaml` later if you want to customize `host_names` or
+> paths. If you do, pick `<you>` to be a name distinct from
+> `host_names:` (default reservations: `eris`, `nao`) — hosts and
+> members are different roles, and `register --name eris` is rejected
 > with a one-line hint to pick a different name.
 
 That's the loop. The whole tool is six verbs:


### PR DESCRIPTION
Three doc papercuts surfaced by the R19 first-impression dogfood (yuki / asteria / miki perspectives).

## What

### README \`30 seconds\` install entry
- Leading \`npm install\` looked clone-first by default. \`npx gate\` / global install were buried in a blockquote. Three explicit install styles (A clone, B drop-in dev-dep, C one-off npx) now lead, so the reader picks before running anything.
- \`export GUILD_ACTOR=\` was bash-only. Fish / PowerShell forms now sit inline as comments.

### README config warning
- "Pick \`<you>\` distinct from \`host_names:\`" read as gatekeeping to fresh agents — the substrate already runs config-less with a clear notice (\`config: none — cwd used as fallback root\`). The "no \`guild.config.yaml\`? no problem" line now leads; host-name collision detail follows as "if you do add a config".

### AGENT.md
- "AI-agent-first" framing read as a membership tier to first-time human readers. New preface reframes it as a **documentation-density choice, not a membership tier**:
  > Humans welcome. This file is the short-form for AI agents because it densifies — verbs, state machine, JSON envelope — into something an agent can consume cold. Humans reading the same file get the same information without the prose padding. The substrate doesn't distinguish: human and AI actors share a content_root, share a trail, share the same verbs.

## Tests

Doc-only. No tests touched. \`npm test\` unchanged.

## Context

R19 first-impression dogfood synthesis at \`repos/eris-shell/dogfood/R19_first_impression.md\` (Round 2 / Yuki finding integrated into PR 4 per magi council judgment 3). Independent perspectives that converged on this PR:
- **eris (touch)**: F1 (install entry clone-first bias) + F2 (config warning overcautious)
- **yuki (human LDD)**: "AI agent first" reads as second-class to humans; suggested 1-line invitation
- **asteria (counter)**: F3-F6 are stance, not friction, but F1+F2 are real papercuts
- **miki (PR plan)**: scope minimization → doc-only, 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)