### PR TITLE
chore(test): bump loreScope counts 15→16 after principle 16 (c0e2e4d)

### DIFF
--- a/tests/scripts/loreScope.test.ts
+++ b/tests/scripts/loreScope.test.ts
@@ -2,11 +2,15 @@
 //
 // What this pins:
 //   * `solo` filter → 14 principles (the unannotated set), and the
-//     one annotated 'swarm' principle (14) is NOT in the result.
-//   * `swarm` filter → all 15 (the 14 default-'all' + principle 14
-//     which explicitly carries applies_to: swarm).
-//   * `all` filter → all 15.
+//     annotated 'swarm' principles (14, 16) are NOT in the result.
+//   * `swarm` filter → all 16 (the 14 default-'all' + principle 14
+//     and principle 16 which explicitly carry applies_to: swarm).
+//   * `all` filter → all 16.
 //   * Invalid audience exits non-zero (POSIX usage convention).
+//
+// Counts shift when a new principle lands. If you add principle 17,
+// bump the swarm/all asserts here. The solo count only changes when
+// the new file omits `applies_to:` (default 'all').
 //
 // Why a subprocess test (and not unit-testing a parser): the script is
 // the contract. Reading frontmatter via shell is the deliverable, and
@@ -70,20 +74,26 @@ test('lore-scope.sh solo includes 14 unannotated principles and excludes 14-', (
   );
 });
 
-test('lore-scope.sh swarm includes principle 14 plus all 14 unannotated', () => {
+test('lore-scope.sh swarm includes the swarm-annotated principles plus all unannotated', () => {
   const out = run('swarm');
   assert.equal(out.status, 0, `swarm should exit 0; stderr=${out.stderr}`);
   const files = lines(out.stdout).map((p) => basename(p));
   assert.equal(
     files.length,
-    15,
-    `expected 15 swarm principles, got ${files.length}: ${files.join(', ')}`,
+    16,
+    `expected 16 swarm principles, got ${files.length}: ${files.join(', ')}`,
   );
-  const annotated = files.filter((f) => f.startsWith('14-'));
+  const p14 = files.filter((f) => f.startsWith('14-'));
   assert.equal(
-    annotated.length,
+    p14.length,
     1,
-    `principle 14 must appear in swarm set exactly once, got ${annotated.length}`,
+    `principle 14 must appear in swarm set exactly once, got ${p14.length}`,
+  );
+  const p16 = files.filter((f) => f.startsWith('16-'));
+  assert.equal(
+    p16.length,
+    1,
+    `principle 16 must appear in swarm set exactly once, got ${p16.length}`,
   );
 });
 
@@ -91,7 +101,7 @@ test('lore-scope.sh all returns every principle', () => {
   const out = run('all');
   assert.equal(out.status, 0, `all should exit 0; stderr=${out.stderr}`);
   const files = lines(out.stdout);
-  assert.equal(files.length, 15, `expected 15 'all' principles, got ${files.length}`);
+  assert.equal(files.length, 16, `expected 16 'all' principles, got ${files.length}`);
 });
 
 test('lore-scope.sh passage:devil includes universal principles (applies_to: all is the floor)', () => {


### PR DESCRIPTION
## Why CI is red on every new PR

Principle 16 (\`16-substrate-as-replay-corpus.md\`, \`applies_to: swarm\`) landed in c0e2e4d. The \`tests/scripts/loreScope.test.ts\` expected counts were not bumped at the same time, so CI on every PR against current main hits two stale-count failures:

\`\`\`
not ok - lore-scope.sh swarm includes principle 14 plus all 14 unannotated
not ok - lore-scope.sh all returns every principle
\`\`\`

This is visible on #410 and #411 (and presumably any other PR with code changes that triggers the full test job).

## Fix

- \`swarm\` count: 15 → 16 (was 14 universal + p14; now + p16)
- \`all\` count: 15 → 16
- \`p16\` presence assertion added (parallel to existing p14 check)
- Leading comment refreshed + a note explaining when to bump counts on future principles

\`solo\` (14 universal) and \`passage:devil\` (14 universal) unchanged because principle 16 carries \`applies_to: swarm\`, not \`'all'\`.

## Tests

\`npm test\`: **1762 / 1762 pass** (zero failures, no skips). Local verification confirmed before commit.

## Context

Discovered while running R20b dogfood PRs (#410 / #411) — they both hit the same 2 failures, which traced back to current main rather than the PRs. Filing this as a small chore PR so #410 / #411 can be re-evaluated against a green baseline.

Land this first, then rebase #410 / #411 to pick up the green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)