### PR TITLE
docs(verbs): document execute non-enforcing transition (#409)

### DIFF
--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -210,6 +210,45 @@ The per-request actionable[] is capped at 5 entries to keep the boot
 payload lean (it sits on the agent hot path); deeper backlogs remain
 visible via `status.reviews_unseen`.
 
+### Execute: non-enforcing transition (#168)
+
+Unlike `complete` and `fail`, `execute` does **not** reject when the
+`--by` actor was not named in `--executors` at request time.
+`complete` / `fail` enforce `rejectIfNonMember` (terminal transitions
+are membership-gated); `execute` is deliberately permissive.
+
+This is intentional. `--executors` records **intent** (who is expected
+to do the work), not access (who is allowed to claim a transition).
+Late-binding executors are common: an actor who picks up a wave a
+peer originally took, or a swarm member who steps in mid-flight,
+runs `execute` with `--by <self>` and the substrate captures both
+the originally-assigned list and the actual executor in the
+`status_log` entry. The terminal `complete` / `fail` is where
+membership enforcement closes the loop, because that is where the
+trail's authoritative claim of "who finished the work" gets stamped.
+
+The asymmetry surfaces a `notice:` on the `execute` response when
+the `--by` actor differs from the assigned list, so the mismatch
+is visible at the surface that did it rather than hidden until the
+post-mortem read. See
+[issue #168](https://github.com/eris-ths/guild-cli/issues/168)
+for the original design discussion.
+
+```bash
+gate request --executors alice --from kiri ...
+# → 2026-04-16-0001 (pending, executors=[alice])
+
+gate approve 2026-04-16-0001 --by kiri
+# → approved
+
+gate execute 2026-04-16-0001 --by bob          # not in executors, but accepted
+# notice: executor 'bob' not in assigned list [alice] — late-binding ok
+# → executing
+
+gate complete 2026-04-16-0001 --by bob         # if bob is not a member: rejected here
+# (membership enforcement is at the terminal transition, not at execute)
+```
+
 ### Write verbs: `--format json` and `suggested_next`
 
 Every write verb (`request`, `approve`, `deny`, `execute`, `complete`,


### PR DESCRIPTION
Closes #409.

## What

Adds an "Execute: non-enforcing transition" section to \`docs/verbs.md\` documenting the asymmetry settled in design judgment #168: \`--executors\` records intent but \`gate execute\` does not reject when \`--by\` is not in the assigned list. \`complete\` / \`fail\` enforce \`rejectIfNonMember\`; \`execute\` deliberately does not.

The new section explains:
- The asymmetry, up front
- The intent / access distinction (\`--executors\` records intent, not access)
- Late-binding executors as the design rationale
- Where membership enforcement actually closes the loop (terminal transitions, not execute)
- The \`notice:\` line that surfaces the mismatch at the surface that did it
- Link back to #168 for the original discussion
- A worked example showing the late-binding flow

## What this is not

- **No behavior change.** Pure documentation.
- **No reopening of #168.** That design judgment is settled. This PR honors the conclusion by making it visible to readers who would otherwise hypothesize a bug.

## Tests

Doc-only. \`docs/verbs.md\` is not under test runner; reviewed by eye.

## Context

Three independent perspectives in the R19 first-impression dogfood converged on the same call: H-3 (execute asymmetry) is **not** an intent change candidate, it's a documentation gap.

- **devil** (paper, source-direct): flagged the asymmetry as a security-adjacent gap
- **asteria** (counter-thesis): "H-3 is inflation; #168 already settled it as intent, doc only"
- **lecteur** (line-level cross-check): "#168 is closed; reopening would be reopening a settled design"

This PR is the smallest-possible doc landing of that convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)