### PR TITLE
docs(readme): gloss fast-track + explain alpha-passage bin path

### DIFF
--- a/.changelog/next/changed-readme-fast-track-and-passages-path.md
+++ b/.changelog/next/changed-readme-fast-track-and-passages-path.md
@@ -1,0 +1,12 @@
+- **README: `gate fast-track` is now glossed where the "30 seconds" loop
+  first uses it.** The quick-start told newcomers to run `gate fast-track`
+  but the verb was absent from the "the whole tool is six verbs" list and
+  never defined — so the loop you're told to run and the loop you're shown
+  didn't line up. An inline comment plus a one-line note now explain that
+  fast-track collapses request → approve → execute for the self-flow case,
+  while the six verbs remain the full deliberation loop.
+- **README: the Passages note says *why* agora / devil / ctx run via
+  `node ./bin/<name>.mjs`.** Only `gate` and `guild` are registered as
+  `bin` commands in `package.json`, so the alpha passages aren't on PATH
+  even after a global install — the README now states that rather than
+  leaving the reader to infer it.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export GUILD_ACTOR=<you>                 # once per shell (POSIX)
                                           #   fish: set -x GUILD_ACTOR <you>
                                           #   powershell: $env:GUILD_ACTOR = "<you>"
 gate boot                                # orient (identity + queues + tail + inbox)
-gate fast-track --action "..." --reason "..."
+gate fast-track --action "..." --reason "..."   # request→approve→execute in one self-flow call
 ```
 
 > Throughout this README `gate <verb>` is the canonical form. After
@@ -69,6 +69,11 @@ gate execute    # take it on
 gate complete   # / fail
 gate review     # leave a judgment under a named lense
 ```
+
+These six are the full deliberation loop — for work someone *else*
+reviews or runs. `gate fast-track` (used in the 30-second loop above)
+is the self-flow shortcut: it collapses request → approve → execute
+into one call when you file *and* run the work yourself.
 
 Everything else is depth on top.
 
@@ -109,9 +114,11 @@ interaction running through the same `content_root`.
 
 Set is open — see [`lore/principle 12`](./lore/principles/12-substrate-pure-module-in-projection-ecosystem.md).
 Architecture detail in [`AGENT.md`](./AGENT.md). agora / devil / ctx
-are alpha and **opt-in**: invoke as `node ./bin/<name>.mjs ...`.
-`gate` is the primary entry; `guild` is the admin-side helper for
-managing the container itself.
+are alpha and **opt-in**: only `gate` and `guild` are registered as
+`bin` commands (see `package.json`), so the alpha passages run via
+their script path — `node ./bin/<name>.mjs ...`. `gate` is the primary
+entry; `guild` is the admin-side helper for managing the container
+itself.
 
 ## Make it yours (optional)
 


### PR DESCRIPTION
Two small first-impression README gaps found during an Opus 4.8 read (split out from the touch-feel fixes in #416, as requested).

### 1. `fast-track` was used in "30 seconds" but never defined
The quick-start tells a newcomer to run:
```bash
gate fast-track --action "..." --reason "..."
```
…yet `fast-track` is absent from the **"the whole tool is six verbs"** list right below it, and nothing says what it does. So the loop you're *told to run* and the loop you're *shown* didn't line up — and a reader can't tell that fast-track self-approves.

Fix: an inline gloss on the quick-start line (`# request→approve→execute in one self-flow call`) plus a one-line note under the six-verb block — the six verbs are the full deliberation loop (for work someone *else* reviews/runs); fast-track is the self-flow shortcut that collapses them. Keeps the "six verbs" framing intact (principle 13: fast-track is a *boundary* one-shot, not a seventh lifecycle verb).

### 2. Why agora / devil / ctx need `node ./bin/<name>.mjs`
The Passages note already says they're alpha and run via the script path, but not *why*. Only `gate` and `guild` are registered as `bin` commands in `package.json`, so the alpha passages aren't on PATH even after a global install. The README now states that rather than leaving the reader to infer it.

No code changes. Changelog fragment added under `.changelog/next/`.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_