### PR TITLE
fix(touch-feel): write-lifecycle not-found errors gain the read-path discovery hint

### DIFF
--- a/.changelog/next/fixed-write-not-found-discovery-hint.md
+++ b/.changelog/next/fixed-write-not-found-discovery-hint.md
@@ -1,0 +1,16 @@
+- **Write-lifecycle not-found errors now carry the same discovery hint
+  the read verbs already emit.** `gate approve` / `deny` / `execute` /
+  `complete` / `fail` on a mistyped or stale id threw `Request not found:
+  <id>` straight through the shared error envelope with no pointer to
+  recovery — while `gate show <id>` (and the other read verbs) had carried
+  `try 'gate list' or 'gate tail'` since the not-found-hint work. The two
+  not-found surfaces disagreed; the write side was the worse touch-feel.
+  `emitErrorEnvelope` now performs the wire-up sweep its own doc
+  anticipated: a recognized `Request not found` gains the prose hint line
+  plus, under `--format json`, an `error.hint` field and a structured
+  `error.recovery` (`{verb: "list", …}`) — `error.message` stays clean so
+  existing parsers are unaffected. Both the dry-run (plain `Error`) and
+  real (`DomainError`) not-found paths are covered. Sibling passages
+  (agora / devil / ctx) that share the envelope are untouched: the hint is
+  attached only for the `request` entity, never stapled onto an unrelated
+  `Play not found` / `Review not found`.

--- a/src/interface/shared/errorEnvelope.ts
+++ b/src/interface/shared/errorEnvelope.ts
@@ -27,6 +27,7 @@
 import { DomainError } from '../../domain/shared/DomainError.js';
 import { LockBusyError } from '../../infrastructure/lock/guildLock.js';
 import { sanitizeError } from './sanitizeError.js';
+import { notFoundHintForMessage } from './notFoundHint.js';
 
 /**
  * Per-call options for {@link emitErrorEnvelope}. All three are
@@ -143,6 +144,27 @@ export function emitErrorEnvelope(
   const rawMsg = err instanceof Error ? err.message : String(err);
   const prefixed = opts.prefix ? `${opts.prefix}${rawMsg}` : rawMsg;
   const msg = sanitizeError(prefixed, contentRoot);
+
+  // Recovery source priority (computed once, used by both surfaces):
+  //   1. `err instanceof RecoverableError` → err.recovery wins
+  //      (the throw site authored the recovery; honour it).
+  //   2. opts.recovery → caller of emitErrorEnvelope supplied one.
+  //   3. generic not-found enrichment (below) → the wire-up sweep the
+  //      doc above anticipated. Read verbs emit their own hint and
+  //      return; the write lifecycle throws `Request not found`, which
+  //      arrives here hint-less. Attach the same per-entity discovery
+  //      hint + recovery the read path uses — but ONLY when the throw
+  //      site didn't already author one, so explicit recoveries win.
+  //   4. absence → no `recovery` field on the wire (the no-known-
+  //      recovery signal consumers branch on).
+  const explicitRecovery =
+    err instanceof RecoverableError ? err.recovery : opts.recovery;
+  const notFound =
+    explicitRecovery === undefined && deriveErrorCode(err) === 'not_found'
+      ? notFoundHintForMessage(msg)
+      : null;
+  const recovery = explicitRecovery ?? notFound?.recovery;
+
   if (format === 'json') {
     const errObj: Record<string, unknown> = { message: msg };
     // field: err.field wins; opts.field is fallback (see EmitOptions doc).
@@ -158,25 +180,24 @@ export function emitErrorEnvelope(
     } else if (opts.code !== undefined) {
       errObj['code'] = opts.code;
     }
-    // recovery: structured next-step. Source priority:
-    //   1. `err instanceof RecoverableError` → err.recovery wins
-    //      (the throw site authored the recovery; honour it).
-    //   2. opts.recovery → caller of emitErrorEnvelope supplied one.
-    //   3. absence → no `recovery` field on the wire.
-    // Consumers branch on field presence; absence is the no-known-
-    // recovery signal. Today only the throw sites with an obvious
-    // "use verb X instead" answer pass this — generic not-found /
-    // validation errors keep their existing prose-only surface
-    // until a wire-up sweep follows.
-    const recovery =
-      err instanceof RecoverableError ? err.recovery : opts.recovery;
+    // hint: the human-facing discovery line, mirrored onto the wire so
+    // JSON consumers see the same recovery affordance as text readers.
+    // `message` stays clean (matches the read-path notFoundEnvelope,
+    // where hint is a sibling field, not folded into message).
+    if (notFound !== null) {
+      errObj['hint'] = notFound.hint;
+    }
     if (recovery !== undefined) {
       errObj['recovery'] = recovery;
     }
     const payload = { ok: false, error: errObj };
     process.stderr.write(JSON.stringify(payload) + '\n');
   }
-  process.stderr.write(`error: ${msg}\n`);
+  // Prose: append the discovery hint on its own indented line so the
+  // terminal reader who mistyped an id recovers in one read — matching
+  // the read-path `not found: <id>\n  try 'gate list' …` shape.
+  const hintSuffix = notFound !== null ? `\n  ${notFound.hint}` : '';
+  process.stderr.write(`error: ${msg}${hintSuffix}\n`);
 }
 
 /**

--- a/src/interface/shared/notFoundHint.ts
+++ b/src/interface/shared/notFoundHint.ts
@@ -59,3 +59,48 @@ export function notFoundEnvelope(
   }
   return notFoundMessage(entity, id);
 }
+
+/**
+ * Map a *thrown* not-found error message to its discovery hint +
+ * structured recovery, when the message is a recognized shape.
+ *
+ * Why this exists separately from {@link notFoundMessage}: the read
+ * verbs (show / why / transcript / summarize / …) call
+ * `notFoundMessage`/`notFoundEnvelope` directly and `return` without
+ * throwing, so they already carry the hint. The WRITE lifecycle verbs
+ * (approve / deny / execute / complete / fail) instead throw a
+ * `Request not found: <id>` that surfaces through the shared
+ * {@link emitErrorEnvelope} catch path — and pre-this-sweep it arrived
+ * hint-less, the worse touch-feel of the two not-found paths. This
+ * function lets the central envelope attach the SAME per-entity hint
+ * the read path uses, keeping the two surfaces in phrasing-sync.
+ *
+ * Returns null for messages that don't name a known entity (e.g.
+ * agora / devil / ctx not-founds, which share `emitErrorEnvelope`),
+ * so the shared envelope leaves those untouched rather than stapling a
+ * gate-specific `gate list` hint onto an unrelated passage's error.
+ */
+export function notFoundHintForMessage(message: string): {
+  entity: NotFoundEntity;
+  hint: string;
+  recovery: { verb: string; args: Record<string, string>; reason: string };
+} | null {
+  // Only `request` reaches the shared catch as a throw today; issues
+  // and members emit their hint + return from their own handlers. The
+  // anchored pattern keeps a passing "review not found" / "play not
+  // found" from a sibling passage out of this branch.
+  if (/\brequest not found\b/i.test(message)) {
+    return {
+      entity: 'request',
+      hint: HINTS.request.trim(),
+      recovery: {
+        verb: 'list',
+        args: {},
+        reason:
+          "id not found — run 'gate list' (or 'gate tail') to see existing request ids",
+      },
+    };
+  }
+  return null;
+}
+

--- a/tests/interface/notFoundHint.test.ts
+++ b/tests/interface/notFoundHint.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 import {
   notFoundMessage,
   notFoundEnvelope,
+  notFoundHintForMessage,
 } from '../../src/interface/shared/notFoundHint.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -173,4 +174,64 @@ test('gate show <bad-id> --format text: keeps the legacy text body', (t) => {
   assert.equal(r.status, 1);
   assert.match(r.stderr, /^not found: 2026-05-05-9999\n/);
   assert.match(r.stderr, /try 'gate list' or 'gate tail'/);
+});
+
+// --- write-lifecycle parity: the THROWN not-found path gains the same
+// hint the read path emits. Pre-this-sweep `gate approve <typo>` (a
+// thrown `Request not found`) dead-ended through the shared error
+// envelope with no `gate list` signal, while `gate show <typo>` (an
+// emit-and-return read) carried it — the two not-found surfaces
+// disagreed. notFoundHintForMessage + emitErrorEnvelope close the gap.
+
+test('notFoundHintForMessage: matches a thrown request not-found, with recovery', () => {
+  const r = notFoundHintForMessage('Request not found: 2026-05-05-9999');
+  assert.ok(r);
+  assert.equal(r!.entity, 'request');
+  assert.match(r!.hint, /try 'gate list' or 'gate tail'/);
+  assert.equal(r!.recovery.verb, 'list');
+});
+
+test('notFoundHintForMessage: returns null for a sibling-passage not-found', () => {
+  // agora / devil / ctx share emitErrorEnvelope; a `Play not found`
+  // must NOT get a gate-specific `gate list` hint stapled on.
+  assert.equal(notFoundHintForMessage('Play "p1" not found'), null);
+  assert.equal(notFoundHintForMessage('all good'), null);
+});
+
+test('gate approve <bad-id>: write path now emits the discovery hint', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['approve', '2026-05-05-9999', '--by', 'alice']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Request not found: 2026-05-05-9999/);
+  assert.match(r.stderr, /try 'gate list' or 'gate tail'/);
+});
+
+test('gate approve <bad-id> --dry-run: hint rides the dry-run throw too', (t) => {
+  // The dry-run branch threw a plain Error (no DomainError.field); the
+  // real branch threw a DomainError from the use-case. Both surface
+  // through the same envelope and must both carry the hint now.
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['approve', '2026-05-05-9999', '--by', 'alice', '--dry-run']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /try 'gate list' or 'gate tail'/);
+});
+
+test('gate complete <bad-id> --format json: hint + recovery on the wire, message stays clean', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  const r = run(GATE, root, ['complete', '2026-05-05-9999', '--by', 'alice', '--format', 'json']);
+  assert.equal(r.status, 1);
+  const line = r.stderr.split('\n').find((l) => l.trim().startsWith('{'));
+  assert.ok(line, 'expected a JSON envelope line on stderr');
+  const p = JSON.parse(line!);
+  assert.equal(p.error.code, 'not_found');
+  // message stays clean (ax.test contract) — hint is a sibling field.
+  assert.match(p.error.message, /^Request not found: 2026-05-05-9999$/);
+  assert.match(p.error.hint, /try 'gate list'/);
+  assert.equal(p.error.recovery.verb, 'list');
 });


### PR DESCRIPTION
## The gap

A second touch-feel pass — this time grounded in `gate lore` before touching anything, per the lesson from #416.

Sweeping the error paths surfaced one clear inconsistency. The **read** verbs already guide you when you mistype an id:

```
$ gate show 2026-05-05-9999
not found: 2026-05-05-9999
  try 'gate list' or 'gate tail' to see existing requests.
```

…but the **write** lifecycle verbs dead-ended:

```
$ gate approve 2026-05-05-9999 --by eris
error: Request not found: 2026-05-05-9999          ← no recovery pointer
```

Same mistake (lost/typo'd id), worse experience — and it's the *write* path where you most want the nudge. The read side throws nothing (it emits `notFoundEnvelope` and returns); the write lifecycle throws `Request not found`, which flows through the shared `emitErrorEnvelope`. That catch path had a `recovery` mechanism and a `not_found` code already wired, and its own doc even said generic not-founds *"keep their existing prose-only surface **until a wire-up sweep follows**."* This is that sweep.

## The fix

`emitErrorEnvelope` now enriches a recognized `Request not found`:

```
$ gate approve 2026-05-05-9999 --by eris
error: Request not found: 2026-05-05-9999
  try 'gate list' or 'gate tail' to see existing requests.

$ gate complete 2026-05-05-9999 --by eris --format json
{"ok":false,"error":{"message":"Request not found: 2026-05-05-9999","field":"id",
  "code":"not_found","hint":"try 'gate list' …","recovery":{"verb":"list","args":{},"reason":"…"}}}
```

- **Single choke point** — covers all five write verbs, both the dry-run (plain `Error`) and real (`DomainError`) not-found paths, at once.
- **`error.message` stays clean** — the hint is a sibling field, matching the read-path `notFoundEnvelope` shape; the `ax.test` contract (`message` matches `/Request not found/`) is preserved.
- **Sibling passages untouched** — `notFoundHintForMessage` matches only the `request` entity, so a shared-envelope `Play not found` / `Review not found` from agora/devil/ctx never gets a gate-specific `gate list` hint stapled on.

### Why this is lore-aligned (and #416's mistake isn't repeated)
This is **error-recovery guidance**, which CLAUDE.md's house style explicitly calls for (`error message に "next:" を添えて recovery path を提示`) — *not* a success-path `next:` hint, so principle 13 (affordance density follows verb shape) doesn't apply. It also closes the `formatContentRootDisclosure`-style arm of `trap_silent_fallback_loses_signal`: a not-found now carries a recovery cue instead of dead-ending.

## Tests
`tests/interface/notFoundHint.test.ts`: unit (`notFoundHintForMessage` matches request, returns null for sibling passages) + e2e (`gate approve <bad>` text, `--dry-run`, `gate complete <bad> --format json` hint+recovery with clean message). Full suite **1784 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_