### PR TITLE
feat(touch-feel): gate execute on a pending request redirects to gate approve

### DIFF
--- a/.changelog/next/changed-execute-from-pending-redirect.md
+++ b/.changelog/next/changed-execute-from-pending-redirect.md
@@ -1,0 +1,12 @@
+- **`gate execute` on a pending request now redirects to `gate approve`
+  by name.** The domain rejects `pending → executing` with a state-name
+  hint ("valid next states from pending: approved, denied"), leaving a
+  caller who skipped approve to translate "approved" back into a verb.
+  `reqExecute` now pre-checks the pending state and throws a
+  `RecoverableError` naming the bridge directly — prose `error:` line
+  plus a structured `error.recovery: {verb:"approve", args:{id}, …}` for
+  JSON consumers. This mirrors the existing `gate fail`-from-pending
+  (→ `deny`) and `gate fail`-from-approved (→ `execute`) redirects; the
+  dry-run path redirects identically rather than throwing the bare
+  domain hint. State vocabulary stays in the domain (RequestState.ts);
+  the verb hint stays an interface concern.

--- a/src/interface/gate/handlers/requestLifecycle.ts
+++ b/src/interface/gate/handlers/requestLifecycle.ts
@@ -235,6 +235,30 @@ export async function reqExecute(c: C, args: ParsedArgs): Promise<number> {
   // the optimistic-lock in YamlRequestRepository.save catches any
   // residual collision at the *record* layer.
   const target = await c.requestUC.show(id);
+  // Verb-shape redirect (mirrors reqFail's pending/approved branches):
+  // the domain rejects pending→executing with a state-name hint
+  // ("valid next states from pending: approved, denied"), but a caller
+  // who skipped approve has to translate "approved" back into a verb.
+  // Surface `gate approve` directly — same RecoverableError shape so
+  // the JSON envelope's `error.recovery` names the next verb + args and
+  // the prose `error:` line carries the human-facing bridge. Pre-empting
+  // here also makes the dry-run preview of this illegal transition
+  // redirect consistently rather than throwing the bare domain hint.
+  if (target !== null && target.state === 'pending') {
+    throw new RecoverableError(
+      `Request ${id} is pending — execute is reachable only from approved.\n` +
+        `  Approve it first, then execute:\n` +
+        `    gate approve ${id} --by <m>\n` +
+        `    gate execute ${id} --by <m>`,
+      {
+        verb: 'approve',
+        args: { id },
+        reason:
+          `${id} is pending; execute is reachable only from approved — ` +
+          `approve is the step before executing.`,
+      },
+    );
+  }
   if (target && target.requiresWorktreeIsolation && target.target !== undefined) {
     const peers = await c.requestUC.listByState('executing');
     for (const peer of peers) {

--- a/tests/interface/executeFromPendingRedirect.test.ts
+++ b/tests/interface/executeFromPendingRedirect.test.ts
@@ -1,0 +1,136 @@
+// gate execute <id> on a pending request — verb-shape redirect.
+//
+// Sibling of failFromPendingRedirect.test.ts. The domain refuses
+// pending → executing and surfaces the valid next states ("approved,
+// denied") by design — state vocabulary lives in the domain, verb
+// hints are an interface concern (RequestState.ts comment). Before
+// this redirect a caller who skipped `gate approve` read the
+// state-name hint and had to translate "approved" back into the verb.
+// The interface pre-check names `gate approve` directly so the next
+// step is one line away, matching the established reqFail pattern
+// (pending→deny, approved→execute).
+//
+// Pins both surfaces: the prose `error:` bridge and the structured
+// `error.recovery` slot the JSON envelope carries for AI dispatch.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-execute-pending-'));
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    status: r.status ?? -1,
+  };
+}
+
+function fileRequest(root: string, action: string): string {
+  const filed = run(
+    root,
+    ['request', '--action', action, '--reason', action, '--executors', 'alice', '--format', 'json'],
+    { GUILD_ACTOR: 'eris' },
+  );
+  assert.equal(filed.status, 0, filed.stderr);
+  return (JSON.parse(filed.stdout) as { id: string }).id;
+}
+
+test('gate execute on a pending request redirects to gate approve by name', () => {
+  const b = bootstrap();
+  try {
+    const id = fileRequest(b.root, 'execute-redirect pin');
+    const r = run(b.root, ['execute', id, '--by', 'alice'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(r.status, 0, 'execute from pending must exit non-zero');
+    const combined = r.stdout + r.stderr;
+    assert.match(combined, /is pending/, 'error must name the pending state');
+    assert.match(combined, /gate approve/, 'error must surface `gate approve` as the next verb');
+    assert.match(
+      combined,
+      new RegExp(`gate approve\\s+${id}\\b`),
+      'redirect must include the id for copy/paste',
+    );
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate execute on a pending request — JSON envelope carries error.recovery', () => {
+  const b = bootstrap();
+  try {
+    const id = fileRequest(b.root, 'execute recovery probe');
+    const r = run(
+      b.root,
+      ['execute', id, '--by', 'alice', '--format', 'json'],
+      { GUILD_ACTOR: 'eris' },
+    );
+    assert.notEqual(r.status, 0);
+    const envelopeLine = r.stderr.split('\n').find((ln) => ln.trim().startsWith('{'));
+    assert.ok(envelopeLine, 'JSON envelope line must be present on stderr');
+    const env = JSON.parse(envelopeLine!);
+    assert.equal(env.ok, false);
+    assert.ok(env.error.recovery, 'error.recovery must be present');
+    assert.equal(env.error.recovery.verb, 'approve');
+    assert.equal(env.error.recovery.args.id, id);
+    assert.match(env.error.recovery.reason, /pending/, 'recovery.reason must name why approve is the path');
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('gate execute --dry-run on a pending request redirects too (no preview of an illegal transition)', () => {
+  const b = bootstrap();
+  try {
+    const id = fileRequest(b.root, 'execute dry-run redirect');
+    const r = run(b.root, ['execute', id, '--by', 'alice', '--dry-run'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout + r.stderr, /gate approve/);
+  } finally {
+    b.cleanup();
+  }
+});
+
+test('regression: execute on an approved request still transitions to executing', () => {
+  const b = bootstrap();
+  try {
+    const id = fileRequest(b.root, 'approved-then-execute');
+    run(b.root, ['approve', id, '--by', 'eris'], { GUILD_ACTOR: 'eris' });
+    const r = run(b.root, ['execute', id, '--by', 'alice'], { GUILD_ACTOR: 'eris' });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /executing/);
+  } finally {
+    b.cleanup();
+  }
+});


### PR DESCRIPTION
## The gap (playbook-grounded)

The playbook's bug-killing flow (`docs/playbook.md` C4) and lifecycle recipes assume `request → approve → execute → complete`. A caller who skips `approve` and runs `gate execute` on a pending request hit the bare domain hint:

```
$ gate execute 2026-05-29-0002 --by worker
error: Illegal state transition: pending → executing.
  valid next states from pending: approved, denied.
```

That names the *state* ("approved") but leaves the caller to translate it back into a *verb*. The codebase already solved this exact shape for the symmetric case — `failFromPendingRedirect` redirects `gate fail` on a pending request to `gate deny`, and `gate fail` on an approved request to `gate execute`, via a `RecoverableError`. The execute-from-pending case was the missing sibling.

## The fix

`reqExecute` now pre-checks the pending state (reusing the `show()` it already performs for the worktree-isolation check) and redirects by name:

```
$ gate execute 2026-05-29-0002 --by worker
error: Request 2026-05-29-0002 is pending — execute is reachable only from approved.
  Approve it first, then execute:
    gate approve 2026-05-29-0002 --by <m>
    gate execute 2026-05-29-0002 --by <m>

$ gate execute 2026-05-29-0002 --by worker --format json
{"ok":false,"error":{"message":"…","recovery":{"verb":"approve","args":{"id":"2026-05-29-0002"},"reason":"…"}}}
```

- Mirrors the established `reqFail` redirect pattern exactly — same `RecoverableError`, same prose + structured `error.recovery` dual surface.
- **Dry-run redirects identically** rather than throwing the bare domain hint (a dry-run of an illegal transition is still illegal).
- **Layering preserved**: state vocabulary stays in the domain (`RequestState.ts`); the verb hint is an interface concern — the same split the fail redirect documents.

### Lore check
This is **error-recovery guidance** (CLAUDE.md house style: `error message に "next:" を添えて recovery path`), not a success-path `next:` hint — principle 13 doesn't apply. It extends an already-shipped pattern rather than inventing a new surface, and follows the same domain/interface boundary `failFromPendingRedirect` set.

## Tests
`tests/interface/executeFromPendingRedirect.test.ts` mirrors `failFromPendingRedirect.test.ts`: prose redirect names `gate approve <id>`, JSON envelope carries `error.recovery.verb === "approve"`, dry-run redirects, and an approved request still transitions (regression). Full suite **1788 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_