### PR TITLE
fix(touch-feel): suggest/boot reconcile pending count when a self-wave is open

### DIFF
--- a/.changelog/next/fixed-suggest-self-wave-pending-count.md
+++ b/.changelog/next/fixed-suggest-self-wave-pending-count.md
@@ -1,0 +1,15 @@
+- **`gate suggest` / `gate boot` no longer undercount pending when a
+  self-wave is open.** A request the actor both authored and is the
+  executor of (a self-wave) is deliberately kept off the suggestion
+  ladder — its only open transition is a self-approve, which
+  `actionableTransitions` won't nudge. But `deriveSuggestedNextNullReason`
+  skipped those requests entirely, so the null-reason's pending tally
+  read one lower than `boot`'s `queues: pending` line for the same
+  substrate (e.g. queues showed `pending=2` while the reason said "1
+  pending"). The two surfaces now reconcile: the reason carries a
+  dedicated self-wave clause ("N pending request(s) you authored also
+  name you as executor (self-wave) — `gate suggest` does not nudge
+  self-approve …"). This also closes a silent-gap sub-case where a
+  *lone* self-wave pending produced no reason at all (the not-mine total
+  was zero) while `queues: pending=1` showed it — the exact "silence
+  reads as a bug" failure the reason field was added to prevent.

--- a/members/alice.yaml
+++ b/members/alice.yaml
@@ -1,0 +1,3 @@
+name: alice
+category: professional
+active: true

--- a/src/interface/gate/handlers/bootActionable.ts
+++ b/src/interface/gate/handlers/bootActionable.ts
@@ -155,23 +155,55 @@ export function deriveSuggestedNextNullReason(
   let pendingNotMine = 0;
   let approvedNotMine = 0;
   let executingNotMine = 0;
+  // Self-wave pending: the actor authored the request AND is its
+  // executor, so the only open transition (approve) is a self-approve
+  // the suggestion ladder deliberately won't nudge — `actionable-
+  // Transitions` requires `from !== actor` for `pending-as-executor`.
+  // These requests count toward `boot`'s `queues: pending` line but
+  // were previously skipped here (the `hasExecutor` guard `continue`d
+  // past them), so `gate suggest`'s tally read one lower than the
+  // queues count for the same substrate — a self-wave pending was
+  // invisible in the reason while visible in queues (dogfood
+  // 2026-05-29). Count them in their own clause so the two surfaces
+  // reconcile. (approved/executing self-waves don't reach here: they
+  // ARE actionable — `approved-for-me` / `executing-mine` — so
+  // suggested_next is non-null and this null-reason isn't computed.)
+  let yourPendingSelfWave = 0;
   for (const r of allRequests) {
-    if (r.hasExecutor(lower)) continue;
+    if (r.hasExecutor(lower)) {
+      if (r.state === 'pending' && r.from.value === lower) {
+        yourPendingSelfWave += 1;
+      }
+      continue;
+    }
     if (r.state === 'pending') pendingNotMine += 1;
     else if (r.state === 'approved') approvedNotMine += 1;
     else if (r.state === 'executing') executingNotMine += 1;
   }
-  if (pendingNotMine + approvedNotMine + executingNotMine === 0) return null;
-  const parts: string[] = [];
-  if (pendingNotMine > 0) parts.push(`${pendingNotMine} pending`);
-  if (approvedNotMine > 0) parts.push(`${approvedNotMine} approved`);
-  if (executingNotMine > 0) parts.push(`${executingNotMine} executing`);
-  return (
-    `${parts.join(', ')} open request(s) on substrate, but none names you ` +
-    'as executor — use `gate list --state pending` (or --state approved / ' +
-    'executing) to read them. Hosts approve from this list rather than ' +
-    'through `gate suggest`.'
-  );
+  const notMineTotal = pendingNotMine + approvedNotMine + executingNotMine;
+  if (notMineTotal === 0 && yourPendingSelfWave === 0) return null;
+
+  const sentences: string[] = [];
+  if (notMineTotal > 0) {
+    const parts: string[] = [];
+    if (pendingNotMine > 0) parts.push(`${pendingNotMine} pending`);
+    if (approvedNotMine > 0) parts.push(`${approvedNotMine} approved`);
+    if (executingNotMine > 0) parts.push(`${executingNotMine} executing`);
+    sentences.push(
+      `${parts.join(', ')} open request(s) on substrate, but none names you ` +
+        'as executor — use `gate list --state pending` (or --state approved / ' +
+        'executing) to read them. Hosts approve from this list rather than ' +
+        'through `gate suggest`.',
+    );
+  }
+  if (yourPendingSelfWave > 0) {
+    sentences.push(
+      `${yourPendingSelfWave} pending request(s) you authored also name you ` +
+        'as executor (self-wave) — `gate suggest` does not nudge self-approve, ' +
+        'so they stay off the ladder; read them with `gate list --state pending`.',
+    );
+  }
+  return sentences.join(' ');
 }
 
 /**

--- a/tests/interface/ax.test.ts
+++ b/tests/interface/ax.test.ts
@@ -347,6 +347,76 @@ test('suggest: null with substrate open-work surfaces suggested_next_reason', ()
   }
 });
 
+test('suggest: self-wave pending is counted so the reason reconciles with queues', () => {
+  // dogfood 2026-05-29: an actor authored a self-wave pending (author ==
+  // executor). suggested_next stayed null (the ladder won't nudge
+  // self-approve — actionableTransitions requires from != actor for
+  // pending-as-executor), but the null-reason skipped it while boot's
+  // `queues: pending` counted it. The two surfaces disagreed (queues
+  // pending=2, reason said "1 pending"). The reason now carries a
+  // self-wave clause so the tallies match.
+  const { root, cleanup } = bootstrap();
+  try {
+    // alice: self-wave (author == executor). bob: a normal wave alice
+    // has no role in. Viewed as alice, neither is actionable, so
+    // suggested_next is null and both must be reflected in the reason.
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'solo', '--reason', 'r', '--executors', 'alice'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    runGate(
+      root,
+      ['request', '--from', 'bob', '--action', 'theirs', '--reason', 'r', '--executors', 'bob'],
+      { GUILD_ACTOR: 'bob' },
+    );
+    const { stdout } = runGate(root, ['suggest'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next, null);
+    const reason: string = payload.suggested_next_reason;
+    // The not-mine clause (bob's) AND the self-wave clause (alice's)
+    // both fire, so the pending tally reconciles with queues.pending=2.
+    assert.match(reason, /none names you as executor/);
+    assert.match(reason, /self-wave/);
+    // Reconciliation: boot's queues.pending must equal the count the
+    // reason accounts for. Both pending requests are acknowledged.
+    const boot = JSON.parse(
+      runGate(root, ['boot', '--format', 'json'], { GUILD_ACTOR: 'alice' }).stdout,
+    );
+    assert.equal(boot.status.pending.total, 2);
+    assert.equal((reason.match(/pending/g) ?? []).length >= 2, true,
+      `reason must account for both pending requests; got: ${reason}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('suggest: a lone self-wave pending no longer goes silent', () => {
+  // Regression for the silent-gap sub-case: when the ONLY open request
+  // is a self-wave pending, the pre-fix null-reason returned null
+  // (not-mine total was 0), so `gate suggest` said nothing while
+  // `queues: pending=1` showed one — exactly the "silence reads as a
+  // bug" failure the reason field exists to prevent.
+  const { root, cleanup } = bootstrap();
+  try {
+    runGate(
+      root,
+      ['request', '--from', 'alice', '--action', 'solo', '--reason', 'r', '--executors', 'alice'],
+      { GUILD_ACTOR: 'alice' },
+    );
+    const { stdout } = runGate(root, ['suggest'], { GUILD_ACTOR: 'alice' });
+    const payload = JSON.parse(stdout);
+    assert.equal(payload.suggested_next, null);
+    assert.ok(
+      typeof payload.suggested_next_reason === 'string' &&
+        /self-wave/.test(payload.suggested_next_reason),
+      `lone self-wave pending must surface a reason; got: ${payload.suggested_next_reason}`,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('suggest --format text: null + reason → (nothing urgent — <reason>)', () => {
   const { root, cleanup } = bootstrap();
   try {


### PR DESCRIPTION
## The bug (surfaced by normal use)

Running a real session, my `gate boot` dashboard didn't add up: `queues: pending=2` but the `→` steer (and `gate suggest`) said **"1 pending … on substrate."** Two surfaces of the same boot disagreed on the pending count.

**Root cause:** I had a *self-wave* pending — a request I both authored (`--from claude`) and was the executor of (`--executors claude`). The suggestion ladder deliberately keeps self-waves off it (its only open transition is a self-approve, which `actionableTransitions` won't nudge — `pending-as-executor` requires `from != actor`). But `deriveSuggestedNextNullReason` skipped those requests entirely via its `hasExecutor` `continue`, so its pending tally read one lower than `queues: pending`, which counts them.

## The fix

`deriveSuggestedNextNullReason` now counts self-wave pendings in a dedicated clause, so the two surfaces reconcile:

```
→ (no suggestion — 1 pending, 1 approved, 1 executing open request(s) on substrate,
   but none names you as executor — … Hosts approve from this list … .
   1 pending request(s) you authored also name you as executor (self-wave) —
   `gate suggest` does not nudge self-approve, so they stay off the ladder;
   read them with `gate list --state pending`.)
```

Now pending mentioned = 1 (not-mine) + 1 (self-wave) = **2 = `queues: pending`**.

It also closes a **silent-gap sub-case**: when the *only* open request is a self-wave pending, the pre-fix reason returned `null` (not-mine total was 0) while `queues: pending=1` showed it — the exact "silence reads as a bug" failure the reason field was added for (Asteria dogfood 2026-05-17). It now surfaces the self-wave clause.

The common host/bystander path (no self-wave) is **unchanged** — the second clause only appears when the actor actually has a self-wave pending, so the existing wording and its test stay intact.

### Lore check
This extends the existing `deriveSuggestedNextNullReason` (the orientation-disclosure / "no silent gaps" mechanism, #228 lineage) rather than adding a new surface. It's a read/orientation accuracy fix — no principle-13 success-hint concern. The self-wave clause points to a *read* (`gate list`), not a self-approve nudge, staying clear of principle 02.

## Tests
`tests/interface/ax.test.ts`: (1) self-wave + not-mine reconciles with `queues.pending=2`; (2) a lone self-wave pending no longer goes silent. The pre-existing host/alice→bob null-reason test still passes (wording for the not-mine clause unchanged). Full suite **1790 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_