### PR TITLE
fix(touch-feel): transition-redirect errors carry error.code, not just recovery

### DIFF
--- a/.changelog/next/fixed-recoverable-error-code.md
+++ b/.changelog/next/fixed-recoverable-error-code.md
@@ -1,0 +1,14 @@
+- **Transition-redirect errors now carry `error.code` again, not just
+  `error.recovery`.** `RecoverableError` (thrown by the verb-shape
+  redirects: `execute`-from-pending → approve, `complete`-from-approved
+  → execute, `deny`-from-executing → fail, `fail`-from-pending/approved)
+  reworded the message away from the domain's "Illegal state transition"
+  phrasing, so `deriveErrorCode`'s prose scan stopped classifying it and
+  the JSON envelope emitted `recovery` but a `code: undefined`. An agent
+  branching on `error.code` was blind to exactly the errors carrying the
+  richest recovery hint (surfaced dogfooding the JSON surface as an
+  orchestrator). `RecoverableError` now carries a `code` (default
+  `illegal_transition`, overridable) and the envelope emits it — so every
+  redirect error classifies as `illegal_transition` *and* ships a
+  dispatchable `recovery`. `not_found` and the plain transition errors are
+  unchanged.

--- a/src/interface/shared/errorEnvelope.ts
+++ b/src/interface/shared/errorEnvelope.ts
@@ -117,10 +117,23 @@ export interface Recovery {
  */
 export class RecoverableError extends Error {
   readonly recovery: Recovery;
-  constructor(message: string, recovery: Recovery) {
+  /**
+   * Macro-classification for the JSON envelope's `error.code`. Defaults
+   * to `illegal_transition` because every current throw site is a
+   * verb-shape transition redirect (pending→deny, approved→execute,
+   * pending→approve, …) — the message is reworded away from the domain's
+   * "Illegal state transition" phrasing, so `deriveErrorCode`'s prose
+   * scan no longer classifies it and a code-branching agent would
+   * otherwise see `undefined` on exactly the errors carrying the richest
+   * `recovery`. A future non-transition RecoverableError passes its own
+   * code explicitly.
+   */
+  readonly code: string;
+  constructor(message: string, recovery: Recovery, code = 'illegal_transition') {
     super(message);
     this.name = 'RecoverableError';
     this.recovery = recovery;
+    this.code = code;
   }
 }
 
@@ -173,10 +186,16 @@ export function emitErrorEnvelope(
     } else if (opts.field !== undefined) {
       errObj['field'] = opts.field;
     }
-    // code: deriveErrorCode(err) wins; opts.code is fallback.
+    // code: deriveErrorCode(err) wins; then a RecoverableError's own
+    // `code` (its reworded message escapes the prose scan, but it still
+    // carries a classification + recovery); opts.code is the last
+    // fallback. Without the RecoverableError arm a code-branching agent
+    // saw `undefined` on every transition redirect.
     const derived = deriveErrorCode(err);
     if (derived !== null) {
       errObj['code'] = derived;
+    } else if (err instanceof RecoverableError) {
+      errObj['code'] = err.code;
     } else if (opts.code !== undefined) {
       errObj['code'] = opts.code;
     }

--- a/tests/interface/denyCompleteRedirect.test.ts
+++ b/tests/interface/denyCompleteRedirect.test.ts
@@ -102,6 +102,7 @@ test('gate complete on approved --format json carries error.recovery {verb:execu
     assert.ok(line, 'expected JSON envelope on stderr');
     const env = JSON.parse(line!);
     assert.equal(env.error.recovery.verb, 'execute');
+    assert.equal(env.error.code, 'illegal_transition');
     assert.equal(env.error.recovery.args.id, id);
   } finally {
     b.cleanup();
@@ -134,6 +135,7 @@ test('gate deny on executing --format json carries error.recovery {verb:fail}', 
     assert.ok(line, 'expected JSON envelope on stderr');
     const env = JSON.parse(line!);
     assert.equal(env.error.recovery.verb, 'fail');
+    assert.equal(env.error.code, 'illegal_transition');
     assert.equal(env.error.recovery.args.id, id);
   } finally {
     b.cleanup();

--- a/tests/interface/executeFromPendingRedirect.test.ts
+++ b/tests/interface/executeFromPendingRedirect.test.ts
@@ -103,6 +103,7 @@ test('gate execute on a pending request — JSON envelope carries error.recovery
     assert.equal(env.ok, false);
     assert.ok(env.error.recovery, 'error.recovery must be present');
     assert.equal(env.error.recovery.verb, 'approve');
+    assert.equal(env.error.code, 'illegal_transition');
     assert.equal(env.error.recovery.args.id, id);
     assert.match(env.error.recovery.reason, /pending/, 'recovery.reason must name why approve is the path');
   } finally {

--- a/tests/interface/failFromPendingRedirect.test.ts
+++ b/tests/interface/failFromPendingRedirect.test.ts
@@ -147,6 +147,10 @@ test('gate fail on a pending request — JSON envelope carries error.recovery', 
     assert.equal(env.ok, false);
     assert.ok(env.error.recovery, 'error.recovery must be present');
     assert.equal(env.error.recovery.verb, 'deny');
+    // The reworded redirect message escapes deriveErrorCode's prose
+    // scan; RecoverableError still classifies it so a code-branching
+    // agent isn't blind to the richest-recovery errors.
+    assert.equal(env.error.code, 'illegal_transition');
     assert.equal(env.error.recovery.args.id, id);
     assert.match(
       env.error.recovery.reason,


### PR DESCRIPTION
## Found by re-checking the touch-feel through the AI-agent lens

You said AI-agent-first is the right default, so I re-dogfooded the **JSON surface as an orchestrator would** — parsing envelopes, dispatching `suggested_next` / `error.recovery` from structured fields, never reading prose. The good news: it works end-to-end. A JSON-only loop can hit an illegal move, read `error.recovery.{verb,args}`, and auto-dispatch the corrected verb to recover (e.g. `execute`-on-pending → reads `{verb:"approve"}` → dispatches `gate approve` → reaches `approved`). No prose parsing needed.

But it surfaced one **machine-contract gap**:

```
execute-on-pending → code=undefined        recovery=approve
fail-on-pending    → code=undefined        recovery=deny
complete-on-apprvd → code=undefined        recovery=execute
deny-on-executing  → code=undefined        recovery=fail
approve-on-apprvd  → code="already_in_state" recovery=undefined   ← plain transition still classifies
```

The verb-shape redirects throw `RecoverableError` with a message **reworded away from** the domain's `"Illegal state transition"` phrasing — so `deriveErrorCode`'s prose scan stopped matching, and the envelope emitted `recovery` but **`code: undefined`**. An agent branching on `error.code` to bucket failures was blind to *exactly the errors carrying the richest recovery*. (Pre-existing — the `fail` redirect had it too; my recent redirects propagated the pattern.)

## Fix

`RecoverableError` now carries a `code` (default `illegal_transition`, overridable for a future non-transition use), and `emitErrorEnvelope` emits it when `deriveErrorCode` returns null. Now:

```
execute-on-pending → code="illegal_transition"  recovery=approve
fail-on-pending    → code="illegal_transition"  recovery=deny
complete-on-apprvd → code="illegal_transition"  recovery=execute
deny-on-executing  → code="illegal_transition"  recovery=fail
not-found          → code="not_found"           recovery=list   (unchanged)
```

Every error an agent hits now classifies, and the redirects additionally ship a dispatchable recovery — the envelope is internally consistent.

## Tests
`error.code === 'illegal_transition'` pinned on all four redirect families' JSON-envelope tests (including the pre-existing `fail`-from-pending). `not_found` and plain-transition codes verified unchanged. Full suite (clean dist) **1797 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_