### PR TITLE
docs: fix v0.6 --executor staleness across README-linked docs

### DIFF
--- a/.changelog/next/docs-maintenance-executor-drift.md
+++ b/.changelog/next/docs-maintenance-executor-drift.md
@@ -1,0 +1,16 @@
+- **Docs maintenance: audited every README-linked doc for drift and fixed
+  the stale spots.** `AGENT.md` claimed the singular `--executor` flag on
+  `gate request` was "still accepted as a deprecated alias (removed at
+  v0.7)" — but v0.6 already removed it (the runtime rejects `gate request
+  --executor` with "unknown flag"); corrected to "removed from `gate
+  request` in v0.6 — use `--executors`." Also fixed an inconsistent
+  relative link (`docs/storage-format.md` → `./docs/storage-format.md`)
+  and, in `docs/verbs.md`, the `--with` actor-validation note that cited
+  `--executor` while describing `gate request` (whose flag is
+  `--executors`). The rest of the linked set (playbook, swarm,
+  eris-playbook, concepts-for-newcomers, POLICY, storage-format,
+  SECURITY, CONTRIBUTING, plugins/README, README.ja) audited clean against
+  current behavior — including the recent not-found-hint / transition-
+  redirect / fresh-start-wording changes, which those docs don't pin
+  verbatim. (`gate list --executor` is unchanged — that singular filter
+  flag is correct and stays.)

--- a/AGENT.md
+++ b/AGENT.md
@@ -149,8 +149,8 @@ the mismatch is visible at the surface that did it. See
 design rationale.
 
 `--executors a[,b,c]` accepts one or many executors for single or
-parallel waves (#230). The singular `--executor <m>` is still accepted
-as a deprecated alias (removed at v0.7 per [#239](https://github.com/eris-ths/guild-cli/issues/239)).
+parallel waves (#230). The singular `--executor <m>` was removed from
+`gate request` in v0.6 (per [#239](https://github.com/eris-ths/guild-cli/issues/239)) — use `--executors`.
 Under `profile: swarm`, parallel waves additionally require worktree
 isolation (`gate execute` refuses same-cwd collisions, #231).
 
@@ -750,7 +750,7 @@ for the end-to-end shape.
 Request IDs: `YYYY-MM-DD-NNNN`. Issue IDs: `i-YYYY-MM-DD-NNNN`.
 
 The agora / devil / ctx subtrees layer on top — see
-[`docs/storage-format.md`](docs/storage-format.md) for the full
+[`docs/storage-format.md`](./docs/storage-format.md) for the full
 per-record YAML schema, hydrate tolerance, and backward-compat rules.
 
 ## Environment

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -42,7 +42,7 @@ works — it just moves the review from "blocking" to "after-the-fact."
 `--with <n1>[,<n2>...]` on `gate request` / `gate fast-track`
 records the dialogue partners during the formation of a request.
 Empty / omitted = solo. Partners go through the same actor
-validation as `--from` / `--executor` (members or hosts).
+validation as `--from` / `--executors` (members or hosts).
 
 ```bash
 gate request --from claude --with eris --action "..." --reason "..."


### PR DESCRIPTION
Maintenance pass over **every doc linked from the README**. I audited the full set against current behavior (with parallel read-only sweeps), including this session's not-found-hint / transition-redirect / fresh-start-wording changes. Good news first: the linked set is **largely clean** — those behavior changes live in error-path output the docs don't pin verbatim, and counts (16 principles, 12 devil lenses) are current.

The one real staleness was the **v0.6 `--executor` removal**:

| file | was | now |
|------|-----|-----|
| `AGENT.md` | "singular `--executor <m>` is **still accepted** as a deprecated alias (removed at **v0.7**)" | "**removed from `gate request` in v0.6** — use `--executors`" — the runtime already rejects `gate request --executor` as an unknown flag |
| `AGENT.md` | `](docs/storage-format.md)` | `](./docs/storage-format.md)` — matches the same link's form elsewhere in the file |
| `docs/verbs.md` | `--with` validation note cited `--executor` while describing `gate request` | → `--executors` (request's actual flag) |

**Deliberately left alone:** `gate list --executor <name>` (and `gate pending --executor`) — that singular **filter** flag is unchanged and correct, so `docs/verbs.md` §"Filtering lists" and `docs/concepts-for-newcomers.md` stay as-is.

Audited clean (no edits): `docs/playbook.md`, `docs/swarm.md`, `docs/eris-playbook.md`, `docs/concepts-for-newcomers.md`, `docs/POLICY.md`, `docs/storage-format.md`, `SECURITY.md`, `CONTRIBUTING.md`, `examples/plugins/README.md`, `README.ja.md`.

Pure docs — no code, no tests.

---

**Separate finding (not in this PR — it's code, not a README-linked doc):** `gate --help`'s BASE catalog advertises `gate list … [--executors a[,b,...]]` (plural), but the `list` verb actually accepts `--executor` (singular) and rejects `--executors` ("unknown flag"). That's a help-text ↔ runtime drift (principle 10 / `trap_help_text_drift_on_new_verb`). Happy to fix the help line in a follow-up if you want.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_