### PR TITLE
fix(help): gate list advertises --executor (singular), matching the runtime

### DIFF
--- a/.changelog/next/fixed-list-help-executor-flag.md
+++ b/.changelog/next/fixed-list-help-executor-flag.md
@@ -1,0 +1,9 @@
+- **`gate --help` now advertises the `list` filter as `--executor <m>`,
+  matching the runtime.** The BASE catalog line showed `gate list …
+  [--executors a[,b,...]]` (plural, copied from `gate request`'s
+  multi-executor flag), but the `list` verb accepts only `--executor`
+  (singular — "match waves naming this one executor") and rejects
+  `--executors` with "unknown flag". An agent copying the advertised flag
+  from `--help` hit a wall — a help-text ↔ runtime drift (principle 10 /
+  `trap_help_text_drift_on_new_verb`). Help line corrected; a regression
+  test pins the help and the runtime KNOWN_FLAGS to the same singular flag.

--- a/src/interface/gate/help.ts
+++ b/src/interface/gate/help.ts
@@ -95,7 +95,7 @@ const SECTIONS: readonly Section[] = [
         tier: 'base',
         text:
           '  gate list --state <state> [--for <m>] [--from <m>]\n' +
-          '                            [--executors a[,b,...]] [--auto-review <m>]',
+          '                            [--executor <m>] [--auto-review <m>]',
       },
       {
         tier: 'base',

--- a/tests/interface/listHelpExecutorFlag.test.ts
+++ b/tests/interface/listHelpExecutorFlag.test.ts
@@ -1,0 +1,71 @@
+// gate list: help text ↔ runtime flag alignment (principle 10 /
+// trap_help_text_drift_on_new_verb).
+//
+// The BASE `gate --help` catalog advertised the list filter as
+// `--executors a[,b,...]` (plural, copied from `gate request`'s
+// multi-executor flag), but the `list` verb's KNOWN_FLAGS only accepts
+// `--executor` (singular — "match waves naming this one executor") and
+// rejects `--executors` with "unknown flag". An agent copying the
+// advertised flag from --help hit a wall. These pin the help line and
+// the runtime to the same singular flag so they can't drift apart again.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-list-help-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [eris]\n');
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('gate --help advertises the list filter as --executor (singular), not --executors', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const { stdout } = run(root, ['--help']);
+    const listLine = stdout.split('\n');
+    const i = listLine.findIndex((l) => l.includes('gate list --state'));
+    assert.ok(i >= 0, 'gate list entry must appear in --help');
+    // The wrapped continuation line carries the filter flags.
+    const block = `${listLine[i]}\n${listLine[i + 1] ?? ''}`;
+    assert.match(block, /--executor <m>/, 'list help must advertise --executor (singular)');
+    assert.doesNotMatch(block, /--executors/, 'list help must not advertise --executors (plural) — list rejects it');
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate list accepts --executor and rejects --executors (runtime truth the help now matches)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const ok = run(root, ['list', '--executor', 'bob'], { GUILD_ACTOR: 'eris' });
+    assert.equal(ok.status, 0, ok.stderr);
+
+    const bad = run(root, ['list', '--executors', 'bob'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(bad.status, 0);
+    assert.match(bad.stderr, /unknown flag: --executors/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
The "separate finding" I flagged on #426 — fixing it as requested.

## Help ↔ runtime drift on `gate list`

`gate --help`'s BASE catalog advertised:
```
gate list --state <state> [--for <m>] [--from <m>]
                          [--executors a[,b,...]] [--auto-review <m>]   ← plural
```
…but the `list` verb's `KNOWN_FLAGS` (`requestReads.ts`) is `{state, for, from, executor, auto-review, format}` — singular `--executor`. So:
```
$ gate list --executors bob   → error: list: unknown flag: --executors
$ gate list --executor bob    → works
```
An agent copying the advertised flag from `--help` hit a wall — a help-text ↔ runtime drift (principle 10 / `trap_help_text_drift_on_new_verb`). The plural form was copied from `gate request`'s genuine multi-executor flag.

## Fix

One line in `help.ts`: the `list` entry now advertises `[--executor <m>]`, matching the runtime and `docs/verbs.md` §"Filtering lists". `gate request` / `fast-track` / `issues promote` keep `--executors` (plural) — those verbs really do take multiple, so their help is correct and untouched.

A regression test (`listHelpExecutorFlag.test.ts`) pins both surfaces to the same singular flag: `--help` advertises `--executor` (and *not* `--executors`), and the runtime accepts `--executor` / rejects `--executors`. So they can't drift apart again.

Full suite (clean dist) **1799 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_