### PR TITLE
fix(touch-feel): gate pending filter-flag docs + self-directing error

### DIFF
--- a/.changelog/next/fixed-pending-filter-flags.md
+++ b/.changelog/next/fixed-pending-filter-flags.md
@@ -1,0 +1,15 @@
+- **Docs + touch-feel: `gate pending`'s filter surface is now accurate
+  and self-directing.** `docs/verbs.md` had lumped `gate list` and `gate
+  pending` together as accepting `--from / --executor / --auto-review /
+  --for`, but `pending` is the lean "--for me" shortcut — its known flags
+  are `{for, format}` and it rejects the richer filters (surfaced by a
+  two-persona review red-teaming the #426/#427 docs work, which had
+  reasoned about `list` in isolation). The doc now describes `list`'s full
+  filter set and `pending`'s narrow one separately, pointing richer
+  pending filtering at `gate list --state pending`. And the runtime
+  matches the advice: `gate pending --executor <m>` (or `--from` /
+  `--auto-review`) no longer dead-ends at "valid flags: --for, --format"
+  — it appends `to filter pending by author/executor/reviewer, use: gate
+  list --state pending …`. (`rejectUnknownFlags` gained an optional
+  `hint`; only `pending` passes one, so every other verb's error is
+  unchanged.) Pinned by `tests/interface/pendingFilterFlags.test.ts`.

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -355,8 +355,7 @@ whoami for voice recovery.
 
 ### Filtering lists
 
-`gate list` and `gate pending` accept filter flags that combine
-via AND:
+`gate list` accepts filter flags that combine via AND:
 
 - `--from <m>` — match author
 - `--executor <m>` — match executor
@@ -364,9 +363,14 @@ via AND:
 - `--for <m>` — match author OR executor OR reviewer (sugar for
   "anything I touch")
 
+`gate pending` is the lean "what's on my plate" shortcut — it is fixed
+to the pending state and accepts only `--for <m>` (plus `--format`). To
+filter pending requests by author / executor / reviewer, reach for
+`gate list --state pending` with any of the flags above.
+
 ```
 $ gate pending --for kiri
-$ gate list --state executing --executor noir
+$ gate list --state pending --executor noir
 $ gate list --state completed --auto-review rin
 ```
 

--- a/src/interface/gate/handlers/requestReads.ts
+++ b/src/interface/gate/handlers/requestReads.ts
@@ -54,10 +54,18 @@ export async function reqList(
 ): Promise<number> {
   // Different known-flag sets per verb so a typo on `gate pending`
   // doesn't get a list-grade hint, and the error names the right verb.
+  // `pending` is the lean "--for me" shortcut (only --for / --format);
+  // when someone reaches for a richer filter on it, point them at the
+  // capable verb instead of dead-ending at "valid flags: --for, --format".
   rejectUnknownFlags(
     args,
     verb === 'pending' ? PENDING_KNOWN_FLAGS : LIST_KNOWN_FLAGS,
     verb,
+    [],
+    verb === 'pending'
+      ? 'to filter pending by author/executor/reviewer, use: ' +
+          'gate list --state pending --executor <m> (or --from / --auto-review)'
+      : undefined,
   );
   maybeEmitExplain(args, verb);
   const fromFilter = optionalOption(args, 'from');

--- a/src/interface/shared/parseArgs.ts
+++ b/src/interface/shared/parseArgs.ts
@@ -266,6 +266,7 @@ export function rejectUnknownFlags(
   known: ReadonlySet<string>,
   verb: string,
   extras: readonly string[] = [],
+  hint?: string,
 ): void {
   if (args.options['help'] === true) {
     throw new HelpRequested(verb, [...known].sort(), extras);
@@ -286,6 +287,7 @@ export function rejectUnknownFlags(
   const badList = unknown.sort().map((k) => `--${k}`).join(', ');
   throw new Error(
     `${verb}: unknown flag${unknown.length === 1 ? '' : 's'}: ${badList}\n` +
-      `  valid flags for '${verb}': ${knownList}`,
+      `  valid flags for '${verb}': ${knownList}` +
+      (hint ? `\n  ${hint}` : ''),
   );
 }

--- a/tests/interface/pendingFilterFlags.test.ts
+++ b/tests/interface/pendingFilterFlags.test.ts
@@ -1,0 +1,92 @@
+// gate pending: filter-flag surface ↔ docs alignment.
+//
+// docs/verbs.md once lumped `gate list` and `gate pending` together as
+// accepting `--from / --executor / --auto-review / --for`, but `pending`
+// is the lean "--for me" shortcut — its KNOWN_FLAGS is {for, format}, and
+// it rejects the richer filters that `gate list` accepts. The docs audit
+// (#426) and the list help fix (#427) both reasoned about `list` in
+// isolation and missed this (surfaced via a two-persona review). These
+// pin pending's actual flag surface AND the redirect that points a
+// would-be filterer at the capable verb (`gate list --state pending`).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-pending-flags-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [eris]\n');
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('gate pending accepts --for and --format (its lean filter surface)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    assert.equal(run(root, ['pending', '--for', 'eris'], { GUILD_ACTOR: 'eris' }).status, 0);
+    assert.equal(run(root, ['pending', '--format', 'json'], { GUILD_ACTOR: 'eris' }).status, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate pending rejects the richer filters (--executor / --from / --auto-review) it never accepted', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    for (const flag of ['--executor', '--from', '--auto-review']) {
+      const r = run(root, ['pending', flag, 'bob'], { GUILD_ACTOR: 'eris' });
+      assert.notEqual(r.status, 0, `pending ${flag} should be rejected`);
+      assert.match(r.stderr, new RegExp(`unknown flag: ${flag}`));
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate pending unknown-filter error redirects to the capable verb (gate list --state pending)', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = run(root, ['pending', '--executor', 'bob'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /valid flags for 'pending': --for, --format/);
+    assert.match(r.stderr, /gate list --state pending/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate list (the capable verb) still accepts the richer filters', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    for (const flag of ['--executor', '--from', '--auto-review']) {
+      const r = run(root, ['list', '--state', 'pending', flag, 'bob'], { GUILD_ACTOR: 'eris' });
+      assert.equal(r.status, 0, `list ${flag} should be accepted; got: ${r.stderr}`);
+    }
+    // ...and list's unknown-flag error is NOT given the pending redirect.
+    const bad = run(root, ['list', '--bogus'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(bad.status, 0);
+    assert.doesNotMatch(bad.stderr, /gate list --state pending/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closing the loop on the bug a **two-persona review** surfaced (the "different use" you asked for): I red-teamed my own #426/#427 docs work wearing a reviewer persona, and it caught a miss both the docs audit and the help fix made by reasoning about `gate list` in isolation.

## The miss

`docs/verbs.md` lumped them together:
> `gate list` **and** `gate pending` accept filter flags … `--from`, `--executor`, `--auto-review`, `--for`

But `pending` is the lean "--for me" shortcut — its `KNOWN_FLAGS` is `{for, format}`. So:
```
$ gate pending --executor bob   → error: unknown flag: --executor   (valid: --for, --format)
$ gate pending --from / --auto-review → same
```
The doc advertised three flags `pending` rejects. `gate list --state pending …` is the capable path.

## Fix (docs + the surrounding touch-feel you asked me to check)

- **`docs/verbs.md`**: describe `list`'s full filter set and `pending`'s narrow one *separately*, and point richer pending filtering at `gate list --state pending`.
- **Runtime self-direction**: `gate pending --executor <m>` no longer dead-ends at "valid flags: --for, --format" — the error now appends:
  ```
  to filter pending by author/executor/reviewer, use: gate list --state pending --executor <m> (or --from / --auto-review)
  ```
  (`rejectUnknownFlags` gained an optional `hint`; **only `pending` passes one**, so every other verb's error is byte-identical — on-theme with the session's "errors point to the next move", scoped to the one verb that needed it.)

## Tests
`tests/interface/pendingFilterFlags.test.ts` pins pending's surface (accepts `--for`/`--format`, rejects the three richer filters), the redirect line, and that `list` (the capable verb) still accepts them and is *not* given the redirect. Full suite (clean dist) **1803 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX