### PR TITLE
fix(touch-feel): gate list --state bogus enumerates the valid states

### DIFF
--- a/.changelog/next/fixed-list-invalid-state-hint.md
+++ b/.changelog/next/fixed-list-invalid-state-hint.md
@@ -1,0 +1,13 @@
+- **`gate list --state <bogus>` now enumerates the valid states instead
+  of dead-ending.** It errored with a bare `Invalid state: <x>` and no
+  valid set, while sibling unknown-flag errors list their valid flags — an
+  asymmetric touch-feel that violated the "error + recovery path" house
+  style. `reqList` now validates `--state` at the interface boundary and,
+  on a miss, names the full CLI-valid set: `pending, approved, executing,
+  completed, failed, denied, all` (built from the domain's `REQUEST_STATES`
+  ∪ the interface-only `all` sugar, so it can't drift from the enum) plus a
+  note that omitting `--state` uses the verb's default. The app-layer guard
+  in `RequestUseCases.listByState` stays as defense-in-depth. State
+  vocabulary lives in the domain; the CLI-facing hint is an interface
+  concern — same split as the deny/execute verb redirects. Pinned by
+  `tests/interface/listInvalidState.test.ts`.

--- a/src/interface/gate/handlers/requestReads.ts
+++ b/src/interface/gate/handlers/requestReads.ts
@@ -21,6 +21,7 @@ import {
 import { maybeEmitExplain } from '../../shared/explain.js';
 import { notFoundEnvelope } from '../../shared/notFoundHint.js';
 import { Request } from '../../../domain/request/Request.js';
+import { REQUEST_STATES } from '../../../domain/request/RequestState.js';
 import { formatDelta, pushMultilineField } from '../voices.js';
 import { C, truncateCodePoints } from './internal.js';
 import { parseFormat } from '../../shared/parseFormat.js';
@@ -78,6 +79,23 @@ export async function reqList(
       : undefined;
   const forFilter = explicitFor ?? envActor;
 
+  // Validate `--state` at the interface boundary, where the full
+  // CLI-valid set is known: the domain's REQUEST_STATES *plus* the
+  // `all` sugar this layer adds (see the comment below). The app layer
+  // (RequestUseCases) throws a bare `Invalid state: <x>` with no valid
+  // set — and it can't enumerate one anyway, because `all` is an
+  // interface affordance it doesn't know about. Surfacing the hint here
+  // mirrors the deny/execute verb-redirect split: state vocabulary
+  // lives in the domain, the CLI-facing hint is an interface concern.
+  // (The app-layer guard stays as defense-in-depth.)
+  if (state !== 'all' && !(REQUEST_STATES as readonly string[]).includes(state)) {
+    const valid = [...REQUEST_STATES, 'all'].join(', ');
+    throw new Error(
+      `${verb}: invalid --state '${state}'.\n` +
+        `  valid states: ${valid}\n` +
+        `  ('all' lists every state; omit --state on '${verb}' for its default)`,
+    );
+  }
   // `--state all` is sugar for "every state, no filter" — parity with
   // `gate issues list --state all`. Implemented at the interface layer
   // because `all` is a CLI-level affordance, not a domain state;

--- a/tests/interface/listInvalidState.test.ts
+++ b/tests/interface/listInvalidState.test.ts
@@ -1,0 +1,67 @@
+// gate list --state <bogus>: the error enumerates the valid states.
+//
+// Bug-killing-flow target (issue i-2026-05-30-0001, root-caused in agora
+// play invalid-state-hint): `gate list --state bogus` errored with a bare
+// `Invalid state: bogus` and no valid set, while sibling unknown-flag
+// errors DO list valid flags — an asymmetric touch-feel that violates the
+// "error + recovery path" house style. The hint must be built at the
+// interface boundary because only it knows the full CLI-valid set =
+// REQUEST_STATES ∪ {all} ('all' is an interface sugar the domain rejects).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), 'guild-invalid-state-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [eris]\n');
+  mkdirSync(join(root, 'members'));
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+test('gate list --state <bogus>: error enumerates the valid states + the all sugar', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    const r = run(root, ['list', '--state', 'bogus'], { GUILD_ACTOR: 'eris' });
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /invalid --state 'bogus'/);
+    // Every domain state must be named, plus the interface-only `all`.
+    for (const s of ['pending', 'approved', 'executing', 'completed', 'failed', 'denied', 'all']) {
+      assert.match(r.stderr, new RegExp(`\\b${s}\\b`), `valid-states hint must name '${s}'`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('gate list: valid states (and the all sugar, and the default) still work', () => {
+  const { root, cleanup } = bootstrap();
+  try {
+    for (const args of [['list', '--state', 'pending'], ['list', '--state', 'all'], ['list']]) {
+      const r = run(root, args, { GUILD_ACTOR: 'eris' });
+      assert.equal(r.status, 0, `${args.join(' ')} should succeed; got: ${r.stderr}`);
+    }
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Found and killed by running the playbook's **C4 bug-killing flow** end-to-end (you asked to try it + Two-Persona Review), all on the substrate:

1. **issue** `i-2026-05-30-0001` — filed the asymmetry as a lightweight notice.
2. **agora** sandbox `invalid-state-hint` — root-caused it in moves: the bare error is thrown in the *app* layer (`RequestUseCases.listByState`), but only the *interface* knows the full CLI-valid set (`REQUEST_STATES` + the `all` sugar the app layer rejects), so the hint must be built at the interface boundary.
3. **promote** issue → request `2026-05-30-0001` (`--auto-review noir`), implemented the fix.
4. **Two-Persona Review** — `noir` red-teamed it on the `layer` + `user` lenses (both `ok` *after* verifying, not rubber-stamped): confirmed `reqList` was the **only** user-input path to the bare app-layer message (`board` uses internal fixed states; `requestLifecycle` passes a literal `'executing'`), so the app guard correctly stays as defense-in-depth.

## The bug

```
$ gate list --state bogus
error: Invalid state: bogus          ← no valid set, unlike unknown-flag errors
```

Sibling unknown-flag errors list their valid flags; this didn't list valid states. Asymmetric, and against the "error + recovery path" house style.

## The fix

```
$ gate list --state bogus
error: list: invalid --state 'bogus'.
  valid states: pending, approved, executing, completed, failed, denied, all
  ('all' lists every state; omit --state on 'list' for its default)
```

`reqList` validates `--state` at the interface boundary. The valid set is built from the domain's `REQUEST_STATES` ∪ the interface-only `all` sugar — single-sourced, so it can't drift from the enum. State vocabulary stays in the domain; the CLI hint is an interface concern — the same split as the deny/execute verb redirects.

## Tests
`tests/interface/listInvalidState.test.ts`: the enumerated hint names all 7 accepted values, and valid states / `all` / the bare default still work. Full suite (clean dist) **1805 pass / 0 fail**.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_