### PR TITLE
docs: refit CLAUDE.md (philosophy-first) + complete AGENT.md verb signatures

### DIFF
--- a/.changelog/next/docs-agent-claude-md-refit.md
+++ b/.changelog/next/docs-agent-claude-md-refit.md
@@ -1,0 +1,12 @@
+- **`CLAUDE.md` and `AGENT.md` refit to current truth.** `CLAUDE.md` (the
+  contributor/development guide) was rewritten to lead with the dogfood
+  loop and the bug-killing flow (issue → agora → gate + two-persona
+  review), and to state the AI-first JSON contract + error-recovery rule +
+  principle-13 hint discipline explicitly; its stale facts were corrected
+  (`--executors` not the removed singular `--executor`; node:test/~1800
+  tests not "Jest/~1250"; `.changelog/next/` fragments not editing
+  `[Unreleased]`; GitHub MCP not `gh`; agora `new/play/move/...` not
+  "improvise"). `AGENT.md` gained four missing verb-signature flags
+  (`gate complete --cliff`, `gate unresponded --max-age-days`, `gate
+  issues add --text`, agora `--format`, `devil list --state all`) to match
+  `<verb> --help`. No behavior change.

--- a/AGENT.md
+++ b/AGENT.md
@@ -134,7 +134,7 @@ gate request --from <m> --action "..." --reason "..." \
 gate approve <id> --by <m> [--note "..."]
 gate deny <id> --by <m> --reason "..."
 gate execute <id> --by <m> [--cwd <path>]                  # cwd stamped on the status_log entry
-gate complete <id> --by <m> [--note "..."]
+gate complete <id> --by <m> [--note "..."] [--cliff "<hint for next agent>"]
 gate fail <id> --by <m> --reason "..."
 gate fast-track --from <m> --action "..." --reason "..." \
                 [--executors a[,b,c]] [--with ...]
@@ -206,7 +206,7 @@ gate transcript <id>                    # narrative prose arc of a request
 gate suggest [--format json|text]       # suggested_next only (hot-loop sibling of boot)
 gate why <id>                           # decision walk: why is this request in this state?
 gate summarize <id> [--limit <N>]       # narrative summary
-gate unresponded [--for <m>]            # concerns recorded but not yet responded to
+gate unresponded [--for <m>] [--max-age-days <N>]   # concerns recorded but not yet responded to
 gate flow-suggest --severity <s> --area <a> [--scope <s>]      # advisory: which flow shape? (#307)
 gate lense-stats [--for <m>] [--since <d>]                     # lense rotation diagnostic (#305)
 gate decisions [--for <m>] [--since <d>]                       # authored state transitions (#336; defaults --for to GUILD_ACTOR)
@@ -324,7 +324,7 @@ open ↔ in_progress ↔ deferred → resolved (reopen → open)
 ```
 
 ```bash
-gate issues add --from <m> --severity <low|med|high> --area <a> "text"
+gate issues add --from <m> --severity <low|med|high> --area <a> --text "<text>"
 gate issues list [--state <s>]
 gate issues resolve|defer|start|reopen <id> --by <m>   # --by required; appends state_log
 gate issues note <id> --by <m> --text "..."          # append annotation
@@ -442,6 +442,9 @@ agora cliff <play-id> [--game <slug>]          # peek closing cliff/invitation, 
 agora schema [--verb <name>]                   # principle 10 contract
 ```
 
+All agora verbs also accept `[--format json|text]` (omitted above for
+density) — the JSON envelope is the agent contract, same as gate.
+
 agora records live under `<content_root>/agora/`:
 
 ```
@@ -486,7 +489,7 @@ devil entry <rev-id> --persona <p> --lense <l> --kind <k> --text "<prose>"
                      [--severity-rationale "<prose>"]   # required when kind=finding
                      [--addresses <e-NNN>]
                      [--by <m>]
-devil list [--state <open|concluded>] [--target-type <pr|file|function|commit|system>]
+devil list [--state <open|concluded|all>] [--target-type <pr|file|function|commit|system>]
 devil show <rev-id>
 devil conclude <rev-id> --synthesis "<prose>" [--unresolved e-001,e-002,...] [--by <m>]
 devil dismiss <rev-id> <entry-id> --reason <r> [--note "..."] [--by <m>]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,94 +1,148 @@
 # CLAUDE.md — guild-cli
 
-このファイルは Claude Code (および互換 AI agent) が guild-cli リポジトリで作業するときの guide。
+Claude Code (および互換 AI agent) が guild-cli リポジトリで作業するときの guide。
+**AGENT.md が CLI の使い方リファレンス**、この CLAUDE.md は **repo を開発する側の指示**。
 
-## What this repo is
+## 一行で
 
-TypeScript 製 CLI `guild-cli` を提供する public repo。4 つの passage を持つ：
+file-based な coordination substrate を作っている TypeScript CLI。
+**自分自身の substrate の上で開発を回す (dogfood)** のが中心原則。
 
-- **gate** — request/approve/execute/complete の wave coordination + claim/witness の cross-session stake
-- **agora** — improvise / suspend / conclude の議論プリミティブ
-- **devil** — devil's advocate review (lenses: devil/layer/cognitive/user + custom)
-- **ctx** — session 跨ぎの文脈 primitive
+## この repo は何か
 
-Domain → Application → Infrastructure → Interface の Clean Architecture (`src/` 配下に layer 分割)。`bin/*.mjs` が CLI dispatcher、各 passage の handler は `src/interface/<passage>/handlers/` に。
+4 つの passage を持つ public CLI:
 
-## Dogfooding rule
+- **gate** — request → approve → execute → complete の wave coordination
+  + claim/witness の cross-session stake
+- **agora** — `new` / `play` / `move` / `suspend` / `resume` / `conclude`
+  の議論・探索プリミティブ (alpha)
+- **devil** — multi-persona security review (lenses: devil/layer/cognitive/user
+  + custom)。security 寄りの変更専用 — 汎用レビューは `gate review` (docs/playbook.md
+  "When NOT to use devil")
+- **ctx** — session 跨ぎの fact accumulation (alpha, phase 1 は `record` のみ)
 
-**guild-cli の開発は guild-cli substrate の上で回す**。これは設計原則ではなく実用要請：
+Clean Architecture: **Domain → Application → Infrastructure → Interface**
+(`src/` 配下に layer 分割)。`bin/*.mjs` が CLI dispatcher、各 passage の
+handler は `src/interface/<passage>/handlers/` (gate) ないし
+`src/passages/<passage>/interface/handlers/` (agora/devil/ctx)。
+
+## Dogfooding rule — 開発の中心原則
+
+**guild-cli の開発は guild-cli substrate の上で回す**。設計原則ではなく実用要請:
 
 - 自分で作った primitive を自分の wave 進行に乗せれば friction が surface する
-- surface した friction が次の improvement issue になる (例: #228 friction bundle、#233 self_approve)
-- records-outlive-writers の原則は開発自身にも効く — 「誰が・なぜ・いつ・何を変えたか」が gate record に残る
+- surface した friction が次の improvement issue になる
+  (例: #228 friction bundle、#233 self_approve)
+- **records-outlive-writers は開発自身に効く** — 「誰が・なぜ・いつ・何を
+  変えたか」が gate record / agora play / ctx fact に残り、次セッションの
+  自分 (or 別 agent) が `gate boot` 一発で読み戻せる
+
+### bug-killing flow (docs/playbook.md C4) — 推奨の一周
+
+実バグは substrate に乗せて殺す。観察 → 探索 → 判断 → レビューが一本の線になる:
+
+```
+gate issues add ...              # 観察を notice として起票
+  → agora new/play/move ...      # sandbox で root-cause を moves に記録
+    → agora conclude + issues promote → gate request   # 判断: 実装の wave 化
+      → 実装 → gate review (別 persona / 別 actor が red-team)   # Two-Persona
+        → gate complete --cliff "..."   # 次へのバトン
+```
+
+`gate why <id>` が aligned / contested を分けて残すので、レビューの不同意が
+消えずに次セッションへ差し戻る。
 
 ### 標準ワークフロー (single-executor wave)
 
 ```bash
-# 起票 (eris は default host、members/ に登録済み actor を --executor に指定)
-gate request --action "ship #N <feature>" --reason "<why>" --executors <actor> --from eris --target "<files>"
-# (Note: --executor (singular) is deprecated as of v0.6 — use --executors. See #239.)
+# 起票 (eris は default host、members/ に登録済み actor を --executors に指定)
+gate request --from eris --action "ship #N <feature>" --reason "<why>" \
+             --executors <actor> --target "<files>"
 # → 2026-MM-DD-NNNN (state=pending)
+# NOTE: flag は --executors (複数)。単数 --executor は v0.6 で削除済み (#239)。
+#       `gate list --executor <m>` (フィルタ単数) だけは別物で現役。
 
-gate approve <id> --by eris        # self-approve は notice 出るが通る (現行)
-gate execute <id> --by <actor>     # → state=executing
-
+gate approve  <id> --by eris        # self-approve は notice 出るが通る (solo profile)
+gate execute  <id> --by <actor>     # → state=executing
 # (worktree 切って実装 / レビュー / テスト)
-
-gate complete <id> --by <actor>    # → terminal、claim/witnesses は auto-reset
+gate complete <id> --by <actor>     # → terminal、claim/witnesses は auto-reset
 ```
+
+間違った順で叩くと、エラーが次の verb を名指しする (例: pending に execute →
+"gate approve <id>")。state vocab は domain、verb hint は interface の分担。
 
 ### 並列 wave (parallel-impl 等)
 
 `gate request --executors a,b,c` で複数 executor を同時記録 (#230)。
-**worktree isolation 必須** — `profile: swarm` で強制される (#231)。
+**worktree isolation 必須** — `profile: swarm` で強制 (#231)。
 attribution race の物理化防止は filesystem 層 + record 層 + agent-loop 層の三層分担。
+swarm の詳細は docs/swarm.md。
 
 ## Cross-session coordination
 
-別セッション (別 SubAgent / 別 main session) が同 issue を独立着手するケースに備える：
+別セッション (別 SubAgent / 別 main session) が同 issue を独立着手するケースに備える:
 
-- `gate claim <id> --by <actor>` — 「私が動かす」exclusive stake (PR #243 / phase 1 ship 済)
-- `gate witness <id> --by <actor>` — 「観察するだけ」non-exclusive (#244 / phase 2)
-- `gate boot` で overlap 検知 (#234 / 設計中)
+- `gate claim <id> --by <actor>` — 「私が動かす」exclusive stake (#243 / ship 済)
+- `gate witness <id> --by <actor>` — 「観察するだけ」non-exclusive (#244)
+- `gate boot` で overlap 検知 (#234)
 
-セッション開始時は **open issue 確認 → 関連 wave に claim 取得 → 作業開始** の routine 推奨。
+セッション開始時の routine: **`gate boot` で orient → open issue / 関連 wave 確認
+→ claim 取得 → 作業開始**。
 
 ## Repository layout
 
 | dir | 内容 | shared? |
 |-----|------|--------|
-| `src/` `tests/` | 実装と test (TS) | ✅ git |
-| `bin/*.mjs` | CLI entrypoint dispatcher | ✅ git |
+| `src/` `tests/` | 実装と test (TS, node:test) | ✅ git |
+| `bin/*.mjs` | CLI entrypoint dispatcher + `bin/_lib/` の plain .mjs helper | ✅ git |
 | `examples/` | sample guild instances (各種 config パターン) | ✅ git |
-| `docs/` | 設計・運用ドキュメント | ✅ git |
+| `docs/` | 設計・運用ドキュメント (README からリンク) | ✅ git |
+| `lore/` | principles (16) + traps (8)。`gate lore list` で読める | ✅ git |
+| `.changelog/next/` | per-PR changelog fragment (release 時に折り込み) | ✅ git |
 | `members/` | gate member 登録 (alice/bob 等) | ❌ local-only via `.git/info/exclude` |
 | `substrate/` | agora plays/games の作業領域 | ❌ local-only |
-| `experiments/` | substrate-experiment 跡地 | ❌ local-only |
-| `.claude/` | worktree shadow / settings | ❌ local-only |
 | `requests/` | gate request YAML records (dogfood 履歴、actor 名含む) | ❌ local-only via `.gitignore` |
+| `.claude/` | worktree shadow / settings | ❌ local-only |
+
+`guild.config.yaml` も local-only。なので fresh clone は素の状態で起動する
+(`gate boot` が register への導線を出す)。
 
 ## Development workflow
 
 1. **branch + worktree**: 大きい変更は `git worktree add ../guild-cli-<topic> -b feat/<topic>` で隔離
-2. **build + test**: `npm run build && npm test` (Jest、~1250 tests)
+2. **build + test**: `npm test` (= `tsc && node tests/run.mjs`、node:test、~1800 tests)。
+   - グループ実行: `npm run test:domain` / `test:interface` / `test:passages` 等
+   - 並列度: `TEST_CONCURRENCY=20` 等で上げ下げ可 (既定 8)
+   - **branch 跨ぎは `rm -rf dist` してから** — `tsc` は追加するが prune しない
+     ので、別 branch でビルドした `.test.js` が残ると count が二重化する
+     (trap_dist_stale_after_branch_switch)
 3. **commit**: 必須 (Task tool / SubAgent の auto-cleanup 防止)
-4. **PR**: `gh pr create`、main rebase してから push、squash merge で fast ship
-5. **docs**: behavior change は `CHANGELOG.md` の `[Unreleased]` に entry 追加
-
-詳細は `docs/` 配下と `.gate-sessions/` (もしあれば) の wave 履歴を参照。
+4. **PR**: main を rebase してから push、squash merge で fast ship
+   - この環境では GitHub MCP tool 経由 (`gh` CLI は無い)
+5. **changelog**: behavior change は `.changelog/next/<category>-<slug>.md` に
+   fragment を1つ落とす。`CHANGELOG.md` の `[Unreleased]` は**直接編集しない**
+   (release script が fragment を折り込む。詳細 .changelog/README.md)
 
 ## Style
 
 - TS strict mode、no `any`
-- domain は外部依存ゼロ (Clean Arch の依存方向厳守)
-- text mode と json mode の両 surface を維持 (LLM 消費前提)
+- domain は外部依存ゼロ (Clean Arch の依存方向厳守。CLI 語彙を domain に漏らさない)
+- text mode と json mode の両 surface を維持 — **AI-first**: substrate (JSON) が
+  contract、text は human projection (principle 11)。`--format json` の envelope
+  shape は verb 横断で安定
 - byte-stable YAML (空 field omit、hydrate tolerance) は永続層の不変条件
-- error message に "next:" を添えて recovery path を提示 (touch-feel UX)
+- **error message に recovery path を添える** (touch-feel UX): 「できない」だけ
+  でなく「次にどの verb / flag を打つか」を示す。illegal transition は
+  bridging verb を名指し、not-found は `gate list`/`tail` を指す。JSON では
+  `error.recovery {verb,args}` + `error.code` を載せる
+- 成功時の trailing `next:` hint は verb shape 依存 (principle 13): bootstrap/
+  boundary は出す、lifecycle/flow は出さない (JSON `suggested_next` が担う)
 
 ## References
 
-- 進行中 wave の resume: `.gate-sessions/` 配下 / 開発者の ctx (例: `data/ctx/guild_cli_dev_resume.md`)
-- Roadmap: #36
-- Profile design: #227 (swarm profile epic)
-- Friction bundle: #228
-- Cross-session: #226 (claim/witness)
+- CLI 使い方の一次リファレンス: [`AGENT.md`](./AGENT.md)
+- combos / recipes / bug-killing flow: [`docs/playbook.md`](./docs/playbook.md)
+- swarm / 並列調整: [`docs/swarm.md`](./docs/swarm.md)
+- principles / traps: [`lore/`](./lore/) または `gate lore list`
+- Roadmap: #36 / Profile design: #227 / Friction bundle: #228 / Cross-session: #226
+- 進行中 wave の resume: `gate boot` + `gate resume` (+ 開発者の ctx)


### PR DESCRIPTION
You asked me to "魔改造" both docs into my ideal form. I read both in full first, confirmed the structure was worth keeping, and chose **refit-to-truth + restructure** over a from-scratch rewrite — the 8 sessions of issue-number provenance and lore links are worth preserving. Every claim I wrote was verified against the runtime.

## `CLAUDE.md` (contributor guide) — restructured + de-rotted

The "ideal form": **lead with the dogfood loop**, add a **bug-killing-flow** section (`issue → agora → gate + two-persona review` — the arc this session actually ran), and make the **Style** section state the philosophy explicitly (AI-first JSON contract per principle 11; error-recovery rule — name the next verb, `error.recovery`+`error.code` in JSON; principle-13 trailing-hint discipline).

Stale facts corrected (all were genuinely wrong):
| was | now |
|-----|-----|
| `--executor` singular + "deprecated, removed at v0.7" | `--executors`; singular removed in v0.6 (#239). Noted `gate list --executor` filter-singular is a separate live flag |
| "Jest、~1250 tests" | node:test via `tests/run.mjs`; ~1800 |
| edit `CHANGELOG.md [Unreleased]` | drop a `.changelog/next/` fragment (the `[Unreleased]` method is explicitly retired) |
| `gh pr create` | GitHub MCP (no `gh` in this env) |
| agora "improvise / suspend / conclude" | `new/play/move/suspend/resume/conclude` (no `improvise`) |

Added: test grouping (`test:domain` etc.), `TEST_CONCURRENCY`, and the `rm -rf dist` branch-switch trap (`trap_dist_stale_after_branch_switch`) to the workflow.

## `AGENT.md` (CLI reference) — surgical signature completion

A full drift audit found the prose **already correct** (links all resolve; `--executor`/`improvise`/lore-counts fixed back in #426). The only gaps were four verb signatures missing flags vs `<verb> --help` — added:

- `gate complete … [--cliff "<hint>"]` — the cliff primitive was absent
- `gate unresponded … [--max-age-days <N>]`
- `gate issues add … --text "<text>"` — canonical form the help advertises (a bare positional still works, so this is "match the surface", not a correctness fix)
- agora verbs: one prose line noting all accept `[--format json|text]` (was omitted on all six)
- `devil list --state <open|concluded|all>` — `all` parity with `gate list`

No behavior change in either file; docs now match the runtime. Changelog fragment included.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_