### PR TITLE
feat(ctx): OKF (Open Knowledge Format) export/import round-trip + prose dedup

### DIFF
--- a/.changelog/next/added-ctx-okf-roundtrip.md
+++ b/.changelog/next/added-ctx-okf-roundtrip.md
@@ -10,5 +10,9 @@
   to `prefix:value` (bare → `topic:`), a non-`Fact` type is preserved as
   an `okf:<type>` provenance tag, missing authors fall back to `--by`,
   and empty/unparseable documents are reported as skipped rather than
-  failing the import. OKF is an interchange *projection* (principle 11),
-  not a storage change — the on-disk substrate stays YAML.
+  failing the import. Prose dedup is on by default — a fact whose
+  normalized prose is already recorded (under any id, or earlier in the
+  same bundle) is skipped, so even an id-less foreign bundle re-imported
+  is a no-op; `--allow-duplicates` opts out. OKF is an interchange
+  *projection* (principle 11), not a storage change — the on-disk
+  substrate stays YAML.

--- a/.changelog/next/added-ctx-okf-roundtrip.md
+++ b/.changelog/next/added-ctx-okf-roundtrip.md
@@ -1,0 +1,14 @@
+- **`ctx export` / `ctx import` — Open Knowledge Format (OKF) round-trip.**
+  ctx facts can now be projected to and recorded from
+  [OKF](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)
+  bundles (a directory of `<id>.md` files: YAML frontmatter + fact prose,
+  plus generated `index.md` / `log.md` views). `ctx export <dir>` writes
+  the bundle; `ctx import <dir>` records it back. Guild-authored bundles
+  round-trip losslessly — id, timestamp, author and tags survive, and a
+  re-import is idempotent (existing ids skip). Foreign bundles import
+  tolerantly: nested subtrees are walked, bare/prefixed tags are coerced
+  to `prefix:value` (bare → `topic:`), a non-`Fact` type is preserved as
+  an `okf:<type>` provenance tag, missing authors fall back to `--by`,
+  and empty/unparseable documents are reported as skipped rather than
+  failing the import. OKF is an interchange *projection* (principle 11),
+  not a storage change — the on-disk substrate stays YAML.

--- a/AGENT.md
+++ b/AGENT.md
@@ -584,7 +584,8 @@ substrate primitive for facts; surrounding ecosystem modules
 (persona-side `*_resume.md`, code comments, ADR docs) hold related
 prose at different layers without absorbing into one another.
 
-Phase 1 ships only `ctx record`. The remaining six verbs (`fork` /
+Phase 1 ships `ctx record` plus the OKF interop pair (`export` /
+`import`, below). The remaining six lifecycle verbs (`fork` /
 `supersede` / `show` / `list` / `chain` / `status`) and schema
 extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
 `branch_ref`) land in phase 2.
@@ -610,6 +611,28 @@ later — filter by `tech:*`, `status:*`, etc. Phase 1 leaves prefix
 choice free-form; phase 2 will introduce strictness levels (0/1/2 =
 loose / middle / strict) for prefix catalogs.
 
+**OKF interchange (export / import).** ctx facts project to and from
+[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)
+bundles — a directory of `<id>.md` files (YAML frontmatter + fact prose)
+plus generated `index.md` / `log.md` views. OKF is an interchange
+*projection* (principle 11), not a storage change: the on-disk substrate
+stays YAML; OKF is another surface, the way `--format text` is.
+
+```bash
+ctx export <dir> [--as okf] [--format json|text]   # facts -> OKF bundle
+ctx import <dir> [--as okf] [--by <m>] [--format json|text]   # bundle -> facts
+```
+
+Round-trip is lossless for guild-authored bundles — `id`, `timestamp`,
+`author` and `tags` survive the trip, and re-importing the same bundle
+is idempotent (existing ids skip). Foreign bundles import tolerantly:
+nested subtrees are walked; bare tags land under `topic:`; a non-`Fact`
+`type` is preserved as an `okf:<type>` provenance tag; documents lacking
+an author fall back to `--by`; empty or unparseable documents are
+reported as skipped rather than failing the whole import. `--as` selects
+the bundle format (only `okf` today; the flag is the seam for a future
+second format).
+
 When to reach for ctx vs the other passages: ctx is the residence
 for prose that doesn't want closure. If the observation is heading
 toward a verdict, file it via `gate request`. If it's
@@ -617,7 +640,8 @@ thought-in-motion across sessions, use `agora play`. If it's a
 finding that needs adversarial scrutiny, use `devil entry`. ctx is
 for what remains: pinned observation, no closure required.
 
-Status: alpha phase 1. Read-side is currently grep on
+Status: alpha phase 1. Structured read-side is `ctx export` (OKF
+projection); ad-hoc read-side is still grep on
 `<content_root>/ctx/*.yaml` — `ctx list` / `ctx chain` arrive in
 phase 2 and that's the design test (junk-drawer risk vs principled
 substrate).

--- a/AGENT.md
+++ b/AGENT.md
@@ -620,7 +620,8 @@ stays YAML; OKF is another surface, the way `--format text` is.
 
 ```bash
 ctx export <dir> [--as okf] [--format json|text]   # facts -> OKF bundle
-ctx import <dir> [--as okf] [--by <m>] [--format json|text]   # bundle -> facts
+ctx import <dir> [--as okf] [--by <m>] [--allow-duplicates]
+                 [--format json|text]               # bundle -> facts
 ```
 
 Round-trip is lossless for guild-authored bundles — `id`, `timestamp`,
@@ -629,9 +630,14 @@ is idempotent (existing ids skip). Foreign bundles import tolerantly:
 nested subtrees are walked; bare tags land under `topic:`; a non-`Fact`
 `type` is preserved as an `okf:<type>` provenance tag; documents lacking
 an author fall back to `--by`; empty or unparseable documents are
-reported as skipped rather than failing the whole import. `--as` selects
-the bundle format (only `okf` today; the flag is the seam for a future
-second format).
+reported as skipped rather than failing the whole import.
+
+**Prose dedup** is on by default: a fact whose normalized prose is
+already recorded — under any id, or earlier in the same bundle — is
+skipped, so even an id-less foreign bundle re-imported is a no-op (the
+skip reason names the record it duplicates). `--allow-duplicates` opts
+out for a deliberate re-record. `--as` selects the bundle format (only
+`okf` today; the flag is the seam for a future second format).
 
 When to reach for ctx vs the other passages: ctx is the residence
 for prose that doesn't want closure. If the observation is heading

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1709,7 +1709,8 @@ stays YAML; the bundle is another surface.
 
 ```bash
 ctx export <dir> [--as okf] [--format json|text]              # facts -> OKF bundle
-ctx import <dir> [--as okf] [--by <m>] [--format json|text]   # bundle -> facts
+ctx import <dir> [--as okf] [--by <m>] [--allow-duplicates]
+                 [--format json|text]                         # bundle -> facts
 ```
 
 A round-trip of guild-authored facts is **lossless** — the exported
@@ -1736,8 +1737,15 @@ Foreign bundles import tolerantly: nested subtrees are walked; bare tags
 land under `topic:`; a non-`Fact` `type` is preserved as an `okf:<type>`
 provenance tag; documents lacking an author fall back to `--by`; empty or
 unparseable documents are reported as skipped rather than failing the
-import. `--as` selects the bundle format (only `okf` today — the flag is
-the seam for a future second format).
+import.
+
+**Prose dedup** is on by default: a fact whose normalized prose
+(trimmed, internal whitespace collapsed) is already recorded — under any
+id, or earlier in the same bundle — is skipped, so even an id-less
+foreign bundle re-imported is a no-op. The skip reason names the record
+it duplicates. `--allow-duplicates` opts out for the rare deliberate
+re-record. `--as` selects the bundle format (only `okf` today — the flag
+is the seam for a future second format).
 
 ### Status (alpha phase 1)
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1648,7 +1648,8 @@ that don't fit into a verdict, a play, or a review.
 
 ### Phase 1 surface
 
-Phase 1 ships only `ctx record`. The remaining six verbs (`fork` /
+Phase 1 ships `ctx record` plus the OKF interop pair (`export` /
+`import`, below). The remaining six lifecycle verbs (`fork` /
 `supersede` / `show` / `list` / `chain` / `status`) and schema
 extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
 `branch_ref`) land in phase 2.
@@ -1698,9 +1699,50 @@ leaves prefix choice free-form (the substrate already in use mixes
 `meta:` / `pr:` / `principle:`); phase 2 introduces strictness
 levels (0/1/2 = loose / middle / strict) for prefix catalogs.
 
+### OKF interchange (`export` / `import`)
+
+ctx facts project to and from [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)
+bundles — a directory of `<id>.md` files (YAML frontmatter + fact prose)
+plus generated `index.md` / `log.md` views. OKF is an interchange
+*projection* (principle 11), not a storage change: the on-disk substrate
+stays YAML; the bundle is another surface.
+
+```bash
+ctx export <dir> [--as okf] [--format json|text]              # facts -> OKF bundle
+ctx import <dir> [--as okf] [--by <m>] [--format json|text]   # bundle -> facts
+```
+
+A round-trip of guild-authored facts is **lossless** — the exported
+frontmatter carries `id`, `timestamp`, `author` and `tags`, so import
+reconstructs the same record, and re-importing the same bundle is
+idempotent (existing ids skip):
+
+```yaml
+# bundle/ctx-2026-05-04-006.md
+---
+type: Fact
+tags:
+  - scope:develop-only
+  - topic:branch-policy
+timestamp: 2026-05-04T13:58:11.476Z
+author: claude
+id: ctx-2026-05-04-006
+---
+
+main↔develop diff is PR #145 only; harness layer stays develop-side
+```
+
+Foreign bundles import tolerantly: nested subtrees are walked; bare tags
+land under `topic:`; a non-`Fact` `type` is preserved as an `okf:<type>`
+provenance tag; documents lacking an author fall back to `--by`; empty or
+unparseable documents are reported as skipped rather than failing the
+import. `--as` selects the bundle format (only `okf` today — the flag is
+the seam for a future second format).
+
 ### Status (alpha phase 1)
 
-Read-side is currently grep on `<content_root>/ctx/*.yaml`.
+Structured read-side is `ctx export` (OKF projection); ad-hoc read-side
+is still grep on `<content_root>/ctx/*.yaml`.
 `ctx list` / `ctx show` / `ctx chain` (phase 2) are the design
 test — whether the substrate stays principled or drifts into a
 junk drawer at the 100-record scale.

--- a/src/domain/okf/OkfDocument.ts
+++ b/src/domain/okf/OkfDocument.ts
@@ -1,0 +1,110 @@
+// OKF — Open Knowledge Format document model (domain, dependency-free).
+//
+// OKF (https://cloud.google.com/blog/products/data-analytics/how-the-
+// open-knowledge-format-can-improve-data-sharing/) is a vendor-neutral
+// interchange format: a bundle is a *directory of markdown files*, each
+// being YAML frontmatter + a markdown body. File paths are concept
+// identities; markdown links between files form the relationship graph.
+//
+// guild-cli treats OKF as an interop *projection* (principle 11), not a
+// storage format. The on-disk substrate stays YAML/JSON-envelope; OKF is
+// another surface records can be exported to and imported from, the way
+// `--format text` is a human projection of the JSON contract. Keeping it
+// a projection means an OKF v0.x churn costs a projector edit, never a
+// stored-data migration.
+//
+// This module is pure: the document shape, the conformance rule, and the
+// small string helpers the export/import mappers share. YAML (de)serial-
+// ization and filesystem IO live in infrastructure — domain stays free
+// of external dependencies (Clean Architecture; CLAUDE.md "Style").
+
+import { DomainError } from '../shared/DomainError.js';
+
+/** The OKF spec revision this projector targets. */
+export const OKF_VERSION = '0.1';
+
+/**
+ * Reserved filenames the spec gives special meaning. `index.md` is the
+ * bundle's table of contents; `log.md` is its chronological history.
+ * Both are *generated views* on export and *skipped* on import — they
+ * are projections of the concept set, not concepts themselves.
+ */
+export const OKF_RESERVED_FILENAMES: ReadonlySet<string> = new Set([
+  'index.md',
+  'log.md',
+]);
+
+/**
+ * OKF frontmatter. The spec requires exactly one field — `type` — and
+ * standardizes a handful of optional ones; everything else is left to
+ * the producer. We model the standard fields explicitly and keep an
+ * open index for producer-defined extras (guild emits `id` and `author`
+ * there so a guild-authored bundle round-trips losslessly).
+ */
+export interface OkfFrontmatter {
+  /** Required: the concept's type (e.g. `Fact`, `BigQuery Table`). */
+  type: string;
+  title?: string;
+  description?: string;
+  resource?: string;
+  tags?: readonly string[];
+  /** ISO-8601 last-update timestamp. */
+  timestamp?: string;
+  /** Producer-defined extras (guild: `id`, `author`). */
+  [key: string]: unknown;
+}
+
+/**
+ * One OKF concept document.
+ *
+ * `path` is the concept's identity within the bundle — a relative path
+ * like `ctx-2026-06-16-001.md`. `body` is the markdown after the
+ * frontmatter block (for a guild fact, the fact prose).
+ */
+export interface OkfDocument {
+  readonly path: string;
+  readonly frontmatter: OkfFrontmatter;
+  readonly body: string;
+}
+
+/** True when `filename` is one of OKF's reserved view files. */
+export function isReservedOkfFilename(filename: string): boolean {
+  return OKF_RESERVED_FILENAMES.has(filename);
+}
+
+/**
+ * Conformance check: every OKF concept must carry a non-empty `type`.
+ * This is the one hard rule the spec states, enforced at the boundary
+ * so a malformed produced document fails loud rather than shipping a
+ * non-conformant bundle.
+ */
+export function assertOkfConformant(doc: OkfDocument): void {
+  const t = doc.frontmatter.type;
+  if (typeof t !== 'string' || t.trim().length === 0) {
+    throw new DomainError(
+      `OKF document ${doc.path} is missing the required 'type' field`,
+      'type',
+    );
+  }
+}
+
+/**
+ * Slugify an OKF `type` (or any free text) into the value half of a
+ * guild tag — lowercase, ASCII alphanumerics and hyphens, collapsed and
+ * trimmed, capped at 48 chars (the `parseCtxTag` value bound). Returns
+ * `null` when nothing usable survives (e.g. an all-symbol input), so the
+ * caller can drop rather than emit an invalid tag.
+ *
+ * Example: `"BigQuery Table"` → `"bigquery-table"`.
+ */
+export function slugifyForTagValue(raw: string): string | null {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+    .replace(/-+$/g, '');
+  // Value must start with an alphanumeric (parseCtxTag bound). A leading
+  // hyphen can't survive the trims above, but an empty result can.
+  return /^[a-z0-9]/.test(slug) ? slug : null;
+}

--- a/src/infrastructure/okf/FsOkfBundleRepository.ts
+++ b/src/infrastructure/okf/FsOkfBundleRepository.ts
@@ -1,0 +1,190 @@
+// FsOkfBundleRepository — filesystem adapter for OKF bundles.
+//
+// Implements OkfBundlePort. Writes go through safeFs (path containment,
+// no-symlink-traversal); reads walk the bundle directory recursively so
+// nested foreign bundles (e.g. `datasets/`, `tables/` subtrees) import,
+// not just guild's own flat export. Symlinked directories are not
+// followed — a hostile bundle can't redirect the walk outside `dir`.
+//
+// The generated `index.md` / `log.md` view files derive their timestamp
+// from the concept set (latest fact), never from wall-clock `now`, so a
+// re-export of the same facts is byte-identical.
+
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { join, basename } from 'node:path';
+import {
+  OkfDocument,
+  isReservedOkfFilename,
+  assertOkfConformant,
+} from '../../domain/okf/OkfDocument.js';
+import {
+  OkfBundlePort,
+  OkfBundleReadResult,
+  OkfBundleWriteResult,
+  OkfSkippedDoc,
+} from '../../passages/ctx/application/OkfBundlePort.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
+import { DomainError } from '../../domain/shared/DomainError.js';
+import {
+  assertUnder,
+  readTextSafe,
+  writeTextSafe,
+  MAX_DIR_ENTRIES,
+} from '../persistence/safeFs.js';
+import { serializeOkfDocument, parseOkfDocument } from './OkfFrontmatter.js';
+
+export class FsOkfBundleRepository implements OkfBundlePort {
+  constructor(private readonly onMalformed: OnMalformed) {}
+
+  async write(
+    dir: string,
+    docs: readonly OkfDocument[],
+  ): Promise<OkfBundleWriteResult> {
+    const written: string[] = [];
+    const sorted = [...docs].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+    for (const doc of sorted) {
+      assertOkfConformant(doc);
+      writeTextSafe(dir, doc.path, serializeOkfDocument(doc));
+      written.push(doc.path);
+    }
+
+    writeTextSafe(dir, 'index.md', serializeOkfDocument(buildIndex(sorted)));
+    written.push('index.md');
+    writeTextSafe(dir, 'log.md', serializeOkfDocument(buildLog(sorted)));
+    written.push('log.md');
+
+    return { written };
+  }
+
+  async read(dir: string): Promise<OkfBundleReadResult> {
+    const baseAbs = assertUnder(dir, '.');
+    if (!existsSync(baseAbs)) {
+      return { docs: [], skipped: [] };
+    }
+    if (!statSync(baseAbs).isDirectory()) {
+      throw new DomainError(`OKF bundle path is not a directory: ${dir}`, 'dir');
+    }
+
+    const rels = this.collectMdFiles(baseAbs, '').sort();
+    const docs: OkfDocument[] = [];
+    const skipped: OkfSkippedDoc[] = [];
+
+    for (const rel of rels) {
+      if (isReservedOkfFilename(basename(rel))) continue; // generated views
+
+      const text = readTextSafe(dir, rel);
+      const source = join(baseAbs, rel);
+      // Capture a frontmatter parse failure for this one file: a
+      // corrupt frontmatter is a real signal, so the document is
+      // reported as skipped rather than half-imported.
+      let failure: string | null = null;
+      const capture: OnMalformed = (src, msg) => {
+        failure = msg;
+        this.onMalformed(src, msg);
+      };
+      const doc = parseOkfDocument(rel, text, source, capture);
+      if (failure !== null) {
+        skipped.push({ path: rel, reason: failure });
+      } else {
+        docs.push(doc);
+      }
+    }
+
+    return { docs, skipped };
+  }
+
+  /**
+   * Recursively collect relative paths of `.md` files under `relDir`.
+   * Symlinks (file or directory) are skipped — the walk never leaves the
+   * bundle root. Entries are bounded by MAX_DIR_ENTRIES per directory to
+   * mirror the substrate's oversized-directory guard.
+   */
+  private collectMdFiles(baseAbs: string, relDir: string): string[] {
+    const dirAbs = relDir === '' ? baseAbs : join(baseAbs, relDir);
+    const entries = readdirSync(dirAbs, { withFileTypes: true });
+    if (entries.length > MAX_DIR_ENTRIES) {
+      throw new DomainError(
+        `OKF bundle directory exceeds ${MAX_DIR_ENTRIES} entries: ${dirAbs}`,
+        'dir',
+      );
+    }
+    const out: string[] = [];
+    for (const entry of entries) {
+      const rel = relDir === '' ? entry.name : `${relDir}/${entry.name}`;
+      // Defeat symlink traversal explicitly (Dirent.isSymbolicLink is
+      // set from lstat, but re-confirm to be robust across node versions).
+      if (lstatSync(join(baseAbs, rel)).isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        out.push(...this.collectMdFiles(baseAbs, rel));
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        out.push(rel);
+      }
+    }
+    return out;
+  }
+}
+
+/** First non-empty line of `body`, collapsed and truncated for a view. */
+function snippet(body: string, max = 80): string {
+  const line = body
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0 && !l.startsWith('#'));
+  if (line === undefined) return '';
+  const collapsed = line.replace(/\s+/g, ' ');
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
+}
+
+/** Bundle id (file stem) for a concept document. */
+function conceptId(doc: OkfDocument): string {
+  return basename(doc.path).replace(/\.md$/, '');
+}
+
+/** Latest `timestamp` across the concept set, or undefined if none. */
+function latestTimestamp(docs: readonly OkfDocument[]): string | undefined {
+  let latest: string | undefined;
+  for (const d of docs) {
+    const t = d.frontmatter.timestamp;
+    if (typeof t === 'string' && (latest === undefined || t > latest)) latest = t;
+  }
+  return latest;
+}
+
+function buildIndex(docs: readonly OkfDocument[]): OkfDocument {
+  const lines = docs.map((d) => {
+    const id = conceptId(d);
+    const snip = snippet(d.body);
+    return snip ? `- [${id}](${d.path}) — ${snip}` : `- [${id}](${d.path})`;
+  });
+  const body = `# Index\n\n${docs.length} concept${docs.length === 1 ? '' : 's'}.\n\n${lines.join('\n')}`;
+  const frontmatter: OkfDocument['frontmatter'] = {
+    type: 'Index',
+    title: 'ctx facts',
+    description: `${docs.length} fact${docs.length === 1 ? '' : 's'} exported from the guild substrate.`,
+  };
+  const ts = latestTimestamp(docs);
+  if (ts !== undefined) frontmatter.timestamp = ts;
+  return { path: 'index.md', frontmatter, body };
+}
+
+function buildLog(docs: readonly OkfDocument[]): OkfDocument {
+  const dated = docs
+    .map((d) => ({
+      id: conceptId(d),
+      path: d.path,
+      ts: typeof d.frontmatter.timestamp === 'string' ? d.frontmatter.timestamp : '',
+    }))
+    .sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  const lines = dated.map((d) => `- ${d.ts || '(no timestamp)'} — [${d.id}](${d.path})`);
+  const body = `# Log\n\nChronological record of exported concepts.\n\n${lines.join('\n')}`;
+  const frontmatter: OkfDocument['frontmatter'] = { type: 'Log', title: 'ctx log' };
+  const ts = latestTimestamp(docs);
+  if (ts !== undefined) frontmatter.timestamp = ts;
+  return { path: 'log.md', frontmatter, body };
+}

--- a/src/infrastructure/okf/OkfFrontmatter.ts
+++ b/src/infrastructure/okf/OkfFrontmatter.ts
@@ -1,0 +1,88 @@
+// OkfFrontmatter — (de)serialize the `---\n<yaml>\n---\n<body>` envelope.
+//
+// Infrastructure, not domain: this is where the external `yaml` dependency
+// lives. Parsing routes through `parseYamlSafe` so an imported bundle —
+// untrusted external input — gets the same prototype-pollution hardening
+// and parse-failure tolerance as every other YAML read in the substrate
+// (issue #154). Serialization emits a canonical field order so guild's own
+// exports are byte-stable (the project's persistence invariant).
+
+import YAML from 'yaml';
+import { OkfDocument, OkfFrontmatter } from '../../domain/okf/OkfDocument.js';
+import { parseYamlSafe } from '../persistence/parseYamlSafe.js';
+import { OnMalformed } from '../../application/ports/OnMalformed.js';
+
+// OKF's standard frontmatter fields, in the order we emit them. Any
+// producer-defined extras (guild: `id`, `author`) follow, sorted, so the
+// output is deterministic regardless of in-memory key order.
+const STANDARD_FIELD_ORDER: readonly string[] = [
+  'type',
+  'title',
+  'description',
+  'resource',
+  'tags',
+  'timestamp',
+];
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+/**
+ * Serialize a document to OKF text. Frontmatter fields are emitted in
+ * canonical order (standard fields first, extras sorted), then a blank
+ * line, then the body with a single trailing newline.
+ */
+export function serializeOkfDocument(doc: OkfDocument): string {
+  const fm = doc.frontmatter;
+  const ordered: Record<string, unknown> = {};
+
+  for (const key of STANDARD_FIELD_ORDER) {
+    const v = fm[key];
+    if (v !== undefined && v !== null) ordered[key] = v;
+  }
+  const extras = Object.keys(fm)
+    .filter((k) => !STANDARD_FIELD_ORDER.includes(k))
+    .sort();
+  for (const key of extras) {
+    const v = fm[key];
+    if (v !== undefined && v !== null) ordered[key] = v;
+  }
+
+  const yamlText = YAML.stringify(ordered).trimEnd();
+  const body = doc.body.trim();
+  return `---\n${yamlText}\n---\n\n${body}\n`;
+}
+
+/**
+ * Parse OKF text into a document. Tolerant on read:
+ *   - missing frontmatter delimiters -> empty frontmatter, whole text as body
+ *   - frontmatter that doesn't parse / isn't a mapping -> empty frontmatter
+ *     (the malformed event is reported via `onMalformed`)
+ *   - missing `type` -> coerced to `''` (the import mapper decides what to do)
+ *
+ * `source` labels the file in `onMalformed` diagnostics.
+ */
+export function parseOkfDocument(
+  path: string,
+  text: string,
+  source: string,
+  onMalformed: OnMalformed,
+): OkfDocument {
+  const m = FRONTMATTER_RE.exec(text);
+  if (m === null) {
+    return { path, frontmatter: { type: '' }, body: text.trim() };
+  }
+
+  const [, yamlText, body] = m;
+  const parsed = parseYamlSafe(yamlText ?? '', source, onMalformed);
+
+  let frontmatter: OkfFrontmatter = { type: '' };
+  if (parsed !== undefined && parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const obj = parsed as Record<string, unknown>;
+    frontmatter = {
+      ...obj,
+      type: typeof obj.type === 'string' ? obj.type : '',
+    };
+  }
+
+  return { path, frontmatter, body: (body ?? '').trim() };
+}

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -1,18 +1,42 @@
-import { Ctx, nextCtxId } from '../domain/Ctx.js';
+import { Ctx, CtxIdCollision, nextCtxId, parseCtxId } from '../domain/Ctx.js';
 import { CtxRepository } from './CtxRepository.js';
+import { OkfBundlePort, OkfSkippedDoc } from './OkfBundlePort.js';
+import { ctxToOkfDocument, okfDocumentToCtxFact } from './OkfCtxMapper.js';
+
+/** Summary of an OKF export. */
+export interface OkfExportSummary {
+  readonly written: readonly string[];
+  readonly count: number;
+}
+
+/** One fact created by an import. */
+export interface OkfImportedFact {
+  readonly id: string;
+  readonly path: string;
+}
+
+/** Summary of an OKF import. */
+export interface OkfImportSummary {
+  readonly imported: readonly OkfImportedFact[];
+  readonly skipped: readonly OkfSkippedDoc[];
+}
 
 /**
- * ctx use cases — phase 1 has only `record`. Phase 2 will add
- * fork / supersede / show / list / chain / status.
+ * ctx use cases. Phase 1 shipped `record`; this adds the OKF interop
+ * pair (`export` / `import`). The phase-2 lifecycle verbs (fork /
+ * supersede / show / list / chain / status) remain separate.
  *
- * `now` is injected so tests can pin time and so the same allocator
- * is used by id-generation (nextCtxId) and timestamp authorship,
- * keeping them consistent within a single record.
+ * `now` is injected so tests can pin time and so id-generation and
+ * timestamp authorship stay consistent within a single record. The OKF
+ * bundle port is optional in the constructor only so existing
+ * record-only wiring/tests need not supply it; the export/import paths
+ * assert it is present.
  */
 export class CtxUseCases {
   constructor(
     private readonly repo: CtxRepository,
     private readonly now: () => Date = () => new Date(),
+    private readonly bundle?: OkfBundlePort,
   ) {}
 
   async record(input: {
@@ -32,5 +56,124 @@ export class CtxUseCases {
     });
     await this.repo.saveNew(ctx);
     return ctx;
+  }
+
+  /**
+   * Export every ctx fact as an OKF bundle under `dir`. Read-only over
+   * the substrate (writes land outside `content_root`, in the chosen
+   * bundle directory).
+   */
+  async exportOkf(input: { dir: string }): Promise<OkfExportSummary> {
+    const bundle = this.requireBundle();
+    const ids = [...(await this.repo.listAllIds())].sort();
+    const docs = [];
+    for (const id of ids) {
+      const ctx = await this.repo.findById(id);
+      if (ctx !== null) docs.push(ctxToOkfDocument(ctx));
+    }
+    const res = await bundle.write(input.dir, docs);
+    return { written: res.written, count: docs.length };
+  }
+
+  /**
+   * Import an OKF bundle from `dir` as ctx facts.
+   *
+   * - A guild-authored bundle round-trips: the `id` frontmatter is
+   *   preserved, so re-importing the same bundle is idempotent (existing
+   *   ids skip) and the original timestamp/author/tags are restored.
+   * - A foreign bundle imports tolerantly: a missing/foreign id gets a
+   *   fresh allocation; missing author falls back to `input.by`; a
+   *   non-`Fact` type and non-conformant tags are preserved as tags.
+   */
+  async importOkf(input: { dir: string; by: string }): Promise<OkfImportSummary> {
+    const bundle = this.requireBundle();
+    const { docs, skipped } = await bundle.read(input.dir);
+
+    const existing = [...(await this.repo.listAllIds())];
+    const now = this.now();
+    const imported: OkfImportedFact[] = [];
+    const allSkipped: OkfSkippedDoc[] = [...skipped];
+
+    for (const doc of docs) {
+      const mapped = okfDocumentToCtxFact(doc);
+      if (mapped.kind === 'skip') {
+        allSkipped.push({ path: doc.path, reason: mapped.reason });
+        continue;
+      }
+
+      // Resolve the id: preserve a well-formed guild id (idempotent skip
+      // if it already exists); allocate fresh for missing/foreign ids.
+      let id: string;
+      const preserved = wellFormedCtxId(mapped.id);
+      if (preserved !== null) {
+        if (existing.includes(preserved)) {
+          allSkipped.push({
+            path: doc.path,
+            reason: `id ${preserved} already present (idempotent skip)`,
+          });
+          continue;
+        }
+        id = preserved;
+      } else {
+        id = nextCtxId(existing, now);
+      }
+
+      // Preserve the original timestamp when present and parseable.
+      const ts =
+        mapped.created_at !== undefined && !Number.isNaN(Date.parse(mapped.created_at))
+          ? mapped.created_at
+          : undefined;
+      const ctxNow = ts !== undefined ? () => new Date(ts) : () => now;
+      const created_by = mapped.created_by ?? input.by;
+
+      let ctx: Ctx;
+      try {
+        ctx = Ctx.create({
+          id,
+          fact: mapped.fact,
+          created_by,
+          tags: mapped.tags,
+          now: ctxNow,
+        });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        allSkipped.push({ path: doc.path, reason: `could not record: ${msg}` });
+        continue;
+      }
+
+      try {
+        await this.repo.saveNew(ctx);
+        existing.push(id);
+        imported.push({ id: ctx.id, path: doc.path });
+      } catch (e) {
+        if (e instanceof CtxIdCollision) {
+          allSkipped.push({
+            path: doc.path,
+            reason: `id ${id} already present (idempotent skip)`,
+          });
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    return { imported, skipped: allSkipped };
+  }
+
+  private requireBundle(): OkfBundlePort {
+    if (this.bundle === undefined) {
+      throw new Error('ctx OKF use cases require an OkfBundlePort (wiring bug)');
+    }
+    return this.bundle;
+  }
+}
+
+/** Return `raw` if it is a well-formed ctx id, else null. */
+function wellFormedCtxId(raw: string | undefined): string | null {
+  if (raw === undefined) return null;
+  try {
+    return parseCtxId(raw);
+  } catch {
+    return null;
   }
 }

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -84,8 +84,16 @@ export class CtxUseCases {
    * - A foreign bundle imports tolerantly: a missing/foreign id gets a
    *   fresh allocation; missing author falls back to `input.by`; a
    *   non-`Fact` type and non-conformant tags are preserved as tags.
+   * - Prose dedup (default on): a fact whose normalized prose already
+   *   exists on the substrate — or appears twice in the same bundle — is
+   *   skipped, so an id-less foreign bundle re-imported is also a no-op.
+   *   `allowDuplicates` opts out for the rare deliberate re-record.
    */
-  async importOkf(input: { dir: string; by: string }): Promise<OkfImportSummary> {
+  async importOkf(input: {
+    dir: string;
+    by: string;
+    allowDuplicates?: boolean;
+  }): Promise<OkfImportSummary> {
     const bundle = this.requireBundle();
     const { docs, skipped } = await bundle.read(input.dir);
 
@@ -93,6 +101,20 @@ export class CtxUseCases {
     const now = this.now();
     const imported: OkfImportedFact[] = [];
     const allSkipped: OkfSkippedDoc[] = [...skipped];
+
+    // Map normalized-prose -> the id that already carries it, so a
+    // duplicate import is skipped *and* the skip reason can name the
+    // record it duplicates. Built by hydrating the existing facts once
+    // (import is a deliberate batch op, so the O(n) read is acceptable);
+    // grows as the batch records new prose to catch in-bundle dups.
+    const dedup = input.allowDuplicates ? false : true;
+    const idByProse = new Map<string, string>();
+    if (dedup) {
+      for (const id of existing) {
+        const ctx = await this.repo.findById(id);
+        if (ctx !== null) idByProse.set(factDedupKey(ctx.fact), id);
+      }
+    }
 
     for (const doc of docs) {
       const mapped = okfDocumentToCtxFact(doc);
@@ -116,6 +138,22 @@ export class CtxUseCases {
         id = preserved;
       } else {
         id = nextCtxId(existing, now);
+      }
+
+      // Prose dedup (after the id-match idempotent skip): a fact whose
+      // normalized prose is already recorded — under any id — is a
+      // duplicate observation. ctx records are immutable, so re-recording
+      // the same prose adds noise rather than signal.
+      const proseKey = factDedupKey(mapped.fact);
+      if (dedup) {
+        const dupId = idByProse.get(proseKey);
+        if (dupId !== undefined) {
+          allSkipped.push({
+            path: doc.path,
+            reason: `duplicate prose (already recorded as ${dupId})`,
+          });
+          continue;
+        }
       }
 
       // Preserve the original timestamp when present and parseable.
@@ -144,6 +182,7 @@ export class CtxUseCases {
       try {
         await this.repo.saveNew(ctx);
         existing.push(id);
+        if (dedup) idByProse.set(proseKey, ctx.id);
         imported.push({ id: ctx.id, path: doc.path });
       } catch (e) {
         if (e instanceof CtxIdCollision) {
@@ -176,4 +215,15 @@ function wellFormedCtxId(raw: string | undefined): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Normalize fact prose into a dedup key: trim, then collapse internal
+ * whitespace runs (including newlines) to a single space. Case is kept —
+ * a case difference is treated as a distinct observation rather than
+ * silently merged. Resilient to markdown re-wrapping, which is the
+ * realistic source of "same fact, different bytes" across a round-trip.
+ */
+function factDedupKey(fact: string): string {
+  return fact.trim().replace(/\s+/g, ' ');
 }

--- a/src/passages/ctx/application/OkfBundlePort.ts
+++ b/src/passages/ctx/application/OkfBundlePort.ts
@@ -1,0 +1,40 @@
+// OkfBundlePort — Application's view of OKF bundle IO.
+//
+// The use case orchestrates "read all facts -> write a bundle" and
+// "read a bundle -> save facts"; the *how* of touching a directory of
+// markdown files (frontmatter serialization, path safety, reserved-file
+// handling) is an infrastructure concern behind this port. Same
+// dependency-inversion shape as CtxRepository.
+
+import { OkfDocument } from '../../../domain/okf/OkfDocument.js';
+
+/** A document the bundle reader could not turn into a usable concept. */
+export interface OkfSkippedDoc {
+  readonly path: string;
+  readonly reason: string;
+}
+
+export interface OkfBundleReadResult {
+  readonly docs: readonly OkfDocument[];
+  readonly skipped: readonly OkfSkippedDoc[];
+}
+
+export interface OkfBundleWriteResult {
+  /** Relative paths written, in write order (concepts then views). */
+  readonly written: readonly string[];
+}
+
+export interface OkfBundlePort {
+  /**
+   * Write `docs` as an OKF bundle under `dir`, plus the generated
+   * `index.md` / `log.md` view files. `dir` is created if absent.
+   */
+  write(dir: string, docs: readonly OkfDocument[]): Promise<OkfBundleWriteResult>;
+
+  /**
+   * Read an OKF bundle from `dir`. Reserved view files (`index.md`,
+   * `log.md`) are excluded from `docs`. Unparseable or non-conformant
+   * files land in `skipped` rather than failing the whole read.
+   */
+  read(dir: string): Promise<OkfBundleReadResult>;
+}

--- a/src/passages/ctx/application/OkfCtxMapper.ts
+++ b/src/passages/ctx/application/OkfCtxMapper.ts
@@ -1,0 +1,152 @@
+// OkfCtxMapper — pure ctx Fact <-> OKF document mapping.
+//
+// Application-layer because it bridges two domain modules (ctx `Ctx`
+// and `OkfDocument`); knowing both is the application's job, and keeping
+// the mapping pure (no IO) means the round-trip is unit-testable without
+// touching the filesystem.
+//
+// Direction-of-fit:
+//   - export (ctx -> OKF): lossless. A guild fact carries id, author,
+//     timestamp and `prefix:value` tags; all survive into frontmatter so
+//     a re-import reconstructs the same record.
+//   - import (OKF -> ctx): tolerant (the guild "strict on write, tolerant
+//     on read" discipline). Foreign bundles whose tags aren't `prefix:
+//     value` are coerced under a `topic:` prefix rather than dropped, and
+//     a non-`Fact` `type` is preserved as an `okf:<type>` provenance tag.
+
+import { Ctx, parseCtxTag } from '../domain/Ctx.js';
+import { OkfDocument, slugifyForTagValue } from '../../../domain/okf/OkfDocument.js';
+
+/**
+ * Result of mapping one OKF document toward a ctx fact. `skip` carries a
+ * human reason the import handler surfaces (so a partially-importable
+ * bundle reports *what* it dropped rather than silently shrinking).
+ */
+export type OkfImportMapping =
+  | {
+      readonly kind: 'fact';
+      readonly id?: string;
+      readonly fact: string;
+      readonly created_by?: string;
+      readonly created_at?: string;
+      readonly tags: readonly string[];
+    }
+  | { readonly kind: 'skip'; readonly reason: string };
+
+/**
+ * ctx Fact -> OKF concept document. The guild id becomes both the file
+ * stem (OKF identity = path) and an explicit `id` frontmatter field so
+ * import can recover the exact record. `author` is a producer-defined
+ * extra; OKF permits fields beyond its standard set.
+ */
+export function ctxToOkfDocument(ctx: Ctx): OkfDocument {
+  const frontmatter: OkfDocument['frontmatter'] = {
+    type: 'Fact',
+    id: ctx.id,
+    timestamp: ctx.created_at,
+    author: ctx.created_by,
+  };
+  if (ctx.tags.length > 0) {
+    frontmatter.tags = [...ctx.tags];
+  }
+  return {
+    path: `${ctx.id}.md`,
+    frontmatter,
+    body: ctx.fact,
+  };
+}
+
+/**
+ * Coerce one free-form tag toward a valid ctx `prefix:value` tag, or
+ * return null if nothing usable survives.
+ *
+ * - `tech:typescript` (already conformant) -> kept as-is.
+ * - `Sales` (no prefix) -> `topic:sales` (bare tags land under `topic:`).
+ * - `Owner: Data Team` (prefix present) -> `owner:data-team`.
+ *
+ * Validation is delegated to the domain `parseCtxTag` so the mapper and
+ * the persistence boundary can never disagree about what a legal tag is.
+ */
+function normalizeToCtxTag(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+
+  let prefixRaw: string;
+  let valueRaw: string;
+  const colon = trimmed.indexOf(':');
+  if (colon >= 0) {
+    prefixRaw = trimmed.slice(0, colon);
+    valueRaw = trimmed.slice(colon + 1);
+  } else {
+    prefixRaw = 'topic';
+    valueRaw = trimmed;
+  }
+
+  const value = slugifyForTagValue(valueRaw);
+  if (value === null) return null;
+
+  // Prefix bound is stricter (must start with a letter, <=16 chars). A
+  // slug that starts with a digit or empties out falls back to `topic:`
+  // rather than dropping the tag's value entirely.
+  let prefix = (slugifyForTagValue(prefixRaw) ?? '').slice(0, 16);
+  if (!/^[a-z]/.test(prefix)) prefix = 'topic';
+
+  try {
+    return parseCtxTag(`${prefix}:${value}`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * OKF concept document -> ctx fact input (or a skip reason). Pure: the
+ * handler decides id allocation and author fallback from this result.
+ *
+ * Tolerant by design — type-less or foreign-typed documents still import
+ * (their body is the fact), with provenance preserved as tags.
+ */
+export function okfDocumentToCtxFact(doc: OkfDocument): OkfImportMapping {
+  const fact = doc.body.trim();
+  if (fact.length === 0) {
+    return { kind: 'skip', reason: 'empty body (no fact prose to record)' };
+  }
+
+  const fm = doc.frontmatter;
+  const id = typeof fm.id === 'string' ? fm.id : undefined;
+  const created_at = typeof fm.timestamp === 'string' ? fm.timestamp : undefined;
+  const created_by = typeof fm.author === 'string' ? fm.author : undefined;
+
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  const push = (t: string | null): void => {
+    if (t !== null && !seen.has(t)) {
+      seen.add(t);
+      tags.push(t);
+    }
+  };
+
+  if (Array.isArray(fm.tags)) {
+    for (const t of fm.tags) {
+      if (typeof t === 'string') push(normalizeToCtxTag(t));
+    }
+  }
+
+  // Preserve a non-`Fact` type as provenance. `Fact` is guild's own
+  // export type and carries no extra signal, so it's left off to keep
+  // round-tripped bundles tag-clean.
+  if (typeof fm.type === 'string') {
+    const typeSlug = slugifyForTagValue(fm.type);
+    if (typeSlug !== null && typeSlug !== 'fact') {
+      push(`okf:${typeSlug}`);
+    }
+  }
+
+  return {
+    kind: 'fact',
+    fact,
+    tags,
+    ...(id !== undefined ? { id } : {}),
+    ...(created_by !== undefined ? { created_by } : {}),
+    ...(created_at !== undefined ? { created_at } : {}),
+  };
+}

--- a/src/passages/ctx/interface/container.ts
+++ b/src/passages/ctx/interface/container.ts
@@ -9,6 +9,7 @@
 
 import { GuildConfig } from '../../../infrastructure/config/GuildConfig.js';
 import { YamlCtxRepository } from '../infrastructure/YamlCtxRepository.js';
+import { FsOkfBundleRepository } from '../../../infrastructure/okf/FsOkfBundleRepository.js';
 import { CtxUseCases } from '../application/CtxUseCases.js';
 
 export interface CtxContainer {
@@ -26,6 +27,7 @@ export function buildCtxContainer(
 ): CtxContainer {
   const config = GuildConfig.load(opts.cwd);
   const repo = new YamlCtxRepository(config);
-  const uc = new CtxUseCases(repo);
+  const bundle = new FsOkfBundleRepository(config.onMalformed);
+  const uc = new CtxUseCases(repo, () => new Date(), bundle);
   return { config, repo, uc };
 }

--- a/src/passages/ctx/interface/handlers/exportOkf.ts
+++ b/src/passages/ctx/interface/handlers/exportOkf.ts
@@ -1,0 +1,93 @@
+import { CtxUseCases } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { OKF_VERSION } from '../../../../domain/okf/OkfDocument.js';
+
+const EXPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['as', 'format']);
+
+/**
+ * Validate `--as <bundle-format>`. OKF is the only bundle format today;
+ * the flag exists so a future second format is an enum addition, not a
+ * new verb — mirroring how `--format json|text` carved its seam.
+ */
+function parseBundleFormat(args: ParsedArgs): 'okf' {
+  const raw = optionalOption(args, 'as') ?? 'okf';
+  if (raw !== 'okf') {
+    throw new DomainError(
+      `--as must be 'okf' (the only bundle format), got: ${raw}`,
+      'as',
+    );
+  }
+  return 'okf';
+}
+
+export interface ExportCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx export — project every ctx fact into an OKF bundle.
+ *
+ * Usage:
+ *   ctx export <dir> [--as okf] [--format json|text]
+ *
+ * Writes one `<id>.md` per fact (YAML frontmatter + fact prose) plus the
+ * generated `index.md` / `log.md` view files. Read-only over the
+ * substrate — the bundle lands outside content_root.
+ */
+export async function exportCtx(
+  deps: ExportCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, EXPORT_KNOWN_FLAGS, 'export');
+  parseBundleFormat(args);
+  const format = parseFormat(args);
+
+  const dir = args.positional[0];
+  if (dir === undefined || dir.length === 0) {
+    throw new DomainError(
+      'export requires a target directory (ctx export <dir>)',
+      'dir',
+    );
+  }
+
+  const summary = await deps.uc.exportOkf({ dir });
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          format: 'okf',
+          okf_version: OKF_VERSION,
+          dir,
+          count: summary.count,
+          written: summary.written,
+          suggested_next: {
+            verb: 'ctx',
+            args: ['import', dir],
+            reason:
+              'Round-trip check: importing the bundle back into a fresh content_root reconstructs the same facts (ids preserved).',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(
+      `✓ exported ${summary.count} fact${summary.count === 1 ? '' : 's'} to ${dir} (OKF v${OKF_VERSION})\n`,
+    );
+    process.stderr.write(
+      `notice: wrote ${summary.written.length} files (concepts + index.md + log.md) under ${dir}\n`,
+    );
+  }
+  return 0;
+}

--- a/src/passages/ctx/interface/handlers/importOkf.ts
+++ b/src/passages/ctx/interface/handlers/importOkf.ts
@@ -1,0 +1,99 @@
+import { CtxUseCases } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { OKF_VERSION } from '../../../../domain/okf/OkfDocument.js';
+
+const IMPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['as', 'by', 'format']);
+
+function parseBundleFormat(args: ParsedArgs): 'okf' {
+  const raw = optionalOption(args, 'as') ?? 'okf';
+  if (raw !== 'okf') {
+    throw new DomainError(
+      `--as must be 'okf' (the only bundle format), got: ${raw}`,
+      'as',
+    );
+  }
+  return 'okf';
+}
+
+export interface ImportCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx import — record an OKF bundle's concepts as ctx facts.
+ *
+ * Usage:
+ *   ctx import <dir> [--as okf] [--by <m>] [--format json|text]
+ *
+ * Idempotent for guild-authored bundles: a concept whose `id` already
+ * exists on the substrate is skipped, so re-importing the same bundle is
+ * a no-op. Foreign concepts import tolerantly (fresh id, `--by` as the
+ * fallback author, provenance preserved as tags). `--by` defaults from
+ * GUILD_ACTOR.
+ */
+export async function importCtx(
+  deps: ImportCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, IMPORT_KNOWN_FLAGS, 'import');
+  parseBundleFormat(args);
+  const format = parseFormat(args);
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+
+  const dir = args.positional[0];
+  if (dir === undefined || dir.length === 0) {
+    throw new DomainError(
+      'import requires a source directory (ctx import <dir>)',
+      'dir',
+    );
+  }
+
+  const summary = await deps.uc.importOkf({ dir, by });
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          format: 'okf',
+          okf_version: OKF_VERSION,
+          dir,
+          imported_count: summary.imported.length,
+          imported: summary.imported,
+          skipped_count: summary.skipped.length,
+          skipped: summary.skipped,
+          suggested_next: {
+            verb: 'gate',
+            args: ['boot'],
+            reason:
+              'Confirm the imported facts landed via `gate boot` (ctx cross-passage count) or the filesystem.',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(
+      `✓ imported ${summary.imported.length} fact${summary.imported.length === 1 ? '' : 's'} from ${dir} (OKF v${OKF_VERSION})\n`,
+    );
+    if (summary.skipped.length > 0) {
+      process.stderr.write(
+        `notice: skipped ${summary.skipped.length} document${summary.skipped.length === 1 ? '' : 's'}:\n`,
+      );
+      for (const s of summary.skipped) {
+        process.stderr.write(`  - ${s.path}: ${s.reason}\n`);
+      }
+    }
+  }
+  return 0;
+}

--- a/src/passages/ctx/interface/handlers/importOkf.ts
+++ b/src/passages/ctx/interface/handlers/importOkf.ts
@@ -10,7 +10,21 @@ import {
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { OKF_VERSION } from '../../../../domain/okf/OkfDocument.js';
 
-const IMPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['as', 'by', 'format']);
+const IMPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'as',
+  'by',
+  'format',
+  'allow-duplicates',
+]);
+
+/**
+ * Boolean flags for `ctx import`, threaded into `parseArgs` by the
+ * dispatcher (issue #158 per-verb pattern) so `--allow-duplicates <dir>`
+ * doesn't speculatively consume the positional directory as its value.
+ */
+export const IMPORT_BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
+  'allow-duplicates',
+]);
 
 function parseBundleFormat(args: ParsedArgs): 'okf' {
   const raw = optionalOption(args, 'as') ?? 'okf';
@@ -39,6 +53,11 @@ export interface ImportCtxDeps {
  * a no-op. Foreign concepts import tolerantly (fresh id, `--by` as the
  * fallback author, provenance preserved as tags). `--by` defaults from
  * GUILD_ACTOR.
+ *
+ * Prose dedup is on by default: a fact whose normalized prose is already
+ * recorded — under any id, or earlier in the same bundle — is skipped,
+ * so even an id-less foreign bundle re-imported is a no-op.
+ * `--allow-duplicates` opts out for a deliberate re-record.
  */
 export async function importCtx(
   deps: ImportCtxDeps,
@@ -48,6 +67,7 @@ export async function importCtx(
   parseBundleFormat(args);
   const format = parseFormat(args);
   const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const allowDuplicates = args.options['allow-duplicates'] === true;
 
   const dir = args.positional[0];
   if (dir === undefined || dir.length === 0) {
@@ -57,7 +77,7 @@ export async function importCtx(
     );
   }
 
-  const summary = await deps.uc.importOkf({ dir, by });
+  const summary = await deps.uc.importOkf({ dir, by, allowDuplicates });
 
   if (format === 'json') {
     process.stdout.write(

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -22,7 +22,7 @@ import { getPackageVersion, isVersionFlag } from '../../../interface/shared/vers
 import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { exportCtx } from './handlers/exportOkf.js';
-import { importCtx } from './handlers/importOkf.js';
+import { importCtx, IMPORT_BOOLEAN_FLAGS } from './handlers/importOkf.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
@@ -42,10 +42,12 @@ Usage:
                               fact + index.md / log.md views).
 
   ctx import <dir>            [--as okf] [--by <m>] [--format json|text]
+                              [--allow-duplicates]
                               Record an OKF bundle's concepts as facts.
                               Guild-authored bundles round-trip (ids
                               preserved, idempotent); foreign bundles
-                              import tolerantly.
+                              import tolerantly. Prose dedup is on by
+                              default; --allow-duplicates opts out.
 
   ctx --help                   This help.
   ctx --version                Print version and exit.
@@ -83,7 +85,16 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
 
   const [cmd, ...rest] = argv;
-  const args = parseArgs(rest);
+  // Per-verb boolean flags (issue #158): registered next to the verb
+  // that owns them so the parser doesn't consume a following positional
+  // (e.g. `ctx import --allow-duplicates <dir>`) as the flag's value.
+  const VERB_BOOLEAN_FLAGS: Record<string, ReadonlySet<string>> = {
+    import: IMPORT_BOOLEAN_FLAGS,
+  };
+  const verbBooleans = VERB_BOOLEAN_FLAGS[cmd ?? ''];
+  const args = verbBooleans
+    ? parseArgs(rest, { booleanFlags: verbBooleans })
+    : parseArgs(rest);
   const { config, uc } = buildCtxContainer();
 
   const dispatch = async (): Promise<number> => {

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -21,11 +21,13 @@ import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
+import { exportCtx } from './handlers/exportOkf.js';
+import { importCtx } from './handlers/importOkf.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
-const HELP = `ctx — fact accumulation passage (phase 1: record only)
+const HELP = `ctx — fact accumulation passage (phase 1: record + OKF interop)
 
 Usage:
   ctx record --fact "<prose>" [--tag tech:foo,status:bar]
@@ -34,10 +36,23 @@ Usage:
                               <content_root>/ctx/<id>.yaml. Id is
                               auto-allocated as ctx-YYYY-MM-DD-NNN.
 
+  ctx export <dir>            [--as okf] [--format json|text]
+                              Project every fact into an Open Knowledge
+                              Format bundle under <dir> (one <id>.md per
+                              fact + index.md / log.md views).
+
+  ctx import <dir>            [--as okf] [--by <m>] [--format json|text]
+                              Record an OKF bundle's concepts as facts.
+                              Guild-authored bundles round-trip (ids
+                              preserved, idempotent); foreign bundles
+                              import tolerantly.
+
   ctx --help                   This help.
   ctx --version                Print version and exit.
 
-Phase 1 status: minimum surface — only \`record\` is implemented.
+Phase 1 status: \`record\` plus the OKF interop pair (\`export\` /
+\`import\`). OKF is an interchange *projection* (principle 11), not a
+storage change — the substrate stays YAML.
 Phase 2 (separate session): fork / supersede / show / list / chain / status.
 
 Substrate: shares content_root and members/ with gate; ctx-specific
@@ -53,7 +68,7 @@ Lore upstream:
 // has only `record`; phase 2 will add fork / supersede / show /
 // list / chain / status. A new verb forgotten here loses its typo
 // hint, doesn't crash anything.
-const CTX_COMMANDS = ['record'] as const;
+const CTX_COMMANDS = ['record', 'export', 'import'] as const;
 
 export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
@@ -62,7 +77,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
   if (isVersionFlag(argv)) {
     process.stdout.write(
-      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record only)\n`,
+      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record + OKF export/import)\n`,
     );
     return 0;
   }
@@ -75,16 +90,20 @@ export async function main(argv: readonly string[]): Promise<number> {
     switch (cmd) {
       case 'record':
         return await recordCtx({ uc, config }, args);
+      case 'export':
+        return await exportCtx({ uc, config }, args);
+      case 'import':
+        return await importCtx({ uc, config }, args);
       default: {
         // Phase 2 will add fork / supersede / show / list / chain /
-        // status; the catalog grows as those land. For now, `record`
-        // is the only valid verb — typos like `recor` should still
-        // get suggested rather than dumping the full HELP.
+        // status; the catalog grows as those land. Valid verbs today are
+        // record / export / import — typos like `recor` should still get
+        // suggested rather than dumping the full HELP.
         const hint = nearestCommand(cmd, CTX_COMMANDS);
         const suggest = hint ? `\n  did you mean: ctx ${hint}?` : '';
         process.stderr.write(
           `ctx: unknown verb: ${cmd}${suggest}\n` +
-            `  see 'ctx --help' for the full verb catalog (phase 1: record only).\n`,
+            `  see 'ctx --help' for the full verb catalog (record / export / import).\n`,
         );
         return 1;
       }

--- a/src/passages/ctx/interface/verbs.ts
+++ b/src/passages/ctx/interface/verbs.ts
@@ -1,12 +1,13 @@
 // ctx verbs — read/write/exempt classification for entry middleware.
 //
 // See gate's verbs.ts header for the rule-of-thumb classification.
-// Phase 1 surface is just `record` (write). Phase 2 will add fork /
-// supersede / show / list / chain / status; this file grows as those
-// land.
+// Phase 1 surface is `record` (write) plus the OKF interop pair:
+// `export` (read — writes a bundle outside content_root, no substrate
+// mutation) and `import` (write — records facts into content_root).
+// Phase 2 will add fork / supersede / show / list / chain / status.
 
-export const READ_VERBS: ReadonlySet<string> = new Set();
+export const READ_VERBS: ReadonlySet<string> = new Set(['export']);
 
-export const WRITE_VERBS: ReadonlySet<string> = new Set(['record']);
+export const WRITE_VERBS: ReadonlySet<string> = new Set(['record', 'import']);
 
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set();

--- a/tests/domain/okfDocument.test.ts
+++ b/tests/domain/okfDocument.test.ts
@@ -1,0 +1,46 @@
+// OkfDocument — pure domain helpers (slugify / reserved / conformance).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isReservedOkfFilename,
+  assertOkfConformant,
+  slugifyForTagValue,
+  OKF_VERSION,
+  OkfDocument,
+} from '../../src/domain/okf/OkfDocument.js';
+import { DomainError } from '../../src/domain/shared/DomainError.js';
+
+test('OKF_VERSION is the targeted spec revision', () => {
+  assert.equal(OKF_VERSION, '0.1');
+});
+
+test('reserved filenames are index.md and log.md only', () => {
+  assert.equal(isReservedOkfFilename('index.md'), true);
+  assert.equal(isReservedOkfFilename('log.md'), true);
+  assert.equal(isReservedOkfFilename('ctx-2026-06-16-001.md'), false);
+  assert.equal(isReservedOkfFilename('INDEX.md'), false); // case-sensitive
+});
+
+test('assertOkfConformant requires a non-empty type', () => {
+  const ok: OkfDocument = { path: 'a.md', frontmatter: { type: 'Fact' }, body: 'x' };
+  assert.doesNotThrow(() => assertOkfConformant(ok));
+
+  const noType: OkfDocument = { path: 'a.md', frontmatter: { type: '' }, body: 'x' };
+  assert.throws(() => assertOkfConformant(noType), DomainError);
+
+  const blankType: OkfDocument = { path: 'a.md', frontmatter: { type: '   ' }, body: 'x' };
+  assert.throws(() => assertOkfConformant(blankType), DomainError);
+});
+
+test('slugifyForTagValue lowercases, hyphenates, and bounds to 48 chars', () => {
+  assert.equal(slugifyForTagValue('BigQuery Table'), 'bigquery-table');
+  assert.equal(slugifyForTagValue('  Data Team  '), 'data-team');
+  assert.equal(slugifyForTagValue('already-slug'), 'already-slug');
+  // all-symbol input yields nothing usable
+  assert.equal(slugifyForTagValue('***'), null);
+  // length bound (48) with no trailing hyphen
+  const long = slugifyForTagValue('a'.repeat(60));
+  assert.ok(long !== null && long.length <= 48);
+  assert.ok(!long.endsWith('-'));
+});

--- a/tests/infrastructure/okfFrontmatter.test.ts
+++ b/tests/infrastructure/okfFrontmatter.test.ts
@@ -1,0 +1,55 @@
+// OkfFrontmatter — serialize/parse the `---\n<yaml>\n---\n<body>` envelope.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  serializeOkfDocument,
+  parseOkfDocument,
+} from '../../src/infrastructure/okf/OkfFrontmatter.js';
+import { OkfDocument } from '../../src/domain/okf/OkfDocument.js';
+
+const noop = (): void => {};
+
+test('serialize emits canonical field order (standard first, extras sorted)', () => {
+  const doc: OkfDocument = {
+    path: 'x.md',
+    // deliberately scrambled in-memory order
+    frontmatter: { author: 'eris', id: 'ctx-1', type: 'Fact', timestamp: '2026-01-01T00:00:00.000Z' },
+    body: 'a fact',
+  };
+  const text = serializeOkfDocument(doc);
+  const order = [...text.matchAll(/^(\w+):/gm)].map((m) => m[1]);
+  // type (standard) before timestamp (standard) before extras author,id (sorted)
+  assert.deepEqual(order, ['type', 'timestamp', 'author', 'id']);
+  assert.match(text, /\n---\n\na fact\n$/);
+});
+
+test('serialize then parse round-trips frontmatter and body', () => {
+  const doc: OkfDocument = {
+    path: 'x.md',
+    frontmatter: { type: 'Fact', id: 'ctx-1', timestamp: '2026-01-01T00:00:00.000Z', tags: ['tech:ts'] },
+    body: 'the body',
+  };
+  const parsed = parseOkfDocument('x.md', serializeOkfDocument(doc), 'x.md', noop);
+  assert.equal(parsed.frontmatter.type, 'Fact');
+  assert.equal(parsed.frontmatter.id, 'ctx-1');
+  assert.equal(parsed.frontmatter.timestamp, '2026-01-01T00:00:00.000Z');
+  assert.deepEqual(parsed.frontmatter.tags, ['tech:ts']);
+  assert.equal(parsed.body, 'the body');
+});
+
+test('parse tolerates a document with no frontmatter (whole text is body)', () => {
+  const parsed = parseOkfDocument('p.md', 'just prose, no frontmatter', 'p.md', noop);
+  assert.equal(parsed.frontmatter.type, '');
+  assert.equal(parsed.body, 'just prose, no frontmatter');
+});
+
+test('parse reports malformed frontmatter via onMalformed and coerces type to empty', () => {
+  let reported = '';
+  const text = '---\n: : bad yaml :\n---\nbody';
+  const parsed = parseOkfDocument('bad.md', text, 'bad.md', (_s, m) => {
+    reported = m;
+  });
+  assert.match(reported, /yaml parse failed/);
+  assert.equal(parsed.frontmatter.type, '');
+});

--- a/tests/interface/nearestCommand.test.ts
+++ b/tests/interface/nearestCommand.test.ts
@@ -117,10 +117,11 @@ test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
   assert.equal(r.status, 1);
   assert.match(r.stderr, /unknown verb: recor/);
   assert.match(r.stderr, /did you mean: ctx record\?/);
-  // Phase-1 callout — flag the constraint at the surface that hit it,
-  // since fork / supersede / show / list / chain / status are not yet
-  // implemented and a typo for any of those would refuse to suggest.
-  assert.match(r.stderr, /phase 1: record only/);
+  // Verb-catalog callout — flag the available surface at the point a
+  // typo hit it, since the phase-2 lifecycle verbs (fork / supersede /
+  // show / list / chain / status) are not yet implemented and a typo
+  // for any of those would refuse to suggest.
+  assert.match(r.stderr, /record \/ export \/ import/);
 });
 
 test('devil <typo>: suggests devil-prefixed verb', (t) => {

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -57,7 +57,7 @@ const DEVIL_ALL = [
   'suspend', 'resume', 'ingest', 'conclude', 'schema',
 ] as const;
 
-const CTX_ALL = ['record'] as const;
+const CTX_ALL = ['record', 'export', 'import'] as const;
 
 const CASES: Case[] = [
   { passage: 'gate', verbs: gateVerbs, all: GATE_ALL },

--- a/tests/passages/ctx/interface/okfRoundtrip.test.ts
+++ b/tests/passages/ctx/interface/okfRoundtrip.test.ts
@@ -124,3 +124,52 @@ test('a foreign OKF bundle imports tolerantly', (t) => {
   assert.match(orders!, /okf:bigquery-table/); // type provenance
   assert.match(orders!, /created_at: 2025-01-02T10:00:00\.000Z/); // foreign ts preserved
 });
+
+test('prose dedup: id-less re-import and in-bundle duplicates are skipped', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const bundle = join(root, 'foreign');
+  mkdirSync(bundle, { recursive: true });
+  // a and b carry the same prose (b differs only in whitespace -> still a
+  // duplicate after normalization); c is unique. None have an id.
+  writeFileSync(join(bundle, 'a.md'), '---\ntype: Note\n---\nshared observation\n');
+  writeFileSync(join(bundle, 'b.md'), '---\ntype: Note\n---\nshared    observation\n');
+  writeFileSync(join(bundle, 'c.md'), '---\ntype: Note\n---\nunique observation\n');
+
+  const first = JSON.parse(
+    runCtx(root, ['import', bundle, '--format', 'json'], { GUILD_ACTOR: 'x' }).stdout,
+  );
+  // a + c imported; b skipped as an in-bundle duplicate.
+  assert.equal(first.imported_count, 2);
+  assert.equal(first.skipped_count, 1);
+  assert.match(first.skipped[0].reason, /duplicate prose \(already recorded as ctx-/);
+
+  // Re-import: every doc now duplicates substrate prose -> all skipped.
+  const second = JSON.parse(
+    runCtx(root, ['import', bundle, '--format', 'json'], { GUILD_ACTOR: 'x' }).stdout,
+  );
+  assert.equal(second.imported_count, 0);
+  assert.equal(second.skipped_count, 3);
+});
+
+test('--allow-duplicates (placed before the dir) opts out of prose dedup', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const bundle = join(root, 'foreign');
+  mkdirSync(bundle, { recursive: true });
+  writeFileSync(join(bundle, 'a.md'), '---\ntype: Note\n---\nrepeatable observation\n');
+
+  runCtx(root, ['import', bundle, '--format', 'json'], { GUILD_ACTOR: 'x' });
+  // Flag before the positional dir: the boolean registration must keep
+  // the parser from swallowing the dir as the flag value.
+  const again = runCtx(
+    root,
+    ['import', '--allow-duplicates', bundle, '--format', 'json'],
+    { GUILD_ACTOR: 'x' },
+  );
+  const env = JSON.parse(again.stdout);
+  assert.equal(env.imported_count, 1);
+  assert.equal(env.skipped_count, 0);
+});

--- a/tests/passages/ctx/interface/okfRoundtrip.test.ts
+++ b/tests/passages/ctx/interface/okfRoundtrip.test.ts
@@ -1,0 +1,126 @@
+// ctx OKF export/import — end-to-end round-trip through the real binary.
+//
+// Covers the three guarantees the feature promises:
+//   1. guild fact -> export -> import (fresh root) restores the record
+//      losslessly (id / created_at / created_by / tags).
+//   2. re-importing the same bundle is idempotent (existing ids skip).
+//   3. a foreign bundle imports tolerantly (fresh id, --by author,
+//      coerced tags, provenance, reserved views skipped, empty skipped).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CTX = resolve(here, '../../../../../bin/ctx.mjs');
+
+function newRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-okf-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [human]\n');
+  return root;
+}
+
+function runCtx(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [CTX, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+test('guild facts round-trip losslessly through an OKF bundle', (t) => {
+  const src = newRoot();
+  const dst = newRoot();
+  t.after(() => {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dst, { recursive: true, force: true });
+  });
+
+  runCtx(src, ['record', '--fact', 'first fact', '--tag', 'tech:typescript,topic:okf'], { GUILD_ACTOR: 'claude' });
+  runCtx(src, ['record', '--fact', 'second fact', '--tag', 'status:active'], { GUILD_ACTOR: 'eris' });
+
+  const exp = runCtx(src, ['export', join(src, 'bundle'), '--format', 'json']);
+  assert.equal(exp.status, 0);
+  const expEnv = JSON.parse(exp.stdout);
+  assert.equal(expEnv.count, 2);
+  assert.ok(expEnv.written.includes('index.md'));
+  assert.ok(expEnv.written.includes('log.md'));
+
+  // Reserved view files exist but carry the right type.
+  const idx = readFileSync(join(src, 'bundle', 'index.md'), 'utf8');
+  assert.match(idx, /type: Index/);
+
+  const imp = runCtx(dst, ['import', join(src, 'bundle'), '--format', 'json'], { GUILD_ACTOR: 'importer' });
+  assert.equal(imp.status, 0);
+  const impEnv = JSON.parse(imp.stdout);
+  assert.equal(impEnv.imported_count, 2);
+  assert.equal(impEnv.skipped_count, 0);
+
+  // Lossless: the restored YAML preserves id, author, tags (not the
+  // importing actor, not a fresh id). Ids are allocated with the real
+  // `now`, so derive today's date rather than hard-coding it.
+  const today = new Date().toISOString().slice(0, 10);
+  const restored = readFileSync(join(dst, 'ctx', `ctx-${today}-001.yaml`), 'utf8');
+  assert.match(restored, new RegExp(`id: ctx-${today}-001`));
+  assert.match(restored, /created_by: claude/);
+  assert.match(restored, /tech:typescript/);
+  assert.doesNotMatch(restored, /created_by: importer/);
+
+  // Idempotent: re-import skips both.
+  const again = runCtx(dst, ['import', join(src, 'bundle'), '--format', 'json'], { GUILD_ACTOR: 'importer' });
+  const againEnv = JSON.parse(again.stdout);
+  assert.equal(againEnv.imported_count, 0);
+  assert.equal(againEnv.skipped_count, 2);
+  assert.match(againEnv.skipped[0].reason, /already present/);
+});
+
+test('a foreign OKF bundle imports tolerantly', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const bundle = join(root, 'foreign');
+  mkdirSync(join(bundle, 'tables'), { recursive: true });
+  writeFileSync(join(bundle, 'index.md'), '---\ntype: Index\n---\n# view, skip me\n');
+  writeFileSync(
+    join(bundle, 'tables', 'orders.md'),
+    '---\ntype: BigQuery Table\ntags: [sales, "Owner: Data Team"]\ntimestamp: 2025-01-02T10:00:00Z\n---\nOne row per order.\n',
+  );
+  writeFileSync(join(bundle, 'plain.md'), 'plain prose, no frontmatter\n');
+  writeFileSync(join(bundle, 'empty.md'), '---\ntype: Nothing\n---\n');
+
+  const imp = runCtx(root, ['import', bundle, '--format', 'json'], { GUILD_ACTOR: 'archivist' });
+  assert.equal(imp.status, 0);
+  const env = JSON.parse(imp.stdout);
+
+  // 2 imported (nested table + plain), 1 skipped (empty), index.md not counted.
+  assert.equal(env.imported_count, 2);
+  assert.equal(env.skipped_count, 1);
+  assert.match(env.skipped[0].reason, /empty body/);
+
+  const files = readdirSync(join(root, 'ctx'));
+  const orders = files
+    .map((f) => readFileSync(join(root, 'ctx', f), 'utf8'))
+    .find((y) => y.includes('One row per order.'));
+  assert.ok(orders, 'foreign table fact should be recorded');
+  assert.match(orders!, /created_by: archivist/); // --by fallback
+  assert.match(orders!, /topic:sales/); // bare tag coerced
+  assert.match(orders!, /owner:data-team/); // prefixed tag coerced
+  assert.match(orders!, /okf:bigquery-table/); // type provenance
+  assert.match(orders!, /created_at: 2025-01-02T10:00:00\.000Z/); // foreign ts preserved
+});

--- a/tests/passages/ctx/okfMapper.test.ts
+++ b/tests/passages/ctx/okfMapper.test.ts
@@ -1,0 +1,85 @@
+// OkfCtxMapper — pure ctx Fact <-> OKF document mapping.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Ctx } from '../../../src/passages/ctx/domain/Ctx.js';
+import {
+  ctxToOkfDocument,
+  okfDocumentToCtxFact,
+} from '../../../src/passages/ctx/application/OkfCtxMapper.js';
+import { OkfDocument } from '../../../src/domain/okf/OkfDocument.js';
+
+function fact(overrides: Partial<{ id: string; fact: string; by: string; tags: string[] }> = {}): Ctx {
+  return Ctx.create({
+    id: overrides.id ?? 'ctx-2026-06-16-001',
+    fact: overrides.fact ?? 'a recorded fact',
+    created_by: overrides.by ?? 'claude',
+    tags: overrides.tags ?? ['tech:typescript'],
+    now: () => new Date('2026-06-16T00:00:00.000Z'),
+  });
+}
+
+test('ctxToOkfDocument carries id, timestamp, author, tags into frontmatter', () => {
+  const doc = ctxToOkfDocument(fact());
+  assert.equal(doc.path, 'ctx-2026-06-16-001.md');
+  assert.equal(doc.frontmatter.type, 'Fact');
+  assert.equal(doc.frontmatter.id, 'ctx-2026-06-16-001');
+  assert.equal(doc.frontmatter.timestamp, '2026-06-16T00:00:00.000Z');
+  assert.equal(doc.frontmatter.author, 'claude');
+  assert.deepEqual(doc.frontmatter.tags, ['tech:typescript']);
+  assert.equal(doc.body, 'a recorded fact');
+});
+
+test('a fact with no tags omits the frontmatter tags field', () => {
+  const doc = ctxToOkfDocument(fact({ tags: [] }));
+  assert.equal('tags' in doc.frontmatter, false);
+});
+
+test('ctx -> okf -> ctx-input round-trips losslessly for a guild fact', () => {
+  const doc = ctxToOkfDocument(fact());
+  const m = okfDocumentToCtxFact(doc);
+  assert.equal(m.kind, 'fact');
+  if (m.kind !== 'fact') return;
+  assert.equal(m.id, 'ctx-2026-06-16-001');
+  assert.equal(m.created_at, '2026-06-16T00:00:00.000Z');
+  assert.equal(m.created_by, 'claude');
+  assert.equal(m.fact, 'a recorded fact');
+  assert.deepEqual(m.tags, ['tech:typescript']);
+});
+
+test('import coerces foreign tags and preserves non-Fact type as provenance', () => {
+  const doc: OkfDocument = {
+    path: 'tables/orders.md',
+    frontmatter: {
+      type: 'BigQuery Table',
+      tags: ['sales', 'Owner: Data Team', 'tech:sql'],
+      timestamp: '2025-01-02T10:00:00Z',
+    },
+    body: 'One row per completed order.',
+  };
+  const m = okfDocumentToCtxFact(doc);
+  assert.equal(m.kind, 'fact');
+  if (m.kind !== 'fact') return;
+  assert.equal(m.id, undefined); // no guild id -> handler allocates fresh
+  assert.equal(m.created_by, undefined); // no author -> handler supplies --by
+  assert.deepEqual(m.tags, ['topic:sales', 'owner:data-team', 'tech:sql', 'okf:bigquery-table']);
+});
+
+test('a Fact type does not add an okf:fact provenance tag', () => {
+  const doc: OkfDocument = {
+    path: 'x.md',
+    frontmatter: { type: 'Fact', tags: ['status:active'] },
+    body: 'b',
+  };
+  const m = okfDocumentToCtxFact(doc);
+  if (m.kind !== 'fact') throw new Error('expected fact');
+  assert.deepEqual(m.tags, ['status:active']);
+});
+
+test('an empty body is skipped with a reason', () => {
+  const doc: OkfDocument = { path: 'empty.md', frontmatter: { type: 'Fact' }, body: '   \n' };
+  const m = okfDocumentToCtxFact(doc);
+  assert.equal(m.kind, 'skip');
+  if (m.kind !== 'skip') return;
+  assert.match(m.reason, /empty body/);
+});


### PR DESCRIPTION
## What

Adds `ctx export <dir>` / `ctx import <dir>` — project ctx facts to and from
[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)
bundles (a directory of `<id>.md` files: YAML frontmatter + fact prose, plus
generated `index.md` / `log.md` views).

OKF is treated as an interchange **projection** (principle 11), not a storage
change: the on-disk substrate stays YAML; OKF is another surface, the way
`--format text` is. Keeping it a projection means an OKF v0.x churn costs a
projector edit, never a stored-data migration.

## Behavior

| Case | Result |
|---|---|
| guild bundle round-trip | **lossless** — `id` / `timestamp` / `author` / `tags` survive; restored YAML matches the original |
| re-import same bundle | **idempotent** — existing ids skip |
| foreign bundle | **tolerant** — nested subtrees walked, bare tags → `topic:`, non-`Fact` type → `okf:<type>` provenance, missing author → `--by`, empty/unparseable → reported as skipped |
| duplicate prose (any id, or in-bundle) | **deduped** by default; skip reason names the record it duplicates |
| `--allow-duplicates` | opts out of prose dedup |

## Layering (Clean Architecture)

- `domain/okf/OkfDocument` — pure model, conformance, tag-slug helpers (zero deps)
- `passages/ctx/application/OkfCtxMapper` — pure ctx Fact ⇄ OKF mapping
- `passages/ctx/application/OkfBundlePort` — dependency-inverted bundle IO port
- `infrastructure/okf/OkfFrontmatter` — frontmatter serde (hardened `parseYamlSafe` on read; canonical, byte-stable order on write)
- `infrastructure/okf/FsOkfBundleRepository` — recursive bundle walk via `safeFs` (path-contained, no symlink traversal)

## Tests

Domain helpers, frontmatter serde, pure mapper, and e2e (export→import round-trip,
idempotent re-import, foreign-bundle import, prose-dedup + `--allow-duplicates`).
Updated the `verbs-consistency` and `nearest-command` mirrors for the two new
verbs. **Full suite 1823/1823 green.**

## Known limitations / concerns (not blockers — flagging for the reviewer)

1. **OKF is v0.1, published 2026-06-12.** Spec churn is likely. The projection-only
   design contains the blast radius (no stored-data migration on a bump), and
   `okf_version` is surfaced in the JSON envelope, but `--as okf` is the only
   value today.
2. **Foreign `id` is trusted by the idempotent-skip path.** A foreign bundle that
   happens to carry a frontmatter `id` matching `ctx-YYYY-MM-DD-NNN` and colliding
   with an existing record is skipped as "already present" even if its prose
   differs. Low probability (foreign bundles rarely use our id namespace), but it's
   a silent-drop edge. A follow-up could gate the id-idempotent skip on a prose
   match and otherwise allocate fresh.
3. **Export overwrites into the target dir** with no empty-dir guard or `--force`.
   Pointing at a non-empty directory rewrites `index.md` / `log.md` and any
   colliding `<id>.md`. A `--force` / empty-check is a reasonable follow-up.
4. **Dedup hydrates all existing facts per import** (O(n) reads) and matches on
   exact-after-whitespace-collapse prose (no near-dup detection; a whitespace-only
   difference *is* merged). Fine at alpha scale; revisit if ctx grows large.
5. **Scope is ctx only.** Exporting gate waves / agora plays into the same bundle
   (the full "portable substrate" pitch) is future work.

If any of 2–4 should be addressed before merge rather than filed as follow-ups,
say the word and I'll fold it in.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_