### PR TITLE
fix(ctx): collision-safe OKF import + export overwrite guard

### DIFF
--- a/.changelog/next/changed-ctx-okf-hardening.md
+++ b/.changelog/next/changed-ctx-okf-hardening.md
@@ -1,0 +1,10 @@
+- **`ctx` OKF hardening — collision-safe import + export overwrite guard.**
+  Two follow-ups from the OKF round-trip review (#431): (1) on import, a
+  foreign `id` that collides with an existing record but carries
+  *different* prose is now reallocated a fresh id instead of being
+  dropped — the idempotent skip is gated on a prose match, so a distinct
+  observation reusing the `ctx-YYYY-MM-DD-NNN` namespace is never
+  silently lost (records-outlive-writers). The incumbent is read on
+  demand only on a collision, so the common path stays a single id-set
+  check. (2) `ctx export` refuses a non-empty target directory unless
+  `--force`, so it can't silently clobber an unrelated tree.

--- a/AGENT.md
+++ b/AGENT.md
@@ -619,9 +619,9 @@ plus generated `index.md` / `log.md` views. OKF is an interchange
 stays YAML; OKF is another surface, the way `--format text` is.
 
 ```bash
-ctx export <dir> [--as okf] [--format json|text]   # facts -> OKF bundle
+ctx export <dir> [--as okf] [--force] [--format json|text]   # facts -> OKF bundle
 ctx import <dir> [--as okf] [--by <m>] [--allow-duplicates]
-                 [--format json|text]               # bundle -> facts
+                 [--format json|text]                         # bundle -> facts
 ```
 
 Round-trip is lossless for guild-authored bundles — `id`, `timestamp`,
@@ -630,7 +630,12 @@ is idempotent (existing ids skip). Foreign bundles import tolerantly:
 nested subtrees are walked; bare tags land under `topic:`; a non-`Fact`
 `type` is preserved as an `okf:<type>` provenance tag; documents lacking
 an author fall back to `--by`; empty or unparseable documents are
-reported as skipped rather than failing the whole import.
+reported as skipped rather than failing the whole import. A foreign `id`
+that collides with an existing record but carries *different* prose is
+reallocated a fresh id rather than dropped (the idempotent skip is gated
+on a prose match, so a distinct observation is never lost). `export`
+refuses a non-empty target directory unless `--force`, so it can't
+silently clobber an unrelated tree.
 
 **Prose dedup** is on by default: a fact whose normalized prose is
 already recorded — under any id, or earlier in the same bundle — is

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1708,10 +1708,16 @@ plus generated `index.md` / `log.md` views. OKF is an interchange
 stays YAML; the bundle is another surface.
 
 ```bash
-ctx export <dir> [--as okf] [--format json|text]              # facts -> OKF bundle
+ctx export <dir> [--as okf] [--force] [--format json|text]    # facts -> OKF bundle
 ctx import <dir> [--as okf] [--by <m>] [--allow-duplicates]
                  [--format json|text]                         # bundle -> facts
 ```
+
+`export` refuses a non-empty target directory unless `--force`, so it
+can't silently clobber an unrelated tree. On import, a foreign `id` that
+collides with an existing record but carries *different* prose is
+reallocated a fresh id rather than dropped — the idempotent skip is gated
+on a prose match, so a distinct observation is never silently lost.
 
 A round-trip of guild-authored facts is **lossless** — the exported
 frontmatter carries `id`, `timestamp`, `author` and `tags`, so import

--- a/src/infrastructure/okf/FsOkfBundleRepository.ts
+++ b/src/infrastructure/okf/FsOkfBundleRepository.ts
@@ -26,6 +26,7 @@ import {
   OkfBundlePort,
   OkfBundleReadResult,
   OkfBundleWriteResult,
+  OkfBundleWriteOptions,
   OkfSkippedDoc,
 } from '../../passages/ctx/application/OkfBundlePort.js';
 import { OnMalformed } from '../../application/ports/OnMalformed.js';
@@ -44,7 +45,28 @@ export class FsOkfBundleRepository implements OkfBundlePort {
   async write(
     dir: string,
     docs: readonly OkfDocument[],
+    opts: OkfBundleWriteOptions = {},
   ): Promise<OkfBundleWriteResult> {
+    // Overwrite guard: refuse to write into a non-empty directory unless
+    // forced, so an export can't silently clobber an unrelated tree (its
+    // own index.md / log.md / colliding <id>.md). An absent or empty dir
+    // is created by the writes below.
+    const baseAbs = assertUnder(dir, '.');
+    if (existsSync(baseAbs)) {
+      if (!statSync(baseAbs).isDirectory()) {
+        throw new DomainError(
+          `export target ${dir} exists and is not a directory`,
+          'dir',
+        );
+      }
+      if (!opts.force && readdirSync(baseAbs).length > 0) {
+        throw new DomainError(
+          `export target ${dir} is not empty; pass --force to overwrite`,
+          'dir',
+        );
+      }
+    }
+
     const written: string[] = [];
     const sorted = [...docs].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
 

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -63,7 +63,7 @@ export class CtxUseCases {
    * the substrate (writes land outside `content_root`, in the chosen
    * bundle directory).
    */
-  async exportOkf(input: { dir: string }): Promise<OkfExportSummary> {
+  async exportOkf(input: { dir: string; force?: boolean }): Promise<OkfExportSummary> {
     const bundle = this.requireBundle();
     const ids = [...(await this.repo.listAllIds())].sort();
     const docs = [];
@@ -71,7 +71,7 @@ export class CtxUseCases {
       const ctx = await this.repo.findById(id);
       if (ctx !== null) docs.push(ctxToOkfDocument(ctx));
     }
-    const res = await bundle.write(input.dir, docs);
+    const res = await bundle.write(input.dir, docs, { force: input.force === true });
     return { written: res.written, count: docs.length };
   }
 
@@ -123,18 +123,29 @@ export class CtxUseCases {
         continue;
       }
 
-      // Resolve the id: preserve a well-formed guild id (idempotent skip
-      // if it already exists); allocate fresh for missing/foreign ids.
+      // Resolve the id. Preserve a well-formed guild id; allocate fresh
+      // for missing/foreign ids. When a preserved id already exists,
+      // distinguish a true round-trip (same prose -> idempotent skip)
+      // from a foreign-id collision (different — or unreadable —
+      // incumbent: don't drop the observation, allocate a fresh id).
+      // Records-outlive-writers: a distinct fact must not be lost just
+      // because a foreign bundle reused our `ctx-YYYY-MM-DD-NNN`
+      // namespace. The incumbent is read on demand only on a collision,
+      // so the common path stays a single id-set membership check.
+      const proseKey = factDedupKey(mapped.fact);
       let id: string;
       const preserved = wellFormedCtxId(mapped.id);
-      if (preserved !== null) {
-        if (existing.includes(preserved)) {
+      if (preserved !== null && existing.includes(preserved)) {
+        const incumbent = await this.repo.findById(preserved);
+        if (incumbent !== null && factDedupKey(incumbent.fact) === proseKey) {
           allSkipped.push({
             path: doc.path,
             reason: `id ${preserved} already present (idempotent skip)`,
           });
           continue;
         }
+        id = nextCtxId(existing, now);
+      } else if (preserved !== null) {
         id = preserved;
       } else {
         id = nextCtxId(existing, now);
@@ -144,7 +155,6 @@ export class CtxUseCases {
       // normalized prose is already recorded — under any id — is a
       // duplicate observation. ctx records are immutable, so re-recording
       // the same prose adds noise rather than signal.
-      const proseKey = factDedupKey(mapped.fact);
       if (dedup) {
         const dupId = idByProse.get(proseKey);
         if (dupId !== undefined) {

--- a/src/passages/ctx/application/OkfBundlePort.ts
+++ b/src/passages/ctx/application/OkfBundlePort.ts
@@ -24,12 +24,22 @@ export interface OkfBundleWriteResult {
   readonly written: readonly string[];
 }
 
+export interface OkfBundleWriteOptions {
+  /** Overwrite into a non-empty target directory instead of refusing. */
+  readonly force?: boolean;
+}
+
 export interface OkfBundlePort {
   /**
    * Write `docs` as an OKF bundle under `dir`, plus the generated
    * `index.md` / `log.md` view files. `dir` is created if absent.
+   * Refuses a non-empty `dir` unless `opts.force` is set.
    */
-  write(dir: string, docs: readonly OkfDocument[]): Promise<OkfBundleWriteResult>;
+  write(
+    dir: string,
+    docs: readonly OkfDocument[],
+    opts?: OkfBundleWriteOptions,
+  ): Promise<OkfBundleWriteResult>;
 
   /**
    * Read an OKF bundle from `dir`. Reserved view files (`index.md`,

--- a/src/passages/ctx/interface/handlers/exportOkf.ts
+++ b/src/passages/ctx/interface/handlers/exportOkf.ts
@@ -9,7 +9,14 @@ import {
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { OKF_VERSION } from '../../../../domain/okf/OkfDocument.js';
 
-const EXPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['as', 'format']);
+const EXPORT_KNOWN_FLAGS: ReadonlySet<string> = new Set(['as', 'format', 'force']);
+
+/**
+ * Boolean flags for `ctx export`, threaded into `parseArgs` by the
+ * dispatcher (issue #158 per-verb pattern) so `--force <dir>` doesn't
+ * speculatively consume the positional directory as its value.
+ */
+export const EXPORT_BOOLEAN_FLAGS: ReadonlySet<string> = new Set(['force']);
 
 /**
  * Validate `--as <bundle-format>`. OKF is the only bundle format today;
@@ -49,6 +56,7 @@ export async function exportCtx(
   rejectUnknownFlags(args, EXPORT_KNOWN_FLAGS, 'export');
   parseBundleFormat(args);
   const format = parseFormat(args);
+  const force = args.options['force'] === true;
 
   const dir = args.positional[0];
   if (dir === undefined || dir.length === 0) {
@@ -58,7 +66,7 @@ export async function exportCtx(
     );
   }
 
-  const summary = await deps.uc.exportOkf({ dir });
+  const summary = await deps.uc.exportOkf({ dir, force });
 
   if (format === 'json') {
     process.stdout.write(

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -21,7 +21,7 @@ import { nearestCommand } from '../../../interface/shared/nearestCommand.js';
 import { getPackageVersion, isVersionFlag } from '../../../interface/shared/version.js';
 import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
-import { exportCtx } from './handlers/exportOkf.js';
+import { exportCtx, EXPORT_BOOLEAN_FLAGS } from './handlers/exportOkf.js';
 import { importCtx, IMPORT_BOOLEAN_FLAGS } from './handlers/importOkf.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
@@ -36,10 +36,11 @@ Usage:
                               <content_root>/ctx/<id>.yaml. Id is
                               auto-allocated as ctx-YYYY-MM-DD-NNN.
 
-  ctx export <dir>            [--as okf] [--format json|text]
+  ctx export <dir>            [--as okf] [--force] [--format json|text]
                               Project every fact into an Open Knowledge
                               Format bundle under <dir> (one <id>.md per
-                              fact + index.md / log.md views).
+                              fact + index.md / log.md views). Refuses a
+                              non-empty <dir> unless --force.
 
   ctx import <dir>            [--as okf] [--by <m>] [--format json|text]
                               [--allow-duplicates]
@@ -89,6 +90,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   // that owns them so the parser doesn't consume a following positional
   // (e.g. `ctx import --allow-duplicates <dir>`) as the flag's value.
   const VERB_BOOLEAN_FLAGS: Record<string, ReadonlySet<string>> = {
+    export: EXPORT_BOOLEAN_FLAGS,
     import: IMPORT_BOOLEAN_FLAGS,
   };
   const verbBooleans = VERB_BOOLEAN_FLAGS[cmd ?? ''];

--- a/tests/passages/ctx/interface/okfRoundtrip.test.ts
+++ b/tests/passages/ctx/interface/okfRoundtrip.test.ts
@@ -1,11 +1,15 @@
 // ctx OKF export/import — end-to-end round-trip through the real binary.
 //
-// Covers the three guarantees the feature promises:
+// Covers the guarantees the feature promises:
 //   1. guild fact -> export -> import (fresh root) restores the record
 //      losslessly (id / created_at / created_by / tags).
 //   2. re-importing the same bundle is idempotent (existing ids skip).
 //   3. a foreign bundle imports tolerantly (fresh id, --by author,
 //      coerced tags, provenance, reserved views skipped, empty skipped).
+//   4. prose dedup + --allow-duplicates opt-out.
+//   5. a foreign id colliding with a *different* fact reallocates rather
+//      than dropping (records-outlive-writers).
+//   6. export refuses a non-empty target dir unless --force.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -172,4 +176,64 @@ test('--allow-duplicates (placed before the dir) opts out of prose dedup', (t) =
   const env = JSON.parse(again.stdout);
   assert.equal(env.imported_count, 1);
   assert.equal(env.skipped_count, 0);
+});
+
+test('a foreign id colliding with a different fact reallocates instead of dropping', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  // Seed one fact -> it takes ctx-<today>-001.
+  runCtx(root, ['record', '--fact', 'the incumbent observation'], { GUILD_ACTOR: 'eris' });
+  const today = new Date().toISOString().slice(0, 10);
+
+  const bundle = join(root, 'foreign');
+  mkdirSync(bundle, { recursive: true });
+  // Foreign doc reuses our id namespace but carries different prose.
+  writeFileSync(
+    join(bundle, 'collide.md'),
+    `---\ntype: Note\nid: ctx-${today}-001\n---\na DIFFERENT observation that must not be dropped\n`,
+  );
+  // And a doc that is a genuine round-trip of the incumbent (same id +
+  // same prose) -> that one is the idempotent skip.
+  writeFileSync(
+    join(bundle, 'same.md'),
+    `---\ntype: Fact\nid: ctx-${today}-001\n---\nthe incumbent observation\n`,
+  );
+
+  const env = JSON.parse(
+    runCtx(root, ['import', bundle, '--format', 'json'], { GUILD_ACTOR: 'x' }).stdout,
+  );
+  // collide.md imported under a fresh id (not 001); same.md idempotent-skipped.
+  assert.equal(env.imported_count, 1);
+  assert.notEqual(env.imported[0].id, `ctx-${today}-001`);
+  assert.equal(env.skipped_count, 1);
+  assert.match(env.skipped[0].reason, /already present \(idempotent skip\)/);
+
+  // The distinct observation survived on the substrate.
+  const survived = readdirSync(join(root, 'ctx'))
+    .map((f) => readFileSync(join(root, 'ctx', f), 'utf8'))
+    .some((y) => y.includes('must not be dropped'));
+  assert.ok(survived, 'colliding-id foreign fact must be reallocated, not dropped');
+});
+
+test('export refuses a non-empty dir unless --force', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  runCtx(root, ['record', '--fact', 'a fact to export'], { GUILD_ACTOR: 'eris' });
+
+  const out = join(root, 'out');
+  mkdirSync(out, { recursive: true });
+  writeFileSync(join(out, 'pre-existing.txt'), 'do not clobber me silently\n');
+
+  const refused = runCtx(root, ['export', out, '--format', 'json']);
+  assert.equal(refused.status, 1);
+  assert.match(refused.stderr, /not empty; pass --force/);
+
+  // --force before the positional dir: boolean registration keeps the
+  // parser from swallowing the dir as the flag value.
+  const forced = runCtx(root, ['export', '--force', out, '--format', 'json']);
+  assert.equal(forced.status, 0);
+  assert.equal(JSON.parse(forced.stdout).count, 1);
+  // The pre-existing file is left in place (export writes alongside).
+  assert.ok(readdirSync(out).includes('pre-existing.txt'));
 });


### PR DESCRIPTION
## What

Closes the two fixable concerns flagged in the #431 review.

### 1. Collision-safe import (was: foreign `id` silent-drop)

Before: import treated *any* existing `id` as an idempotent skip. A foreign
bundle that reused our `ctx-YYYY-MM-DD-NNN` namespace for a **different**
observation would be dropped silently.

Now: the idempotent skip is gated on a **prose match**. When a preserved `id`
already exists, the incumbent is read and compared:
- same prose → idempotent skip (true round-trip, unchanged)
- different (or unreadable) incumbent → reallocate a fresh id rather than drop
  the observation (records-outlive-writers)

The incumbent is read **on demand only on a collision**, so the common path
stays a single id-set membership check (no extra O(n) cost).

### 2. Export overwrite guard

`ctx export` now refuses a non-empty target directory unless `--force`, so it
can't silently clobber an unrelated tree (its own `index.md` / `log.md` /
colliding `<id>.md`). `--force` is a per-verb boolean flag (#158) so
`--force <dir>` doesn't swallow the positional directory.

## Tests

- foreign-id collision reallocates to a fresh id while a same-id/same-prose
  doc still idempotent-skips
- export refuses a non-empty dir (names `--force`) and succeeds with `--force`
  placed before the dir; the pre-existing file is left in place

**Full suite 1825/1825 green.**

## Deferred (not in this PR)

The remaining #431 concerns are structural / out-of-scope, left as future work:
OKF v0.1 spec-churn (a watch item, contained by the projection design); dedup's
O(n)-per-import hydrate and exact-after-whitespace matching (needs an index for
near-dup); and exporting gate waves / agora plays into the same bundle (a new
feature, not ctx).

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_