### PR TITLE
fix(ctx): gitignore /ctx/ + roadmap-aware phase-2 verb message (dogfood findings)

### DIFF
--- a/.changelog/next/changed-ctx-phase2-verb-hint.md
+++ b/.changelog/next/changed-ctx-phase2-verb-hint.md
@@ -1,0 +1,8 @@
+- **`ctx <phase-2 verb>` now gives a roadmap-aware message.** Typing a
+  verb that the help / docs name as "arriving in phase 2" (`fork` /
+  `supersede` / `show` / `list` / `chain` / `status`) used to produce the
+  same bare `unknown verb` a typo gets. It now says the verb is *planned
+  for phase 2, not yet implemented* and points at the phase-1 surface
+  (`record` / `export` / `import`). Genuine typos still get the
+  did-you-mean suggestion. Surfaced by dogfooding ctx from a user's
+  perspective.

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,10 @@ examples/*/data/
 
 # Local gate dogfood records (actor names + session content — do not publish)
 # Root-anchored so examples/*/requests/ + examples/*/issues/ + examples/*/agora/
-# fixtures stay tracked. Same rationale across stores — issues and agora
-# plays carry actor names and free-form session content the same way
-# requests do.
+# + examples/*/ctx/ fixtures stay tracked. Same rationale across all four
+# substrate stores — issues, agora plays and ctx facts carry actor names and
+# free-form session content the same way requests do.
 /requests/
 /issues/
 /agora/
+/ctx/

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -68,10 +68,23 @@ Lore upstream:
 `;
 
 // Mirror of the switch below for did-you-mean suggestions. Phase 1
-// has only `record`; phase 2 will add fork / supersede / show /
-// list / chain / status. A new verb forgotten here loses its typo
-// hint, doesn't crash anything.
+// ships record / export / import; a new verb forgotten here loses its
+// typo hint, doesn't crash anything.
 const CTX_COMMANDS = ['record', 'export', 'import'] as const;
+
+// The phase-2 lifecycle verbs named in HELP / AGENT.md / docs as
+// "arriving in phase 2". A user who read the docs and types one of these
+// deserves a roadmap-aware message ("planned, not yet implemented")
+// rather than the same "unknown verb" a typo gets. Keep in sync with the
+// HELP phase-2 line above.
+const CTX_PHASE2_VERBS: ReadonlySet<string> = new Set([
+  'fork',
+  'supersede',
+  'show',
+  'list',
+  'chain',
+  'status',
+]);
 
 export async function main(argv: readonly string[]): Promise<number> {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
@@ -108,6 +121,16 @@ export async function main(argv: readonly string[]): Promise<number> {
       case 'import':
         return await importCtx({ uc, config }, args);
       default: {
+        // A documented phase-2 verb that isn't implemented yet gets a
+        // roadmap-aware message, so a reader of the docs isn't told the
+        // same "unknown verb" a typo gets (dogfood finding).
+        if (cmd !== undefined && CTX_PHASE2_VERBS.has(cmd)) {
+          process.stderr.write(
+            `ctx: '${cmd}' is a planned phase-2 verb, not yet implemented.\n` +
+              `  phase 1 surface: record / export / import. See 'ctx --help'.\n`,
+          );
+          return 1;
+        }
         // Phase 2 will add fork / supersede / show / list / chain /
         // status; the catalog grows as those land. Valid verbs today are
         // record / export / import — typos like `recor` should still get

--- a/tests/interface/nearestCommand.test.ts
+++ b/tests/interface/nearestCommand.test.ts
@@ -124,6 +124,19 @@ test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
   assert.match(r.stderr, /record \/ export \/ import/);
 });
 
+test('ctx <phase-2 verb>: roadmap-aware message, not a bare "unknown verb"', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  run(GATE, root, ['register', '--name', 'alice']);
+  // `list` is documented as a phase-2 verb; a reader of the docs who
+  // types it should be told it's planned, not treated like a typo.
+  const r = run(CTX, root, ['list']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /planned phase-2 verb, not yet implemented/);
+  assert.match(r.stderr, /phase 1 surface: record \/ export \/ import/);
+  assert.doesNotMatch(r.stderr, /unknown verb/);
+});
+
 test('devil <typo>: suggests devil-prefixed verb', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);


### PR DESCRIPTION
## What

Two frictions surfaced by **dogfooding ctx from a user's perspective** (recording
real session facts, reading them back, exporting to OKF).

### 1. `/ctx/` missing from the root `.gitignore` (leak risk)

`.gitignore` root-anchors `/requests/`, `/issues/`, `/agora/` — the substrate
stores that "carry actor names + free-form session content". **`/ctx/` was
missing**, even though ctx facts (`created_by` + free-form `fact` prose) carry
exactly that. Recording a fact in the repo root left `ctx/*.yaml` untracked
(`?? ctx/`), risking an accidental commit of actor names + session content. The
existing comment's own "same rationale across stores" rule already implied the
fix. Root-anchored so `examples/*/ctx/` fixtures stay tracked.

### 2. Roadmap-aware message for documented phase-2 verbs

`ctx list` / `show` / `fork` / `supersede` / `chain` / `status` are named in
help / AGENT.md / docs as "arriving in phase 2", but typing one gave the same
bare `unknown verb` a typo gets — disconnected from the roadmap the user just
read. They now get *"'list' is a planned phase-2 verb, not yet implemented"*
pointing at the phase-1 surface. Genuine typos still get the did-you-mean
suggestion.

## Tests

`ctx list` produces the roadmap message (not `unknown verb`), exit 1; the
existing typo test still asserts the did-you-mean path. **Full suite 1826/1826
green.**

## Dogfood notes (not fixed here — by design)

The read-side is still grep (`ctx list` / `show` / tag-filter are the phase-2
verbs). That's the documented phase-1 limitation and the real pull toward
phase 2 — left as future work, consistent with the earlier call to defer the
larger ctx/OKF items.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_