### PR TITLE
feat(ctx): phase-1 read-side — ctx list + ctx show

### DIFF
--- a/.changelog/next/added-ctx-list-show.md
+++ b/.changelog/next/added-ctx-list-show.md
@@ -1,0 +1,10 @@
+- **`ctx list` / `ctx show` — phase-1 read-side.** Facts can now be read
+  back without grep. `ctx list` prints recorded facts newest-first (id,
+  author, timestamp, tags, snippet); `--tag prefix:value` filters by an
+  exact tag and `--by <m>` by author. `ctx list` with no records and
+  `ctx list` with a filter that matches nothing give distinct messages.
+  `ctx show <id>` prints one fact in full; a well-formed but absent id
+  raises a not-found that names `ctx list` as the recovery (text hint +
+  structured `error.recovery` in JSON), and a malformed id fails at the
+  domain boundary. `list` / `show` leave the phase-2 verb set. Surfaced as
+  the strongest pull toward phase 2 while dogfooding ctx.

--- a/AGENT.md
+++ b/AGENT.md
@@ -584,15 +584,17 @@ substrate primitive for facts; surrounding ecosystem modules
 (persona-side `*_resume.md`, code comments, ADR docs) hold related
 prose at different layers without absorbing into one another.
 
-Phase 1 ships `ctx record` plus the OKF interop pair (`export` /
-`import`, below). The remaining six lifecycle verbs (`fork` /
-`supersede` / `show` / `list` / `chain` / `status`) and schema
-extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
-`branch_ref`) land in phase 2.
+Phase 1 ships `ctx record`, the read-side `list` / `show`, and the OKF
+interop pair (`export` / `import`, below). The remaining lifecycle verbs
+(`fork` / `supersede` / `chain` / `status`) and schema extensions
+(`evidence` / `supersedes` / `sub_of` / `chain_after` / `branch_ref`)
+land in phase 2.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
                             [--by <m>] [--format json|text]
+ctx list [--tag prefix:value] [--by <m>] [--format json|text]  # read back, newest first
+ctx show <id> [--format json|text]                             # one fact in full
 ```
 
 ctx records live under `<content_root>/ctx/`:
@@ -651,11 +653,10 @@ thought-in-motion across sessions, use `agora play`. If it's a
 finding that needs adversarial scrutiny, use `devil entry`. ctx is
 for what remains: pinned observation, no closure required.
 
-Status: alpha phase 1. Structured read-side is `ctx export` (OKF
-projection); ad-hoc read-side is still grep on
-`<content_root>/ctx/*.yaml` — `ctx list` / `ctx chain` arrive in
-phase 2 and that's the design test (junk-drawer risk vs principled
-substrate).
+Status: alpha phase 1. Read-side is `ctx list` (newest-first, `--tag` /
+`--by` filters) + `ctx show <id>`, plus `ctx export` (OKF projection).
+`ctx chain` arrives in phase 2 and that's the design test (junk-drawer
+risk vs principled substrate at the 100-record scale).
 
 # Tier: Diagnostic
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1648,16 +1648,28 @@ that don't fit into a verdict, a play, or a review.
 
 ### Phase 1 surface
 
-Phase 1 ships `ctx record` plus the OKF interop pair (`export` /
-`import`, below). The remaining six lifecycle verbs (`fork` /
-`supersede` / `show` / `list` / `chain` / `status`) and schema
-extensions (`evidence` / `supersedes` / `sub_of` / `chain_after` /
-`branch_ref`) land in phase 2.
+Phase 1 ships `ctx record`, the read-side `list` / `show`, and the OKF
+interop pair (`export` / `import`, below). The remaining lifecycle verbs
+(`fork` / `supersede` / `chain` / `status`) and schema extensions
+(`evidence` / `supersedes` / `sub_of` / `chain_after` / `branch_ref`)
+land in phase 2.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
                             [--by <m>] [--format json|text]
+ctx list   [--tag prefix:value] [--by <m>] [--format json|text]
+ctx show   <id> [--format json|text]
 ```
+
+### Reading facts back (`list` / `show`)
+
+`ctx list` prints recorded facts newest-first (id, author, timestamp,
+tags, and a one-line snippet); `--tag` filters by an exact tag, `--by` by
+author. `ctx show <id>` prints one fact in full. A `show` on a
+well-formed but absent id raises a not-found that names `ctx list` as the
+recovery (text hint + structured `error.recovery` in JSON). This is the
+phase-1 read surface — before it, reading facts back meant grep over
+`<content_root>/ctx/*.yaml`.
 
 ### A worked record
 
@@ -1755,11 +1767,10 @@ is the seam for a future second format).
 
 ### Status (alpha phase 1)
 
-Structured read-side is `ctx export` (OKF projection); ad-hoc read-side
-is still grep on `<content_root>/ctx/*.yaml`.
-`ctx list` / `ctx show` / `ctx chain` (phase 2) are the design
-test — whether the substrate stays principled or drifts into a
-junk drawer at the 100-record scale.
+Read-side is `ctx list` (newest-first, `--tag` / `--by` filters) +
+`ctx show <id>`, plus `ctx export` (OKF projection). `ctx chain` (phase
+2) is the remaining design test — whether the substrate stays principled
+or drifts into a junk drawer at the 100-record scale.
 
 For the conceptual framing alongside the other passages, see the
 `## ctx` section of [`AGENT.md`](../AGENT.md).

--- a/src/passages/ctx/application/CtxRepository.ts
+++ b/src/passages/ctx/application/CtxRepository.ts
@@ -1,13 +1,17 @@
 import { Ctx } from '../domain/Ctx.js';
 
 /**
- * Port — Application's view of ctx persistence. Phase 1 needs three
- * operations: list existing ids (for nextCtxId allocation), save new,
- * and find by id (for handler verification, even though `ctx show`
- * itself ships in phase 2 — internal callers may need round-tripping).
+ * Port — Application's view of ctx persistence.
+ *
+ * - `listAllIds` — id enumeration (for nextCtxId allocation).
+ * - `saveNew` / `findById` — write + point read.
+ * - `listAll` — hydrate every fact (for `ctx list` and OKF export).
+ *   Malformed records are skipped on read (same tolerance as findById),
+ *   so this never throws on a single bad file.
  */
 export interface CtxRepository {
   listAllIds(): Promise<readonly string[]>;
   saveNew(ctx: Ctx): Promise<void>;
   findById(id: string): Promise<Ctx | null>;
+  listAll(): Promise<readonly Ctx[]>;
 }

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -59,18 +59,48 @@ export class CtxUseCases {
   }
 
   /**
+   * List recorded facts, newest first, optionally filtered by an exact
+   * tag and/or author. Read-only.
+   */
+  async list(filter: { tag?: string; by?: string } = {}): Promise<readonly Ctx[]> {
+    let out = [...(await this.repo.listAll())];
+    if (filter.tag !== undefined) {
+      out = out.filter((c) => c.tags.includes(filter.tag!));
+    }
+    if (filter.by !== undefined) {
+      out = out.filter((c) => c.created_by === filter.by);
+    }
+    // Newest first: created_at desc, id desc as a stable tiebreak.
+    out.sort((a, b) =>
+      a.created_at < b.created_at
+        ? 1
+        : a.created_at > b.created_at
+          ? -1
+          : a.id < b.id
+            ? 1
+            : a.id > b.id
+              ? -1
+              : 0,
+    );
+    return out;
+  }
+
+  /** Show a single fact by id, or null if absent. Read-only. */
+  async show(id: string): Promise<Ctx | null> {
+    return this.repo.findById(id);
+  }
+
+  /**
    * Export every ctx fact as an OKF bundle under `dir`. Read-only over
    * the substrate (writes land outside `content_root`, in the chosen
    * bundle directory).
    */
   async exportOkf(input: { dir: string; force?: boolean }): Promise<OkfExportSummary> {
     const bundle = this.requireBundle();
-    const ids = [...(await this.repo.listAllIds())].sort();
-    const docs = [];
-    for (const id of ids) {
-      const ctx = await this.repo.findById(id);
-      if (ctx !== null) docs.push(ctxToOkfDocument(ctx));
-    }
+    const facts = [...(await this.repo.listAll())].sort((a, b) =>
+      a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+    );
+    const docs = facts.map(ctxToOkfDocument);
     const res = await bundle.write(input.dir, docs, { force: input.force === true });
     return { written: res.written, count: docs.length };
   }

--- a/src/passages/ctx/infrastructure/YamlCtxRepository.ts
+++ b/src/passages/ctx/infrastructure/YamlCtxRepository.ts
@@ -46,6 +46,16 @@ export class YamlCtxRepository implements CtxRepository {
     return out;
   }
 
+  async listAll(): Promise<readonly Ctx[]> {
+    const ids = await this.listAllIds();
+    const out: Ctx[] = [];
+    for (const id of ids) {
+      const ctx = await this.findById(id);
+      if (ctx !== null) out.push(ctx); // malformed records skip via findById
+    }
+    return out;
+  }
+
   async saveNew(ctx: Ctx): Promise<void> {
     const rel = `${ctx.id}.yaml`;
     if (existsSafe(this.base, rel)) {

--- a/src/passages/ctx/interface/handlers/list.ts
+++ b/src/passages/ctx/interface/handlers/list.ts
@@ -1,0 +1,97 @@
+import { CtxUseCases } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { parseCtxTag } from '../../domain/Ctx.js';
+
+const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['tag', 'by', 'format']);
+
+/** First non-empty, non-heading line of `fact`, collapsed and truncated. */
+function snippet(fact: string, max = 100): string {
+  const line = fact
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (line === undefined) return '';
+  const collapsed = line.replace(/\s+/g, ' ');
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
+}
+
+export interface ListCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx list — read recorded facts back, newest first.
+ *
+ * Usage:
+ *   ctx list [--tag prefix:value] [--by <m>] [--format json|text]
+ *
+ * Closes the phase-1 read-side gap surfaced by dogfooding: before this,
+ * the only way to read facts back was `grep` over `<content_root>/ctx/`.
+ * `--tag` filters by an exact tag (validated at the boundary).
+ */
+export async function listCtx(
+  deps: ListCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, LIST_KNOWN_FLAGS, 'list');
+  const format = parseFormat(args);
+
+  const tag = optionalOption(args, 'tag');
+  if (tag !== undefined) parseCtxTag(tag); // validate the filter shape loud
+  const by = optionalOption(args, 'by');
+
+  const filter: { tag?: string; by?: string } = {};
+  if (tag !== undefined) filter.tag = tag;
+  if (by !== undefined) filter.by = by;
+
+  const facts = await deps.uc.list(filter);
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          count: facts.length,
+          filter,
+          facts: facts.map((f) => f.toJSON()),
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    return 0;
+  }
+
+  const filtered = tag !== undefined || by !== undefined;
+  if (facts.length === 0) {
+    if (filtered) {
+      process.stdout.write('no ctx facts match the filter.\n');
+    } else {
+      process.stdout.write(
+        'no ctx facts recorded yet.\n' +
+          '  record one: ctx record --fact "<prose>" [--tag prefix:value]\n',
+      );
+    }
+    return 0;
+  }
+
+  const scope = filtered ? ' (filtered)' : '';
+  process.stdout.write(
+    `${facts.length} ctx fact${facts.length === 1 ? '' : 's'}${scope} — newest first\n\n`,
+  );
+  for (const f of facts) {
+    process.stdout.write(`${f.id}  ${f.created_by}  ${f.created_at.slice(0, 16)}\n`);
+    if (f.tags.length > 0) {
+      process.stdout.write(`  [${f.tags.join(', ')}]\n`);
+    }
+    process.stdout.write(`  ${snippet(f.fact)}\n\n`);
+  }
+  return 0;
+}

--- a/src/passages/ctx/interface/handlers/show.ts
+++ b/src/passages/ctx/interface/handlers/show.ts
@@ -1,0 +1,66 @@
+import { CtxUseCases } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
+import {
+  ParsedArgs,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { RecoverableError } from '../../../../interface/shared/errorEnvelope.js';
+
+const SHOW_KNOWN_FLAGS: ReadonlySet<string> = new Set(['format']);
+
+export interface ShowCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx show — display a single recorded fact in full.
+ *
+ * Usage:
+ *   ctx show <id> [--format json|text]
+ *
+ * A malformed id fails at the domain boundary (parseCtxId); a
+ * well-formed but absent id raises a not-found that names `ctx list` as
+ * the recovery path (both text hint and structured `error.recovery`).
+ */
+export async function showCtx(
+  deps: ShowCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, SHOW_KNOWN_FLAGS, 'show');
+  const format = parseFormat(args);
+
+  const id = args.positional[0];
+  if (id === undefined || id.length === 0) {
+    throw new DomainError('show requires a fact id (ctx show <id>)', 'id');
+  }
+
+  const fact = await deps.uc.show(id); // findById validates id shape
+
+  if (fact === null) {
+    throw new RecoverableError(
+      `ctx fact ${id} not found.\n` +
+        '  list the recorded facts to find the right id:\n' +
+        '    ctx list',
+      { verb: 'list', args: {}, reason: 'list the recorded facts to find the right id' },
+      'not_found',
+    );
+  }
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify({ ok: true, ...fact.toJSON() }, null, 2) + '\n',
+    );
+    return 0;
+  }
+
+  process.stdout.write(`${fact.id}\n`);
+  process.stdout.write(`  created ${fact.created_at} by ${fact.created_by}\n`);
+  if (fact.tags.length > 0) {
+    process.stdout.write(`  tags: ${fact.tags.join(', ')}\n`);
+  }
+  process.stdout.write(`\n${fact.fact}\n`);
+  return 0;
+}

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -23,11 +23,13 @@ import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { exportCtx, EXPORT_BOOLEAN_FLAGS } from './handlers/exportOkf.js';
 import { importCtx, IMPORT_BOOLEAN_FLAGS } from './handlers/importOkf.js';
+import { listCtx } from './handlers/list.js';
+import { showCtx } from './handlers/show.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
-const HELP = `ctx — fact accumulation passage (phase 1: record + OKF interop)
+const HELP = `ctx — fact accumulation passage (phase 1: record / list / show + OKF interop)
 
 Usage:
   ctx record --fact "<prose>" [--tag tech:foo,status:bar]
@@ -35,6 +37,13 @@ Usage:
                               Append a fact to the substrate. Lands at
                               <content_root>/ctx/<id>.yaml. Id is
                               auto-allocated as ctx-YYYY-MM-DD-NNN.
+
+  ctx list                    [--tag prefix:value] [--by <m>] [--format json|text]
+                              Read facts back, newest first. --tag filters
+                              by an exact tag, --by by author.
+
+  ctx show <id>               [--format json|text]
+                              Show one fact in full.
 
   ctx export <dir>            [--as okf] [--force] [--format json|text]
                               Project every fact into an Open Knowledge
@@ -53,10 +62,10 @@ Usage:
   ctx --help                   This help.
   ctx --version                Print version and exit.
 
-Phase 1 status: \`record\` plus the OKF interop pair (\`export\` /
-\`import\`). OKF is an interchange *projection* (principle 11), not a
-storage change — the substrate stays YAML.
-Phase 2 (separate session): fork / supersede / show / list / chain / status.
+Phase 1 status: \`record\` / \`list\` / \`show\` plus the OKF interop
+pair (\`export\` / \`import\`). OKF is an interchange *projection*
+(principle 11), not a storage change — the substrate stays YAML.
+Phase 2 (separate session): fork / supersede / chain / status.
 
 Substrate: shares content_root and members/ with gate; ctx-specific
 data goes under <content_root>/ctx/.
@@ -70,18 +79,16 @@ Lore upstream:
 // Mirror of the switch below for did-you-mean suggestions. Phase 1
 // ships record / export / import; a new verb forgotten here loses its
 // typo hint, doesn't crash anything.
-const CTX_COMMANDS = ['record', 'export', 'import'] as const;
+const CTX_COMMANDS = ['record', 'export', 'import', 'list', 'show'] as const;
 
 // The phase-2 lifecycle verbs named in HELP / AGENT.md / docs as
 // "arriving in phase 2". A user who read the docs and types one of these
 // deserves a roadmap-aware message ("planned, not yet implemented")
 // rather than the same "unknown verb" a typo gets. Keep in sync with the
-// HELP phase-2 line above.
+// HELP phase-2 line above (list / show shipped — they left this set).
 const CTX_PHASE2_VERBS: ReadonlySet<string> = new Set([
   'fork',
   'supersede',
-  'show',
-  'list',
   'chain',
   'status',
 ]);
@@ -93,7 +100,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
   if (isVersionFlag(argv)) {
     process.stdout.write(
-      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record + OKF export/import)\n`,
+      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record / list / show + OKF export/import)\n`,
     );
     return 0;
   }
@@ -116,6 +123,10 @@ export async function main(argv: readonly string[]): Promise<number> {
     switch (cmd) {
       case 'record':
         return await recordCtx({ uc, config }, args);
+      case 'list':
+        return await listCtx({ uc, config }, args);
+      case 'show':
+        return await showCtx({ uc, config }, args);
       case 'export':
         return await exportCtx({ uc, config }, args);
       case 'import':
@@ -131,15 +142,15 @@ export async function main(argv: readonly string[]): Promise<number> {
           );
           return 1;
         }
-        // Phase 2 will add fork / supersede / show / list / chain /
-        // status; the catalog grows as those land. Valid verbs today are
-        // record / export / import — typos like `recor` should still get
+        // Phase 2 will add fork / supersede / chain / status; the catalog
+        // grows as those land. Valid verbs today are record / list / show
+        // / export / import — typos like `recor` should still get
         // suggested rather than dumping the full HELP.
         const hint = nearestCommand(cmd, CTX_COMMANDS);
         const suggest = hint ? `\n  did you mean: ctx ${hint}?` : '';
         process.stderr.write(
           `ctx: unknown verb: ${cmd}${suggest}\n` +
-            `  see 'ctx --help' for the full verb catalog (record / export / import).\n`,
+            `  see 'ctx --help' for the full verb catalog (record / list / show / export / import).\n`,
         );
         return 1;
       }

--- a/src/passages/ctx/interface/verbs.ts
+++ b/src/passages/ctx/interface/verbs.ts
@@ -1,12 +1,13 @@
 // ctx verbs — read/write/exempt classification for entry middleware.
 //
 // See gate's verbs.ts header for the rule-of-thumb classification.
-// Phase 1 surface is `record` (write) plus the OKF interop pair:
-// `export` (read — writes a bundle outside content_root, no substrate
-// mutation) and `import` (write — records facts into content_root).
-// Phase 2 will add fork / supersede / show / list / chain / status.
+// Phase 1 surface: `record` (write); the OKF interop pair `export`
+// (read — writes a bundle outside content_root, no substrate mutation)
+// and `import` (write — records facts into content_root); and the
+// read-side `list` / `show`. Phase 2 will add fork / supersede / chain /
+// status.
 
-export const READ_VERBS: ReadonlySet<string> = new Set(['export']);
+export const READ_VERBS: ReadonlySet<string> = new Set(['export', 'list', 'show']);
 
 export const WRITE_VERBS: ReadonlySet<string> = new Set(['record', 'import']);
 

--- a/tests/interface/nearestCommand.test.ts
+++ b/tests/interface/nearestCommand.test.ts
@@ -119,18 +119,19 @@ test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
   assert.match(r.stderr, /did you mean: ctx record\?/);
   // Verb-catalog callout — flag the available surface at the point a
   // typo hit it, since the phase-2 lifecycle verbs (fork / supersede /
-  // show / list / chain / status) are not yet implemented and a typo
-  // for any of those would refuse to suggest.
-  assert.match(r.stderr, /record \/ export \/ import/);
+  // chain / status) are not yet implemented and a typo for any of those
+  // would refuse to suggest.
+  assert.match(r.stderr, /record \/ list \/ show \/ export \/ import/);
 });
 
 test('ctx <phase-2 verb>: roadmap-aware message, not a bare "unknown verb"', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   run(GATE, root, ['register', '--name', 'alice']);
-  // `list` is documented as a phase-2 verb; a reader of the docs who
-  // types it should be told it's planned, not treated like a typo.
-  const r = run(CTX, root, ['list']);
+  // `fork` is documented as a phase-2 verb (list / show shipped); a
+  // reader of the docs who types it should be told it's planned, not
+  // treated like a typo.
+  const r = run(CTX, root, ['fork']);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /planned phase-2 verb, not yet implemented/);
   assert.match(r.stderr, /phase 1 surface: record \/ export \/ import/);

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -57,7 +57,7 @@ const DEVIL_ALL = [
   'suspend', 'resume', 'ingest', 'conclude', 'schema',
 ] as const;
 
-const CTX_ALL = ['record', 'export', 'import'] as const;
+const CTX_ALL = ['record', 'list', 'show', 'export', 'import'] as const;
 
 const CASES: Case[] = [
   { passage: 'gate', verbs: gateVerbs, all: GATE_ALL },

--- a/tests/passages/ctx/interface/readSide.test.ts
+++ b/tests/passages/ctx/interface/readSide.test.ts
@@ -1,0 +1,126 @@
+// ctx read-side (list / show) — end-to-end through the real binary.
+//
+// Closes the phase-1 read-side gap surfaced by dogfooding: before this,
+// reading facts back meant grep over <content_root>/ctx/. Covers:
+//   - list newest-first
+//   - list --tag (exact) and --by filters
+//   - list empty (no records) vs empty (filter matched nothing)
+//   - show by id (full fact)
+//   - show absent id -> not-found with structured recovery
+//   - show malformed id -> domain validation error
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CTX = resolve(here, '../../../../../bin/ctx.mjs');
+
+function newRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-read-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [human]\n');
+  return root;
+}
+
+function runCtx(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [CTX, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function seed(root: string): void {
+  runCtx(root, ['record', '--fact', 'first okf fact', '--tag', 'topic:okf'], { GUILD_ACTOR: 'claude' });
+  runCtx(root, ['record', '--fact', 'a dogfood note', '--tag', 'topic:dogfood'], { GUILD_ACTOR: 'eris' });
+  runCtx(root, ['record', '--fact', 'second okf fact', '--tag', 'topic:okf'], { GUILD_ACTOR: 'claude' });
+}
+
+test('ctx list returns facts newest-first', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+
+  const env = JSON.parse(runCtx(root, ['list', '--format', 'json']).stdout);
+  assert.equal(env.count, 3);
+  // newest first: -003, -002, -001 (same day, NNN order).
+  const ids = env.facts.map((f: { id: string }) => f.id);
+  assert.deepEqual(ids, [...ids].sort().reverse());
+});
+
+test('ctx list --tag filters by exact tag; --by filters by author', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+
+  const byTag = JSON.parse(runCtx(root, ['list', '--tag', 'topic:okf', '--format', 'json']).stdout);
+  assert.equal(byTag.count, 2);
+  assert.ok(byTag.facts.every((f: { tags: string[] }) => f.tags.includes('topic:okf')));
+
+  const byAuthor = JSON.parse(runCtx(root, ['list', '--by', 'eris', '--format', 'json']).stdout);
+  assert.equal(byAuthor.count, 1);
+  assert.equal(byAuthor.facts[0].created_by, 'eris');
+});
+
+test('ctx list distinguishes empty store from empty filter (text)', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const empty = runCtx(root, ['list']);
+  assert.match(empty.stdout, /no ctx facts recorded yet/);
+  assert.match(empty.stdout, /ctx record --fact/);
+
+  seed(root);
+  const noMatch = runCtx(root, ['list', '--tag', 'topic:absent']);
+  assert.match(noMatch.stdout, /no ctx facts match the filter/);
+});
+
+test('ctx list rejects a malformed --tag at the boundary', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+  const r = runCtx(root, ['list', '--tag', 'nocolon']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /ctx tag must match/);
+});
+
+test('ctx show <id> prints the full fact', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+  const today = new Date().toISOString().slice(0, 10);
+  const r = runCtx(root, ['show', `ctx-${today}-002`]);
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /a dogfood note/);
+  assert.match(r.stdout, /by eris/);
+});
+
+test('ctx show <absent> raises not-found with structured recovery', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+  const r = runCtx(root, ['show', 'ctx-2020-01-01-001', '--format', 'json']);
+  assert.equal(r.status, 1);
+  const env = JSON.parse(r.stderr.split('\n')[0]!);
+  assert.equal(env.ok, false);
+  assert.equal(env.error.code, 'not_found');
+  assert.equal(env.error.recovery.verb, 'list');
+});
+
+test('ctx show <malformed id> is a domain validation error', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  seed(root);
+  const r = runCtx(root, ['show', 'not-an-id']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /ctx id must match/);
+});


### PR DESCRIPTION
## What

The phase-1 **read-side** for ctx — the friction surfaced by dogfooding (recording
facts then reaching for `grep` to read them back). This is the strongest pull
toward phase 2 that the dogfood call-out named.

```bash
ctx list [--tag prefix:value] [--by <m>] [--format json|text]
ctx show <id> [--format json|text]
```

- **`ctx list`** — facts newest-first (id, author, timestamp, tags, one-line
  snippet). `--tag` filters by an exact tag (validated at the domain boundary,
  so a bad filter fails loud); `--by` filters by author. An empty store and a
  filter that matches nothing give distinct messages.
- **`ctx show <id>`** — one fact in full. A well-formed but absent id raises a
  not-found that names `ctx list` as the recovery (text hint + structured
  `error.recovery` in JSON, `code: not_found`); a malformed id fails at the
  domain boundary (`parseCtxId`).

## Plumbing

`CtxRepository` gains `listAll()` (hydrate-all, malformed-skip — same tolerance
as `findById`); `exportOkf` is refactored onto it. `list` / `show` are READ
verbs (no lock) and leave the phase-2 verb set, so `ctx list` now lists instead
of emitting the "planned phase-2 verb" message added last PR.

## Tests

list newest-first + `--tag`/`--by` filters + empty-vs-no-match + malformed-tag
reject; show found + not-found-recovery + malformed-id. `verbs-consistency`
`CTX_ALL` and the nearest-command mirrors updated. **Full suite 1833/1833 green.**

## Scope

`--tag` is exact-match (the named friction was "filter by `topic:okf`"); prefix
wildcards and `ctx chain` / `fork` / `supersede` / `status` remain phase 2.

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_