### PR TITLE
feat(ctx): tag type-less OKF imports okf:untyped + document dedup strength

### DIFF
--- a/.changelog/next/added-ctx-okf-roundtrip.md
+++ b/.changelog/next/added-ctx-okf-roundtrip.md
@@ -10,9 +10,10 @@
   to `prefix:value` (bare → `topic:`), a non-`Fact` type is preserved as
   an `okf:<type>` provenance tag, missing authors fall back to `--by`,
   and empty/unparseable documents are reported as skipped rather than
-  failing the import. Prose dedup is on by default — a fact whose
-  normalized prose is already recorded (under any id, or earlier in the
-  same bundle) is skipped, so even an id-less foreign bundle re-imported
-  is a no-op; `--allow-duplicates` opts out. OKF is an interchange
+  failing the import. Prose dedup is on by default — a fact whose prose
+  (matched on a trim + whitespace-collapse, so case and punctuation are
+  significant) is already recorded (under any id, or earlier in the same
+  bundle) is skipped, so even an id-less foreign bundle re-imported is a
+  no-op; `--allow-duplicates` opts out. OKF is an interchange
   *projection* (principle 11), not a storage change — the on-disk
   substrate stays YAML.

--- a/.changelog/next/added-ctx-okf-untyped-tag.md
+++ b/.changelog/next/added-ctx-okf-untyped-tag.md
@@ -1,0 +1,12 @@
+- **`ctx import` tags type-less docs `okf:untyped`.** OKF requires a
+  `type` on every concept; import stays tolerant (a frontmatter-less or
+  `type`-empty `.md` still records — its body is the fact) but now tags
+  such a doc `okf:untyped` instead of letting it pass as a plain Fact. A
+  stray non-concept file in a bundle (a README, a note) is therefore
+  auditable after the fact via `ctx list --tag okf:untyped`, rather than
+  being indistinguishable from a real guild fact. A document with a usable
+  type is unchanged (`Fact` stays tag-clean; other types keep their
+  `okf:<type>` provenance tag). Also clarifies, in help and the docs, that
+  prose dedup matches on a **trim + whitespace-collapse only — case and
+  punctuation are significant** (it catches a markdown re-wrap, not a
+  hand-edited copy).

--- a/AGENT.md
+++ b/AGENT.md
@@ -630,21 +630,30 @@ Round-trip is lossless for guild-authored bundles — `id`, `timestamp`,
 `author` and `tags` survive the trip, and re-importing the same bundle
 is idempotent (existing ids skip). Foreign bundles import tolerantly:
 nested subtrees are walked; bare tags land under `topic:`; a non-`Fact`
-`type` is preserved as an `okf:<type>` provenance tag; documents lacking
-an author fall back to `--by`; empty or unparseable documents are
-reported as skipped rather than failing the whole import. A foreign `id`
-that collides with an existing record but carries *different* prose is
-reallocated a fresh id rather than dropped (the idempotent skip is gated
-on a prose match, so a distinct observation is never lost). `export`
-refuses a non-empty target directory unless `--force`, so it can't
-silently clobber an unrelated tree.
+`type` is preserved as an `okf:<type>` provenance tag; a doc with no
+usable `type` (frontmatter-less, or `type` empty) still records but is
+tagged `okf:untyped` so a stray non-concept `.md` (a README, a note) is
+auditable via `ctx list --tag okf:untyped` rather than passing silently
+as a Fact; documents lacking an author fall back to `--by`; empty or
+unparseable documents are reported as skipped rather than failing the
+whole import. A foreign `id` that collides with an existing record but
+carries *different* prose is reallocated a fresh id rather than dropped
+(the idempotent skip is gated on a prose match, so a distinct observation
+is never lost). `export` refuses a non-empty target directory unless
+`--force`, so it can't silently clobber an unrelated tree.
 
-**Prose dedup** is on by default: a fact whose normalized prose is
-already recorded — under any id, or earlier in the same bundle — is
-skipped, so even an id-less foreign bundle re-imported is a no-op (the
-skip reason names the record it duplicates). `--allow-duplicates` opts
-out for a deliberate re-record. `--as` selects the bundle format (only
-`okf` today; the flag is the seam for a future second format).
+**Prose dedup** is on by default: a fact whose prose is already recorded
+— under any id, or earlier in the same bundle — is skipped, so even an
+id-less foreign bundle re-imported is a no-op (the skip reason names the
+record it duplicates). The match is **trim + whitespace-collapse only —
+case and punctuation are significant**, so it catches re-wraps but not a
+hand-edited copy (capitalized, re-punctuated). For a guild-authored
+bundle the `id` carries that case via the idempotent skip; a *foreignized*
+copy (id stripped + body reworded) can re-import as a new fact. That is
+intentional — dedup is a cheap exact-prose guard, not a similarity model.
+`--allow-duplicates` opts out for a deliberate re-record. `--as` selects
+the bundle format (only `okf` today; the flag is the seam for a future
+second format).
 
 When to reach for ctx vs the other passages: ctx is the residence
 for prose that doesn't want closure. If the observation is heading

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1753,17 +1753,25 @@ main↔develop diff is PR #145 only; harness layer stays develop-side
 
 Foreign bundles import tolerantly: nested subtrees are walked; bare tags
 land under `topic:`; a non-`Fact` `type` is preserved as an `okf:<type>`
-provenance tag; documents lacking an author fall back to `--by`; empty or
-unparseable documents are reported as skipped rather than failing the
-import.
+provenance tag; a doc with no usable `type` (frontmatter-less, or `type`
+empty) still records but is tagged `okf:untyped` — so a stray non-concept
+`.md` (a README, a note) is auditable via `ctx list --tag okf:untyped`
+rather than passing silently as a Fact; documents lacking an author fall
+back to `--by`; empty or unparseable documents are reported as skipped
+rather than failing the import.
 
-**Prose dedup** is on by default: a fact whose normalized prose
-(trimmed, internal whitespace collapsed) is already recorded — under any
-id, or earlier in the same bundle — is skipped, so even an id-less
-foreign bundle re-imported is a no-op. The skip reason names the record
-it duplicates. `--allow-duplicates` opts out for the rare deliberate
-re-record. `--as` selects the bundle format (only `okf` today — the flag
-is the seam for a future second format).
+**Prose dedup** is on by default: a fact whose prose is already recorded
+— under any id, or earlier in the same bundle — is skipped, so even an
+id-less foreign bundle re-imported is a no-op. The skip reason names the
+record it duplicates. The match is **trim + whitespace-collapse only —
+case and punctuation are significant**: it catches a markdown re-wrap but
+not a hand-edited copy (capitalized, re-punctuated). A guild-authored
+bundle survives that via the `id`-based idempotent skip; a *foreignized*
+copy (id stripped + body reworded) can re-import as a new fact. That is
+intentional — dedup is a cheap exact-prose guard, not a similarity model.
+`--allow-duplicates` opts out for the rare deliberate re-record. `--as`
+selects the bundle format (only `okf` today — the flag is the seam for a
+future second format).
 
 ### Status (alpha phase 1)
 

--- a/src/passages/ctx/application/OkfCtxMapper.ts
+++ b/src/passages/ctx/application/OkfCtxMapper.ts
@@ -131,14 +131,23 @@ export function okfDocumentToCtxFact(doc: OkfDocument): OkfImportMapping {
     }
   }
 
-  // Preserve a non-`Fact` type as provenance. `Fact` is guild's own
-  // export type and carries no extra signal, so it's left off to keep
-  // round-tripped bundles tag-clean.
-  if (typeof fm.type === 'string') {
-    const typeSlug = slugifyForTagValue(fm.type);
-    if (typeSlug !== null && typeSlug !== 'fact') {
-      push(`okf:${typeSlug}`);
-    }
+  // Provenance via the `type` field:
+  //   - `Fact`        -> no tag (guild's own export type, kept tag-clean)
+  //   - any other type -> `okf:<type-slug>`
+  //   - missing / empty / unusable type -> `okf:untyped`
+  // The import side is deliberately tolerant (a frontmatter-less or
+  // type-less .md still records — its body is the fact), but OKF requires
+  // a `type` on every concept, so a doc without a usable one isn't a
+  // conformant concept. Tagging it `okf:untyped` keeps the tolerance while
+  // making the gap auditable: `ctx list --tag okf:untyped` surfaces every
+  // fact that came in without a real OKF type (e.g. a stray README.md), so
+  // it can be reviewed or culled rather than silently passing as a Fact.
+  const rawType = typeof fm.type === 'string' ? fm.type : '';
+  const typeSlug = slugifyForTagValue(rawType);
+  if (typeSlug === null) {
+    push('okf:untyped');
+  } else if (typeSlug !== 'fact') {
+    push(`okf:${typeSlug}`);
   }
 
   return {

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -56,8 +56,12 @@ Usage:
                               Record an OKF bundle's concepts as facts.
                               Guild-authored bundles round-trip (ids
                               preserved, idempotent); foreign bundles
-                              import tolerantly. Prose dedup is on by
-                              default; --allow-duplicates opts out.
+                              import tolerantly (a type-less doc is tagged
+                              okf:untyped so it's auditable). Prose dedup
+                              is on by default — it matches on trimmed,
+                              whitespace-collapsed prose, so case and
+                              punctuation are significant. --allow-duplicates
+                              opts out.
 
   ctx --help                   This help.
   ctx --version                Print version and exit.

--- a/tests/passages/ctx/interface/okfRoundtrip.test.ts
+++ b/tests/passages/ctx/interface/okfRoundtrip.test.ts
@@ -127,6 +127,14 @@ test('a foreign OKF bundle imports tolerantly', (t) => {
   assert.match(orders!, /owner:data-team/); // prefixed tag coerced
   assert.match(orders!, /okf:bigquery-table/); // type provenance
   assert.match(orders!, /created_at: 2025-01-02T10:00:00\.000Z/); // foreign ts preserved
+
+  // The frontmatter-less plain.md records but is tagged okf:untyped so a
+  // stray non-concept .md is auditable rather than passing as a Fact.
+  const plain = files
+    .map((f) => readFileSync(join(root, 'ctx', f), 'utf8'))
+    .find((y) => y.includes('plain prose, no frontmatter'));
+  assert.ok(plain, 'frontmatter-less doc should still record');
+  assert.match(plain!, /okf:untyped/);
 });
 
 test('prose dedup: id-less re-import and in-bundle duplicates are skipped', (t) => {

--- a/tests/passages/ctx/okfMapper.test.ts
+++ b/tests/passages/ctx/okfMapper.test.ts
@@ -83,3 +83,18 @@ test('an empty body is skipped with a reason', () => {
   if (m.kind !== 'skip') return;
   assert.match(m.reason, /empty body/);
 });
+
+test('a type-less doc (frontmatter-less) is tagged okf:untyped for audit', () => {
+  // parseOkfDocument coerces a frontmatter-less file to type ''.
+  const doc: OkfDocument = { path: 'nofm.md', frontmatter: { type: '' }, body: 'plain prose' };
+  const m = okfDocumentToCtxFact(doc);
+  if (m.kind !== 'fact') throw new Error('expected fact');
+  assert.deepEqual(m.tags, ['okf:untyped']);
+});
+
+test('a type that slugs to nothing also falls back to okf:untyped', () => {
+  const doc: OkfDocument = { path: 'x.md', frontmatter: { type: '***' }, body: 'b' };
+  const m = okfDocumentToCtxFact(doc);
+  if (m.kind !== 'fact') throw new Error('expected fact');
+  assert.deepEqual(m.tags, ['okf:untyped']);
+});


### PR DESCRIPTION
Two related import touch-feel improvements, both from the same review thread.

## 1. `okf:untyped` for type-less imports (option C)

The only structural filter on import was the reserved `index.md` / `log.md`; the
only content gate was "is the body non-empty?". So a stray non-concept `.md`
(README, a note, a LICENSE) sitting in a bundle dir was ingested as a fact —
**indistinguishable** from a real one, because a type-less doc got no provenance
tag (the `okf:<type>` tag is only added for non-`Fact` types).

OKF requires a `type` on every concept, so a type-less file isn't a conformant
concept. Import stays tolerant (it still records — the body is the fact), but a
doc with no usable `type` (frontmatter-less, or `type` empty/unslug-able) is now
tagged **`okf:untyped`**. That keeps records-outlive-writers *and* makes the gap
auditable:

```bash
ctx list --tag okf:untyped   # surfaces every fact that came in without a real type
```

A doc with a usable type is unchanged — `Fact` stays tag-clean (lossless
round-trip preserved), others keep their `okf:<type>` tag.

## 2. Document the dedup normalization strength

Help and the docs said "normalized prose" without saying how strong the
normalization is — a dogfooder had to read the `factDedupKey` comment to learn it
is **trim + whitespace-collapse only (case and punctuation significant)**. That's
now stated in `ctx import --help`, AGENT.md and docs/verbs.md, with the honest
caveat: dedup catches a markdown re-wrap but not a hand-edited copy. A
guild-authored bundle survives a re-wrap via the `id`-based idempotent skip; a
*foreignized* copy (id stripped + body reworded) can re-import as a new fact —
intentional, because dedup is a cheap exact-prose guard, not a similarity model.

## Tests

type-less and unslug-able `type` → `okf:untyped` (mapper unit); the e2e
foreign-bundle import asserts the frontmatter-less doc carries `okf:untyped`.
**Full suite 1835/1835 green.**

https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHKfJKPDkGBDqMxGRWHECX)_