### PR TITLE
docs(devil): document extension lenses for judgment-axis review (#134 G)

### DIFF
--- a/.changelog/next/docs-devil-extension-lense-judgment.md
+++ b/.changelog/next/docs-devil-extension-lense-judgment.md
@@ -1,0 +1,16 @@
+- **Docs: documented that devil's no-gaps coverage gate extends to
+  judgment axes via content_root extension lenses (#134 G).** The
+  `ComposedLenseCatalog` override path (`<content_root>/devil/lenses/
+  <name>.yaml`, merged over bundled defaults at startup, wired in
+  `interface/container.ts`) was shipped and wired but undocumented —
+  every doc still framed devil as security-only. Dogfooding it for real
+  (authored a `correctness.yaml` extension, opened a `--type system`
+  review, filled the lense with zero skip-spam) confirmed the path
+  works end to end. Added an "Extending the catalog per content_root"
+  section to `src/passages/devil/README.md` (with a YAML example and the
+  `LenseCollision` extend-only policy), an "Extending instead of
+  skipping" subsection to the playbook's "When NOT to use devil"
+  (the skip-spam warning is about the *bundled* catalog; an extension
+  catalog removes the spam), and corrected the `CLAUDE.md` devil
+  one-liner, which mislabeled gate's review lenses (devil/layer/
+  cognitive/user) as devil's catalog and called devil security-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,12 @@ file-based な coordination substrate を作っている TypeScript CLI。
   + claim/witness の cross-session stake
 - **agora** — `new` / `play` / `move` / `suspend` / `resume` / `conclude`
   の議論・探索プリミティブ (alpha)
-- **devil** — multi-persona security review (lenses: devil/layer/cognitive/user
-  + custom)。security 寄りの変更専用 — 汎用レビューは `gate review` (docs/playbook.md
-  "When NOT to use devil")
+- **devil** — multi-persona security review。bundled catalog は security
+  12-lense (injection / path-network / supply-chain ...)。security 寄りの
+  変更が主用途で、汎用レビューは `gate review` (docs/playbook.md
+  "When NOT to use devil")。ただし no-gaps 強制 (全 lense に entry、silent
+  gap 禁止) 自体は security 専用でなく、`<content_root>/devil/lenses/*.yaml`
+  の extension lense で judgment 軸にも転用できる (#134 G、ComposedLenseCatalog)
 - **ctx** — session 跨ぎの fact accumulation (alpha, phase 1 は `record` のみ)
 
 Clean Architecture: **Domain → Application → Infrastructure → Interface**

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -710,6 +710,21 @@ Skip devil for:
 - Test-only changes
 - Documentation changes (this PR, for example)
 
+### Extending instead of skipping (#134 G)
+
+The skip-spam problem above is a property of forcing a
+non-security review through the **bundled** 12-lense catalog.
+If you genuinely want devil's no-gaps coercion on a judgment
+axis (correctness, architecture, LDD/user-impact), don't fill
+9 security lenses with `n/a` — author a content_root extension
+lense instead. Drop `<content_root>/devil/lenses/correctness.yaml`
+(see devil's README "Extending the catalog"), then `devil open
+--type system` and fill *that* lense with zero skip noise. The
+coverage gate then raises the floor on judgment, which is what
+you wanted devil for. The "use gate review instead" advice still
+holds when you don't need the no-gaps floor — extension is for
+when you specifically do.
+
 ---
 
 ## Tips for AI agents

--- a/src/passages/devil/README.md
+++ b/src/passages/devil/README.md
@@ -152,6 +152,40 @@ Four devil-specific lenses extend the catalog:
   Surfaced as a methodology gap and promoted to a first-class
   lense so the audit posture itself is auditable.
 
+### Extending the catalog per content_root (#134 G)
+
+The 12 bundled lenses are security-shaped, but the
+coverage-gate machinery (every lense needs an entry before
+`conclude`; silent gaps forbidden) is not security-specific —
+it is a general no-gaps coercion. To apply that coercion to a
+**non-security review axis**, drop one YAML file per extension
+lense under `<content_root>/devil/lenses/<name>.yaml`:
+
+```yaml
+# <content_root>/devil/lenses/correctness.yaml
+name: correctness
+title: Correctness (judgment-axis)
+description: >-
+  Does the change do what it claims, for the cases that matter?
+  Logic errors, off-by-one, wrong default, broken invariant.
+ingest_sources: []
+examples:
+  - "guard checks is_set but consumer needs full completeness"
+```
+
+`ComposedLenseCatalog` (wired in `interface/container.ts`)
+merges these over the bundled defaults at startup, pins
+`source: extension` provenance on each, and **hard-errors at
+load** if an extension name collides with a bundled one
+(`LenseCollision` — extend-only, so old review records stay
+unambiguous). A `devil open --type system` review can then
+fill `correctness` (or any judgment lense you author) with no
+`skip` noise — the no-gaps floor now guards judgment, not only
+security. This is the configured-escape-hatch the playbook's
+"When NOT to use devil" warning points at: the warning is about
+skip-spam when you force a judgment review through the *bundled*
+catalog; an extension catalog removes the spam.
+
 ## Persona catalog (v1, 6 personas)
 
 Three hand-rolled (a reviewer can pick by hand):


### PR DESCRIPTION
## What

The `ComposedLenseCatalog` override path (`<content_root>/devil/lenses/<name>.yaml`, merged over bundled defaults at startup, wired in `interface/container.ts`) was shipped and wired (#134 G) but **undocumented** — every doc still framed devil as security-only.

Dogfooded the path for real before writing: authored a `correctness.yaml` extension lense, opened a `devil open --type system` review, and filled the lense with zero skip-spam. The override path works end to end.

## Changes (docs-only)

- **`src/passages/devil/README.md`** — new *Extending the catalog per content_root* section with a YAML example and the `LenseCollision` extend-only policy.
- **`docs/playbook.md`** (When NOT to use devil) — new *Extending instead of skipping* subsection: the skip-spam warning is about the **bundled** catalog; an extension catalog removes the spam.
- **`CLAUDE.md`** — corrected the devil one-liner that mislabeled gate's review lenses (devil/layer/cognitive/user) as devil's catalog and called devil security-only.

## Why it matters

devil's essence is the **no-gaps coercion** (every lense needs an entry before conclude; silent gaps forbidden), not the security content. The extension path lets that coercion guard judgment axes too — the docs now say so.
