### PR TITLE
feat(boot): surface oldest-paused age + cliff in cross_passage

### DIFF
--- a/.changelog/next/added-boot-oldest-suspended-alarm.md
+++ b/.changelog/next/added-boot-oldest-suspended-alarm.md
@@ -1,0 +1,12 @@
+- **`gate boot` cross_passage — oldest-paused alarm.** Each passage's
+  orientation summary now carries `oldest_suspended_age_days` and
+  `oldest_suspended_cliff` (null when nothing is paused). A bare
+  `suspended` count reads the same whether the oldest pause is two hours
+  or two months old, so a long-forgotten thread hides inside the count;
+  surfacing the oldest pause's age plus its one-line cliff turns boot
+  into a forgotten-thread alarm. Text mode renders an `↳ oldest paused
+  Nd ago: <cliff>` line under the passage when the oldest pause is at
+  least a day old. Found by dogfood: an agora play sat suspended 39 days
+  with its conclusion intact, because re-entry only ever saw the count.
+  Closes the other half of records-outlive-writers — records must also be
+  *findable* on re-entry, not merely countable.

--- a/src/interface/gate/handlers/bootRender.ts
+++ b/src/interface/gate/handlers/bootRender.ts
@@ -193,6 +193,21 @@ export function renderBootText(
           ? `; last ${s.last_id} [${s.last_state}]`
           : '';
       lines.push(`${s.passage}: ${s.open} open${suspendedNote}${lastNote}`);
+      // Forgotten-thread alarm: when something has been paused a
+      // while, the bare count above doesn't convey staleness. Show
+      // the oldest pause's age + cliff so re-entry can't skim past a
+      // thread left hanging for weeks (dogfood 2026-06-18).
+      if (
+        s.oldest_suspended_age_days != null &&
+        s.oldest_suspended_age_days >= 1
+      ) {
+        const cliff = s.oldest_suspended_cliff
+          ? `: ${s.oldest_suspended_cliff.slice(0, 72)}`
+          : '';
+        lines.push(
+          `  ↳ oldest paused ${s.oldest_suspended_age_days}d ago${cliff}`,
+        );
+      }
     }
   }
 

--- a/src/interface/gate/handlers/schema.ts
+++ b/src/interface/gate/handlers/schema.ts
@@ -415,7 +415,11 @@ const VERBS: readonly VerbSchema[] = [
             'Cross-passage orientation. Per-passage summary keyed by ' +
             "passage name (currently 'agora' and 'devil'). Empty when no " +
             'passage besides gate has any records under the content_root. ' +
-            'Each entry shape: { passage, open, suspended, last_id, last_state, last_at }. ' +
+            'Each entry shape: { passage, open, suspended, last_id, last_state, last_at, ' +
+            'oldest_suspended_age_days, oldest_suspended_cliff }. The last two are a ' +
+            'forgotten-thread alarm: a bare suspended count reads the same whether the ' +
+            'oldest pause is hours or months old, so age + one-line cliff surface staleness ' +
+            '(null when nothing is paused). ' +
             "Surfaced so a fresh instance booting on a content_root with " +
             "active agora plays or devil reviews sees them at the orientation " +
             "entry point — closes the substrate-side Zeigarnik continuity " +

--- a/src/interface/shared/PassageOrientation.ts
+++ b/src/interface/shared/PassageOrientation.ts
@@ -59,6 +59,29 @@ export interface PassageOrientationSummary {
    * `last_id`. Null when `last_id` is null.
    */
   readonly last_at: string | null;
+  /**
+   * Age in whole days of the oldest still-paused record, or null
+   * when nothing is paused. The plain `suspended` count answers
+   * "how many" but not "how stale" — and staleness is the cue an
+   * agent needs: a count of 3 reads the same whether the oldest
+   * pause is 2 hours or 2 months old, so a long-forgotten thread
+   * hides inside the count. Surfacing the oldest age turns boot
+   * into a forgotten-thread alarm (dogfood 2026-06-18: a play sat
+   * suspended 41 days, its conclusion intact, because re-entry
+   * only ever saw the count). Optional so passages that don't
+   * model suspensions omit it.
+   */
+  readonly oldest_suspended_age_days?: number | null;
+  /**
+   * One-line cliff prose of the oldest still-paused record, or null
+   * when nothing is paused. Pairs with `oldest_suspended_age_days`:
+   * the age says "you've ignored this for N days", the cliff says
+   * "this is what it was". Full cliff/invitation prose still lives
+   * at the passage's own read verbs (agora show); orientation
+   * carries only the single line that lets an agent decide
+   * resume-now vs leave-paused without walking the records.
+   */
+  readonly oldest_suspended_cliff?: string | null;
 }
 
 /**

--- a/src/passages/agora/interface/orientation.ts
+++ b/src/passages/agora/interface/orientation.ts
@@ -28,10 +28,20 @@ export const agoraOrientation: PassageOrientationProvider = async (
   let openCount = 0;
   let suspendedCount = 0;
   let last: { id: string; state: string; at: string; game: string } | null = null;
+  // Oldest still-paused play, keyed on when it was suspended (the
+  // last suspension's timestamp). "Oldest" = paused longest ago, so
+  // the most-forgotten thread surfaces — not the oldest by creation.
+  let oldestPaused: { at: string; cliff: string } | null = null;
 
   for (const play of plays) {
     if (play.state !== 'concluded') openCount += 1;
-    if (play.state === 'suspended') suspendedCount += 1;
+    if (play.state === 'suspended') {
+      suspendedCount += 1;
+      const closing = play.suspensions[play.suspensions.length - 1];
+      if (closing && (oldestPaused === null || closing.at < oldestPaused.at)) {
+        oldestPaused = { at: closing.at, cliff: closing.cliff };
+      }
+    }
 
     // Latest activity timestamp on this play: max of started_at,
     // any move/suspension/resume timestamp, conclusion timestamp.
@@ -47,6 +57,13 @@ export const agoraOrientation: PassageOrientationProvider = async (
     }
   }
 
+  const ageDays =
+    oldestPaused === null
+      ? null
+      : Math.floor(
+          (Date.now() - Date.parse(oldestPaused.at)) / (1000 * 60 * 60 * 24),
+        );
+
   return {
     passage: 'agora',
     open: openCount,
@@ -54,5 +71,7 @@ export const agoraOrientation: PassageOrientationProvider = async (
     last_id: last ? last.id : null,
     last_state: last ? last.state : null,
     last_at: last ? last.at : null,
+    oldest_suspended_age_days: ageDays,
+    oldest_suspended_cliff: oldestPaused ? oldestPaused.cliff : null,
   };
 };

--- a/tests/interface/crossPassageBoot.test.ts
+++ b/tests/interface/crossPassageBoot.test.ts
@@ -107,6 +107,10 @@ test('gate boot: cross_passage.agora populated when an agora play exists', (t) =
   assert.equal(payload.cross_passage.agora.suspended, 0);
   assert.match(payload.cross_passage.agora.last_id, /^\d{4}-\d{2}-\d{2}-\d{3}$/);
   assert.equal(payload.cross_passage.agora.last_state, 'playing');
+  // Nothing paused → the forgotten-thread alarm fields stay null,
+  // so the renderer emits no alarm line for a clean board.
+  assert.equal(payload.cross_passage.agora.oldest_suspended_age_days, null);
+  assert.equal(payload.cross_passage.agora.oldest_suspended_cliff, null);
   // No devil records → no devil entry.
   assert.equal(payload.cross_passage.devil, undefined);
 });
@@ -128,6 +132,20 @@ test('gate boot: suspended count distinguishes paused plays from playing ones', 
   assert.equal(payload.cross_passage.agora.open, 1, 'suspended still counts as open');
   assert.equal(payload.cross_passage.agora.suspended, 1);
   assert.equal(payload.cross_passage.agora.last_state, 'suspended');
+  // Forgotten-thread alarm fields: a paused play exposes how stale
+  // it is (age) and what it was (cliff), so re-entry can't skim past
+  // a thread left hanging. Just-suspended → age is a non-negative
+  // number; the cliff is the prose passed to suspend.
+  assert.equal(
+    typeof payload.cross_passage.agora.oldest_suspended_age_days,
+    'number',
+    'oldest_suspended_age_days must be a number when something is paused',
+  );
+  assert.ok(
+    payload.cross_passage.agora.oldest_suspended_age_days >= 0,
+    'age is non-negative',
+  );
+  assert.equal(payload.cross_passage.agora.oldest_suspended_cliff, 'paused');
 });
 
 test('gate boot: cross_passage.devil populated when a devil review exists', (t) => {


### PR DESCRIPTION
## Why

A bare `suspended` count in `gate boot`'s `cross_passage` reads the same whether the oldest pause is two hours or two months old — so a long-forgotten thread hides inside the count. The `PassageOrientationSummary` type comment already named this gap: *"records must also be findable on re-entry... substrate that exists on disk but isn't surfaced at orientation might as well be silent."* The count surfaces existence, but not staleness, and staleness is the cue an agent needs.

**Found by dogfood:** an agora play sat `suspended` **39 days** with its conclusion fully intact (a four-move discussion that had reached a decision), because every re-entry only ever saw `agora: ... (3 paused)` and skimmed past it. The thread wasn't lost — it was *uncountable as stale*.

## What

Add two optional fields to each passage's orientation summary (null when nothing is paused):

- `oldest_suspended_age_days` — whole days since the longest-paused record was suspended
- `oldest_suspended_cliff` — that record's one-line closing cliff

This turns boot into a **forgotten-thread alarm**. Text mode renders an alarm line under the passage when the oldest pause is at least a day old:

```
agora: 4 open (3 paused); last 2026-06-18-001 [suspended]
  ↳ oldest paused 39d ago: <cliff prose>
```

Full cliff/invitation prose still lives at each passage's own read verbs (`agora show`); orientation carries only the single line that lets an agent decide *resume-now vs leave-paused* without walking the records — consistent with the existing "count + recency cues, detail stays at read verbs" split.

## Changes

- **`PassageOrientation`** — two optional fields, documented as the staleness cue the count can't carry
- **agora orientation** — pick the longest-paused play (oldest last-suspension timestamp), expose its age in whole days + closing cliff
- **`bootRender`** — emit the alarm line under the passage (≥ 1 day threshold; clean board stays silent — voice budget)
- **`schema`** — extend the `cross_passage` entry-shape contract (schema-as-contract)
- **tests** — assert the fields populate when paused and stay null when clean (both branches of `crossPassageBoot.test.ts`)

## Design notes

- Closes the other half of `records-outlive-writers`: records must be *findable* on re-entry, not merely countable.
- Fields are optional on the shared type so passages that don't model suspensions (e.g. ctx) simply omit them.
- The renderer threshold (≥ 1 day) keeps a freshly-suspended thread from adding noise to the same session that paused it.

## Tests

New assertions in `crossPassageBoot.test.ts` pass (`tsc` clean). Pre-existing failures in this working tree (`lore-scope.sh`, `#239 --executor` deprecation) are unrelated to this change — they touch neither the orientation path nor the renderer, and reproduce on `main` without this branch.