### PR TITLE
feat(changelog-release): release 時に manifest version を同期 + タグ規約明文化 (#441/#442 follow-up)

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -60,13 +60,27 @@ Wrap prose at ~72 cols, matching the rest of `CHANGELOG.md`.
 
 A maintainer:
 
-1. Runs `node scripts/changelog-release.mjs <version>` (or does it
-   by hand) — collects all fragments under `.changelog/next/`, groups
-   by category, and prepends a `## [<version>] - <date>` block to
-   `CHANGELOG.md`.
-2. Deletes the fragment files under `.changelog/next/` (release
-   script does this).
-3. Commits both edits together.
+1. Runs `node scripts/changelog-release.mjs <version>` (or
+   `npm run changelog:release -- <version>`). The script, in one step:
+   - collects all fragments under `.changelog/next/`, groups by
+     category, and prepends a `## [<version>] - <date>` block to
+     `CHANGELOG.md`;
+   - **bumps the `version` field in `package.json` and
+     `package-lock.json`** (root + `packages[""]`) to `<version>`, so
+     they never drift from the release (CI has a version-drift guard
+     that fails the build otherwise — the trap that surfaced in the
+     0.7.0 dogfood, #441/#442);
+   - deletes the collected fragment files under `.changelog/next/`.
+   It **refuses to run** if `next/` holds a file with an unrecognized
+   category (see the filename convention above).
+2. Commits all edits together (`CHANGELOG.md`, `package.json`,
+   `package-lock.json`, removed fragments).
+3. Tags the release commit: **`git tag -a v<version> -m "guild-cli
+   <version>"` then `git push origin v<version>`**. Tags are annotated
+   and `v`-prefixed (`v0.6.0`, `v0.7.0`), one per release.
+
+`npm run changelog:preview -- <version>` (a `--dry-run`) prints the
+block and the would-bump note without writing anything.
 
 The `[Unreleased]` block in `CHANGELOG.md` becomes a placeholder
 that points readers at this directory — it is no longer where

--- a/.changelog/next/changed-changelog-release-bumps-manifest-version.md
+++ b/.changelog/next/changed-changelog-release-bumps-manifest-version.md
@@ -1,0 +1,11 @@
+- **`changelog-release` now also bumps the `version` field in
+  `package.json` and `package-lock.json` (root + `packages[""]`) to the
+  release version**, in the same step that rewrites `CHANGELOG.md`.
+  Previously the script only touched the changelog, so a release had to
+  remember to bump the manifests by hand — and the 0.7.0 release didn't,
+  leaving `package-lock.json` at `0.6.0` until CI's version-drift guard
+  caught it (#442). The bump is a byte-stable text replacement (only the
+  version line(s) move), and `--dry-run`/`changelog:preview` reports the
+  would-bump without writing. `.changelog/README.md` documents the new
+  release step and the annotated `vX.Y.Z` tag convention. (#441/#442
+  follow-up.)

--- a/scripts/changelog-release.mjs
+++ b/scripts/changelog-release.mjs
@@ -30,6 +30,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(here, '..');
 const FRAG_DIR = join(ROOT, '.changelog', 'next');
 const CHANGELOG = join(ROOT, 'CHANGELOG.md');
+const PKG = join(ROOT, 'package.json');
+const LOCK = join(ROOT, 'package-lock.json');
 
 const CATEGORY_ORDER = [
   'breaking',
@@ -165,6 +167,43 @@ function rewriteChangelog(text, newBlock) {
   return before + placeholder + folded + rest;
 }
 
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Sync the `version` field(s) in package.json / package-lock.json to the
+// release version. Targeted text replacement (not JSON re-serialize) keeps
+// the byte layout stable — only the version line(s) move. Without this the
+// manifests drift from CHANGELOG and CI's version-drift guard fails the
+// release (the trap that surfaced in the 0.7.0 dogfood, #441/#442).
+function bumpManifestVersion(path, version, { isLock = false } = {}) {
+  const raw = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(raw);
+  const rootOld = parsed.version;
+  const lockOld = isLock ? (parsed.packages?.['']?.version ?? rootOld) : rootOld;
+  let next = raw;
+  // Top-level "version" — 2-space indent in npm manifests; the only
+  // 2-space `"version"` key in either file, so first-match is the root.
+  next = next.replace(
+    new RegExp(`(\\n  "version": ")${escapeRe(rootOld)}(",)`),
+    `$1${version}$2`,
+  );
+  if (isLock) {
+    // packages[""].version — 6-space indent; "" is the first packages
+    // entry, so the first 6-space match is the self-version.
+    next = next.replace(
+      new RegExp(`(\\n      "version": ")${escapeRe(lockOld)}(",)`),
+      `$1${version}$2`,
+    );
+  }
+  if (next === raw) {
+    if (rootOld === version) return false; // already at target
+    throw new Error(`could not locate version field to bump in ${path}`);
+  }
+  writeFileSync(path, next);
+  return true;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
@@ -209,11 +248,22 @@ function main() {
   const newBlock = buildNewBlock(version, byCategory);
   if (dryRun) {
     process.stdout.write(newBlock);
+    process.stderr.write(
+      `\n(dry-run: would set package.json + package-lock.json version to ` +
+        `${version})\n`,
+    );
     return;
   }
   const original = readFileSync(CHANGELOG, 'utf8');
   const next = rewriteChangelog(original, newBlock);
   writeFileSync(CHANGELOG, next);
+  // Keep the manifests in lockstep with the release so CI's version-drift
+  // guard stays green (see bumpManifestVersion).
+  bumpManifestVersion(PKG, version);
+  bumpManifestVersion(LOCK, version, { isLock: true });
+  process.stderr.write(
+    `Set package.json + package-lock.json version to ${version}.\n`,
+  );
   for (const f of files) {
     try {
       unlinkSync(f);


### PR DESCRIPTION
## なぜ

#442 の 0.7.0 dogfood で、release 手順が `package.json` を bump しても
`package-lock.json` を同期せず、CI の version-drift guard が落ちた。真因は
**release script が CHANGELOG しか書き換えない**こと——version bump は手作業
任せで、抜けが構造的に起こりうる状態だった。

## 何を

- **`bumpManifestVersion`** を追加。`changelog-release` が CHANGELOG 折込と
  同じ一手で `package.json` と `package-lock.json`（root + `packages[""]`）の
  `version` を release version に同期する。**byte-stable な text 置換**で
  version 行だけを動かす（JSON 再シリアライズしない＝差分最小）。
  - `--dry-run`/`changelog:preview` は would-bump を表示するのみ（無書込）。
- **`.changelog/README.md`** の release 手順を更新し、**annotated な
  `vX.Y.Z` タグ規約（1 release 1 tag）**を明文化。

## 検証

- dry-run preview: 正常終了 + would-bump note 表示。
- bump の byte-stability: 実 manifest のコピーに適用し、**diff は version 行
  のみ**（package.json 1 行 / package-lock 2 行）。bump 後に version-drift
  guard 相当チェックが consistent を返すことを確認。

## 補足（環境制約・要 follow-up）

- **v0.7.0 タグはこの実行環境からは push できなかった**。git proxy が
  `refs/tags/*` の push を一律に弾く（branch ref は通る、annotated/lightweight
  とも `send-pack: unexpected disconnect`）。GitHub MCP にもタグ/release 作成
  tool が無い。→ **v0.7.0 タグは tag-push 可能な環境 or GitHub UI から手動で
  打つ必要がある**（規約は本 PR で確定済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFvSe4z4aD7qZxPvJuWC72)_