### PR TITLE
feat(ctx): phase-2 supersede — correct an immutable fact via forward link

### DIFF
--- a/.changelog/next/added-ctx-supersede.md
+++ b/.changelog/next/added-ctx-supersede.md
@@ -1,0 +1,16 @@
+- **`ctx supersede <old-id> --fact "..."` — the first phase-2 ctx verb.**
+  ctx records are immutable on save, so a correction is not an in-place
+  edit: `supersede` records a **new** fact whose `supersedes` field points
+  back at the one it replaces. The old record is never mutated, so the
+  ledger keeps both and the supersession is reconstructable from the
+  forward-only link alone. `ctx list` now folds superseded facts out by
+  default (showing the current head of each chain) and gains `--all` to
+  keep every fact, marking the superseded ones; `ctx show <old-id>` stays
+  readable and resolves the reverse `superseded_by` link at read time. A
+  chain is allowed (C supersedes B supersedes A) and stays acyclic — every
+  link points strictly backward to an id that already existed, and the
+  domain rejects a self-supersession outright. Superseding an id with no
+  record is a recoverable not-found (a correction must point at something
+  real). The `supersedes` key is omitted from an ordinary record's YAML, so
+  phase-1 records round-trip byte-for-byte. Remaining phase-2 verbs: `fork`
+  / `chain` / `status`.

--- a/.changelog/next/added-ctx-supersede.md
+++ b/.changelog/next/added-ctx-supersede.md
@@ -6,11 +6,15 @@
   forward-only link alone. `ctx list` now folds superseded facts out by
   default (showing the current head of each chain) and gains `--all` to
   keep every fact, marking the superseded ones; `ctx show <old-id>` stays
-  readable and resolves the reverse `superseded_by` link at read time. A
-  chain is allowed (C supersedes B supersedes A) and stays acyclic — every
-  link points strictly backward to an id that already existed, and the
-  domain rejects a self-supersession outright. Superseding an id with no
-  record is a recoverable not-found (a correction must point at something
-  real). The `supersedes` key is omitted from an ordinary record's YAML, so
-  phase-1 records round-trip byte-for-byte. Remaining phase-2 verbs: `fork`
-  / `chain` / `status`.
+  readable and resolves the reverse link at read time as `superseded_by`, an
+  **array** of successor ids (empty while current, more than one when two
+  independent corrections fork the same fact — both are reported rather than
+  silently picking one). A chain is allowed (C supersedes B supersedes A)
+  and stays acyclic — every link points strictly backward to an id that
+  already existed, and the domain rejects a self-supersession outright;
+  since the newest fact can never be superseded, a non-empty store always
+  keeps at least one current head. Superseding an id with no record is a
+  recoverable not-found (a correction must point at something real). The
+  `supersedes` key is omitted from an ordinary record's YAML, so phase-1
+  records round-trip byte-for-byte. Remaining phase-2 verbs: `fork` /
+  `chain` / `status`.

--- a/AGENT.md
+++ b/AGENT.md
@@ -587,11 +587,12 @@ prose at different layers without absorbing into one another.
 Shipped: `ctx record`, the correction verb `ctx supersede` (a correction
 is a *new* fact whose `supersedes` points back at the old one — the old
 record is never mutated; `ctx list` folds it out by default, `--all` keeps
-it marked, `ctx show <old-id>` resolves the reverse `superseded_by` link),
-the read-side `list` / `show`, and the OKF interop pair (`export` /
-`import`, below). The remaining lifecycle verbs (`fork` / `chain` /
-`status`) and schema extensions (`evidence` / `sub_of` / `chain_after` /
-`branch_ref`) land in phase 2.
+it marked, `ctx show <old-id>` resolves the reverse `superseded_by` link as
+an **array** of successor ids — empty while current, more than one when two
+corrections fork the same fact), the read-side `list` / `show`, and the OKF
+interop pair (`export` / `import`, below). The remaining lifecycle verbs
+(`fork` / `chain` / `status`) and schema extensions (`evidence` / `sub_of`
+/ `chain_after` / `branch_ref`) land in phase 2.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]

--- a/AGENT.md
+++ b/AGENT.md
@@ -570,7 +570,7 @@ findings / SCG verdict output into devil's strict v0 ingest JSON
 shapes are out of scope for the in-tree passage and would land as
 separate utilities (or in the source tools themselves).
 
-## ctx (fourth passage — fact accumulation, alpha phase 1)
+## ctx (fourth passage — fact accumulation, alpha phase 2)
 
 `ctx` is the fourth passage under guild — alongside `gate`, `agora`,
 and `devil`. Where gate carries decisions, agora carries narrative,
@@ -584,11 +584,14 @@ substrate primitive for facts; surrounding ecosystem modules
 (persona-side `*_resume.md`, code comments, ADR docs) hold related
 prose at different layers without absorbing into one another.
 
-Phase 1 ships `ctx record`, the read-side `list` / `show`, and the OKF
-interop pair (`export` / `import`, below). The remaining lifecycle verbs
-(`fork` / `supersede` / `chain` / `status`) and schema extensions
-(`evidence` / `supersedes` / `sub_of` / `chain_after` / `branch_ref`)
-land in phase 2.
+Shipped: `ctx record`, the correction verb `ctx supersede` (a correction
+is a *new* fact whose `supersedes` points back at the old one — the old
+record is never mutated; `ctx list` folds it out by default, `--all` keeps
+it marked, `ctx show <old-id>` resolves the reverse `superseded_by` link),
+the read-side `list` / `show`, and the OKF interop pair (`export` /
+`import`, below). The remaining lifecycle verbs (`fork` / `chain` /
+`status`) and schema extensions (`evidence` / `sub_of` / `chain_after` /
+`branch_ref`) land in phase 2.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
@@ -662,10 +665,11 @@ thought-in-motion across sessions, use `agora play`. If it's a
 finding that needs adversarial scrutiny, use `devil entry`. ctx is
 for what remains: pinned observation, no closure required.
 
-Status: alpha phase 1. Read-side is `ctx list` (newest-first, `--tag` /
-`--by` filters) + `ctx show <id>`, plus `ctx export` (OKF projection).
-`ctx chain` arrives in phase 2 and that's the design test (junk-drawer
-risk vs principled substrate at the 100-record scale).
+Status: alpha, phase 2 in progress. Write-side is `ctx record` +
+`ctx supersede`; read-side is `ctx list` (newest-first, `--tag` / `--by` /
+`--all` filters) + `ctx show <id>`, plus `ctx export` (OKF projection).
+`ctx chain` still arrives in phase 2 and that's the design test
+(junk-drawer risk vs principled substrate at the 100-record scale).
 
 # Tier: Diagnostic
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1670,12 +1670,26 @@ is never touched, so the ledger keeps both and the supersession is
 reconstructable from the link alone. `ctx list` folds the superseded fact
 out by default (showing the current head of each chain); `ctx list --all`
 keeps every fact, marking the superseded ones, and `ctx show <old-id>`
-stays readable and resolves the reverse `superseded_by` link at read time.
+stays readable and resolves the reverse link at read time.
+
+`ctx show` reports that reverse link as `superseded_by`, **an array of
+ids** (JSON) — empty while the fact is current, and possibly more than one:
+nothing forbids two independent corrections of the same fact, so a fork (A
+superseded by both B and C) is legal and both successors are reported
+rather than silently picking one. Both forks are current heads in the
+default `list`. The reverse link is derived at read time by scanning the
+substrate (the flat per-file layout has no reverse index in phase 2), which
+is fine at the alpha record scale; a persisted index is the planned remedy
+if `chain` pushes the substrate past the junk-drawer threshold.
+
 A chain is allowed (C supersedes B supersedes A): every link points
 strictly backward to an id that already existed, so no cycle can form (the
-domain also rejects a self-supersession outright). Superseding an id that
-has no record is a recoverable not-found — a correction must point at
-something real, so a dangling link is refused rather than written.
+domain also rejects a self-supersession outright). And because the newest
+fact can never be superseded — nothing is written after it to point back —
+a non-empty store always has at least one current head; an empty default
+list means the store is genuinely empty. Superseding an id that has no
+record is a recoverable not-found — a correction must point at something
+real, so a dangling link is refused rather than written.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -1624,7 +1624,7 @@ outside the in-tree passage.
 For substrate paths and the persona/lense schema reference, see
 the `## devil-review` section of [`AGENT.md`](../AGENT.md).
 
-## ctx — the fourth passage (alpha phase 1)
+## ctx — the fourth passage (alpha, phase 2: + supersede)
 
 `ctx` is the fourth passage under guild, alongside `gate`, `agora`,
 and `devil`. Where gate carries decisions, agora carries narrative,
@@ -1646,13 +1646,36 @@ that don't fit into a verdict, a play, or a review.
   ripe for `lore/`, cross-session knowledge a future instance
   should be able to grep with `created_by:` intact.
 
-### Phase 1 surface
+### Surface
 
-Phase 1 ships `ctx record`, the read-side `list` / `show`, and the OKF
-interop pair (`export` / `import`, below). The remaining lifecycle verbs
-(`fork` / `supersede` / `chain` / `status`) and schema extensions
-(`evidence` / `supersedes` / `sub_of` / `chain_after` / `branch_ref`)
-land in phase 2.
+Shipped: `ctx record`, the correction verb `ctx supersede`, the read-side
+`list` / `show`, and the OKF interop pair (`export` / `import`, below).
+The remaining lifecycle verbs (`fork` / `chain` / `status`) and schema
+extensions (`evidence` / `sub_of` / `chain_after` / `branch_ref`) land in
+phase 2.
+
+#### `ctx supersede` — correct an immutable fact
+
+ctx records are immutable on save, so a "correction" is not an in-place
+edit — it is a **new** fact whose `supersedes` field points back at the
+one it replaces:
+
+```bash
+ctx supersede <old-id> --fact "<corrected prose>" [--tag prefix:value]
+              [--by <m>] [--format json|text]
+```
+
+The forward-only link lives on the new (correcting) fact; the old record
+is never touched, so the ledger keeps both and the supersession is
+reconstructable from the link alone. `ctx list` folds the superseded fact
+out by default (showing the current head of each chain); `ctx list --all`
+keeps every fact, marking the superseded ones, and `ctx show <old-id>`
+stays readable and resolves the reverse `superseded_by` link at read time.
+A chain is allowed (C supersedes B supersedes A): every link points
+strictly backward to an id that already existed, so no cycle can form (the
+domain also rejects a self-supersession outright). Superseding an id that
+has no record is a recoverable not-found — a correction must point at
+something real, so a dangling link is refused rather than written.
 
 ```bash
 ctx record --fact "<prose>" [--tag prefix:value,prefix:value]
@@ -1775,12 +1798,13 @@ intentional — dedup is a cheap exact-prose guard, not a similarity model.
 selects the bundle format (only `okf` today — the flag is the seam for a
 future second format).
 
-### Status (alpha phase 1)
+### Status (alpha, phase 2 in progress)
 
-Read-side is `ctx list` (newest-first, `--tag` / `--by` filters) +
-`ctx show <id>`, plus `ctx export` (OKF projection). `ctx chain` (phase
-2) is the remaining design test — whether the substrate stays principled
-or drifts into a junk drawer at the 100-record scale.
+Write-side is `ctx record` + `ctx supersede` (corrections as new facts);
+read-side is `ctx list` (newest-first, `--tag` / `--by` / `--all` filters)
++ `ctx show <id>`, plus `ctx export` (OKF projection). `ctx chain` (still
+phase 2) is the remaining design test — whether the substrate stays
+principled or drifts into a junk drawer at the 100-record scale.
 
 For the conceptual framing alongside the other passages, see the
 `## ctx` section of [`AGENT.md`](../AGENT.md).

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -44,18 +44,7 @@ export class CtxUseCases {
     fact: string;
     tags?: readonly string[];
   }): Promise<Ctx> {
-    const now = this.now();
-    const existing = await this.repo.listAllIds();
-    const id = nextCtxId(existing, now);
-    const ctx = Ctx.create({
-      id,
-      created_by: input.by,
-      fact: input.fact,
-      tags: input.tags ?? [],
-      now: () => now,
-    });
-    await this.repo.saveNew(ctx);
-    return ctx;
+    return this.appendFact({ by: input.by, fact: input.fact, tags: input.tags });
   }
 
   /**
@@ -79,10 +68,30 @@ export class CtxUseCases {
     tags?: readonly string[];
   }): Promise<Ctx> {
     const oldId = parseCtxId(input.oldId);
-    const target = await this.repo.findById(oldId);
-    if (target === null) {
+    if ((await this.repo.findById(oldId)) === null) {
       throw new SupersedeTargetMissing(oldId);
     }
+    return this.appendFact({
+      by: input.by,
+      fact: input.fact,
+      tags: input.tags,
+      supersedes: oldId,
+    });
+  }
+
+  /**
+   * Append a new fact to the substrate: allocate the next id for `now`,
+   * build the immutable Ctx, persist it. The single write path shared by
+   * `record` (no link) and `supersede` (a `supersedes` link, validated by
+   * the caller). Keeps id allocation + timestamp authorship consistent
+   * within one write and gives both verbs the same persistence behavior.
+   */
+  private async appendFact(input: {
+    by: string;
+    fact: string;
+    tags: readonly string[] | undefined;
+    supersedes?: string | undefined;
+  }): Promise<Ctx> {
     const now = this.now();
     const existing = await this.repo.listAllIds();
     const id = nextCtxId(existing, now);
@@ -91,7 +100,7 @@ export class CtxUseCases {
       created_by: input.by,
       fact: input.fact,
       tags: input.tags ?? [],
-      supersedes: oldId,
+      supersedes: input.supersedes,
       now: () => now,
     });
     await this.repo.saveNew(ctx);
@@ -126,18 +135,7 @@ export class CtxUseCases {
     if (filter.by !== undefined) {
       out = out.filter((c) => c.created_by === filter.by);
     }
-    // Newest first: created_at desc, id desc as a stable tiebreak.
-    out.sort((a, b) =>
-      a.created_at < b.created_at
-        ? 1
-        : a.created_at > b.created_at
-          ? -1
-          : a.id < b.id
-            ? 1
-            : a.id > b.id
-              ? -1
-              : 0,
-    );
+    out.sort(byNewestFirst);
     return out;
   }
 
@@ -165,19 +163,7 @@ export class CtxUseCases {
    */
   async supersededBy(id: string): Promise<readonly Ctx[]> {
     const all = await this.repo.listAll();
-    const successors = all.filter((c) => c.supersedes === id);
-    // Newest first: created_at desc, id desc as a stable tiebreak (mirrors list()).
-    return [...successors].sort((a, b) =>
-      a.created_at < b.created_at
-        ? 1
-        : a.created_at > b.created_at
-          ? -1
-          : a.id < b.id
-            ? 1
-            : a.id > b.id
-              ? -1
-              : 0,
-    );
+    return all.filter((c) => c.supersedes === id).sort(byNewestFirst);
   }
 
   /**
@@ -335,6 +321,19 @@ export class CtxUseCases {
     }
     return this.bundle;
   }
+}
+
+/**
+ * Order facts newest-first: `created_at` descending, with `id` descending
+ * as a stable tiebreak for same-instant writes (the `ctx-…-NNN` suffix
+ * monotonically increases within a day). The single ordering used by every
+ * read surface (`list`, `supersededBy`), so they stay consistent and a
+ * future verb (e.g. `chain`) can reuse the same comparator.
+ */
+function byNewestFirst(a: Ctx, b: Ctx): number {
+  if (a.created_at !== b.created_at) return a.created_at < b.created_at ? 1 : -1;
+  if (a.id !== b.id) return a.id < b.id ? 1 : -1;
+  return 0;
 }
 
 /**

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -59,11 +59,67 @@ export class CtxUseCases {
   }
 
   /**
+   * Supersede an older fact with a correction. Records a *new* fact whose
+   * `supersedes` points back at `oldId`; the old record is left untouched
+   * (immutable substrate). Throws SupersedeTargetMissing if the target id
+   * has no record — a correction must point at something real, and a
+   * dangling link would silently lose the correction's meaning.
+   *
+   * The domain guards shape + self-loop; existence is checked here because
+   * only the application layer holds a repository. A chain is allowed
+   * (B supersedes A, C supersedes B): each link names exactly one parent,
+   * so the graph stays a forest and `latest` resolution walks it without
+   * cycles — every node points strictly backward to an id that already
+   * existed when it was written, so no cycle can form.
+   */
+  async supersede(input: {
+    oldId: string;
+    by: string;
+    fact: string;
+    tags?: readonly string[];
+  }): Promise<Ctx> {
+    const oldId = parseCtxId(input.oldId);
+    const target = await this.repo.findById(oldId);
+    if (target === null) {
+      throw new SupersedeTargetMissing(oldId);
+    }
+    const now = this.now();
+    const existing = await this.repo.listAllIds();
+    const id = nextCtxId(existing, now);
+    const ctx = Ctx.create({
+      id,
+      created_by: input.by,
+      fact: input.fact,
+      tags: input.tags ?? [],
+      supersedes: oldId,
+      now: () => now,
+    });
+    await this.repo.saveNew(ctx);
+    return ctx;
+  }
+
+  /**
    * List recorded facts, newest first, optionally filtered by an exact
    * tag and/or author. Read-only.
+   *
+   * By default superseded facts are folded out (only the surviving head of
+   * each supersession chain is shown), so the everyday list stays the
+   * current view rather than drifting into a junk drawer. `includeAll`
+   * keeps every fact, superseded ones included, for audit / history.
    */
-  async list(filter: { tag?: string; by?: string } = {}): Promise<readonly Ctx[]> {
-    let out = [...(await this.repo.listAll())];
+  async list(
+    filter: { tag?: string; by?: string; includeAll?: boolean } = {},
+  ): Promise<readonly Ctx[]> {
+    const all = [...(await this.repo.listAll())];
+    // A fact is superseded iff some other fact's `supersedes` names it.
+    const supersededIds = new Set<string>();
+    for (const c of all) {
+      if (c.supersedes !== undefined) supersededIds.add(c.supersedes);
+    }
+    let out = all;
+    if (filter.includeAll !== true) {
+      out = out.filter((c) => !supersededIds.has(c.id));
+    }
     if (filter.tag !== undefined) {
       out = out.filter((c) => c.tags.includes(filter.tag!));
     }
@@ -88,6 +144,20 @@ export class CtxUseCases {
   /** Show a single fact by id, or null if absent. Read-only. */
   async show(id: string): Promise<Ctx | null> {
     return this.repo.findById(id);
+  }
+
+  /**
+   * Find the fact that supersedes `id`, if any — the reverse of the
+   * forward-only `supersedes` link. Read-only; returns null when `id` is
+   * still the current head (nothing corrects it). Used by `show` to mark a
+   * superseded fact with its successor.
+   */
+  async supersededBy(id: string): Promise<Ctx | null> {
+    const all = await this.repo.listAll();
+    for (const c of all) {
+      if (c.supersedes === id) return c;
+    }
+    return null;
   }
 
   /**
@@ -244,6 +314,19 @@ export class CtxUseCases {
       throw new Error('ctx OKF use cases require an OkfBundlePort (wiring bug)');
     }
     return this.bundle;
+  }
+}
+
+/**
+ * Raised when `supersede` targets an id that has no record. A correction
+ * must point at something real; a dangling link would silently strip the
+ * correction of its referent. The interface layer maps this to a
+ * recoverable not-found that names `ctx list` as the recovery path.
+ */
+export class SupersedeTargetMissing extends Error {
+  constructor(public readonly id: string) {
+    super(`ctx supersede target not found: ${id}`);
+    this.name = 'SupersedeTargetMissing';
   }
 }
 

--- a/src/passages/ctx/application/CtxUseCases.ts
+++ b/src/passages/ctx/application/CtxUseCases.ts
@@ -147,17 +147,37 @@ export class CtxUseCases {
   }
 
   /**
-   * Find the fact that supersedes `id`, if any — the reverse of the
-   * forward-only `supersedes` link. Read-only; returns null when `id` is
-   * still the current head (nothing corrects it). Used by `show` to mark a
-   * superseded fact with its successor.
+   * Find every fact that supersedes `id` — the reverse of the forward-only
+   * `supersedes` link. Read-only; returns [] when `id` is still a current
+   * head (nothing corrects it). Used by `show` to mark a superseded fact
+   * with its successor(s).
+   *
+   * Returns a list, not a single fact, because the link is forward-only and
+   * nothing forbids two independent corrections of the same fact (a fork: A
+   * superseded by both B and C). Reporting only the first would silently
+   * hide the second. Newest-first so the most recent correction reads first.
+   *
+   * Cost is one full hydration scan of the substrate, inherent to the flat
+   * per-file layout (no reverse index in phase 2). Fine at the alpha record
+   * scale; if `chain` lands and the substrate grows past the junk-drawer
+   * threshold the docs warn about, a persisted reverse index is the planned
+   * remedy — see the `## ctx` design notes.
    */
-  async supersededBy(id: string): Promise<Ctx | null> {
+  async supersededBy(id: string): Promise<readonly Ctx[]> {
     const all = await this.repo.listAll();
-    for (const c of all) {
-      if (c.supersedes === id) return c;
-    }
-    return null;
+    const successors = all.filter((c) => c.supersedes === id);
+    // Newest first: created_at desc, id desc as a stable tiebreak (mirrors list()).
+    return [...successors].sort((a, b) =>
+      a.created_at < b.created_at
+        ? 1
+        : a.created_at > b.created_at
+          ? -1
+          : a.id < b.id
+            ? 1
+            : a.id > b.id
+              ? -1
+              : 0,
+    );
   }
 
   /**

--- a/src/passages/ctx/domain/Ctx.ts
+++ b/src/passages/ctx/domain/Ctx.ts
@@ -6,8 +6,12 @@
 //
 // Phase 1 ships the minimum: id, attribution, the fact prose, and
 // optional prefix-tagged labels (e.g. `tech:typescript`, `status:active`).
-// `evidence`, `supersedes`, `sub_of`, `chain_after`, `branch_ref` arrive
-// in phase 2 — see issue tracker.
+// Phase 2 begins with `supersedes` — a forward-only link to the older
+// fact this one corrects. The old record is never mutated (immutable on
+// save); the correction is a *new* fact pointing back, so the ledger keeps
+// both and the supersession is reconstructable from the link alone.
+// `evidence`, `sub_of`, `chain_after`, `branch_ref` remain phase-2 work —
+// see issue tracker.
 //
 // AI-first per principle 11:
 //   - immutable on save (re-reading agents must see what was written)
@@ -68,6 +72,10 @@ export interface CtxProps {
   readonly created_by: string; // member or host name
   readonly fact: string;       // non-empty prose
   readonly tags: readonly string[]; // possibly empty; each `prefix:value`
+  // phase-2: forward link to the older fact this corrects. `string | undefined`
+  // (not `?:`) so callers can pass an explicit undefined under
+  // exactOptionalPropertyTypes; toJSON omits it when undefined for byte stability.
+  readonly supersedes: string | undefined;
 }
 
 export class Ctx {
@@ -76,6 +84,14 @@ export class Ctx {
   readonly created_by: string;
   readonly fact: string;
   readonly tags: readonly string[];
+  /**
+   * The id of an older fact this one corrects, or undefined for an
+   * ordinary fact. Forward-only: the *new* (correcting) fact carries the
+   * link; the superseded fact is never mutated. A reader reconstructs the
+   * "superseded_by" direction by scanning for facts whose `supersedes`
+   * names a given id.
+   */
+  readonly supersedes: string | undefined;
 
   private constructor(props: CtxProps) {
     this.id = props.id;
@@ -83,6 +99,7 @@ export class Ctx {
     this.created_by = props.created_by;
     this.fact = props.fact;
     this.tags = props.tags;
+    this.supersedes = props.supersedes;
   }
 
   static create(input: {
@@ -90,6 +107,7 @@ export class Ctx {
     fact: string;
     created_by: string;
     tags?: readonly string[];
+    supersedes?: string;
     now?: () => Date;
   }): Ctx {
     const id = parseCtxId(input.id);
@@ -100,6 +118,7 @@ export class Ctx {
       throw new DomainError('created_by required (non-empty string)', 'created_by');
     }
     const tags = (input.tags ?? []).map((t) => parseCtxTag(t));
+    const supersedes = parseSupersedes(input.supersedes, id);
     const created_at = (input.now ?? (() => new Date()))().toISOString();
     return new Ctx({
       id,
@@ -107,6 +126,7 @@ export class Ctx {
       created_by: input.created_by.trim(),
       fact: input.fact.trim(),
       tags: Object.freeze([...tags]),
+      supersedes,
     });
   }
 
@@ -116,24 +136,45 @@ export class Ctx {
    */
   static restore(input: CtxProps): Ctx {
     const tags = (input.tags ?? []).map((t) => parseCtxTag(t));
+    const id = parseCtxId(input.id);
     return new Ctx({
-      id: parseCtxId(input.id),
+      id,
       created_at: input.created_at,
       created_by: input.created_by,
       fact: input.fact,
       tags: Object.freeze([...tags]),
+      supersedes: parseSupersedes(input.supersedes, id),
     });
   }
 
   toJSON(): Record<string, unknown> {
-    return {
+    const out: Record<string, unknown> = {
       id: this.id,
       created_at: this.created_at,
       created_by: this.created_by,
       fact: this.fact,
       tags: [...this.tags],
     };
+    // byte-stable YAML: omit the link entirely on an ordinary fact, so a
+    // phase-1 record round-trips unchanged and diffs stay minimal.
+    if (this.supersedes !== undefined) out['supersedes'] = this.supersedes;
+    return out;
   }
+}
+
+/**
+ * Validate an optional `supersedes` link: must be a well-formed ctx id and
+ * must not point at the fact's own id (a self-supersession is incoherent —
+ * a fact cannot correct itself). Existence of the target is an application
+ * concern (the domain has no repository); this guards shape + self-loop.
+ */
+function parseSupersedes(raw: unknown, ownId: string): string | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const target = parseCtxId(raw);
+  if (target === ownId) {
+    throw new DomainError('a fact cannot supersede itself', 'supersedes');
+  }
+  return target;
 }
 
 export class CtxIdCollision extends Error {

--- a/src/passages/ctx/domain/Ctx.ts
+++ b/src/passages/ctx/domain/Ctx.ts
@@ -107,7 +107,7 @@ export class Ctx {
     fact: string;
     created_by: string;
     tags?: readonly string[];
-    supersedes?: string;
+    supersedes?: string | undefined;
     now?: () => Date;
   }): Ctx {
     const id = parseCtxId(input.id);

--- a/src/passages/ctx/infrastructure/YamlCtxRepository.ts
+++ b/src/passages/ctx/infrastructure/YamlCtxRepository.ts
@@ -98,6 +98,8 @@ export class YamlCtxRepository implements CtxRepository {
         tags: Array.isArray(obj['tags'])
           ? (obj['tags'] as unknown[]).filter((t): t is string => typeof t === 'string')
           : [],
+        supersedes:
+          typeof obj['supersedes'] === 'string' ? (obj['supersedes'] as string) : undefined,
       });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/passages/ctx/interface/handlers/list.ts
+++ b/src/passages/ctx/interface/handlers/list.ts
@@ -80,17 +80,12 @@ export async function listCtx(
   if (facts.length === 0) {
     if (filtered) {
       process.stdout.write('no ctx facts match the filter.\n');
-    } else if (!includeAll && (await deps.uc.list({ includeAll: true })).length > 0) {
-      // Default view is empty only because every fact is superseded — the
-      // store isn't actually empty. Point at the history rather than the
-      // "record your first fact" prompt (which would be misleading).
-      process.stdout.write(
-        'no current ctx facts.\n' +
-          '  every recorded fact has been superseded — see history: ctx list --all\n',
-      );
     } else {
-      // Genuinely empty store (under --all, or default view with no facts
-      // at all): prompt for the first record.
+      // An empty default view means an empty store: the newest fact can
+      // never be superseded (nothing is written after it to point back at
+      // it), so a non-empty store always keeps at least one current head.
+      // There is therefore no "everything is superseded" state to message —
+      // an empty unfiltered list is genuinely empty, --all or not.
       process.stdout.write(
         'no ctx facts recorded yet.\n' +
           '  record one: ctx record --fact "<prose>" [--tag prefix:value]\n',

--- a/src/passages/ctx/interface/handlers/list.ts
+++ b/src/passages/ctx/interface/handlers/list.ts
@@ -8,7 +8,10 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { parseCtxTag } from '../../domain/Ctx.js';
 
-const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['tag', 'by', 'format']);
+const LIST_KNOWN_FLAGS: ReadonlySet<string> = new Set(['tag', 'by', 'all', 'format']);
+
+/** Boolean flags `ctx list` owns (so the parser doesn't eat a positional). */
+export const LIST_BOOLEAN_FLAGS: ReadonlySet<string> = new Set(['all']);
 
 /** First non-empty, non-heading line of `fact`, collapsed and truncated. */
 function snippet(fact: string, max = 100): string {
@@ -30,11 +33,13 @@ export interface ListCtxDeps {
  * ctx list — read recorded facts back, newest first.
  *
  * Usage:
- *   ctx list [--tag prefix:value] [--by <m>] [--format json|text]
+ *   ctx list [--tag prefix:value] [--by <m>] [--all] [--format json|text]
  *
  * Closes the phase-1 read-side gap surfaced by dogfooding: before this,
  * the only way to read facts back was `grep` over `<content_root>/ctx/`.
- * `--tag` filters by an exact tag (validated at the boundary).
+ * `--tag` filters by an exact tag (validated at the boundary). By default
+ * superseded facts are folded out (current view); `--all` keeps every
+ * fact, superseded ones included, for audit / history.
  */
 export async function listCtx(
   deps: ListCtxDeps,
@@ -46,10 +51,12 @@ export async function listCtx(
   const tag = optionalOption(args, 'tag');
   if (tag !== undefined) parseCtxTag(tag); // validate the filter shape loud
   const by = optionalOption(args, 'by');
+  const includeAll = args.options['all'] === true;
 
-  const filter: { tag?: string; by?: string } = {};
+  const filter: { tag?: string; by?: string; includeAll?: boolean } = {};
   if (tag !== undefined) filter.tag = tag;
   if (by !== undefined) filter.by = by;
+  if (includeAll) filter.includeAll = true;
 
   const facts = await deps.uc.list(filter);
 
@@ -73,7 +80,17 @@ export async function listCtx(
   if (facts.length === 0) {
     if (filtered) {
       process.stdout.write('no ctx facts match the filter.\n');
+    } else if (!includeAll && (await deps.uc.list({ includeAll: true })).length > 0) {
+      // Default view is empty only because every fact is superseded — the
+      // store isn't actually empty. Point at the history rather than the
+      // "record your first fact" prompt (which would be misleading).
+      process.stdout.write(
+        'no current ctx facts.\n' +
+          '  every recorded fact has been superseded — see history: ctx list --all\n',
+      );
     } else {
+      // Genuinely empty store (under --all, or default view with no facts
+      // at all): prompt for the first record.
       process.stdout.write(
         'no ctx facts recorded yet.\n' +
           '  record one: ctx record --fact "<prose>" [--tag prefix:value]\n',
@@ -82,12 +99,26 @@ export async function listCtx(
     return 0;
   }
 
-  const scope = filtered ? ' (filtered)' : '';
+  // With --all, superseded facts are present; mark them so the reader can
+  // tell the current head from a corrected predecessor without a second
+  // call. supersededIds is the set of ids that some shown fact corrects.
+  const supersededIds = new Set<string>();
+  if (includeAll) {
+    for (const f of facts) {
+      if (f.supersedes !== undefined) supersededIds.add(f.supersedes);
+    }
+  }
+
+  const scope = filtered ? ' (filtered)' : includeAll ? ' (all, incl. superseded)' : '';
   process.stdout.write(
     `${facts.length} ctx fact${facts.length === 1 ? '' : 's'}${scope} — newest first\n\n`,
   );
   for (const f of facts) {
-    process.stdout.write(`${f.id}  ${f.created_by}  ${f.created_at.slice(0, 16)}\n`);
+    const mark = supersededIds.has(f.id) ? '  ⊘ superseded' : '';
+    process.stdout.write(`${f.id}  ${f.created_by}  ${f.created_at.slice(0, 16)}${mark}\n`);
+    if (f.supersedes !== undefined) {
+      process.stdout.write(`  ↳ supersedes ${f.supersedes}\n`);
+    }
     if (f.tags.length > 0) {
       process.stdout.write(`  [${f.tags.join(', ')}]\n`);
     }

--- a/src/passages/ctx/interface/handlers/parseTagList.ts
+++ b/src/passages/ctx/interface/handlers/parseTagList.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse `--tag tech:typescript,status:active` (comma-separated) into a
+ * clean tag list. Same convention as gate's `--with` (request.ts:
+ * `parseWithList`). Tag-shape validation happens upstream in
+ * Ctx.create -> parseCtxTag, so this only splits / trims / drops empties.
+ *
+ * Shared by the write handlers (`record`, `supersede`) so the `--tag`
+ * surface is parsed identically across them.
+ */
+export function parseTagList(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/passages/ctx/interface/handlers/record.ts
+++ b/src/passages/ctx/interface/handlers/record.ts
@@ -68,10 +68,10 @@ export async function recordCtx(
           where_written: `${deps.config.contentRoot}/ctx/${ctx.id}.yaml`,
           config_file: deps.config.configFile,
           suggested_next: {
-            verb: 'gate',
-            args: ['boot'],
+            verb: 'ctx',
+            args: ['list'],
             reason:
-              "phase 1 ships record only; show / list / fork / supersede / chain / status arrive in phase 2. Confirm the write landed via filesystem or `gate boot`.",
+              'read the fact back (newest first) to confirm it landed; correct it later with `ctx supersede <id>`. fork / chain / status remain phase-2.',
           },
         },
         null,

--- a/src/passages/ctx/interface/handlers/record.ts
+++ b/src/passages/ctx/interface/handlers/record.ts
@@ -7,6 +7,7 @@ import {
   requireOption,
   rejectUnknownFlags,
 } from '../../../../interface/shared/parseArgs.js';
+import { parseTagList } from './parseTagList.js';
 
 const RECORD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'fact',
@@ -14,20 +15,6 @@ const RECORD_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
   'format',
 ]);
-
-/**
- * Parse `--tag tech:typescript,status:active` (comma-separated) into a
- * clean tag list. Same convention as gate's `--with` (request.ts:
- * `parseWithList`). Tag-shape validation happens upstream in
- * Ctx.create -> parseCtxTag.
- */
-function parseTagList(raw: string | undefined): string[] {
-  if (raw === undefined) return [];
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
 
 export interface RecordCtxDeps {
   readonly uc: CtxUseCases;

--- a/src/passages/ctx/interface/handlers/show.ts
+++ b/src/passages/ctx/interface/handlers/show.ts
@@ -50,9 +50,11 @@ export async function showCtx(
   }
 
   // A superseded fact stays readable (immutable substrate) but is marked
-  // with the fact that corrects it, so a reader who pulls up an old id sees
-  // it has a successor rather than treating it as current.
-  const successor = await deps.uc.supersededBy(id);
+  // with the fact(s) that correct it, so a reader who pulls up an old id
+  // sees it has a successor rather than treating it as current. It can have
+  // more than one successor — two independent corrections fork the link.
+  const successors = await deps.uc.supersededBy(id);
+  const successorIds = successors.map((s) => s.id);
 
   if (format === 'json') {
     process.stdout.write(
@@ -61,8 +63,9 @@ export async function showCtx(
           ok: true,
           ...fact.toJSON(),
           // reverse link, resolved at read time (the substrate stores only
-          // the forward `supersedes`); null when this fact is still current.
-          superseded_by: successor !== null ? successor.id : null,
+          // the forward `supersedes`); empty array when this fact is still
+          // current, multiple ids when corrections forked.
+          superseded_by: successorIds,
         },
         null,
         2,
@@ -76,8 +79,8 @@ export async function showCtx(
   if (fact.supersedes !== undefined) {
     process.stdout.write(`  supersedes: ${fact.supersedes}\n`);
   }
-  if (successor !== null) {
-    process.stdout.write(`  ⊘ superseded by: ${successor.id}\n`);
+  if (successorIds.length > 0) {
+    process.stdout.write(`  ⊘ superseded by: ${successorIds.join(', ')}\n`);
   }
   if (fact.tags.length > 0) {
     process.stdout.write(`  tags: ${fact.tags.join(', ')}\n`);

--- a/src/passages/ctx/interface/handlers/show.ts
+++ b/src/passages/ctx/interface/handlers/show.ts
@@ -49,15 +49,36 @@ export async function showCtx(
     );
   }
 
+  // A superseded fact stays readable (immutable substrate) but is marked
+  // with the fact that corrects it, so a reader who pulls up an old id sees
+  // it has a successor rather than treating it as current.
+  const successor = await deps.uc.supersededBy(id);
+
   if (format === 'json') {
     process.stdout.write(
-      JSON.stringify({ ok: true, ...fact.toJSON() }, null, 2) + '\n',
+      JSON.stringify(
+        {
+          ok: true,
+          ...fact.toJSON(),
+          // reverse link, resolved at read time (the substrate stores only
+          // the forward `supersedes`); null when this fact is still current.
+          superseded_by: successor !== null ? successor.id : null,
+        },
+        null,
+        2,
+      ) + '\n',
     );
     return 0;
   }
 
   process.stdout.write(`${fact.id}\n`);
   process.stdout.write(`  created ${fact.created_at} by ${fact.created_by}\n`);
+  if (fact.supersedes !== undefined) {
+    process.stdout.write(`  supersedes: ${fact.supersedes}\n`);
+  }
+  if (successor !== null) {
+    process.stdout.write(`  ⊘ superseded by: ${successor.id}\n`);
+  }
   if (fact.tags.length > 0) {
     process.stdout.write(`  tags: ${fact.tags.join(', ')}\n`);
   }

--- a/src/passages/ctx/interface/handlers/supersede.ts
+++ b/src/passages/ctx/interface/handlers/supersede.ts
@@ -1,0 +1,110 @@
+import { CtxUseCases, SupersedeTargetMissing } from '../../application/CtxUseCases.js';
+import { GuildConfig } from '../../../../infrastructure/config/GuildConfig.js';
+import { parseFormat } from '../../../../interface/shared/parseFormat.js';
+import {
+  ParsedArgs,
+  optionalOption,
+  requireOption,
+  rejectUnknownFlags,
+} from '../../../../interface/shared/parseArgs.js';
+import { DomainError } from '../../../../domain/shared/DomainError.js';
+import { RecoverableError } from '../../../../interface/shared/errorEnvelope.js';
+
+const SUPERSEDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  'fact',
+  'tag',
+  'by',
+  'format',
+]);
+
+/**
+ * Parse `--tag tech:typescript,status:active` into a clean tag list.
+ * Same convention as record.ts (Ctx.create validates the shape upstream).
+ */
+function parseTagList(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export interface SupersedeCtxDeps {
+  readonly uc: CtxUseCases;
+  readonly config: GuildConfig;
+}
+
+/**
+ * ctx supersede — correct an older fact with a new one.
+ *
+ * Usage:
+ *   ctx supersede <old-id> --fact "<corrected prose>"
+ *                          [--tag tech:foo,status:bar] [--by <m>] [--format json|text]
+ *
+ * Records a *new* fact whose `supersedes` points back at <old-id>. The old
+ * record is never mutated (immutable substrate); `ctx list` folds it out by
+ * default and `ctx list --all` / `ctx show <old-id>` keep it visible, marked
+ * with its successor. A missing <old-id> is a recoverable not-found that
+ * names `ctx list` as the recovery path — a correction must point at
+ * something real, so a dangling link is rejected loudly rather than written.
+ */
+export async function supersedeCtx(
+  deps: SupersedeCtxDeps,
+  args: ParsedArgs,
+): Promise<number> {
+  rejectUnknownFlags(args, SUPERSEDE_KNOWN_FLAGS, 'supersede');
+
+  const oldId = args.positional[0];
+  if (oldId === undefined || oldId.length === 0) {
+    throw new DomainError(
+      'supersede requires the id being corrected (ctx supersede <old-id> --fact "...")',
+      'id',
+    );
+  }
+
+  const fact = requireOption(args, 'fact', '"..."');
+  const tags = parseTagList(optionalOption(args, 'tag'));
+  const by = requireOption(args, 'by', '<m>', 'GUILD_ACTOR');
+  const format = parseFormat(args);
+
+  let ctx;
+  try {
+    ctx = await deps.uc.supersede({ oldId, by, fact, tags });
+  } catch (e) {
+    if (e instanceof SupersedeTargetMissing) {
+      throw new RecoverableError(
+        `ctx supersede target ${e.id} not found.\n` +
+          '  a correction must point at a real fact. list them to find the id:\n' +
+          '    ctx list',
+        { verb: 'list', args: {}, reason: 'list the recorded facts to find the right id' },
+        'not_found',
+      );
+    }
+    throw e;
+  }
+
+  if (format === 'json') {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok: true,
+          id: ctx.id,
+          ...ctx.toJSON(),
+          where_written: `${deps.config.contentRoot}/ctx/${ctx.id}.yaml`,
+          config_file: deps.config.configFile,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  } else {
+    process.stdout.write(`✓ ctx ${ctx.id} supersedes ${oldId}\n`);
+    if (tags.length > 0) {
+      process.stdout.write(`  tags: ${tags.join(', ')}\n`);
+    }
+    process.stderr.write(
+      `notice: wrote ${deps.config.contentRoot}/ctx/${ctx.id}.yaml (config: ${deps.config.configFile})\n`,
+    );
+  }
+  return 0;
+}

--- a/src/passages/ctx/interface/handlers/supersede.ts
+++ b/src/passages/ctx/interface/handlers/supersede.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../../interface/shared/parseArgs.js';
 import { DomainError } from '../../../../domain/shared/DomainError.js';
 import { RecoverableError } from '../../../../interface/shared/errorEnvelope.js';
+import { parseTagList } from './parseTagList.js';
 
 const SUPERSEDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'fact',
@@ -16,18 +17,6 @@ const SUPERSEDE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'by',
   'format',
 ]);
-
-/**
- * Parse `--tag tech:typescript,status:active` into a clean tag list.
- * Same convention as record.ts (Ctx.create validates the shape upstream).
- */
-function parseTagList(raw: string | undefined): string[] {
-  if (raw === undefined) return [];
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
 
 export interface SupersedeCtxDeps {
   readonly uc: CtxUseCases;

--- a/src/passages/ctx/interface/index.ts
+++ b/src/passages/ctx/interface/index.ts
@@ -6,8 +6,8 @@
 // append-only. See lore/principles/12 for the boundary with adjacent
 // modules.
 //
-// Phase 1 ships only `ctx record`. The remaining six verbs (fork /
-// supersede / show / list / chain / status) land iteratively in
+// Surface: record / supersede / list / show + OKF export/import. The
+// remaining lifecycle verbs (fork / chain / status) land iteratively in
 // phase 2 as use surfaces what shape they need.
 //
 // AI-first per principle 11: the substrate is machine-parseable JSON /
@@ -23,13 +23,14 @@ import { buildCtxContainer } from './container.js';
 import { recordCtx } from './handlers/record.js';
 import { exportCtx, EXPORT_BOOLEAN_FLAGS } from './handlers/exportOkf.js';
 import { importCtx, IMPORT_BOOLEAN_FLAGS } from './handlers/importOkf.js';
-import { listCtx } from './handlers/list.js';
+import { listCtx, LIST_BOOLEAN_FLAGS } from './handlers/list.js';
 import { showCtx } from './handlers/show.js';
+import { supersedeCtx } from './handlers/supersede.js';
 import { withEntryLock } from '../../../infrastructure/lock/withEntryLock.js';
 import { resolveGuildActor } from '../../../interface/shared/resolveGuildActor.js';
 import { READ_VERBS, WRITE_VERBS, LOCK_EXEMPT_VERBS } from './verbs.js';
 
-const HELP = `ctx — fact accumulation passage (phase 1: record / list / show + OKF interop)
+const HELP = `ctx — fact accumulation passage (phase 2: + supersede)
 
 Usage:
   ctx record --fact "<prose>" [--tag tech:foo,status:bar]
@@ -38,12 +39,23 @@ Usage:
                               <content_root>/ctx/<id>.yaml. Id is
                               auto-allocated as ctx-YYYY-MM-DD-NNN.
 
-  ctx list                    [--tag prefix:value] [--by <m>] [--format json|text]
-                              Read facts back, newest first. --tag filters
-                              by an exact tag, --by by author.
+  ctx supersede <old-id>      --fact "<corrected prose>"
+                              [--tag prefix:value] [--by <m>] [--format json|text]
+                              Correct an older fact. Records a NEW fact whose
+                              supersedes points back at <old-id>; the old
+                              record is left untouched (immutable). list folds
+                              the superseded one out by default.
+
+  ctx list                    [--tag prefix:value] [--by <m>] [--all]
+                              [--format json|text]
+                              Read facts back, newest first. --tag filters by
+                              an exact tag, --by by author. Superseded facts
+                              are folded out by default; --all keeps them
+                              (marked) for audit / history.
 
   ctx show <id>               [--format json|text]
-                              Show one fact in full.
+                              Show one fact in full. A superseded fact stays
+                              readable, marked with its successor.
 
   ctx export <dir>            [--as okf] [--force] [--format json|text]
                               Project every fact into an Open Knowledge
@@ -66,10 +78,10 @@ Usage:
   ctx --help                   This help.
   ctx --version                Print version and exit.
 
-Phase 1 status: \`record\` / \`list\` / \`show\` plus the OKF interop
+Status: \`record\` / \`supersede\` / \`list\` / \`show\` plus the OKF interop
 pair (\`export\` / \`import\`). OKF is an interchange *projection*
 (principle 11), not a storage change — the substrate stays YAML.
-Phase 2 (separate session): fork / supersede / chain / status.
+Remaining phase-2 verbs: fork / chain / status.
 
 Substrate: shares content_root and members/ with gate; ctx-specific
 data goes under <content_root>/ctx/.
@@ -80,19 +92,18 @@ Lore upstream:
   lore/principles/04-records-outlive-writers.md
 `;
 
-// Mirror of the switch below for did-you-mean suggestions. Phase 1
-// ships record / export / import; a new verb forgotten here loses its
-// typo hint, doesn't crash anything.
-const CTX_COMMANDS = ['record', 'export', 'import', 'list', 'show'] as const;
+// Mirror of the switch below for did-you-mean suggestions. A new verb
+// forgotten here loses its typo hint, doesn't crash anything.
+const CTX_COMMANDS = ['record', 'supersede', 'export', 'import', 'list', 'show'] as const;
 
 // The phase-2 lifecycle verbs named in HELP / AGENT.md / docs as
 // "arriving in phase 2". A user who read the docs and types one of these
 // deserves a roadmap-aware message ("planned, not yet implemented")
 // rather than the same "unknown verb" a typo gets. Keep in sync with the
-// HELP phase-2 line above (list / show shipped — they left this set).
+// HELP "remaining phase-2 verbs" line above (record/supersede/list/show
+// shipped — they left this set).
 const CTX_PHASE2_VERBS: ReadonlySet<string> = new Set([
   'fork',
-  'supersede',
   'chain',
   'status',
 ]);
@@ -104,7 +115,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
   if (isVersionFlag(argv)) {
     process.stdout.write(
-      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 1 (record / list / show + OKF export/import)\n`,
+      `ctx (under guild-cli ${getPackageVersion()}) — alpha phase 2 (record / supersede / list / show + OKF export/import)\n`,
     );
     return 0;
   }
@@ -116,6 +127,7 @@ export async function main(argv: readonly string[]): Promise<number> {
   const VERB_BOOLEAN_FLAGS: Record<string, ReadonlySet<string>> = {
     export: EXPORT_BOOLEAN_FLAGS,
     import: IMPORT_BOOLEAN_FLAGS,
+    list: LIST_BOOLEAN_FLAGS,
   };
   const verbBooleans = VERB_BOOLEAN_FLAGS[cmd ?? ''];
   const args = verbBooleans
@@ -127,6 +139,8 @@ export async function main(argv: readonly string[]): Promise<number> {
     switch (cmd) {
       case 'record':
         return await recordCtx({ uc, config }, args);
+      case 'supersede':
+        return await supersedeCtx({ uc, config }, args);
       case 'list':
         return await listCtx({ uc, config }, args);
       case 'show':
@@ -142,19 +156,19 @@ export async function main(argv: readonly string[]): Promise<number> {
         if (cmd !== undefined && CTX_PHASE2_VERBS.has(cmd)) {
           process.stderr.write(
             `ctx: '${cmd}' is a planned phase-2 verb, not yet implemented.\n` +
-              `  phase 1 surface: record / export / import. See 'ctx --help'.\n`,
+              `  current surface: record / supersede / list / show / export / import. See 'ctx --help'.\n`,
           );
           return 1;
         }
-        // Phase 2 will add fork / supersede / chain / status; the catalog
-        // grows as those land. Valid verbs today are record / list / show
-        // / export / import — typos like `recor` should still get
-        // suggested rather than dumping the full HELP.
+        // Remaining phase-2 verbs (fork / chain / status) land as use
+        // surfaces their shape; the catalog grows then. Valid verbs today
+        // are record / supersede / list / show / export / import — typos
+        // like `recor` should still get suggested rather than dumping HELP.
         const hint = nearestCommand(cmd, CTX_COMMANDS);
         const suggest = hint ? `\n  did you mean: ctx ${hint}?` : '';
         process.stderr.write(
           `ctx: unknown verb: ${cmd}${suggest}\n` +
-            `  see 'ctx --help' for the full verb catalog (record / list / show / export / import).\n`,
+            `  see 'ctx --help' for the full verb catalog (record / supersede / list / show / export / import).\n`,
         );
         return 1;
       }

--- a/src/passages/ctx/interface/verbs.ts
+++ b/src/passages/ctx/interface/verbs.ts
@@ -1,14 +1,14 @@
 // ctx verbs — read/write/exempt classification for entry middleware.
 //
 // See gate's verbs.ts header for the rule-of-thumb classification.
-// Phase 1 surface: `record` (write); the OKF interop pair `export`
-// (read — writes a bundle outside content_root, no substrate mutation)
-// and `import` (write — records facts into content_root); and the
-// read-side `list` / `show`. Phase 2 will add fork / supersede / chain /
-// status.
+// Surface: `record` / `supersede` (write — both append a new fact); the
+// OKF interop pair `export` (read — writes a bundle outside content_root,
+// no substrate mutation) and `import` (write — records facts into
+// content_root); and the read-side `list` / `show`. Phase 2 will still add
+// fork / chain / status.
 
 export const READ_VERBS: ReadonlySet<string> = new Set(['export', 'list', 'show']);
 
-export const WRITE_VERBS: ReadonlySet<string> = new Set(['record', 'import']);
+export const WRITE_VERBS: ReadonlySet<string> = new Set(['record', 'supersede', 'import']);
 
 export const LOCK_EXEMPT_VERBS: ReadonlySet<string> = new Set();

--- a/tests/interface/nearestCommand.test.ts
+++ b/tests/interface/nearestCommand.test.ts
@@ -109,7 +109,7 @@ test('agora <unrelated>: refuses to suggest when nothing close', (t) => {
   assert.match(r.stderr, /agora --help/);
 });
 
-test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
+test('ctx <typo>: suggests ctx-prefixed verb (current catalog)', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   run(GATE, root, ['register', '--name', 'alice']);
@@ -118,23 +118,23 @@ test('ctx <typo>: suggests ctx-prefixed verb (phase-1 catalog)', (t) => {
   assert.match(r.stderr, /unknown verb: recor/);
   assert.match(r.stderr, /did you mean: ctx record\?/);
   // Verb-catalog callout — flag the available surface at the point a
-  // typo hit it, since the phase-2 lifecycle verbs (fork / supersede /
+  // typo hit it, since the remaining phase-2 lifecycle verbs (fork /
   // chain / status) are not yet implemented and a typo for any of those
   // would refuse to suggest.
-  assert.match(r.stderr, /record \/ list \/ show \/ export \/ import/);
+  assert.match(r.stderr, /record \/ supersede \/ list \/ show \/ export \/ import/);
 });
 
 test('ctx <phase-2 verb>: roadmap-aware message, not a bare "unknown verb"', (t) => {
   const { root, cleanup } = bootstrap();
   t.after(cleanup);
   run(GATE, root, ['register', '--name', 'alice']);
-  // `fork` is documented as a phase-2 verb (list / show shipped); a
-  // reader of the docs who types it should be told it's planned, not
-  // treated like a typo.
+  // `fork` is documented as a remaining phase-2 verb (record / supersede /
+  // list / show shipped); a reader of the docs who types it should be told
+  // it's planned, not treated like a typo.
   const r = run(CTX, root, ['fork']);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /planned phase-2 verb, not yet implemented/);
-  assert.match(r.stderr, /phase 1 surface: record \/ export \/ import/);
+  assert.match(r.stderr, /current surface: record \/ supersede \/ list \/ show \/ export \/ import/);
   assert.doesNotMatch(r.stderr, /unknown verb/);
 });
 

--- a/tests/interface/passageVersion.test.ts
+++ b/tests/interface/passageVersion.test.ts
@@ -68,10 +68,10 @@ test('devil -v: same as --version', () => {
   assert.equal(run(DEVIL, ['-v']), run(DEVIL, ['--version']));
 });
 
-test('ctx --version: includes package version + phase 1 status', () => {
+test('ctx --version: includes package version + phase 2 status', () => {
   const out = run(CTX, ['--version']);
   assert.match(out, new RegExp(`ctx \\(under guild-cli ${SEMVER.source}\\)`));
-  assert.match(out, /alpha phase 1/);
+  assert.match(out, /alpha phase 2/);
 });
 
 test('ctx -v: same as --version', () => {

--- a/tests/interface/verbs-consistency.test.ts
+++ b/tests/interface/verbs-consistency.test.ts
@@ -57,7 +57,7 @@ const DEVIL_ALL = [
   'suspend', 'resume', 'ingest', 'conclude', 'schema',
 ] as const;
 
-const CTX_ALL = ['record', 'list', 'show', 'export', 'import'] as const;
+const CTX_ALL = ['record', 'supersede', 'list', 'show', 'export', 'import'] as const;
 
 const CASES: Case[] = [
   { passage: 'gate', verbs: gateVerbs, all: GATE_ALL },

--- a/tests/passages/ctx/interface/supersede.test.ts
+++ b/tests/passages/ctx/interface/supersede.test.ts
@@ -102,11 +102,33 @@ test('show <old-id> resolves the reverse superseded_by link', (t) => {
 
   const r = JSON.parse(runCtx(root, ['show', oldId, '--format', 'json']).stdout);
   assert.equal(r.ok, true);
-  assert.equal(r.superseded_by, sup.id);
+  assert.deepEqual(r.superseded_by, [sup.id]);
 
-  // a current (un-superseded) fact reports null
+  // a current (un-superseded) fact reports an empty list
   const cur = JSON.parse(runCtx(root, ['show', sup.id, '--format', 'json']).stdout);
-  assert.equal(cur.superseded_by, null);
+  assert.deepEqual(cur.superseded_by, []);
+});
+
+test('show reports every successor when corrections fork the link', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'forked base');
+  // two independent corrections of the same fact -> two successors
+  const b = JSON.parse(
+    runCtx(root, ['supersede', oldId, '--fact', 'correction B', '--format', 'json'], { GUILD_ACTOR: 'eris' }).stdout,
+  );
+  const c = JSON.parse(
+    runCtx(root, ['supersede', oldId, '--fact', 'correction C', '--format', 'json'], { GUILD_ACTOR: 'eris' }).stdout,
+  );
+
+  const r = JSON.parse(runCtx(root, ['show', oldId, '--format', 'json']).stdout);
+  assert.equal(r.superseded_by.length, 2, 'both forks are reported, not just the first');
+  assert.deepEqual([...r.superseded_by].sort(), [b.id, c.id].sort());
+
+  // text surface lists both
+  const txt = runCtx(root, ['show', oldId]).stdout;
+  assert.match(txt, new RegExp(b.id));
+  assert.match(txt, new RegExp(c.id));
 });
 
 test('supersede a missing target is a recoverable not-found', (t) => {

--- a/tests/passages/ctx/interface/supersede.test.ts
+++ b/tests/passages/ctx/interface/supersede.test.ts
@@ -1,0 +1,154 @@
+// ctx supersede (phase-2 verb #1) — end-to-end through the real binary.
+//
+// supersede corrects an older fact by recording a *new* fact whose
+// `supersedes` points back at it; the old record is never mutated
+// (immutable substrate). Covers:
+//   - supersede records a new fact carrying the forward link
+//   - the superseded fact is folded out of `list` by default
+//   - `list --all` keeps both, marking the predecessor
+//   - `show <old-id>` resolves the reverse `superseded_by` link
+//   - missing target -> recoverable not-found (text + json envelope)
+//   - malformed old-id -> domain validation error
+//   - byte-stable YAML: ordinary record omits `supersedes`, correction has it
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CTX = resolve(here, '../../../../../bin/ctx.mjs');
+
+function newRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'ctx-supersede-'));
+  writeFileSync(join(root, 'guild.config.yaml'), 'content_root: .\nhost_names: [human]\n');
+  return root;
+}
+
+function runCtx(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [CTX, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+/** Record a fact and return its allocated id (read back via list --format json). */
+function recordFact(root: string, fact: string, tags?: string): string {
+  const args = ['record', '--fact', fact];
+  if (tags !== undefined) args.push('--tag', tags);
+  runCtx(root, args, { GUILD_ACTOR: 'eris' });
+  const env = JSON.parse(runCtx(root, ['list', '--all', '--format', 'json']).stdout);
+  return env.facts[0].id; // newest first
+}
+
+test('ctx supersede records a new fact with a forward link to the old', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'tebot deploy uses node 18', 'tech:node');
+
+  const r = runCtx(root, ['supersede', oldId, '--fact', 'tebot deploy uses node 20', '--format', 'json'], {
+    GUILD_ACTOR: 'eris',
+  });
+  assert.equal(r.status, 0);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.ok, true);
+  assert.equal(out.supersedes, oldId);
+  assert.notEqual(out.id, oldId); // a *new* fact, not an edit
+});
+
+test('the superseded fact is folded out of list by default, kept under --all', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'old fact', 'topic:x');
+  runCtx(root, ['supersede', oldId, '--fact', 'new fact', '--tag', 'topic:x'], { GUILD_ACTOR: 'eris' });
+
+  const def = JSON.parse(runCtx(root, ['list', '--format', 'json']).stdout);
+  assert.equal(def.count, 1, 'default list shows only the surviving head');
+  assert.equal(def.facts[0].fact, 'new fact');
+
+  const all = JSON.parse(runCtx(root, ['list', '--all', '--format', 'json']).stdout);
+  assert.equal(all.count, 2, '--all keeps the superseded predecessor');
+  const ids = all.facts.map((f: { id: string }) => f.id);
+  assert.ok(ids.includes(oldId));
+});
+
+test('list --all marks the superseded predecessor (text)', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'old fact');
+  runCtx(root, ['supersede', oldId, '--fact', 'new fact'], { GUILD_ACTOR: 'eris' });
+
+  const r = runCtx(root, ['list', '--all']);
+  assert.match(r.stdout, /⊘ superseded/);
+  assert.match(r.stdout, /↳ supersedes/);
+});
+
+test('show <old-id> resolves the reverse superseded_by link', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'old fact');
+  const sup = JSON.parse(
+    runCtx(root, ['supersede', oldId, '--fact', 'new fact', '--format', 'json'], { GUILD_ACTOR: 'eris' }).stdout,
+  );
+
+  const r = JSON.parse(runCtx(root, ['show', oldId, '--format', 'json']).stdout);
+  assert.equal(r.ok, true);
+  assert.equal(r.superseded_by, sup.id);
+
+  // a current (un-superseded) fact reports null
+  const cur = JSON.parse(runCtx(root, ['show', sup.id, '--format', 'json']).stdout);
+  assert.equal(cur.superseded_by, null);
+});
+
+test('supersede a missing target is a recoverable not-found', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const r = runCtx(root, ['supersede', 'ctx-2020-01-01-001', '--fact', 'x', '--format', 'json'], {
+    GUILD_ACTOR: 'eris',
+  });
+  assert.equal(r.status, 1);
+  const env = JSON.parse(r.stderr.split('\n')[0]!);
+  assert.equal(env.ok, false);
+  assert.equal(env.error.code, 'not_found');
+  assert.equal(env.error.recovery.verb, 'list');
+});
+
+test('supersede with a malformed old-id is a domain validation error', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const r = runCtx(root, ['supersede', 'not-an-id', '--fact', 'x'], { GUILD_ACTOR: 'eris' });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /ctx id must match/);
+});
+
+test('an empty store still prompts to record (supersede did not change this)', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  // Regression guard: folding superseded facts out of the default view must
+  // not turn the genuinely-empty message into the "all superseded" one.
+  assert.match(runCtx(root, ['list']).stdout, /no ctx facts recorded yet/);
+  assert.match(runCtx(root, ['list', '--all']).stdout, /no ctx facts recorded yet/);
+});
+
+test('byte-stable YAML: ordinary record omits supersedes, correction carries it', (t) => {
+  const root = newRoot();
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const oldId = recordFact(root, 'old fact');
+  const oldYaml = readFileSync(join(root, 'ctx', `${oldId}.yaml`), 'utf8');
+  assert.ok(!/supersedes:/.test(oldYaml), 'an ordinary record must not write a supersedes key');
+
+  const sup = JSON.parse(
+    runCtx(root, ['supersede', oldId, '--fact', 'new fact', '--format', 'json'], { GUILD_ACTOR: 'eris' }).stdout,
+  );
+  const newYaml = readFileSync(join(root, 'ctx', `${sup.id}.yaml`), 'utf8');
+  assert.match(newYaml, new RegExp(`supersedes: ${oldId}`));
+});


### PR DESCRIPTION
## What

The first phase-2 `ctx` verb: **`ctx supersede <old-id> --fact "..."`**.

ctx records are immutable on save, so a "correction" is not an in-place edit — it records a **new** fact whose `supersedes` field points back at the one it replaces. The old record is never mutated, so the ledger keeps both and the supersession is reconstructable from the forward-only link alone.

## Surface

- **`ctx supersede <old-id> --fact "..." [--tag ...] [--by ...]`** — records the correction with a `supersedes` link. A missing target is a recoverable not-found (a correction must point at something real); a self-supersession is rejected at the domain boundary.
- **`ctx list`** — folds superseded facts out by default (current view); **`--all`** keeps every fact, marking the superseded ones.
- **`ctx show <old-id>`** — stays readable, resolves the reverse link at read time as `superseded_by`, **an array** of successor ids (empty while current; more than one when two independent corrections fork the same fact — both are reported rather than silently picking one).

## Invariants

- **Acyclic by construction.** Every link points strictly backward to an id that already existed, so no cycle can form; the domain also rejects self-supersession outright. A chain (C supersedes B supersedes A) is allowed.
- **Always a current head.** The newest fact can never be superseded (nothing is written after it to point back), so a non-empty store always keeps at least one current head; an empty default `list` means the store is genuinely empty.
- **Byte-stable YAML.** The `supersedes` key is omitted from an ordinary record's YAML, so phase-1 records round-trip byte-for-byte.

## Commits

1. `feat(ctx): phase-2 supersede` — domain field + use case + handlers + wiring + docs + tests.
2. `refactor(ctx): supersede follow-ups` — fork-aware reverse link (returns all successors), drop an unreachable empty-message branch.
3. `refactor(ctx): dedup write path, sort comparator, tag parsing` — `appendFact()` (shared write path), `byNewestFirst()` (shared comparator), `parseTagList()` (shared `--tag` splitter).

## Verification

- Full suite green: **1846/1846 pass, 0 fail** (`node tests/run.mjs`, exit 0).
- Dogfooded through the real binary: record → supersede → list fold → `--all` → show reverse-link array → fork (two successors) → error paths (missing target, malformed id, missing `--fact`) → byte-stable YAML.
- Updated the verb-consistency / version-string / nearest-command tests that pinned the phase-1 surface.

## Remaining phase-2

`fork` / `chain` / `status`. `chain` is the design test the docs flag (junk-drawer risk at the 100-record scale); `supersededBy` notes where a persisted reverse index would land if that materializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)