### PR TITLE
fix(cli/docs): close CLI↔doc friction surfaced by a playbook dogfood

### DIFF
--- a/.changelog/next/added-issues-promote-format.md
+++ b/.changelog/next/added-issues-promote-format.md
@@ -1,0 +1,11 @@
+- **`gate issues promote` now accepts `--format json|text`.** It is a
+  write verb but previously had no `--format`, so an agent couldn't
+  receive the created request id as JSON — a schema-as-contract gap
+  (principle 10), since every other write verb returns the unified
+  `ok` / `id` / `state` / `message` / `suggested_next` envelope. promote
+  now shares that envelope via `emitWriteResponse`, so its JSON shape is
+  stable with `gate request`. The resolved-issue id rides in `message`
+  (`✓ promoted i-… → … (issue resolved)`), so both the new request id and
+  the resolved issue id stay greppable from the structured output
+  (records-outlive-writers). Text output is unchanged; no `--format`
+  defaults to text (back-compatible). Surfaced by a playbook dogfood pass.

--- a/.changelog/next/changed-guild-help-passages.md
+++ b/.changelog/next/changed-guild-help-passages.md
@@ -1,0 +1,9 @@
+- **`guild --help` now discloses the four passages.** `guild` is the
+  admin-side helper for managing actors, so its help listed only
+  member-management verbs — an agent that entered via `guild` had no
+  in-CLI path to the passages where the work actually happens
+  (orientation-disclosure gap, principle 09). The help now names
+  `gate` / `agora` / `devil` / `ctx` with their one-line shape and a
+  `<passage> --help` pointer, and points a newcomer at `gate --help`
+  and `AGENT.md`. Member-management docs are unchanged. Surfaced by a
+  "what if the entry point is guild, not gate?" walkthrough.

--- a/AGENT.md
+++ b/AGENT.md
@@ -41,7 +41,7 @@ gate complete <id> --by <you>
 `<mirror>` is a second persona / different `--by` for the same
 actor (you-as-critic, or another registered agent). Two-Persona
 Devil discipline: even solo, the approver / reviewer is a
-different lense from the executor. The default solo profile sets
+different lense from the executor. The default `standard` profile sets
 `self_approve: allowed` so `--by <you>` works for `approve` and
 `review` too, but the mirror is the discipline the substrate is
 shaped around — when you later flip to `swarm` profile,

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -287,10 +287,12 @@ the action lives in another passage. Example: during a long
 gate decision but isn't part of this thread. Drop a `ctx record`
 mentioning the play id and tag it `cross-passage:agora` — the
 fact accumulates outside the play's scope, queryable later via
-`ctx list --tag cross-passage:agora`. And when you pull up a
-related ctx fact, `ctx chain <id>` surfaces the breadcrumbs that
-name it (inbound) and the ids it names (outbound) in one hop, so
-the side-observation reconnects to its context without a grep.
+`ctx list --tag cross-passage:agora`. The tag is the cross-passage
+retrieval path: `ctx chain` only walks links between *ctx* facts
+(prose mentions of `ctx-…` ids plus supersession), so a breadcrumb
+naming an `agora` / `gate` id is found by its tag, not by `chain`.
+Use `chain` when one ctx fact references another; use the tag when
+the breadcrumb points into a different passage.
 
 This pattern keeps the agora play focused on its own thread
 without losing the side-observation, and avoids inflating the
@@ -346,7 +348,7 @@ devil conclude <rev-id> --synthesis "..." [--unresolved ...]
 # Back to gate: critic reviews, factoring devil's findings
 gate review <request-id> --by <critic> --lense devil \
   --verdict <ok|concern|reject> \
-  --comment "see devil-review <rev-id>: <synthesis summary>"
+  --note "see devil-review <rev-id>: <synthesis summary>"
 
 # Then the lifecycle continues
 gate execute <request-id> --by <executor>
@@ -354,8 +356,8 @@ gate complete <request-id> --by <executor>
 ```
 
 The two passages run in parallel, not nested. `gate review`'s
-free-text `--comment` carries the cross-reference to the
-devil session.
+free-text `--note` carries the cross-reference to the
+devil session. (`--comment` is a deprecated alias of `--note`.)
 
 ### C3: agora + devil — explore-then-audit
 
@@ -408,7 +410,7 @@ gate issues promote <issue-id> --from <you> [--executors <you>] \
 
 # Phase 4a: routine fix → gate review only
 gate review <request-id> --by <critic> --lense layer \
-  --verdict ok --comment "fix matches the diagnosis in agora <play-id>"
+  --verdict ok --note "fix matches the diagnosis in agora <play-id>"
 
 # Phase 4b: security-implicated fix → ALSO devil
 devil open <fix-pr-url> --type pr
@@ -418,7 +420,7 @@ devil conclude <rev-id> --synthesis "..."
 # Then in gate review:
 gate review <request-id> --by <critic> --lense devil \
   --verdict <ok|concern> \
-  --comment "devil <rev-id> concluded clean / with N unresolved"
+  --note "devil <rev-id> concluded clean / with N unresolved"
 
 # Phase 5: ship + close
 gate execute <request-id> --by <executor>
@@ -492,12 +494,14 @@ you're solo.
 **Trade-off.** Review depth is operator discipline, not enforced.
 The mirror is the same actor wearing a different hat; if the
 hat-swap is shallow, the discipline degrades to a self-stamp. The
-`self_approve: allowed` default on the solo profile means a flat
+`self_approve: allowed` default on the `standard` profile means a flat
 `--by <you>` arc *also* succeeds (just with a "notice: claude
 approved their own request" surfaced on the approve event). The
 synergy is the *practiced shape*, not a code-enforced one. Flip to
 `profile: swarm` and `self_approve: forbidden` makes the separate
-`--by` mandatory — same arc, different enforcement.
+`--by` mandatory — same arc, different enforcement. (The two valid
+profiles are `standard` and `swarm`; there is no `solo` profile —
+"solo" describes the single-actor *situation*, not a config value.)
 
 **E2E test.** [`tests/e2e/synergy_s1_mirror_persona_loop.test.ts`](../tests/e2e/synergy_s1_mirror_persona_loop.test.ts)
 pins three contracts:

--- a/src/interface/gate/handlers/issues.ts
+++ b/src/interface/gate/handlers/issues.ts
@@ -8,6 +8,7 @@ import { notFoundMessage } from '../../shared/notFoundHint.js';
 import { resolveGuildSessionId } from '../../shared/resolveGuildSessionId.js';
 import { parseExecutorsList } from './request.js';
 import { parseFormat } from '../../shared/parseFormat.js';
+import { emitWriteResponse } from './writeFormat.js';
 import {
   C,
   readStdin,
@@ -40,6 +41,7 @@ const ISSUES_PROMOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set([
   'auto-review',
   'action',
   'reason',
+  'format',
 ]);
 const ISSUES_NOTE_KNOWN_FLAGS: ReadonlySet<string> = new Set(['by', 'text']);
 // `gate issues resolve/defer/start/reopen` take `--by <m>` (or fall
@@ -339,9 +341,10 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
   if (!id) {
     throw new Error(
       'Usage: gate issues promote <id> --from <m> [--executors a,b] ' +
-        '[--auto-review <m>] [--action <a>] [--reason <r>]',
+        '[--auto-review <m>] [--action <a>] [--reason <r>] [--format json|text]',
     );
   }
+  const format = parseFormat(args);
   const from = requireOption(args, 'from', '<m>', 'GUILD_ACTOR');
   const executorsRaw = optionalOption(args, 'executors');
   const autoReview = optionalOption(args, 'auto-review');
@@ -423,8 +426,19 @@ async function issuesPromote(c: C, args: ParsedArgs): Promise<number> {
     );
     return 1;
   }
-  process.stdout.write(
-    `✓ promoted ${id} → ${req.id.value} (issue resolved)\n`,
+  // Unified write-envelope (ok/id/state/message/suggested_next) shared
+  // with `gate request` — keeps the JSON shape stable across write verbs
+  // (principle 10 schema-as-contract). The promote-specific fact (which
+  // issue was resolved) rides in `message`, so it survives in the JSON
+  // payload too (records-outlive-writers): the new request id and the
+  // resolved issue id are both greppable from the structured output.
+  // Decided in agora play promote-format-impl 2026-06-23-001 with
+  // devil (shape integrity) + noir (principle 04) review.
+  emitWriteResponse(
+    format,
+    req,
+    `✓ promoted ${id} → ${req.id.value} (issue resolved)`,
+    c.config,
   );
   return 0;
 }

--- a/src/interface/guild/index.ts
+++ b/src/interface/guild/index.ts
@@ -34,6 +34,14 @@ Usage:
   guild --version                         Print version and exit
 
 Categories: core | professional | assignee | trial | special | host
+
+guild manages *who* the actors are. The work itself runs through the
+passages — separate CLIs over the same content_root:
+  gate   — judgment: request → review → complete   (gate --help)
+  agora  — exploration: play / move / suspend       (agora --help)
+  devil  — defense: multi-persona security review   (devil --help)
+  ctx    — fact accumulation: record / chain        (ctx --help)
+New here? Start with \`gate --help\`. Full map: AGENT.md.
 `;
 
 export async function main(argv: readonly string[]): Promise<number> {

--- a/tests/interface/guildHelpPassages.test.ts
+++ b/tests/interface/guildHelpPassages.test.ts
@@ -1,0 +1,43 @@
+// guild --help discloses the passages (CLI↔doc friction #7)
+//
+// guild is the admin-side helper for managing actors; the work runs
+// through the passages (gate / agora / devil / ctx), each a separate CLI.
+// Pre-this, `guild --help` listed only member-management verbs, so an
+// agent that entered via `guild` had no in-CLI path to the passages — an
+// orientation-disclosure gap (principle 09). This pins that guild --help
+// now names the four passages and points a newcomer at `gate --help`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GUILD = resolve(here, '../../../bin/guild.mjs');
+
+function guildHelp(): string {
+  const r = spawnSync(process.execPath, [GUILD, '--help'], { encoding: 'utf8' });
+  return (r.stdout ?? '') + (r.stderr ?? '');
+}
+
+test('guild --help names the four passages with their --help pointers', () => {
+  const out = guildHelp();
+  for (const passage of ['gate', 'agora', 'devil', 'ctx']) {
+    assert.match(out, new RegExp(`${passage}\\b`), `mentions ${passage}`);
+    assert.match(out, new RegExp(`${passage} --help`), `points at ${passage} --help`);
+  }
+});
+
+test('guild --help points a newcomer at gate and the full map', () => {
+  const out = guildHelp();
+  assert.match(out, /Start with `gate --help`/);
+  assert.match(out, /AGENT\.md/);
+});
+
+test('guild --help still documents member management', () => {
+  const out = guildHelp();
+  // the original purpose must remain front-and-center
+  assert.match(out, /member management/);
+  assert.match(out, /guild list/);
+});

--- a/tests/interface/issuePromoteFormat.test.ts
+++ b/tests/interface/issuePromoteFormat.test.ts
@@ -1,0 +1,105 @@
+// gate issues promote --format (CLI↔doc friction #2)
+//
+// promote is a write verb but pre-this lacked --format, so an agent
+// couldn't receive the created request id as JSON — a schema-as-contract
+// gap (principle 10): every other write verb returns the unified
+// ok/id/state/message/suggested_next envelope. This pins that promote now
+// shares that envelope, and that the resolved-issue id survives in the
+// message field (records-outlive-writers, principle 04).
+//
+// Decided in agora play promote-format-impl 2026-06-23-001
+// (devil: shape integrity / noir: principle 04).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeTempRoot } from '../util/tempRoot.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GATE = resolve(here, '../../../bin/gate.mjs');
+
+function bootstrap(): { root: string; cleanup: () => void } {
+  const root = makeTempRoot('guild-issue-promote-fmt-');
+  writeFileSync(
+    join(root, 'guild.config.yaml'),
+    'content_root: .\nhost_names: [eris]\n',
+  );
+  mkdirSync(join(root, 'members'));
+  writeFileSync(
+    join(root, 'members', 'alice.yaml'),
+    'name: alice\ncategory: professional\nactive: true\n',
+  );
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+function run(
+  cwd: string,
+  args: string[],
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; status: number } {
+  const r = spawnSync(process.execPath, [GATE, ...args], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { stdout: r.stdout ?? '', stderr: r.stderr ?? '', status: r.status ?? -1 };
+}
+
+function addIssue(root: string): string {
+  run(root, ['issues', 'add', '--from', 'alice', '--severity', 'low', '--area', 'docs', 'an observation'], {
+    GUILD_ACTOR: 'alice',
+  });
+  const env = JSON.parse(run(root, ['issues', 'list', '--state', 'open', '--format', 'json']).stdout);
+  return env[0].id;
+}
+
+test('promote --format json returns the unified write envelope', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const issueId = addIssue(root);
+
+  const r = run(root, ['issues', 'promote', issueId, '--from', 'alice', '--executors', 'alice', '--reason', 'fix it', '--format', 'json'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  const env = JSON.parse(r.stdout);
+  // Same envelope keys as `gate request` (schema-as-contract, principle 10).
+  assert.equal(env.ok, true);
+  assert.match(env.id, /^\d{4}-\d{2}-\d{2}-\d{4}$/);
+  assert.equal(env.state, 'pending');
+  assert.ok(env.suggested_next, 'carries suggested_next like other write verbs');
+  // The resolved-issue id survives in the message (records-outlive-writers).
+  assert.match(env.message, new RegExp(issueId));
+  assert.match(env.message, new RegExp(env.id));
+});
+
+test('promote --format text keeps the original line', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const issueId = addIssue(root);
+
+  const r = run(root, ['issues', 'promote', issueId, '--from', 'alice', '--executors', 'alice', '--reason', 'fix it', '--format', 'text'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ promoted/);
+  assert.match(r.stdout, new RegExp(issueId));
+  assert.match(r.stdout, /issue resolved/);
+});
+
+test('promote with no --format defaults to text (back-compat)', (t) => {
+  const { root, cleanup } = bootstrap();
+  t.after(cleanup);
+  const issueId = addIssue(root);
+
+  const r = run(root, ['issues', 'promote', issueId, '--from', 'alice', '--executors', 'alice', '--reason', 'fix it'], {
+    GUILD_ACTOR: 'alice',
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /✓ promoted/);
+  // not JSON
+  assert.doesNotMatch(r.stdout, /^\{/);
+});


### PR DESCRIPTION
## What

A walkthrough of `guild → gate → agora → ctx → devil` (and "what if the entry point is `guild`, not `gate`?") surfaced gaps between the docs and the running CLI. Each fix was decided **on the substrate** (gate request + agora play + principle-grounded review), not by desk reasoning.

## Changes (with the principle each is grounded in)

- **`gate issues promote` gains `--format json|text`** — it was a write verb with no `--format`, so an agent couldn't receive the created request id as JSON. That's a **schema-as-contract gap (principle 10)**: every other write verb returns the unified `ok`/`id`/`state`/`message`/`suggested_next` envelope. promote now shares it via `emitWriteResponse`; the resolved-issue id rides in `message` so both ids stay greppable (**records-outlive-writers, principle 04**). Text output unchanged; no `--format` → text (back-compatible). *Decided in agora play `promote-format-impl` with devil (shape integrity) + noir (principle 04).*
- **`guild --help` discloses the four passages** — guild was member-management-only, leaving a guild-entry agent with no in-CLI path to the passages where work happens (**orientation-disclosure, principle 09**). Now names gate/agora/devil/ctx with `<passage> --help` pointers and a newcomer path to `gate --help` + AGENT.md.
- **playbook**: `gate review --comment` → `--note` (`--comment` is a deprecated alias).
- **playbook / AGENT.md**: "solo profile" → "standard" — valid profiles are `standard | swarm`; "solo" is the *situation*, not a config value.
- **playbook X2**: `ctx chain` only walks links between *ctx* facts; a breadcrumb naming an `agora`/`gate` id is found by its **tag**, not by `chain` (was overclaimed in the prior chain PR — corrected per **principle 03 legibility-costs**: don't pad the docs).

## Not a bug (dropped after schema-first check)

The walkthrough first suspected "`gate issues promote` requires `--reason`". Verified on the real CLI: `--reason` is **optional** (the handler defaults it). The original error was a misread `unknown flag: --format`. Dropped — the playbook's `[--reason]` was already correct.

## Filed as follow-up issues (different layer)

`ctx chain` cross-passage walk (#5b), play-id game collision needing `--game` (#9), `gate voices` vs agora-move channel boundary docs (#10).

## Verification

- Full suite **1865/1865 green** (`node tests/run.mjs`, exit 0).
- New tests: `issuePromoteFormat` (envelope keys + back-compat), `guildHelpPassages` (passage disclosure + member-mgmt retained).
- Dogfooded through the real binary; merge-readiness reviewed by noir + devil (both ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)